### PR TITLE
[Conan]Update Conan, CMake and Ninja;Fix Conan builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ Software Package indicates your acceptance of the Agreements.**
 Product | Supported Version | Installed by Conan | Conan Package Source | Package Install Location on Linux* | License
 :--- | :--- | :--- | :--- | :--- | :---
 Python | 3.6 or higher | No | *N/A* | *Pre-installed or Installed by user* | [PSF](https://docs.python.org/3.6/license.html)
-[Conan C++ Package Manager](https://conan.io/downloads.html) | 1.23 or higher | No | *N/A* | *Installed by user* | [MIT](https://github.com/conan-io/conan/blob/develop/LICENSE.md)
-[CMake](https://cmake.org/download/) | 3.13 or higher | Yes | conan-center | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [The OSI-approved BSD 3-clause License](https://gitlab.kitware.com/cmake/cmake/raw/master/Copyright.txt)
-[Ninja](https://ninja-build.org/) | 1.9.0 | Yes | conan-center | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [Apache License v2.0](https://github.com/ninja-build/ninja/blob/master/COPYING)
+[Conan C++ Package Manager](https://conan.io/downloads.html) | 1.24 or higher | No | *N/A* | *Installed by user* | [MIT](https://github.com/conan-io/conan/blob/develop/LICENSE.md)
+[CMake](https://cmake.org/download/) | 3.13 or higher | Yes<br>(3.15 or higher) | conan-center | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [The OSI-approved BSD 3-clause License](https://gitlab.kitware.com/cmake/cmake/raw/master/Copyright.txt)
+[Ninja](https://ninja-build.org/) | 1.10.0 | Yes | conan-center | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [Apache License v2.0](https://github.com/ninja-build/ninja/blob/master/COPYING)
 [GNU* FORTRAN Compiler](https://gcc.gnu.org/wiki/GFortran) | 7.4.0 or higher | Yes | apt | /usr/bin | [GNU General Public License, version 3](https://gcc.gnu.org/onlinedocs/gcc-7.5.0/gfortran/Copying.html)
 [Intel(R) oneAPI DPC++ Compiler](https://software.intel.com/en-us/oneapi/dpc-compiler) | 2021.1-beta06 | No | *N/A* | *Installed by user* | [End User License Agreement for the Intel(R) Software Development Products](https://software.intel.com/en-us/license/eula-for-intel-software-development-products)
 [Intel project for LLVM* technology binary for Intel CPU](https://github.com/intel/llvm/releases) | Daily builds (experimental) tested with [20200331](https://github.com/intel/llvm/releases/download/20200331/dpcpp-compiler.tar.gz) | No | *N/A* | *Installed by user* | [Apache License v2](https://github.com/intel/llvm/blob/sycl/sycl/LICENSE.TXT)

--- a/conan/profiles/inteldpcpp_lnx
+++ b/conan/profiles/inteldpcpp_lnx
@@ -30,8 +30,8 @@ compiler.libcxx=libstdc++11
 build_type=Release
 
 [build_requires]
-ninja/1.9.0
-cmake/[>=3.13]
+cmake/[>=3.15]
+ninja/1.10.0
 
 [env]
 CONAN_CMAKE_GENERATOR="Ninja"

--- a/conanfile.py
+++ b/conanfile.py
@@ -135,7 +135,7 @@ THIRD-PARTY-PROGRAMS file and in the README.md file included with the Software P
             # Paramaters
             # Conan does not officially support the DPC++ compiler, hence disable the compiler_id check
             "CONAN_DISABLE_CHECK_COMPILER" : True,
-            "MKL_ROOT"                 : f"/opt/intel/inteloneapi/mkl/latest",
+            "MKL_ROOT"                 : f"/opt/intel/inteloneapi/mkl/{self.oneapi_version}",
         })
         cmake.configure()
         cmake.build()

--- a/conanfile.py
+++ b/conanfile.py
@@ -133,7 +133,9 @@ THIRD-PARTY-PROGRAMS file and in the README.md file included with the Software P
             "BUILD_DOC"                : self.options.build_doc,
 
             # Paramaters
-            "MKL_ROOT"                 : f"/opt/intel/inteloneapi/mkl/{self.oneapi_version}",
+            # Conan does not officially support the DPC++ compiler, hence disable the compiler_id check
+            "CONAN_DISABLE_CHECK_COMPILER" : True,
+            "MKL_ROOT"                 : f"/opt/intel/inteloneapi/mkl/latest",
         })
         cmake.configure()
         cmake.build()


### PR DESCRIPTION
# Description

*Update Ninja to 1.10.0 to support FORTRAN builds (Fixes Netlib LAPACK builds via Conan)
*Update CMake to 3.15 to support Ninja 1.10.0
*Update Conan to 1.24 to support OpenSSL package(new dependency for CMake package)
*Disable Conan compiler check to avoid failure when using DPC++ compiler
