### PR TITLE
Extend RNG domain APIs and enable oneMKL beta10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
   foreach (flag_var
            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
            CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
+  string(REGEX REPLACE "/M[TD]+[d]*" "" ${flag_var} "${${flag_var}}")
   endforeach()
 endif()
 

--- a/deps/googletest/cmake/internal_utils.cmake
+++ b/deps/googletest/cmake/internal_utils.cmake
@@ -114,7 +114,7 @@ macro(config_compiler_and_linker)
     # explicitly.
     set(cxx_no_rtti_flags "-qnortti -DGTEST_HAS_RTTI=0")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "HP")
-    set(cxx_base_flags "-AA -md")
+    set(cxx_base_flags "-AA -mt")
     set(cxx_exception_flags "-DGTEST_HAS_EXCEPTIONS=1")
     set(cxx_no_exception_flags "+noeh -DGTEST_HAS_EXCEPTIONS=0")
     # RTTI can not be disabled in HP aCC compiler.
@@ -133,7 +133,11 @@ macro(config_compiler_and_linker)
   set(cxx_exception "${cxx_base_flags} ${cxx_exception_flags}")
   set(cxx_no_exception
     "${CMAKE_CXX_FLAGS} ${cxx_base_flags} ${cxx_no_exception_flags}")
+  if(NOT WIN32)
   set(cxx_default "${cxx_exception}")
+  else()
+  set(cxx_default "${cxx_exception} /MD")
+  endif()
   set(cxx_no_rtti "${cxx_default} ${cxx_no_rtti_flags}")
 
   # For building the gtest libraries.

--- a/deps/googletest/cmake/internal_utils.cmake
+++ b/deps/googletest/cmake/internal_utils.cmake
@@ -34,7 +34,7 @@ macro(fix_default_compiler_settings_)
         # preferable to use CRT as static libraries, as we don't have to rely
         # on CRT DLLs being available. CMake always defaults to using shared
         # CRT libraries, so we override that default here.
-        string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
+        string(REGEX REPLACE "/M[TD]+[d]*" "" ${flag_var} "${${flag_var}}")
       endif()
 
       # We prefer more strict warning checking for building Google Test.
@@ -114,7 +114,7 @@ macro(config_compiler_and_linker)
     # explicitly.
     set(cxx_no_rtti_flags "-qnortti -DGTEST_HAS_RTTI=0")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "HP")
-    set(cxx_base_flags "-AA -mt")
+    set(cxx_base_flags "-AA -md")
     set(cxx_exception_flags "-DGTEST_HAS_EXCEPTIONS=1")
     set(cxx_no_exception_flags "+noeh -DGTEST_HAS_EXCEPTIONS=0")
     # RTTI can not be disabled in HP aCC compiler.

--- a/include/oneapi/mkl/rng/detail/engine_impl.hpp
+++ b/include/oneapi/mkl/rng/detail/engine_impl.hpp
@@ -41,34 +41,58 @@ public:
 
     // Buffers API
     virtual void generate(const uniform<float, uniform_method::standard>& distr, std::int64_t n,
-                          cl::sycl::buffer<float, 1> r) = 0;
+                          cl::sycl::buffer<float, 1>& r) = 0;
 
     virtual void generate(const uniform<double, uniform_method::standard>& distr, std::int64_t n,
-                          cl::sycl::buffer<double, 1> r) = 0;
+                          cl::sycl::buffer<double, 1>& r) = 0;
 
     virtual void generate(const uniform<std::int32_t, uniform_method::standard>& distr,
-                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1> r) = 0;
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) = 0;
 
     virtual void generate(const uniform<float, uniform_method::accurate>& distr, std::int64_t n,
-                          cl::sycl::buffer<float, 1> r) = 0;
+                          cl::sycl::buffer<float, 1>& r) = 0;
 
     virtual void generate(const uniform<double, uniform_method::accurate>& distr, std::int64_t n,
-                          cl::sycl::buffer<double, 1> r) = 0;
+                          cl::sycl::buffer<double, 1>& r) = 0;
 
     virtual void generate(const gaussian<float, gaussian_method::box_muller2>& distr,
-                          std::int64_t n, cl::sycl::buffer<float, 1> r) = 0;
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) = 0;
 
     virtual void generate(const gaussian<double, gaussian_method::box_muller2>& distr,
-                          std::int64_t n, cl::sycl::buffer<double, 1> r) = 0;
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) = 0;
 
     virtual void generate(const gaussian<float, gaussian_method::icdf>& distr, std::int64_t n,
-                          cl::sycl::buffer<float, 1> r) = 0;
+                          cl::sycl::buffer<float, 1>& r) = 0;
 
     virtual void generate(const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n,
-                          cl::sycl::buffer<double, 1> r) = 0;
+                          cl::sycl::buffer<double, 1>& r) = 0;
+
+    virtual void generate(const lognormal<float, lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) = 0;
+
+    virtual void generate(const lognormal<double, lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) = 0;
+
+    virtual void generate(const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n,
+                          cl::sycl::buffer<float, 1>& r) = 0;
+
+    virtual void generate(const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n,
+                          cl::sycl::buffer<double, 1>& r) = 0;
+
+    virtual void generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) = 0;
+
+    virtual void generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) = 0;
+
+    virtual void generate(const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) = 0;
+
+    virtual void generate(const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) = 0;
 
     virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
-                          cl::sycl::buffer<std::uint32_t, 1> r) = 0;
+                          cl::sycl::buffer<std::uint32_t, 1>& r) = 0;
 
     // USM APIs
     virtual cl::sycl::event generate(
@@ -106,6 +130,38 @@ public:
     virtual cl::sycl::event generate(
         const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n, double* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const lognormal<float, lognormal_method::box_muller2>& distr, std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const lognormal<double, lognormal_method::box_muller2>& distr, std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+
+    virtual cl::sycl::event generate(
+        const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,

--- a/include/oneapi/mkl/rng/detail/mklcpu/onemkl_rng_mklcpu.hpp
+++ b/include/oneapi/mkl/rng/detail/mklcpu/onemkl_rng_mklcpu.hpp
@@ -37,6 +37,12 @@ ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(cl::sy
 ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
     cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed);
 
+ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(cl::sycl::queue queue,
+                                                                     std::uint32_t seed);
+
+ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(
+    cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed);
+
 } // namespace mklcpu
 } // namespace rng
 } // namespace mkl

--- a/include/oneapi/mkl/rng/detail/mklgpu/onemkl_rng_mklgpu.hpp
+++ b/include/oneapi/mkl/rng/detail/mklgpu/onemkl_rng_mklgpu.hpp
@@ -37,6 +37,12 @@ ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(cl::sy
 ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
     cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed);
 
+ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(cl::sycl::queue queue,
+                                                                     std::uint32_t seed);
+
+ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(
+    cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed);
+
 } // namespace mklgpu
 } // namespace rng
 } // namespace mkl

--- a/include/oneapi/mkl/rng/detail/rng_loader.hpp
+++ b/include/oneapi/mkl/rng/detail/rng_loader.hpp
@@ -39,6 +39,12 @@ ONEMKL_EXPORT engine_impl* create_philox4x32x10(oneapi::mkl::device libkey, cl::
 ONEMKL_EXPORT engine_impl* create_philox4x32x10(oneapi::mkl::device libkey, cl::sycl::queue queue,
                                                 std::initializer_list<std::uint64_t> seed);
 
+ONEMKL_EXPORT engine_impl* create_mrg32k3a(oneapi::mkl::device libkey, cl::sycl::queue queue,
+                                           std::uint32_t seed);
+
+ONEMKL_EXPORT engine_impl* create_mrg32k3a(oneapi::mkl::device libkey, cl::sycl::queue queue,
+                                           std::initializer_list<std::uint32_t> seed);
+
 } // namespace detail
 } // namespace rng
 } // namespace mkl

--- a/include/oneapi/mkl/rng/engines.hpp
+++ b/include/oneapi/mkl/rng/engines.hpp
@@ -190,7 +190,7 @@ private:
                                 const sycl::vector_class<sycl::event>& dependencies);
 };
 
-// default engine to be used for common cases
+// Default engine to be used for common cases
 using default_engine = philox4x32x10;
 
 } // namespace rng

--- a/include/oneapi/mkl/rng/engines.hpp
+++ b/include/oneapi/mkl/rng/engines.hpp
@@ -29,6 +29,7 @@
 #include "oneapi/mkl/detail/backend_selector.hpp"
 
 #include "oneapi/mkl/rng/detail/engine_impl.hpp"
+#include "oneapi/mkl/rng/detail/rng_loader.hpp"
 
 #ifdef ENABLE_MKLCPU_BACKEND
 #include "oneapi/mkl/rng/detail/mklcpu/onemkl_rng_mklcpu.hpp"
@@ -115,6 +116,82 @@ private:
                                 typename Distr::result_type* r,
                                 const sycl::vector_class<sycl::event>& dependencies);
 };
+
+// Class oneapi::mkl::rng::mrg32k3a
+//
+// Represents the combined recurcive pseudorandom number generator
+//
+// Supported parallelization methods:
+//      skip_ahead
+class mrg32k3a {
+public:
+    static constexpr std::uint32_t default_seed = 1;
+
+    mrg32k3a(sycl::queue queue, std::uint32_t seed = default_seed)
+            : pimpl_(detail::create_mrg32k3a(get_device_id(queue), queue, seed)) {}
+
+    mrg32k3a(sycl::queue queue, std::initializer_list<std::uint32_t> seed)
+            : pimpl_(detail::create_mrg32k3a(get_device_id(queue), queue, seed)) {}
+
+#ifdef ENABLE_MKLCPU_BACKEND
+    mrg32k3a(backend_selector<backend::mklcpu> selector, std::uint32_t seed = default_seed)
+            : pimpl_(mklcpu::create_mrg32k3a(selector.get_queue(), seed)) {}
+
+    mrg32k3a(backend_selector<backend::mklcpu> selector, std::initializer_list<std::uint32_t> seed)
+            : pimpl_(mklcpu::create_mrg32k3a(selector.get_queue(), seed)) {}
+#endif
+
+#ifdef ENABLE_MKLGPU_BACKEND
+    mrg32k3a(backend_selector<backend::mklgpu> selector, std::uint32_t seed = default_seed)
+            : pimpl_(mklgpu::create_mrg32k3a(selector.get_queue(), seed)) {}
+
+    mrg32k3a(backend_selector<backend::mklgpu> selector, std::initializer_list<std::uint32_t> seed)
+            : pimpl_(mklgpu::create_mrg32k3a(selector.get_queue(), seed)) {}
+#endif
+
+    mrg32k3a(const mrg32k3a& other) {
+        pimpl_.reset(other.pimpl_.get()->copy_state());
+    }
+
+    mrg32k3a(mrg32k3a&& other) {
+        pimpl_ = std::move(other.pimpl_);
+    }
+
+    mrg32k3a& operator=(const mrg32k3a& other) {
+        if (this == &other)
+            return *this;
+        pimpl_.reset(other.pimpl_.get()->copy_state());
+        return *this;
+    }
+
+    mrg32k3a& operator=(mrg32k3a&& other) {
+        if (this == &other)
+            return *this;
+        pimpl_ = std::move(other.pimpl_);
+        return *this;
+    }
+
+private:
+    std::unique_ptr<detail::engine_impl> pimpl_;
+
+    template <typename Engine>
+    friend void skip_ahead(Engine& engine, std::uint64_t num_to_skip);
+
+    template <typename Engine>
+    friend void skip_ahead(Engine& engine, std::initializer_list<std::uint64_t> num_to_skip);
+
+    template <typename Distr, typename Engine>
+    friend void generate(const Distr& distr, Engine& engine, std::int64_t n,
+                         sycl::buffer<typename Distr::result_type, 1>& r);
+
+    template <typename Distr, typename Engine>
+    friend sycl::event generate(const Distr& distr, Engine& engine, std::int64_t n,
+                                typename Distr::result_type* r,
+                                const sycl::vector_class<sycl::event>& dependencies);
+};
+
+// default engine to be used for common cases
+using default_engine = philox4x32x10;
 
 } // namespace rng
 } // namespace mkl

--- a/src/rng/backends/mklcpu/CMakeLists.txt
+++ b/src/rng/backends/mklcpu/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
   cpu_common.hpp
   philox4x32x10.cpp
+  mrg32k3a.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_rng_cpu_wrappers.cpp>
 )
 

--- a/src/rng/backends/mklcpu/mkl_rng_cpu_wrappers.cpp
+++ b/src/rng/backends/mklcpu/mkl_rng_cpu_wrappers.cpp
@@ -24,5 +24,6 @@
 
 extern "C" ONEMKL_EXPORT rng_function_table_t mkl_rng_table = {
     WRAPPER_VERSION, oneapi::mkl::rng::mklcpu::create_philox4x32x10,
-    oneapi::mkl::rng::mklcpu::create_philox4x32x10
+    oneapi::mkl::rng::mklcpu::create_philox4x32x10, oneapi::mkl::rng::mklcpu::create_mrg32k3a,
+    oneapi::mkl::rng::mklcpu::create_mrg32k3a
 };

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -33,24 +33,22 @@ namespace mkl {
 namespace rng {
 namespace mklcpu {
 
-class philox4x32x10_impl : public oneapi::mkl::rng::detail::engine_impl {
+class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:
-    philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)
+    mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)
             : oneapi::mkl::rng::detail::engine_impl(queue) {
-        vslNewStreamEx(&stream_, VSL_BRNG_PHILOX4X32X10, 2,
-                       reinterpret_cast<std::uint32_t*>(&seed));
+        vslNewStream(&stream_, VSL_BRNG_MRG32K3A, seed);
         state_size_ = vslGetStreamSize(stream_);
     }
 
-    philox4x32x10_impl(cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed)
+    mrg32k3a_impl(cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed)
             : oneapi::mkl::rng::detail::engine_impl(queue) {
-        vslNewStreamEx(&stream_, VSL_BRNG_PHILOX4X32X10, 2 * seed.size(),
+        vslNewStreamEx(&stream_, VSL_BRNG_MRG32K3A, 2 * seed.size(),
                        reinterpret_cast<const std::uint32_t*>(seed.begin()));
         state_size_ = vslGetStreamSize(stream_);
     }
 
-    philox4x32x10_impl(const philox4x32x10_impl* other)
-            : oneapi::mkl::rng::detail::engine_impl(*other) {
+    mrg32k3a_impl(const mrg32k3a_impl* other) : oneapi::mkl::rng::detail::engine_impl(*other) {
         vslCopyStream(&stream_, other->stream_);
         state_size_ = vslGetStreamSize(stream_);
     }
@@ -63,7 +61,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                              acc_r.get_pointer(), distr.a(), distr.b());
@@ -77,7 +75,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                              acc_r.get_pointer(), distr.a(), distr.b());
@@ -91,7 +89,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                              acc_r.get_pointer(), distr.a(), distr.b());
@@ -105,7 +103,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                              acc_r.get_pointer(), distr.a(), distr.b());
@@ -119,7 +117,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                              acc_r.get_pointer(), distr.a(), distr.b());
@@ -133,7 +131,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                               acc_r.get_pointer(), distr.mean(), distr.stddev());
@@ -147,7 +145,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                               acc_r.get_pointer(), distr.mean(), distr.stddev());
@@ -161,7 +159,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                               acc_r.get_pointer(), distr.mean(), distr.stddev());
@@ -175,7 +173,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                               acc_r.get_pointer(), distr.mean(), distr.stddev());
@@ -189,7 +187,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
                                static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                                acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
@@ -204,7 +202,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
                                static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                                acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
@@ -219,7 +217,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
                                static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                                acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
@@ -234,7 +232,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
                                static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                                acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
@@ -249,7 +247,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
                                static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                                acc_r.get_pointer(), distr.p());
@@ -263,7 +261,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 std::uint32_t* r_ptr = acc_r.get_pointer();
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
                                static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
@@ -278,7 +276,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                              acc_r.get_pointer(), distr.lambda());
@@ -292,7 +290,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 std::uint32_t* r_ptr = acc_r.get_pointer();
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
@@ -307,7 +305,7 @@ public:
         queue_.submit([&](sycl::handler& cgh) {
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD,
                                  static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
                                  acc_r.get_pointer());
@@ -323,7 +321,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -335,7 +333,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -347,7 +345,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -359,7 +357,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, stream, n, r, distr.a(),
                              distr.b());
             });
@@ -372,7 +370,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, stream, n, r, distr.a(),
                              distr.b());
             });
@@ -385,7 +383,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -398,7 +396,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -411,7 +409,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -424,7 +422,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -437,7 +435,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2, stream, n, r, distr.m(),
                                distr.s(), distr.displ(), distr.scale());
             });
@@ -450,7 +448,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2, stream, n, r, distr.m(),
                                distr.s(), distr.displ(), distr.scale());
             });
@@ -463,7 +461,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF, stream, n, r, distr.m(), distr.s(),
                                distr.displ(), distr.scale());
             });
@@ -476,7 +474,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF, stream, n, r, distr.m(), distr.s(),
                                distr.displ(), distr.scale());
             });
@@ -489,7 +487,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, n, r, distr.p());
             });
         });
@@ -501,7 +499,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, n,
                                reinterpret_cast<int32_t*>(r), distr.p());
             });
@@ -514,7 +512,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, stream, n, r, distr.lambda());
             });
         });
@@ -526,7 +524,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, stream, n,
                              reinterpret_cast<int32_t*>(r), distr.lambda());
             });
@@ -539,13 +537,13 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(
+            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(
                 cgh, [=]() { viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD, stream, n, r); });
         });
     }
 
     virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
-        return new philox4x32x10_impl(this);
+        return new mrg32k3a_impl(this);
     }
 
     virtual void skip_ahead(std::uint64_t num_to_skip) override {
@@ -560,7 +558,7 @@ public:
         throw oneapi::mkl::unimplemented("rng", "leapfrog");
     }
 
-    virtual ~philox4x32x10_impl() override {
+    virtual ~mrg32k3a_impl() override {
         vslDeleteStream(&stream_);
     }
 
@@ -569,14 +567,13 @@ private:
     std::int32_t state_size_;
 };
 
-oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(cl::sycl::queue queue,
-                                                            std::uint64_t seed) {
-    return new philox4x32x10_impl(queue, seed);
+oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(cl::sycl::queue queue, std::uint32_t seed) {
+    return new mrg32k3a_impl(queue, seed);
 }
 
-oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
-    cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed) {
-    return new philox4x32x10_impl(queue, seed);
+oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(cl::sycl::queue queue,
+                                                       std::initializer_list<std::uint32_t> seed) {
+    return new mrg32k3a_impl(queue, seed);
 }
 
 } // namespace mklcpu

--- a/src/rng/backends/mklgpu/CMakeLists.txt
+++ b/src/rng/backends/mklgpu/CMakeLists.txt
@@ -23,7 +23,9 @@ find_package(MKL REQUIRED)
 
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
+  mkl_internal_rng_gpu.hpp
   philox4x32x10.cpp
+  mrg32k3a.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_rng_gpu_wrappers.cpp>
 )
 

--- a/src/rng/backends/mklgpu/mkl_internal_rng_gpu.hpp
+++ b/src/rng/backends/mklgpu/mkl_internal_rng_gpu.hpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _MKL_INTERNAL_RNG_GPU_HPP_
+#define _MKL_INTERNAL_RNG_GPU_HPP_
+
+#include <CL/sycl.hpp>
+
+namespace oneapi {
+namespace mkl {
+namespace rng {
+namespace detail {
+
+template <typename EngineType>
+class engine_base_impl;
+
+namespace gpu {
+
+template <typename EngineType>
+engine_base_impl<EngineType>* create_engine(sycl::queue& queue, std::uint64_t seed);
+
+template <typename EngineType>
+engine_base_impl<EngineType>* create_engine(sycl::queue& queue, std::int64_t n,
+                                            const unsigned int* seed_ptr);
+
+template <typename EngineType>
+engine_base_impl<EngineType>* create_engine(sycl::queue& queue,
+                                            engine_base_impl<EngineType>* other_impl);
+
+template <typename EngineType>
+void skip_ahead(sycl::queue& queue, engine_base_impl<EngineType>* impl, std::uint64_t num_to_skip);
+
+template <typename EngineType>
+void skip_ahead(sycl::queue& queue, engine_base_impl<EngineType>* impl,
+                std::initializer_list<std::uint64_t> num_to_skip);
+
+template <typename EngineType>
+void leapfrog(sycl::queue& queue, engine_base_impl<EngineType>* impl, std::uint64_t idx,
+              std::uint64_t stride);
+
+template <typename EngineType>
+void delete_engine(sycl::queue& queue, engine_base_impl<EngineType>* impl);
+
+template <typename EngineType, typename DistrType>
+sycl::event generate(sycl::queue& queue, const DistrType& distr,
+                     engine_base_impl<EngineType>* engine, std::int64_t n,
+                     sycl::buffer<typename DistrType::result_type, 1>& r);
+
+template <typename EngineType, typename DistrType>
+sycl::event generate(sycl::queue& queue, const DistrType& distr,
+                     engine_base_impl<EngineType>* engine, std::int64_t n,
+                     typename DistrType::result_type* r,
+                     const sycl::vector_class<sycl::event>& dependencies = {});
+
+} // namespace gpu
+} // namespace detail
+} // namespace rng
+} // namespace mkl
+} // namespace oneapi
+
+#endif //_MKL_INTERNAL_RNG_GPU_HPP_

--- a/src/rng/backends/mklgpu/mkl_rng_gpu_wrappers.cpp
+++ b/src/rng/backends/mklgpu/mkl_rng_gpu_wrappers.cpp
@@ -24,5 +24,6 @@
 
 extern "C" ONEMKL_EXPORT rng_function_table_t mkl_rng_table = {
     WRAPPER_VERSION, oneapi::mkl::rng::mklgpu::create_philox4x32x10,
-    oneapi::mkl::rng::mklgpu::create_philox4x32x10
+    oneapi::mkl::rng::mklgpu::create_philox4x32x10, oneapi::mkl::rng::mklgpu::create_mrg32k3a,
+    oneapi::mkl::rng::mklgpu::create_mrg32k3a
 };

--- a/src/rng/backends/mklgpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklgpu/mrg32k3a.cpp
@@ -35,24 +35,23 @@ namespace rng {
 namespace mklgpu {
 
 #if !defined(_WIN64)
-class philox4x32x10_impl : public oneapi::mkl::rng::detail::engine_impl {
+class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:
-    philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)
+    mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)
             : oneapi::mkl::rng::detail::engine_impl(queue) {
-        engine_ = oneapi::mkl::rng::detail::gpu::create_engine<oneapi::mkl::rng::philox4x32x10>(
-            queue, seed);
+        engine_ =
+            oneapi::mkl::rng::detail::gpu::create_engine<oneapi::mkl::rng::mrg32k3a>(queue, seed);
     }
 
-    philox4x32x10_impl(cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed)
+    mrg32k3a_impl(cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed)
             : oneapi::mkl::rng::detail::engine_impl(queue) {
-        engine_ = oneapi::mkl::rng::detail::gpu::create_engine<oneapi::mkl::rng::philox4x32x10>(
-            queue, (std::int64_t)(seed.size() * 2), (const unsigned int*)seed.begin());
+        engine_ = oneapi::mkl::rng::detail::gpu::create_engine<oneapi::mkl::rng::mrg32k3a>(
+            queue, (std::int64_t)(seed.size()), (const unsigned int*)seed.begin());
     }
 
-    philox4x32x10_impl(const philox4x32x10_impl* other)
-            : oneapi::mkl::rng::detail::engine_impl(*other) {
+    mrg32k3a_impl(const mrg32k3a_impl* other) : oneapi::mkl::rng::detail::engine_impl(*other) {
         sycl::queue queue(other->queue_);
-        engine_ = oneapi::mkl::rng::detail::gpu::create_engine<oneapi::mkl::rng::philox4x32x10>(
+        engine_ = oneapi::mkl::rng::detail::gpu::create_engine<oneapi::mkl::rng::mrg32k3a>(
             queue, other->engine_);
     }
 
@@ -291,7 +290,7 @@ public:
     }
 
     virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
-        return new philox4x32x10_impl(this);
+        return new mrg32k3a_impl(this);
     }
 
     virtual void skip_ahead(std::uint64_t num_to_skip) override {
@@ -306,29 +305,28 @@ public:
         throw oneapi::mkl::unimplemented("rng", "leapfrog");
     }
 
-    virtual ~philox4x32x10_impl() override {
+    virtual ~mrg32k3a_impl() override {
         oneapi::mkl::rng::detail::gpu::delete_engine(queue_, engine_);
     }
 
 private:
-    oneapi::mkl::rng::detail::engine_base_impl<oneapi::mkl::rng::philox4x32x10>* engine_;
+    oneapi::mkl::rng::detail::engine_base_impl<oneapi::mkl::rng::mrg32k3a>* engine_;
 };
 #else // GPU backend is not supported for Windows OS currently
-class philox4x32x10_impl : public oneapi::mkl::rng::detail::engine_impl {
+class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:
-    philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)
+    mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)
             : oneapi::mkl::rng::detail::engine_impl(queue) {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
-    philox4x32x10_impl(cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed)
+    mrg32k3a_impl(cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed)
             : oneapi::mkl::rng::detail::engine_impl(queue) {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
-    philox4x32x10_impl(const philox4x32x10_impl* other)
-            : oneapi::mkl::rng::detail::engine_impl(*other) {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    mrg32k3a_impl(const mrg32k3a_impl* other) : oneapi::mkl::rng::detail::engine_impl(*other) {
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     // Buffers API
@@ -336,104 +334,104 @@ public:
     virtual void generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const oneapi::mkl::rng::uniform<
                               std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
                           std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const oneapi::mkl::rng::gaussian<
                               float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
                           std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const oneapi::mkl::rng::gaussian<
                               double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
                           std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const oneapi::mkl::rng::lognormal<
                               float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
                           std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const oneapi::mkl::rng::lognormal<
                               double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
                           std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
                           std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
                           std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
                           std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
                           std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
                           cl::sycl::buffer<std::uint32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     // USM APIs
@@ -442,7 +440,7 @@ public:
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -450,7 +448,7 @@ public:
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -459,7 +457,7 @@ public:
             distr,
         std::int64_t n, std::int32_t* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -467,7 +465,7 @@ public:
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -475,7 +473,7 @@ public:
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -484,7 +482,7 @@ public:
             distr,
         std::int64_t n, float* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -493,7 +491,7 @@ public:
             distr,
         std::int64_t n, double* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -501,7 +499,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -509,7 +507,7 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -518,7 +516,7 @@ public:
             distr,
         std::int64_t n, float* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -527,7 +525,7 @@ public:
             distr,
         std::int64_t n, double* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -535,7 +533,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
@@ -543,73 +541,73 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
         std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
         std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
         std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
         std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
         const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return nullptr;
     }
 
     virtual void skip_ahead(std::uint64_t num_to_skip) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void skip_ahead(std::initializer_list<std::uint64_t> num_to_skip) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
     virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
-        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
     }
 
-    virtual ~philox4x32x10_impl() override {}
+    virtual ~mrg32k3a_impl() override {}
 };
 #endif
 
-oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(sycl::queue queue, std::uint64_t seed) {
-    return new philox4x32x10_impl(queue, seed);
+oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(sycl::queue queue, std::uint32_t seed) {
+    return new mrg32k3a_impl(queue, seed);
 }
 
-oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
-    cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed) {
-    return new philox4x32x10_impl(queue, seed);
+oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(cl::sycl::queue queue,
+                                                       std::initializer_list<std::uint32_t> seed) {
+    return new mrg32k3a_impl(queue, seed);
 }
 
 } // namespace mklgpu

--- a/src/rng/function_table.hpp
+++ b/src/rng/function_table.hpp
@@ -32,6 +32,11 @@ typedef struct {
                                                                         std::uint64_t seed);
     oneapi::mkl::rng::detail::engine_impl* (*create_philox4x32x10_ex_sycl)(
         cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed);
+
+    oneapi::mkl::rng::detail::engine_impl* (*create_mrg32k3a_sycl)(cl::sycl::queue queue,
+                                                                   std::uint32_t seed);
+    oneapi::mkl::rng::detail::engine_impl* (*create_mrg32k3a_ex_sycl)(
+        cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed);
 } rng_function_table_t;
 
 #endif //_RNG_FUNCTION_TABLE_HPP_

--- a/src/rng/rng_loader.cpp
+++ b/src/rng/rng_loader.cpp
@@ -39,6 +39,16 @@ engine_impl* create_philox4x32x10(oneapi::mkl::device libkey, cl::sycl::queue qu
     return function_tables[libkey].create_philox4x32x10_ex_sycl(queue, seed);
 }
 
+engine_impl* create_mrg32k3a(oneapi::mkl::device libkey, cl::sycl::queue queue,
+                             std::uint32_t seed) {
+    return function_tables[libkey].create_mrg32k3a_sycl(queue, seed);
+}
+
+engine_impl* create_mrg32k3a(oneapi::mkl::device libkey, cl::sycl::queue queue,
+                             std::initializer_list<std::uint32_t> seed) {
+    return function_tables[libkey].create_mrg32k3a_ex_sycl(queue, seed);
+}
+
 } // namespace detail
 } // namespace rng
 } // namespace mkl

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -37,6 +37,13 @@
 #define GAUSSIAN_ARGS_FLOAT  -1.0f, 5.0f
 #define GAUSSIAN_ARGS_DOUBLE -1.0, 5.0
 
+#define LOGNORMAL_ARGS_FLOAT  -1.0f, 5.0f, 1.0f, 2.0f
+#define LOGNORMAL_ARGS_DOUBLE -1.0, 5.0, 1.0, 2.0
+
+#define BERNOULLI_ARGS 0.5f
+
+#define POISSON_ARGS 0.5
+
 template <typename Distr, typename Engine>
 class statistics_test {
 public:

--- a/tests/unit_tests/rng/service/engines_api_test.cpp
+++ b/tests/unit_tests/rng/service/engines_api_test.cpp
@@ -46,4 +46,25 @@ INSTANTIATE_TEST_SUITE_P(Philox4x32x10ConstructorsTestsuite, Philox4x32x10Constr
 INSTANTIATE_TEST_SUITE_P(Philox4x32x10CopyTestsuite, Philox4x32x10CopyTests,
                          ::testing::ValuesIn(devices), ::DeviceNamePrint());
 
+class Mrg32k3aConstructorsTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+class Mrg32k3aCopyTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(Mrg32k3aConstructorsTests, BinaryPrecision) {
+    rng_test<engines_constructors_test<oneapi::mkl::rng::mrg32k3a>> test;
+    std::initializer_list<std::uint32_t> seed_ex = { SEED, 1, 1, 1, 1, 1 };
+    EXPECT_TRUEORSKIP((test(GetParam(), seed_ex)));
+}
+
+TEST_P(Mrg32k3aCopyTests, BinaryPrecision) {
+    rng_test<engines_copy_test<oneapi::mkl::rng::mrg32k3a>> test;
+    EXPECT_TRUEORSKIP((test(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(Mrg32k3aConstructorsTestsuite, Mrg32k3aConstructorsTests,
+                         ::testing::ValuesIn(devices), ::DeviceNamePrint());
+
+INSTANTIATE_TEST_SUITE_P(Mrg32k3aCopyTestsuite, Mrg32k3aCopyTests, ::testing::ValuesIn(devices),
+                         ::DeviceNamePrint());
+
 } // anonymous namespace

--- a/tests/unit_tests/rng/service/skip_ahead.cpp
+++ b/tests/unit_tests/rng/service/skip_ahead.cpp
@@ -45,4 +45,24 @@ INSTANTIATE_TEST_SUITE_P(Philox4x32x10SkipAheadTestSuite, Philox4x32x10SkipAhead
 INSTANTIATE_TEST_SUITE_P(Philox4x32x10SkipAheadExTestSuite, Philox4x32x10SkipAheadExTests,
                          ::testing::ValuesIn(devices), ::DeviceNamePrint());
 
+class Mrg32k3aSkipAheadTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+class Mrg32k3aSkipAheadExTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(Mrg32k3aSkipAheadTests, BinaryPrecision) {
+    rng_test<skip_ahead_test<oneapi::mkl::rng::mrg32k3a>> test;
+    EXPECT_TRUEORSKIP((test(GetParam())));
+}
+
+TEST_P(Mrg32k3aSkipAheadExTests, BinaryPrecision) {
+    rng_test<skip_ahead_ex_test<oneapi::mkl::rng::mrg32k3a>> test;
+    EXPECT_TRUEORSKIP((test(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(Mrg32k3aSkipAheadTestSuite, Mrg32k3aSkipAheadTests,
+                         ::testing::ValuesIn(devices), ::DeviceNamePrint());
+
+INSTANTIATE_TEST_SUITE_P(Mrg32k3aSkipAheadExTestSuite, Mrg32k3aSkipAheadExTests,
+                         ::testing::ValuesIn(devices), ::DeviceNamePrint());
+
 } // anonymous namespace

--- a/tests/unit_tests/rng/statistics_check/CMakeLists.txt
+++ b/tests/unit_tests/rng/statistics_check/CMakeLists.txt
@@ -18,7 +18,7 @@
 #===============================================================================
 
 # Build object from all test sources
-set(STATS_CHECK_SOURCES "uniform.cpp" "uniform_usm.cpp" "gaussian_usm.cpp" "gaussian.cpp")
+set(STATS_CHECK_SOURCES "uniform.cpp" "uniform_usm.cpp" "gaussian_usm.cpp" "gaussian.cpp" "lognormal_usm.cpp" "lognormal.cpp" "bernoulli_usm.cpp" "bernoulli.cpp" "poisson_usm.cpp" "poisson.cpp")
 
 if(BUILD_SHARED_LIBS)
   add_library(rng_statistics_rt OBJECT ${STATS_CHECK_SOURCES})

--- a/tests/unit_tests/rng/statistics_check/bernoulli.cpp
+++ b/tests/unit_tests/rng/statistics_check/bernoulli.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "statistics_check_test.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<cl::sycl::device*> devices;
+
+namespace {
+
+class BernoulliIcdfTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(BernoulliIcdfTests, IntegerPrecision) {
+    rng_test<statistics_test<
+        oneapi::mkl::rng::bernoulli<std::int32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, BERNOULLI_ARGS)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::bernoulli<std::int32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, BERNOULLI_ARGS)));
+}
+
+TEST_P(BernoulliIcdfTests, UnsignedIntegerPrecision) {
+    rng_test<statistics_test<
+        oneapi::mkl::rng::bernoulli<std::uint32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, BERNOULLI_ARGS)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::bernoulli<std::uint32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, BERNOULLI_ARGS)));
+}
+
+INSTANTIATE_TEST_SUITE_P(BernoulliIcdfTestSuite, BernoulliIcdfTests, ::testing::ValuesIn(devices),
+                         ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/rng/statistics_check/bernoulli_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/bernoulli_usm.cpp
@@ -1,0 +1,59 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "statistics_check_test.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<cl::sycl::device*> devices;
+
+namespace {
+
+class BernoulliIcdfUsmTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(BernoulliIcdfUsmTests, IntegerPrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::bernoulli<std::int32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, BERNOULLI_ARGS)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::bernoulli<std::int32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, BERNOULLI_ARGS)));
+}
+
+TEST_P(BernoulliIcdfUsmTests, UnsignedIntegerPrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::bernoulli<std::uint32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, BERNOULLI_ARGS)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::bernoulli<std::int32_t, oneapi::mkl::rng::bernoulli_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, BERNOULLI_ARGS)));
+}
+
+INSTANTIATE_TEST_SUITE_P(BernoulliIcdfUsmTestSuite, BernoulliIcdfUsmTests,
+                         ::testing::ValuesIn(devices), ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/rng/statistics_check/gaussian.cpp
+++ b/tests/unit_tests/rng/statistics_check/gaussian.cpp
@@ -33,32 +33,52 @@ TEST_P(GaussianIcdfTest, RealSinglePrecision) {
     rng_test<
         statistics_test<oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>,
                         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+    rng_test<
+        statistics_test<oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>,
+                        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
 }
 
 TEST_P(GaussianIcdfTest, RealDoublePrecision) {
     rng_test<
         statistics_test<oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
                         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+    rng_test<
+        statistics_test<oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
+                        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
 }
 
 TEST_P(GaussianBoxmullerTest, RealSinglePrecision) {
     rng_test<statistics_test<
         oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
 }
 
 TEST_P(GaussianBoxmullerTest, RealDoublePrecision) {
     rng_test<statistics_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
 }
 
 INSTANTIATE_TEST_SUITE_P(GaussianIcdfTestSuite, GaussianIcdfTest, ::testing::ValuesIn(devices),

--- a/tests/unit_tests/rng/statistics_check/gaussian_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/gaussian_usm.cpp
@@ -33,32 +33,52 @@ TEST_P(GaussianIcdfUsmTest, RealSinglePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
 }
 
 TEST_P(GaussianIcdfUsmTest, RealDoublePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
 }
 
 TEST_P(GaussianBoxmullerUsmTest, RealSinglePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_FLOAT)));
 }
 
 TEST_P(GaussianBoxmullerUsmTest, RealDoublePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, GAUSSIAN_ARGS_DOUBLE)));
 }
 
 INSTANTIATE_TEST_SUITE_P(GaussianIcdfUsmTestSuite, GaussianIcdfUsmTest,

--- a/tests/unit_tests/rng/statistics_check/lognormal.cpp
+++ b/tests/unit_tests/rng/statistics_check/lognormal.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "statistics_check_test.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<cl::sycl::device*> devices;
+
+namespace {
+
+class LognormalBoxmullerTest : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+class LognormalIcdfTest : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(LognormalIcdfTest, RealSinglePrecision) {
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+}
+
+TEST_P(LognormalIcdfTest, RealDoublePrecision) {
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+}
+
+TEST_P(LognormalBoxmullerTest, RealSinglePrecision) {
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+}
+
+TEST_P(LognormalBoxmullerTest, RealDoublePrecision) {
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+}
+
+INSTANTIATE_TEST_SUITE_P(LognormalIcdfTestSuite, LognormalIcdfTest, ::testing::ValuesIn(devices),
+                         ::DeviceNamePrint());
+
+INSTANTIATE_TEST_SUITE_P(LognormalBoxmullerTestSuite, LognormalBoxmullerTest,
+                         ::testing::ValuesIn(devices), ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/rng/statistics_check/lognormal_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/lognormal_usm.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "statistics_check_test.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<cl::sycl::device*> devices;
+
+namespace {
+
+class LognormalBoxmullerUsmTest : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+class LognormalIcdfUsmTest : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(LognormalIcdfUsmTest, RealSinglePrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+}
+
+TEST_P(LognormalIcdfUsmTest, RealDoublePrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+}
+
+TEST_P(LognormalBoxmullerUsmTest, RealSinglePrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_FLOAT)));
+}
+
+TEST_P(LognormalBoxmullerUsmTest, RealDoublePrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, LOGNORMAL_ARGS_DOUBLE)));
+}
+
+INSTANTIATE_TEST_SUITE_P(LognormalIcdfUsmTestSuite, LognormalIcdfUsmTest,
+                         ::testing::ValuesIn(devices), ::DeviceNamePrint());
+
+INSTANTIATE_TEST_SUITE_P(LognormalBoxmullerUsmTestSuite, LognormalBoxmullerUsmTest,
+                         ::testing::ValuesIn(devices), ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/rng/statistics_check/poisson.cpp
+++ b/tests/unit_tests/rng/statistics_check/poisson.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "statistics_check_test.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<cl::sycl::device*> devices;
+
+namespace {
+
+class PoissonIcdfTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(PoissonIcdfTests, IntegerPrecision) {
+    rng_test<
+        statistics_test<oneapi::mkl::rng::poisson<
+                            std::int32_t, oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+                        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, POISSON_ARGS)));
+    rng_test<
+        statistics_test<oneapi::mkl::rng::poisson<
+                            std::int32_t, oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+                        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, POISSON_ARGS)));
+}
+
+TEST_P(PoissonIcdfTests, UnsignedIntegerPrecision) {
+    rng_test<
+        statistics_test<oneapi::mkl::rng::poisson<
+                            std::uint32_t, oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+                        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, POISSON_ARGS)));
+    rng_test<
+        statistics_test<oneapi::mkl::rng::poisson<
+                            std::int32_t, oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+                        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, POISSON_ARGS)));
+}
+
+INSTANTIATE_TEST_SUITE_P(PoissonIcdfTestSuite, PoissonIcdfTests, ::testing::ValuesIn(devices),
+                         ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/rng/statistics_check/poisson_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/poisson_usm.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "statistics_check_test.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<cl::sycl::device*> devices;
+
+namespace {
+
+class PoissonIcdfUsmTests : public ::testing::TestWithParam<cl::sycl::device*> {};
+
+TEST_P(PoissonIcdfUsmTests, IntegerPrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::poisson<std::int32_t,
+                                  oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, POISSON_ARGS)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::poisson<std::int32_t,
+                                  oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, POISSON_ARGS)));
+}
+
+TEST_P(PoissonIcdfUsmTests, UnsignedIntegerPrecision) {
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::poisson<std::uint32_t,
+                                  oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+        oneapi::mkl::rng::philox4x32x10>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, POISSON_ARGS)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::poisson<std::int32_t,
+                                  oneapi::mkl::rng::poisson_method::gaussian_icdf_based>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, POISSON_ARGS)));
+}
+
+INSTANTIATE_TEST_SUITE_P(PoissonIcdfUsmTestSuite, PoissonIcdfUsmTests, ::testing::ValuesIn(devices),
+                         ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/rng/statistics_check/uniform.cpp
+++ b/tests/unit_tests/rng/statistics_check/uniform.cpp
@@ -33,40 +33,65 @@ TEST_P(UniformStdTests, RealSinglePrecision) {
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
 }
 
 TEST_P(UniformStdTests, RealDoublePrecision) {
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
 }
 
 TEST_P(UniformStdTests, IntegerPrecision) {
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_INT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_INT)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_INT)));
 }
 
 TEST_P(UniformAccurateTests, RealSinglePrecision) {
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
 }
 
 TEST_P(UniformAccurateTests, RealDoublePrecision) {
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+    rng_test<statistics_test<
+        oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
 }
 
 INSTANTIATE_TEST_SUITE_P(UniformStdTestSuite, UniformStdTests, ::testing::ValuesIn(devices),

--- a/tests/unit_tests/rng/statistics_check/uniform_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/uniform_usm.cpp
@@ -33,40 +33,65 @@ TEST_P(UniformStdUsmTests, RealSinglePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
 }
 
 TEST_P(UniformStdUsmTests, RealDoublePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
 }
 
 TEST_P(UniformStdUsmTests, IntegerPrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_INT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_INT)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_INT)));
 }
 
 TEST_P(UniformAccurateUsmTests, RealSinglePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_FLOAT)));
 }
 
 TEST_P(UniformAccurateUsmTests, RealDoublePrecision) {
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,
         oneapi::mkl::rng::philox4x32x10>>
-        test;
-    EXPECT_TRUEORSKIP((test(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
+    rng_test<statistics_usm_test<
+        oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,
+        oneapi::mkl::rng::mrg32k3a>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam(), N_GEN, UNIFORM_ARGS_DOUBLE)));
 }
 
 INSTANTIATE_TEST_SUITE_P(UniformStdUsmTestSuite, UniformStdUsmTests, ::testing::ValuesIn(devices),


### PR DESCRIPTION
# Description

- RNG: Add mrg32k3a engine and default engine
- RNG: Add lognormal, bernoulli, poisson distributions
- RNG: change entry points for mklgpu backend
- Add /MD option for windows in cmake

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
[lnx_rng_test_log.txt](https://github.com/oneapi-src/oneMKL/files/5517627/lnx_rng_test_log.txt)

- [x] Have you formatted the code using clang-format?
