### PR TITLE
Remove duplicate devices from testing

### DIFF
--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -121,8 +121,13 @@ int main(int argc, char** argv) {
 #if defined(ENABLE_MKLCPU_BACKEND) || defined(ENABLE_NETLIB_BACKEND)
     local_devices.push_back(cl::sycl::device(cl::sycl::host_selector()));
 #endif
-    for (int i = 0; i < local_devices.size(); i++) {
-        devices.push_back(&(local_devices[i]));
+#define GET_NAME(d) (d).template get_info<cl::sycl::info::device::name>()
+    for (auto& local_dev : local_devices) {
+        // Test only unique devices
+        if (std::find_if(devices.begin(), devices.end(), [&](cl::sycl::device* dev) {
+                return GET_NAME(*dev) == GET_NAME(local_dev);
+            }) == devices.end())
+            devices.push_back(&local_dev);
     }
 
     // start Google Test pickup and output


### PR DESCRIPTION
# Description

oneMKL gtests use device name as an unique parameter, but in some cases we have several similar devises on the machine (e.g. host selector is not fully supported and it behaves as CPU device instead). This PR removes duplicate devices from testing as it doesn't make sense to test functionality twice on the same devices.

Fixes #57 

# Checklist

## All Submissions

- [x] Have you formatted the code using clang-format?
- [x] Do all unit tests pass locally? Attach a log.

Log:

```
[ 98%] Building CXX object tests/unit_tests/blas/level2/CMakeFiles/blas_level2_ct.dir/sbmv_usm.cpp.o
[ 99%] Building CXX object tests/unit_tests/blas/level2/CMakeFiles/blas_level2_ct.dir/hpr_usm.cpp.o
[ 99%] Built target blas_level2_ct
Scanning dependencies of target test_main_blas_ct
[ 99%] Building CXX object tests/unit_tests/CMakeFiles/test_main_blas_ct.dir/main_test.cpp.o
[100%] Linking CXX executable ../../bin/test_main_blas_ct
[100%] Built target test_main_blas_ct

          Start    1: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
   1/1408 Test    #1: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz ..................................   Passed    0.57 sec
          Start    2: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
   2/1408 Test    #2: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz .....................................   Passed    0.51 sec
          Start    3: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Column_Major_Intel_R__Graphics_Gen9__0x193b_
   3/1408 Test    #3: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Column_Major_Intel_R__Graphics_Gen9__0x193b_ ............................................   Passed    0.91 sec
          Start    4: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Row_Major_Intel_R__Graphics_Gen9__0x193b_
   4/1408 Test    #4: BLAS/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Row_Major_Intel_R__Graphics_Gen9__0x193b_ ...............................................   Passed    0.91 sec
```
