### PR TITLE
Use module `errno` instead of `os.errno`

### DIFF
--- a/scripts/generate_backend_api.py
+++ b/scripts/generate_backend_api.py
@@ -22,6 +22,7 @@ from sys import argv, exit, stdin
 from subprocess import call
 from pprint import pprint
 from collections import defaultdict
+import errno
 import re
 import os
 
@@ -75,7 +76,7 @@ def print_declaration(func_list):
 try:
     os.makedirs(os.path.dirname(out_headername))
 except OSError as exc:
-    if exc.errno != os.errno.EEXIST:
+    if exc.errno != errno.EEXIST:
         raise
 
 out_file = open(out_headername, "w+")
@@ -112,6 +113,6 @@ try:
     lc = ["clang-format", "-style=file", "-i", out_headername]
     call(lc)
 except OSError as exc:
-    if exc.errno == os.errno.ENOENT:
+    if exc.errno == errno.ENOENT:
         print("Error: clang-format is not found")
 

--- a/scripts/generate_ct_instant.py
+++ b/scripts/generate_ct_instant.py
@@ -22,6 +22,7 @@ from sys import argv, exit, stdin
 from subprocess import call
 from pprint import pprint
 from collections import defaultdict
+import errno
 import re
 import os
 
@@ -82,7 +83,7 @@ template<>
 try:
     os.makedirs(os.path.dirname(out_filename))
 except OSError as exc:
-    if exc.errno != os.errno.EEXIST:
+    if exc.errno != errno.EEXIST:
         raise
 
 out_file = open(out_filename, "w+")
@@ -124,6 +125,6 @@ try:
     lc = ["clang-format", "-style=file", "-i", out_filename]
     call(lc)
 except OSError as exc:
-    if exc.errno == os.errno.ENOENT:
+    if exc.errno == errno.ENOENT:
         print("Error: clang-format is not found")
 

--- a/scripts/generate_ct_templates.py
+++ b/scripts/generate_ct_templates.py
@@ -22,6 +22,7 @@ from sys import argv, exit, stdin
 from subprocess import call
 from pprint import pprint
 from collections import defaultdict
+import errno
 import re
 import os
 
@@ -71,7 +72,7 @@ template <oneapi::mkl::backend backend> static inline {ret_type} {name}{par_str}
 try:
     os.makedirs(os.path.dirname(out_filename))
 except OSError as exc:
-    if exc.errno != os.errno.EEXIST:
+    if exc.errno != errno.EEXIST:
         raise
 
 out_file = open(out_filename, "w+")
@@ -112,6 +113,6 @@ try:
     lc = ["clang-format", "-style=file", "-i", out_filename]
     retcode=call(lc)
 except OSError as exc:
-    if exc.errno == os.errno.ENOENT:
+    if exc.errno == errno.ENOENT:
         print("Error: clang-format is not found")
 

--- a/scripts/generate_wrappers.py
+++ b/scripts/generate_wrappers.py
@@ -22,6 +22,7 @@ from sys import argv, exit, stdin
 from subprocess import call
 from pprint import pprint
 from collections import defaultdict
+import errno
 import re
 import os
 
@@ -79,7 +80,7 @@ def print_funcs(func_list):
 try:
     os.makedirs(os.path.dirname(out_filename))
 except OSError as exc:
-    if exc.errno != os.errno.EEXIST:
+    if exc.errno != errno.EEXIST:
         raise
 
 out_file = open(out_filename, "w+")
@@ -115,7 +116,7 @@ try:
     lc = ["clang-format", "-style=file", "-i", out_filename]
     call(lc)
 except OSError as exc:
-    if exc.errno == os.errno.ENOENT:
+    if exc.errno == errno.ENOENT:
         print("Error: clang-format is not found")
     else:
         raise
@@ -126,7 +127,7 @@ print("Generate " + table_file)
 try:
     os.makedirs(os.path.dirname(table_file))
 except OSError as exc:
-    if exc.errno != os.errno.EEXIST:
+    if exc.errno != errno.EEXIST:
         raise
 
 out_file = open(table_file, "w+")
@@ -161,7 +162,7 @@ try:
     lc = ["clang-format", "-style=file", "-i", table_file]
     call(lc)
 except OSError as exc:
-    if exc.errno == os.errno.ENOENT:
+    if exc.errno == errno.ENOENT:
         print("Error: clang-format is not found")
     else:
         raise


### PR DESCRIPTION
# Description
`os.errno` was deprecated as of Python 3.7. This patch uses instead the preferred `errno` module which is supported Python >= 2.7 (required minimum Python version is for oneMKL is 3.6).

Fixes #68

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
Not applicable.
- [X] Have you formatted the code using clang-format?

## Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
See #68 
