### PR TITLE
Fix cmake configuration when cuBLAS back-end is enabled

### DIFF
--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -18,7 +18,6 @@
 #=========================================================================
 
 find_package(CUDA 10.0 REQUIRED)
-find_path(CUBLAS_INCLUDE_DIR "cublas_v2.h" HINTS ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 # the OpenCL include file from cuda is opencl 1.1 and it is not compatible with DPC++
 # the OpenCL include headers 1.2 onward is required. This is used to bypass NVIDIA OpenCL headers
@@ -27,8 +26,6 @@ HINTS
 ${OPENCL_INCLUDE_DIR}
 ${SYCL_BINARY_DIR}/../include/sycl/
 )
-find_library(CUBLAS_LIBRARY cublas)
-find_library(CUDA_DRIVER_LIBRARY cuda)
 # this is work around to avoid duplication half creation in both cuda and SYCL
 add_compile_definitions(CUDA_NO_HALF)
 
@@ -37,19 +34,18 @@ find_package(Threads REQUIRED)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(cuBLAS
     REQUIRED_VARS
-        CUBLAS_INCLUDE_DIR
-        CUDA_INCLUDE_DIRS
-        CUBLAS_LIBRARY
+	CUDA_TOOLKIT_INCLUDE
+	CUDA_cublas_LIBRARY
         CUDA_LIBRARIES
-        CUDA_DRIVER_LIBRARY
+        CUDA_CUDA_LIBRARY
         OPENCL_INCLUDE_DIR
 )
 if(NOT TARGET ONEMKL::cuBLAS::cuBLAS)
   add_library(ONEMKL::cuBLAS::cuBLAS SHARED IMPORTED)
   set_target_properties(ONEMKL::cuBLAS::cuBLAS PROPERTIES
-      IMPORTED_LOCATION ${CUBLAS_LIBRARY}
-      INTERFACE_INCLUDE_DIRECTORIES "${OPENCL_INCLUDE_DIR};${CUDA_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "Threads::Threads;${CUDA_DRIVER_LIBRARY};${CUDA_LIBRARIES}"
+      IMPORTED_LOCATION ${CUDA_cublas_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES "${OPENCL_INCLUDE_DIR};${CUDA_TOOLKIT_INCLUDE}"
+      INTERFACE_LINK_LIBRARIES "Threads::Threads;${CUDA_CUDA_LIBRARY};${CUDA_LIBRARIES}"
   )
 
 endif()


### PR DESCRIPTION
# Description
`CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES` -- which provides a
semicolon-separated list of include directories as per the CUDA
Toolkit -- is not defined by default, therefore cuBLAS is not
found during configuration on all systems.

Updated required variables and target properties to use correct
includes and libraries.

Fixes #72 

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
N/A
- [X] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests?
N/A
- [X] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
See #72.