### PR TITLE
Enable Level0 runtime for GPU device

### DIFF
--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -790,7 +790,7 @@ void gemm_f16f16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE tra
                     cl::sycl::buffer<half, 1> &a, int64_t lda, cl::sycl::buffer<half, 1> &b,
                     int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
 
-void gemm_s8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
+cl::sycl::event gemm_s8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                        MKL_TRANSPOSE transb, CBLAS_OFFSET offsetc, int64_t m, int64_t n, int64_t k,
                        float alpha, cl::sycl::buffer<int8_t, 1> *a, int64_t lda, int8_t ao,
                        cl::sycl::buffer<uint8_t, 1> *b, int64_t ldb, uint8_t bo, float beta,

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -791,12 +791,14 @@ void gemm_f16f16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE tra
                     int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
 
 cl::sycl::event gemm_s8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
-                       MKL_TRANSPOSE transb, CBLAS_OFFSET offsetc, int64_t m, int64_t n, int64_t k,
-                       float alpha, cl::sycl::buffer<int8_t, 1> *a, int64_t lda, int8_t ao,
-                       cl::sycl::buffer<uint8_t, 1> *b, int64_t ldb, uint8_t bo, float beta,
-                       cl::sycl::buffer<int32_t, 1> *c, int64_t ldc,
-                       cl::sycl::buffer<int32_t, 1> *co, int64_t offset_a = 0, int64_t offset_b = 0,
-                       int64_t offset_c = 0, int64_t offset_co = 0);
+                                  MKL_TRANSPOSE transb, CBLAS_OFFSET offsetc, int64_t m, int64_t n,
+                                  int64_t k, float alpha, cl::sycl::buffer<int8_t, 1> *a,
+                                  int64_t lda, int8_t ao, cl::sycl::buffer<uint8_t, 1> *b,
+                                  int64_t ldb, uint8_t bo, float beta,
+                                  cl::sycl::buffer<int32_t, 1> *c, int64_t ldc,
+                                  cl::sycl::buffer<int32_t, 1> *co, int64_t offset_a = 0,
+                                  int64_t offset_b = 0, int64_t offset_c = 0,
+                                  int64_t offset_co = 0);
 
 // USM APIs
 

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -86,15 +86,15 @@ int main(int argc, char** argv) {
             auto plat_devs = plat.get_devices();
             for (auto dev : plat_devs) {
                 try {
+                    /* Do not test for OpenCL backend on GPU */
+                    if (dev.is_gpu() && plat.get_info<cl::sycl::info::platform::name>().find(
+                                            "OpenCL") != std::string::npos)
+                        continue;
                     if (unique_devices.find(dev.get_info<cl::sycl::info::device::name>()) ==
                         unique_devices.end()) {
                         unique_devices.insert(dev.get_info<cl::sycl::info::device::name>());
                         unsigned int vendor_id = static_cast<unsigned int>(
                             dev.get_info<cl::sycl::info::device::vendor_id>());
-                        /* Do not test for OpenCL backend on GPU */
-                        if (dev.is_gpu() && plat.get_info<cl::sycl::info::platform::name>().find(
-                                                "OpenCL") != std::string::npos)
-                            continue;
 #ifndef ENABLE_MKLCPU_BACKEND
                         if (dev.is_cpu())
                             continue;


### PR DESCRIPTION
# Description

With new driver, Level0 and OpenCL device names are identical. As a result, we can not detect the Level0 runtime for GPU device and hence, no tests are run for Linux. This PR is fixing the issue.

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Yes.
- [ ] Have you formatted the code using clang-format? Yes

