### PR TITLE
Templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/RFC.md
+++ b/.github/ISSUE_TEMPLATE/RFC.md
@@ -1,0 +1,22 @@
+---
+name: RFC for new interface
+about: Use this template to request new functionality or change behavior of the
+library
+title: ''
+labels: 'RFC'
+assignees: ''
+---
+
+# Summary
+Include a short summary of the request. Sections below provide guidance on
+what factors are considered important. Describe how new interface will meet
+[library functionality guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md#library-functionality-guidelines).
+
+# Problem statement
+Describe the problem you are trying to solve with reasonable level of details.
+
+# Details
+* The definition of the function including interface and semantics. How this
+interface will be extendable for different HW implementations.
+* What existing libraries have implementation of this function and can be used
+under oneMKL interface.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Report a bug or a performance issue
+about: Use this template to report unexpected behavior
+title: ''
+labels: ''
+assignees: ''
+---
+
+# Summary
+Provide a short summary of the issue. Sections below provide guidance on what
+factors are considered important to reproduce an issue.
+
+# Version
+Report oneMKL version and githash.
+If it is a regression, report githash for the last known good revision.
+
+# Environment
+oneMKL works with multiple HW and backend libraries and also depends on the
+compiler and build environment. Include
+the following information to help reproduce the issue:
+* HW you use
+* Backend library version
+* OS name and version
+* Compiler version
+* CMake output log
+
+# Steps to reproduce
+Please check that the issue is reproducible with the latest revision on
+master. Include all the steps to reproduce the issue.
+
+# Observed behavior
+Document behavior you observe. For performance defects, like performance
+regressions or a function being slow, provide a log including output generated
+by your application, as well as details on what performance is expected or to
+what performance was compared to.
+
+# Expected behavior
+Document behavior you expect.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,20 @@
+---
+name: Request a documentation change
+about: Use this template to report documentation issue or request documentation
+changes
+title: ''
+labels: 'documentation'
+assignees: ''
+---
+
+# Summary
+Include a short summary of the issue or request. Sections below provide
+guidance on what factors are considered important for a documentation
+issue.
+
+# URLs
+Include pointers to documents that are impacted.
+
+# Additional details
+Provide detailed description of the expected changes in documentation
+and suggestions you have.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Request a feature
+about: Use this template to request new functionality or change behavior of the
+library
+title: ''
+labels: ''
+assignees: ''
+---
+
+# Summary
+Include a short summary of the request. Sections below provide guidance on
+what factors are considered important for a feature request.
+
+# Problem statement
+Describe the problem you are trying to solve with reasonable level of details.
+
+# Preferred solution
+Document your thoughts on what solution may look like.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,7 @@
+---
+name: Ask a question
+about: Use this template for everything that is not a bug or a feature request
+title: ''
+labels: 'question'
+assignees: ''
+---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+# Description
+
+Please include a summary of the change. Please also include relevant
+motivation and context. See
+[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
+for more details. If the change fixes an issue not documented in the project's
+Github issue tracker, please document all steps necessary to reproduce it.
+
+Fixes # (GitHub issue)
+
+# Checklist
+
+## All Submissions
+
+- [ ] Do all unit tests pass locally? Attach a log.
+- [ ] Have you formatted the code using clang-format?
+
+## New interfaces
+
+- [ ] Have you provided motivation for adding a new feature as part of RFC and
+it was accepted? # (RFC)
+- [ ] What version of oneAPI spec the interface is targeted?
+- [ ] Complete [New features](pull_request_template.md#new-features) checklist
+
+## New features
+
+- [ ] Have you provided motivation for adding a new feature?
+- [ ] Have you added relevant tests?
+
+## Bug fixes
+
+- [ ] Have you added relevant regression tests?
+- [ ] Have you included information on how to reproduce the issue (either in a
+      GitHub issue or in this PR)?


### PR DESCRIPTION
This PR adds templates for issues and PRs that Github will apply automatically to help users provide required level of details.

See templates in action here:
* [Issues](https://github.com/jasukhar/oneMKL/issues/new/choose)
* [PRs](https://github.com/jasukhar/oneMKL/compare/master...NadyaTen:patch-1)
