### PR TITLE
[CONAN]Update profile to use specific CMake version, use conan 1.33+

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Software Package indicates your acceptance of the Agreements.**
 Product | Supported Version | Installed by Conan | Conan Package Source | Package Install Location on Linux* | License
 :--- | :--- | :--- | :--- | :--- | :---
 Python | 3.6 or higher | No | *N/A* | *Pre-installed or Installed by user* | [PSF](https://docs.python.org/3.6/license.html)
-[Conan C++ Package Manager](https://conan.io/downloads.html) | 1.24 or higher | No | *N/A* | *Installed by user* | [MIT](https://github.com/conan-io/conan/blob/develop/LICENSE.md)
+[Conan C++ Package Manager](https://conan.io/downloads.html) | 1.33 or higher | No | *N/A* | *Installed by user* | [MIT](https://github.com/conan-io/conan/blob/develop/LICENSE.md)
 [CMake](https://cmake.org/download/) | 3.13 or higher | Yes<br>(3.15 or higher) | conan-center | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [The OSI-approved BSD 3-clause License](https://gitlab.kitware.com/cmake/cmake/raw/master/Copyright.txt)
 [Ninja](https://ninja-build.org/) | 1.10.0 | Yes | conan-center | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [Apache License v2.0](https://github.com/ninja-build/ninja/blob/master/COPYING)
 [GNU* FORTRAN Compiler](https://gcc.gnu.org/wiki/GFortran) | 7.4.0 or higher | Yes | apt | /usr/bin | [GNU General Public License, version 3](https://gcc.gnu.org/onlinedocs/gcc-7.5.0/gfortran/Copying.html)

--- a/conan/profiles/inteldpcpp_lnx
+++ b/conan/profiles/inteldpcpp_lnx
@@ -30,7 +30,7 @@ compiler.libcxx=libstdc++11
 build_type=Release
 
 [build_requires]
-cmake/[>=3.15]
+cmake/3.15.7
 ninja/1.10.0
 
 [env]


### PR DESCRIPTION
# Description

1. Lowest version of CMake available on conan-center is 3.15.7. Using a specific version is easy to debug in-case of failures, as compared to previous approach to use any version >=3.15.
2. CMake 3.15.7 requires openssl/1.1.1j package, which requires Conan 1.33 at minimum.

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
```
Will run testing after Conan is enabled in CI.
```
- [ ] Have you formatted the code using clang-format?
`N/A`

## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?

Follow build steps from [Building with Conan](https://github.com/oneapi-src/oneMKL#building-with-conan) to reproduce failures with building zlib and openssl packages.
