### PR TITLE
Fixed legal notice in contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [Build Setup](#build-setup)
 - [Building with CMake](#building-with-cmake)
 - [Project Cleanup](#project-cleanup)
-- [Notice and Disclaimer](#notice-and-disclaimer)
+- [Legal Information](#legal-information)
 
 ---
 
@@ -284,4 +284,4 @@ ninja -t clean
 
 ---
 
-[Legal information](legal_information.md)
+## [Legal information](legal_information.md)


### PR DESCRIPTION
Notice and disclaimer hyperlink is broken in original README.md. Since we use a legal disclaimer at the end of README.md, I renamed the item in "Contents". Also, the Legal Notice is a header, not just a statement (for markdown navigation purpose).