### PR TITLE
[RNG] Fix mklcpu backend kernel names and clang-format to curand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ option(BUILD_SHARED_LIBS "Build dynamic libraries" ON)
 
 # Override default CXX compile/link lines for Windows after project
 if(WIN32)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -w")
   foreach (flag_var
            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ option(BUILD_SHARED_LIBS "Build dynamic libraries" ON)
 
 # Override default CXX compile/link lines for Windows after project
 if(WIN32)
-  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function -w")
   foreach (flag_var
            CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE

--- a/include/oneapi/mkl/rng/detail/curand/onemkl_rng_curand.hpp
+++ b/include/oneapi/mkl/rng/detail/curand/onemkl_rng_curand.hpp
@@ -70,21 +70,21 @@ namespace mkl {
 namespace rng {
 namespace curand {
 
-ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
-    cl::sycl::queue queue, std::uint64_t seed);
+ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(cl::sycl::queue queue,
+                                                                          std::uint64_t seed);
 
 ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
     cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed);
 
-ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(
-    cl::sycl::queue queue, std::uint32_t seed);
+ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(cl::sycl::queue queue,
+                                                                     std::uint32_t seed);
 
 ONEMKL_EXPORT oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(
     cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed);
 
-}  // namespace curand
-}  // namespace rng
-}  // namespace mkl
-}  // namespace oneapi
+} // namespace curand
+} // namespace rng
+} // namespace mkl
+} // namespace oneapi
 
-#endif  //_ONEMKL_RNG_CURAND_HPP_
+#endif //_ONEMKL_RNG_CURAND_HPP_

--- a/src/rng/backends/curand/curand_helper.hpp
+++ b/src/rng/backends/curand/curand_helper.hpp
@@ -75,137 +75,120 @@ namespace rng {
 namespace curand {
 
 class curand_error : virtual public std::runtime_error {
- protected:
-  inline const char* curand_error_map(curandStatus_t error) {
-    switch (error) {
-      case CURAND_STATUS_SUCCESS:
-        return "CURAND_STATUS_SUCCESS";
+protected:
+    inline const char* curand_error_map(curandStatus_t error) {
+        switch (error) {
+            case CURAND_STATUS_SUCCESS: return "CURAND_STATUS_SUCCESS";
 
-      case CURAND_STATUS_VERSION_MISMATCH:
-        return "CURAND_STATUS_VERSION_MISMATCH";
+            case CURAND_STATUS_VERSION_MISMATCH: return "CURAND_STATUS_VERSION_MISMATCH";
 
-      case CURAND_STATUS_NOT_INITIALIZED:
-        return "CURAND_STATUS_NOT_INITIALIZED";
+            case CURAND_STATUS_NOT_INITIALIZED: return "CURAND_STATUS_NOT_INITIALIZED";
 
-      case CURAND_STATUS_ALLOCATION_FAILED:
-        return "CURAND_STATUS_ALLOCATION_FAILED";
+            case CURAND_STATUS_ALLOCATION_FAILED: return "CURAND_STATUS_ALLOCATION_FAILED";
 
-      case CURAND_STATUS_TYPE_ERROR:
-        return "CURAND_STATUS_TYPE_ERROR";
+            case CURAND_STATUS_TYPE_ERROR: return "CURAND_STATUS_TYPE_ERROR";
 
-      case CURAND_STATUS_OUT_OF_RANGE:
-        return "CURAND_STATUS_OUT_OF_RANGE";
+            case CURAND_STATUS_OUT_OF_RANGE: return "CURAND_STATUS_OUT_OF_RANGE";
 
-      case CURAND_STATUS_LENGTH_NOT_MULTIPLE:
-        return "CURAND_STATUS_LENGTH_NOT_MULTIPLE";
+            case CURAND_STATUS_LENGTH_NOT_MULTIPLE: return "CURAND_STATUS_LENGTH_NOT_MULTIPLE";
 
-      case CURAND_STATUS_DOUBLE_PRECISION_REQUIRED:
-        return "CURAND_STATUS_DOUBLE_PRECISION_REQUIRED";
+            case CURAND_STATUS_DOUBLE_PRECISION_REQUIRED:
+                return "CURAND_STATUS_DOUBLE_PRECISION_REQUIRED";
 
-      case CURAND_STATUS_LAUNCH_FAILURE:
-        return "CURAND_STATUS_LAUNCH_FAILURE";
+            case CURAND_STATUS_LAUNCH_FAILURE: return "CURAND_STATUS_LAUNCH_FAILURE";
 
-      case CURAND_STATUS_PREEXISTING_FAILURE:
-        return "CURAND_STATUS_PREEXISTING_FAILURE";
+            case CURAND_STATUS_PREEXISTING_FAILURE: return "CURAND_STATUS_PREEXISTING_FAILURE";
 
-      case CURAND_STATUS_INITIALIZATION_FAILED:
-        return "CURAND_STATUS_INITIALIZATION_FAILED";
+            case CURAND_STATUS_INITIALIZATION_FAILED: return "CURAND_STATUS_INITIALIZATION_FAILED";
 
-      case CURAND_STATUS_ARCH_MISMATCH:
-        return "CURAND_STATUS_ARCH_MISMATCH";
+            case CURAND_STATUS_ARCH_MISMATCH: return "CURAND_STATUS_ARCH_MISMATCH";
 
-      case CURAND_STATUS_INTERNAL_ERROR:
-        return "CURAND_STATUS_INTERNAL_ERROR";
+            case CURAND_STATUS_INTERNAL_ERROR: return "CURAND_STATUS_INTERNAL_ERROR";
 
-      default:
-        return "<unknown>";
+            default: return "<unknown>";
+        }
     }
-  }
 
-  int error_number;  ///< Error number
- public:
-  /** Constructor (C++ STL string, curandStatus_t).
+    int error_number; ///< Error number
+public:
+    /** Constructor (C++ STL string, curandStatus_t).
    *  @param msg The error message
    *  @param err_num error number
    */
-  explicit curand_error(std::string message, curandStatus_t result)
-      : std::runtime_error((message + std::string(curand_error_map(result)))) {
-    error_number = static_cast<int>(result);
-  }
+    explicit curand_error(std::string message, curandStatus_t result)
+            : std::runtime_error((message + std::string(curand_error_map(result)))) {
+        error_number = static_cast<int>(result);
+    }
 
-  /** Destructor.
+    /** Destructor.
    *  Virtual to allow for subclassing.
    */
-  virtual ~curand_error() throw() {}
+    virtual ~curand_error() throw() {}
 
-  /** Returns error number.
+    /** Returns error number.
    *  @return #error_number
    */
-  virtual int getErrorNumber() const throw() { return error_number; }
+    virtual int getErrorNumber() const throw() {
+        return error_number;
+    }
 };
 
 class cuda_error : virtual public std::runtime_error {
- protected:
-  inline const char* cuda_error_map(CUresult result) {
-    switch (result) {
-      case CUDA_SUCCESS:
-        return "CUDA_SUCCESS";
+protected:
+    inline const char* cuda_error_map(CUresult result) {
+        switch (result) {
+            case CUDA_SUCCESS: return "CUDA_SUCCESS";
 
-      case CUDA_ERROR_NOT_PERMITTED:
-        return "CUDA_ERROR_NOT_PERMITTED";
+            case CUDA_ERROR_NOT_PERMITTED: return "CUDA_ERROR_NOT_PERMITTED";
 
-      case CUDA_ERROR_INVALID_CONTEXT:
-        return "CUDA_ERROR_INVALID_CONTEXT";
+            case CUDA_ERROR_INVALID_CONTEXT: return "CUDA_ERROR_INVALID_CONTEXT";
 
-      case CUDA_ERROR_INVALID_DEVICE:
-        return "CUDA_ERROR_INVALID_DEVICE";
+            case CUDA_ERROR_INVALID_DEVICE: return "CUDA_ERROR_INVALID_DEVICE";
 
-      case CUDA_ERROR_INVALID_VALUE:
-        return "CUDA_ERROR_INVALID_VALUE";
+            case CUDA_ERROR_INVALID_VALUE: return "CUDA_ERROR_INVALID_VALUE";
 
-      case CUDA_ERROR_OUT_OF_MEMORY:
-        return "CUDA_ERROR_OUT_OF_MEMORY";
+            case CUDA_ERROR_OUT_OF_MEMORY: return "CUDA_ERROR_OUT_OF_MEMORY";
 
-      case CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES:
-        return "CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES";
+            case CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES: return "CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES";
 
-      default:
-        return "<unknown>";
+            default: return "<unknown>";
+        }
     }
-  }
-  int error_number;  ///< error number
- public:
-  /** Constructor (C++ STL string, CUresult).
+    int error_number; ///< error number
+public:
+    /** Constructor (C++ STL string, CUresult).
    *  @param msg The error message
    *  @param err_num Error number
    */
-  explicit cuda_error(std::string message, CUresult result)
-      : std::runtime_error((message + std::string(cuda_error_map(result)))) {
-    error_number = static_cast<int>(result);
-  }
+    explicit cuda_error(std::string message, CUresult result)
+            : std::runtime_error((message + std::string(cuda_error_map(result)))) {
+        error_number = static_cast<int>(result);
+    }
 
-  /** Destructor.
+    /** Destructor.
    *  Virtual to allow for subclassing.
    */
-  virtual ~cuda_error() throw() {}
+    virtual ~cuda_error() throw() {}
 
-  /** Returns error number.
+    /** Returns error number.
    *  @return #error_number
    */
-  virtual int getErrorNumber() const throw() { return error_number; }
+    virtual int getErrorNumber() const throw() {
+        return error_number;
+    }
 };
 
-#define CUDA_ERROR_FUNC(name, err, ...)                             \
-  err = name(__VA_ARGS__);                                          \
-  if (err != CUDA_SUCCESS) {                                        \
-    throw cuda_error(std::string(#name) + std::string(" : "), err); \
-  }
+#define CUDA_ERROR_FUNC(name, err, ...)                                 \
+    err = name(__VA_ARGS__);                                            \
+    if (err != CUDA_SUCCESS) {                                          \
+        throw cuda_error(std::string(#name) + std::string(" : "), err); \
+    }
 
-#define CURAND_CALL(func, status, ...)                                   \
-  status = func(__VA_ARGS__);                                            \
-  if (status != CURAND_STATUS_SUCCESS) {                                 \
-    throw curand_error(std::string(#func) + std::string(" : "), status); \
-  }
+#define CURAND_CALL(func, status, ...)                                       \
+    status = func(__VA_ARGS__);                                              \
+    if (status != CURAND_STATUS_SUCCESS) {                                   \
+        throw curand_error(std::string(#func) + std::string(" : "), status); \
+    }
 
 // Static template functions oneapi::mkl::rng::curand::range_transform_fp for
 // Buffer and USM APIs
@@ -224,53 +207,52 @@ class cuda_error : virtual public std::runtime_error {
 //      b     - range upper bound (exclusive)
 //      r     - buffer to store transformed random numbers
 template <typename T>
-static inline void range_transform_fp(cl::sycl::queue& queue, T a, T b,
-                                      std::int64_t n,
+static inline void range_transform_fp(cl::sycl::queue& queue, T a, T b, std::int64_t n,
                                       cl::sycl::buffer<T, 1>& r) {
-  queue.submit([&](cl::sycl::handler& cgh) {
-    auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
-    cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) {
-      acc[id] = acc[id] * (b - a) + a;
+    queue.submit([&](cl::sycl::handler& cgh) {
+        auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.parallel_for(cl::sycl::range<1>(n),
+                         [=](cl::sycl::id<1> id) { acc[id] = acc[id] * (b - a) + a; });
     });
-  });
 }
 template <typename T>
-static inline cl::sycl::event range_transform_fp(cl::sycl::queue& queue, T a,
-                                                 T b, std::int64_t n, T* r) {
-  return queue.submit([&](cl::sycl::handler& cgh) {
-    cgh.parallel_for(cl::sycl::range<1>(n),
-                     [=](cl::sycl::id<1> id) { r[id] = r[id] * (b - a) + a; });
-  });
+static inline cl::sycl::event range_transform_fp(cl::sycl::queue& queue, T a, T b, std::int64_t n,
+                                                 T* r) {
+    return queue.submit([&](cl::sycl::handler& cgh) {
+        cgh.parallel_for(cl::sycl::range<1>(n),
+                         [=](cl::sycl::id<1> id) { r[id] = r[id] * (b - a) + a; });
+    });
 }
 template <typename T>
-static inline void range_transform_fp_accurate(cl::sycl::queue& queue, T a, T b,
-                                               std::int64_t n,
+static inline void range_transform_fp_accurate(cl::sycl::queue& queue, T a, T b, std::int64_t n,
                                                cl::sycl::buffer<T, 1>& r) {
-  queue.submit([&](cl::sycl::handler& cgh) {
-    auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
-    cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) {
-      acc[id] = acc[id] * (b - a) + a;
-      if (acc[id] < a) {
-        acc[id] = a;
-      } else if (acc[id] > b) {
-        acc[id] = b;
-      }
+    queue.submit([&](cl::sycl::handler& cgh) {
+        auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) {
+            acc[id] = acc[id] * (b - a) + a;
+            if (acc[id] < a) {
+                acc[id] = a;
+            }
+            else if (acc[id] > b) {
+                acc[id] = b;
+            }
+        });
     });
-  });
 }
 template <typename T>
-static inline cl::sycl::event range_transform_fp_accurate(
-    cl::sycl::queue& queue, T a, T b, std::int64_t n, T* r) {
-  return queue.submit([&](cl::sycl::handler& cgh) {
-    cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) {
-      r[id] = r[id] * (b - a) + a;
-      if (r[id] < a) {
-        r[id] = a;
-      } else if (r[id] > b) {
-        r[id] = b;
-      }
+static inline cl::sycl::event range_transform_fp_accurate(cl::sycl::queue& queue, T a, T b,
+                                                          std::int64_t n, T* r) {
+    return queue.submit([&](cl::sycl::handler& cgh) {
+        cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) {
+            r[id] = r[id] * (b - a) + a;
+            if (r[id] < a) {
+                r[id] = a;
+            }
+            else if (r[id] > b) {
+                r[id] = b;
+            }
+        });
     });
-  });
 }
 
 // Static template functions oneapi::mkl::rng::curand::range_transform_int for
@@ -290,27 +272,23 @@ static inline cl::sycl::event range_transform_fp_accurate(
 //      b     - range upper bound (exclusive)
 //      r     - buffer to store transformed random numbers
 template <typename T>
-inline void range_transform_int(cl::sycl::queue& queue, T a, T b,
-                                std::int64_t n,
+inline void range_transform_int(cl::sycl::queue& queue, T a, T b, std::int64_t n,
                                 cl::sycl::buffer<std::uint32_t, 1>& in,
                                 cl::sycl::buffer<T, 1>& out) {
-  queue.submit([&](cl::sycl::handler& cgh) {
-    auto acc_in = in.template get_access<cl::sycl::access::mode::read>(cgh);
-    auto acc_out = out.template get_access<cl::sycl::access::mode::write>(cgh);
-    cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) {
-      acc_out[id] = a + acc_in[id] % (b - a);
+    queue.submit([&](cl::sycl::handler& cgh) {
+        auto acc_in = in.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto acc_out = out.template get_access<cl::sycl::access::mode::write>(cgh);
+        cgh.parallel_for(cl::sycl::range<1>(n),
+                         [=](cl::sycl::id<1> id) { acc_out[id] = a + acc_in[id] % (b - a); });
     });
-  });
 }
 template <typename T>
-inline cl::sycl::event range_transform_int(cl::sycl::queue& queue, T a, T b,
-                                           std::int64_t n, std::uint32_t* in,
-                                           T* out) {
-  return queue.submit([&](cl::sycl::handler& cgh) {
-    cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) {
-      out[id] = a + in[id] % (b - a);
+inline cl::sycl::event range_transform_int(cl::sycl::queue& queue, T a, T b, std::int64_t n,
+                                           std::uint32_t* in, T* out) {
+    return queue.submit([&](cl::sycl::handler& cgh) {
+        cgh.parallel_for(cl::sycl::range<1>(n),
+                         [=](cl::sycl::id<1> id) { out[id] = a + in[id] % (b - a); });
     });
-  });
 }
 
 // Static template functions oneapi::mkl::rng::curand::sample_bernoulli for
@@ -330,29 +308,27 @@ inline cl::sycl::event range_transform_int(cl::sycl::queue& queue, T a, T b,
 //      in    - buffer containing uniformly-generated random numbers
 //      out   - buffer to store Bernoulli
 template <typename T>
-static inline void sample_bernoulli_from_uniform(cl::sycl::queue& queue,
-                                                 float p, std::int64_t n,
+static inline void sample_bernoulli_from_uniform(cl::sycl::queue& queue, float p, std::int64_t n,
                                                  cl::sycl::buffer<float, 1> in,
                                                  cl::sycl::buffer<T, 1>& out) {
-  queue.submit([&](cl::sycl::handler& cgh) {
-    auto acc_in = in.template get_access<cl::sycl::access::mode::read>(cgh);
-    auto acc_out = out.template get_access<cl::sycl::access::mode::write>(cgh);
-    cgh.parallel_for(cl::sycl::range<1>(n),
-                     [=](cl::sycl::id<1> id) { acc_out[id] = acc_in[id] < p; });
-  });
+    queue.submit([&](cl::sycl::handler& cgh) {
+        auto acc_in = in.template get_access<cl::sycl::access::mode::read>(cgh);
+        auto acc_out = out.template get_access<cl::sycl::access::mode::write>(cgh);
+        cgh.parallel_for(cl::sycl::range<1>(n),
+                         [=](cl::sycl::id<1> id) { acc_out[id] = acc_in[id] < p; });
+    });
 }
 template <typename T>
-static inline cl::sycl::event sample_bernoulli_from_uniform(
-    cl::sycl::queue& queue, float p, std::int64_t n, float* in, T* out) {
-  return queue.submit([&](cl::sycl::handler& cgh) {
-    cgh.parallel_for(cl::sycl::range<1>(n),
-                     [=](cl::sycl::id<1> id) { out[id] = in[id] < p; });
-  });
+static inline cl::sycl::event sample_bernoulli_from_uniform(cl::sycl::queue& queue, float p,
+                                                            std::int64_t n, float* in, T* out) {
+    return queue.submit([&](cl::sycl::handler& cgh) {
+        cgh.parallel_for(cl::sycl::range<1>(n), [=](cl::sycl::id<1> id) { out[id] = in[id] < p; });
+    });
 }
 
-}  // namespace curand
-}  // namespace rng
-}  // namespace mkl
-}  // namespace oneapi
+} // namespace curand
+} // namespace rng
+} // namespace mkl
+} // namespace oneapi
 
-#endif  // _MKL_RNG_CURAND_HELPER_HPP_
+#endif // _MKL_RNG_CURAND_HELPER_HPP_

--- a/src/rng/backends/curand/mkl_rng_curand_wrappers.cpp
+++ b/src/rng/backends/curand/mkl_rng_curand_wrappers.cpp
@@ -63,6 +63,6 @@
 
 extern "C" ONEMKL_EXPORT rng_function_table_t mkl_rng_table = {
     WRAPPER_VERSION, oneapi::mkl::rng::curand::create_philox4x32x10,
-    oneapi::mkl::rng::curand::create_philox4x32x10,
-    oneapi::mkl::rng::curand::create_mrg32k3a,
-    oneapi::mkl::rng::curand::create_mrg32k3a};
+    oneapi::mkl::rng::curand::create_philox4x32x10, oneapi::mkl::rng::curand::create_mrg32k3a,
+    oneapi::mkl::rng::curand::create_mrg32k3a
+};

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -73,883 +73,812 @@ namespace curand {
 
 #if !defined(_WIN64)
 class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
- public:
-  mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    curandStatus_t status;
-    CURAND_CALL(curandCreateGenerator, status, &engine_,
-                CURAND_RNG_PSEUDO_MRG32K3A);
-    CURAND_CALL(curandSetPseudoRandomGeneratorSeed, status, engine_,
-                (unsigned long long)seed);
-  }
-
-  mrg32k3a_impl(cl::sycl::queue queue,
-                std::initializer_list<std::uint32_t> seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine", "multi-seed unsupported by cuRAND backend");
-  }
-
-  mrg32k3a_impl(const mrg32k3a_impl* other)
-      : oneapi::mkl::rng::detail::engine_impl(*other) {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "copy construction unsupported by cuRAND backend");
-  }
-
-  // Buffers API
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    cl::sycl::buffer<std::uint32_t, 1> ib(n);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = ib.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto ib_ptr = reinterpret_cast<std::uint32_t*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerate, status, engine_, ib_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_int<std::int32_t>(queue_, distr.a(), distr.b(), n, ib, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n,
-                        distr.mean(), distr.stddev());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n,
-                        distr.mean(), distr.stddev());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n,
-                        distr.m(), distr.s());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr,
-                        n, distr.m(), distr.s());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
-                        cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc =
-              r.template get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<std::uint32_t*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-  }
-
-  // USM APIs
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    std::uint32_t* ib = (std::uint32_t*)malloc_device(
-        n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerate, status, engine_, ib, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_int(queue_, distr.a(), distr.b(), n, ib, r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n,
-                                              r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n,
-                                               r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+public:
+    mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
         curandStatus_t status;
-        CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
-                    distr.stddev());
-      });
-    });
-  }
+        CURAND_CALL(curandCreateGenerator, status, &engine_, CURAND_RNG_PSEUDO_MRG32K3A);
+        CURAND_CALL(curandSetPseudoRandomGeneratorSeed, status, engine_, (unsigned long long)seed);
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+    mrg32k3a_impl(cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine",
+                                         "multi-seed unsupported by cuRAND backend");
+    }
+
+    mrg32k3a_impl(const mrg32k3a_impl* other) : oneapi::mkl::rng::detail::engine_impl(*other) {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine",
+                                         "copy construction unsupported by cuRAND backend");
+    }
+
+    // Buffers API
+
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(const oneapi::mkl::rng::uniform<
+                              std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        cl::sycl::buffer<std::uint32_t, 1> ib(n);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = ib.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto ib_ptr = reinterpret_cast<std::uint32_t*>(
+                        ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerate, status, engine_, ib_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_int<std::int32_t>(queue_, distr.a(), distr.b(), n, ib, r);
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n, distr.mean(),
+                                distr.stddev());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n, distr.mean(),
+                                distr.stddev());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n, distr.m(),
+                                distr.s());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr, n, distr.m(),
+                                distr.s());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                          cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr = reinterpret_cast<std::uint32_t*>(
+                        ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+    }
+
+    // USM APIs
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
+            distr,
+        std::int64_t n, std::int32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* ib = (std::uint32_t*)malloc_device(
+            n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerate, status, engine_, ib, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_int(queue_, distr.a(), distr.b(), n, ib, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
+                            distr.stddev());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
+                            distr.stddev());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
+                            distr.s());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "mrg32ka engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerate, status, engine_, r, n);
+            });
+        });
+    }
+
+    virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
+        return new mrg32k3a_impl(this);
+    }
+
+    virtual void skip_ahead(std::uint64_t num_to_skip) override {
         curandStatus_t status;
-        CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n,
-                    distr.mean(), distr.stddev());
-      });
-    });
-  }
+        CURAND_CALL(curandSetGeneratorOffset, status, engine_, num_to_skip);
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
+    virtual void skip_ahead(std::initializer_list<std::uint64_t> num_to_skip) override {
+        throw oneapi::mkl::unimplemented("rng", "skip_ahead",
+                                         "initializer list unsupported by cuRAND backend");
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
+    virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
+        throw oneapi::mkl::unimplemented("rng", "leapfrog", "unsupported by cuRAND backend");
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-        curandStatus_t status;
-        CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(),
-                    distr.s());
-      });
-    });
-  }
+    virtual ~mrg32k3a_impl() override {
+        curandDestroyGenerator(engine_);
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-        curandStatus_t status;
-        CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n,
-                    distr.m(), distr.s());
-      });
-    });
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "mrg32ka engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-        curandStatus_t status;
-        CURAND_CALL(curandGenerate, status, engine_, r, n);
-      });
-    });
-  }
-
-  virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
-    return new mrg32k3a_impl(this);
-  }
-
-  virtual void skip_ahead(std::uint64_t num_to_skip) override {
-    curandStatus_t status;
-    CURAND_CALL(curandSetGeneratorOffset, status, engine_, num_to_skip);
-  }
-
-  virtual void skip_ahead(
-      std::initializer_list<std::uint64_t> num_to_skip) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "skip_ahead", "initializer list unsupported by cuRAND backend");
-  }
-
-  virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
-    throw oneapi::mkl::unimplemented("rng", "leapfrog",
-                                     "unsupported by cuRAND backend");
-  }
-
-  virtual ~mrg32k3a_impl() override { curandDestroyGenerator(engine_); }
-
- private:
-  curandGenerator_t engine_;
-  std::uint32_t seed_;
+private:
+    curandGenerator_t engine_;
+    std::uint32_t seed_;
 };
-#else  // cuRAND backend is currently not supported on Windows
+#else // cuRAND backend is currently not supported on Windows
 class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
- public:
-  mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+public:
+    mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  mrg32k3a_impl(cl::sycl::queue queue,
-                std::initializer_list<std::uint32_t> seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    mrg32k3a_impl(cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  mrg32k3a_impl(const mrg32k3a_impl* other)
-      : oneapi::mkl::rng::detail::engine_impl(*other) {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    mrg32k3a_impl(const mrg32k3a_impl* other) : oneapi::mkl::rng::detail::engine_impl(*other) {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  // Buffers API
+    // Buffers API
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::uniform<
+                              std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
-                        cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                          cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  // USM APIs
+    // USM APIs
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
+            distr,
+        std::int64_t n, std::int32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return cl::sycl::event{};
+    }
 
-  virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-    return nullptr;
-  }
+    virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+        return nullptr;
+    }
 
-  virtual void skip_ahead(std::uint64_t num_to_skip) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void skip_ahead(std::uint64_t num_to_skip) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void skip_ahead(
-      std::initializer_list<std::uint64_t> num_to_skip) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void skip_ahead(std::initializer_list<std::uint64_t> num_to_skip) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
-    throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
-  }
+    virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
+        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
+    }
 
-  virtual ~mrg32k3a_impl() override {}
+    virtual ~mrg32k3a_impl() override {}
 };
 #endif
 
-oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(sycl::queue queue,
-                                                       std::uint32_t seed) {
-  return new mrg32k3a_impl(queue, seed);
+oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(sycl::queue queue, std::uint32_t seed) {
+    return new mrg32k3a_impl(queue, seed);
 }
 
-oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(
-    cl::sycl::queue queue, std::initializer_list<std::uint32_t> seed) {
-  return new mrg32k3a_impl(queue, seed);
+oneapi::mkl::rng::detail::engine_impl* create_mrg32k3a(cl::sycl::queue queue,
+                                                       std::initializer_list<std::uint32_t> seed) {
+    return new mrg32k3a_impl(queue, seed);
 }
 
-}  // namespace curand
-}  // namespace rng
-}  // namespace mkl
-}  // namespace oneapi
+} // namespace curand
+} // namespace rng
+} // namespace mkl
+} // namespace oneapi

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -95,883 +95,813 @@ namespace curand {
  *
  */
 class philox4x32x10_impl : public oneapi::mkl::rng::detail::engine_impl {
- public:
-  philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    curandStatus_t status;
-    CURAND_CALL(curandCreateGenerator, status, &engine_,
-                CURAND_RNG_PSEUDO_PHILOX4_32_10);
-    CURAND_CALL(curandSetPseudoRandomGeneratorSeed, status, engine_,
-                (unsigned long long)seed);
-  }
-
-  philox4x32x10_impl(cl::sycl::queue queue,
-                     std::initializer_list<std::uint64_t> seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "multi-seed unsupported by cuRAND backend");
-  }
-
-  philox4x32x10_impl(const philox4x32x10_impl* other)
-      : oneapi::mkl::rng::detail::engine_impl(*other) {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "copy construction unsupported by cuRAND backend");
-  }
-
-  // Buffers API
-
-  virtual inline void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    cl::sycl::buffer<std::uint32_t, 1> ib(n);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = ib.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<std::uint32_t*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_int<std::int32_t>(queue_, distr.a(), distr.b(), n, ib, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-    range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n,
-                        distr.mean(), distr.stddev());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n,
-                        distr.mean(), distr.stddev());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<float*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n,
-                        distr.m(), distr.s());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<double*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr,
-                        n, distr.m(), distr.s());
-          });
-        })
-        .wait_and_throw();
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-  }
-
-  virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
-                        cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          auto acc =
-              r.template get_access<cl::sycl::access::mode::read_write>(cgh);
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            auto r_ptr = reinterpret_cast<std::uint32_t*>(
-                ih.get_native_mem<cl::sycl::backend::cuda>(acc));
-            curandStatus_t status;
-            CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
-          });
-        })
-        .wait_and_throw();
-  }
-
-  // USM APIs
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    std::uint32_t* ib = (std::uint32_t*)malloc_device(
-        n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerate, status, engine_, ib, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_int(queue_, distr.a(), distr.b(), n, ib, r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n,
-                                              r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    queue_
-        .submit([&](cl::sycl::handler& cgh) {
-          cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-            curandStatus_t status;
-            CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
-          });
-        })
-        .wait_and_throw();
-    return range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n,
-                                               r);
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+public:
+    philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
         curandStatus_t status;
-        CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
-                    distr.stddev());
-      });
-    });
-  }
+        CURAND_CALL(curandCreateGenerator, status, &engine_, CURAND_RNG_PSEUDO_PHILOX4_32_10);
+        CURAND_CALL(curandSetPseudoRandomGeneratorSeed, status, engine_, (unsigned long long)seed);
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+    philox4x32x10_impl(cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine",
+                                         "multi-seed unsupported by cuRAND backend");
+    }
+
+    philox4x32x10_impl(const philox4x32x10_impl* other)
+            : oneapi::mkl::rng::detail::engine_impl(*other) {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine",
+                                         "copy construction unsupported by cuRAND backend");
+    }
+
+    // Buffers API
+
+    virtual inline void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(const oneapi::mkl::rng::uniform<
+                              std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        cl::sycl::buffer<std::uint32_t, 1> ib(n);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = ib.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr = reinterpret_cast<std::uint32_t*>(
+                        ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_int<std::int32_t>(queue_, distr.a(), distr.b(), n, ib, r);
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+        range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n, distr.mean(),
+                                distr.stddev());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n, distr.mean(),
+                                distr.stddev());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n, distr.m(),
+                                distr.s());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr =
+                        reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr, n, distr.m(),
+                                distr.s());
+                });
+            })
+            .wait_and_throw();
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+    }
+
+    virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                          cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    auto r_ptr = reinterpret_cast<std::uint32_t*>(
+                        ih.get_native_mem<cl::sycl::backend::cuda>(acc));
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
+                });
+            })
+            .wait_and_throw();
+    }
+
+    // USM APIs
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
+            distr,
+        std::int64_t n, std::int32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* ib = (std::uint32_t*)malloc_device(
+            n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerate, status, engine_, ib, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_int(queue_, distr.a(), distr.b(), n, ib, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        queue_
+            .submit([&](cl::sycl::handler& cgh) {
+                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                    curandStatus_t status;
+                    CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
+                });
+            })
+            .wait_and_throw();
+        return range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
+                            distr.stddev());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
+                            distr.stddev());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
+                            distr.s());
+            });
+        });
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented(
+            "rng", "philox4x32x10 engine",
+            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        return cl::sycl::event{};
+    }
+
+    virtual cl::sycl::event generate(
+        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        cl::sycl::event::wait_and_throw(dependencies);
+        return queue_.submit([&](cl::sycl::handler& cgh) {
+            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                curandStatus_t status;
+                CURAND_CALL(curandGenerate, status, engine_, r, n);
+            });
+        });
+    }
+
+    virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
+        return new philox4x32x10_impl(this);
+    }
+
+    virtual void skip_ahead(std::uint64_t num_to_skip) override {
         curandStatus_t status;
-        CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n,
-                    distr.mean(), distr.stddev());
-      });
-    });
-  }
+        CURAND_CALL(curandSetGeneratorOffset, status, engine_, num_to_skip);
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
+    virtual void skip_ahead(std::initializer_list<std::uint64_t> num_to_skip) override {
+        throw oneapi::mkl::unimplemented("rng", "skip_ahead",
+                                         "initializer list unsupported by cuRAND backend");
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
+    virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
+        throw oneapi::mkl::unimplemented("rng", "leapfrog", "unsupported by cuRAND backend");
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-        curandStatus_t status;
-        CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(),
-                    distr.s());
-      });
-    });
-  }
+    virtual ~philox4x32x10_impl() override {
+        curandDestroyGenerator(engine_);
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-        curandStatus_t status;
-        CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n,
-                    distr.m(), distr.s());
-      });
-    });
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "philox4x32x10 engine",
-        "ICDF method not used for pseudorandom generators in cuRAND backend");
-    return cl::sycl::event{};
-  }
-
-  virtual cl::sycl::event generate(
-      const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    cl::sycl::event::wait_and_throw(dependencies);
-    return queue_.submit([&](cl::sycl::handler& cgh) {
-      cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
-        curandStatus_t status;
-        CURAND_CALL(curandGenerate, status, engine_, r, n);
-      });
-    });
-  }
-
-  virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
-    return new philox4x32x10_impl(this);
-  }
-
-  virtual void skip_ahead(std::uint64_t num_to_skip) override {
-    curandStatus_t status;
-    CURAND_CALL(curandSetGeneratorOffset, status, engine_, num_to_skip);
-  }
-
-  virtual void skip_ahead(
-      std::initializer_list<std::uint64_t> num_to_skip) override {
-    throw oneapi::mkl::unimplemented(
-        "rng", "skip_ahead", "initializer list unsupported by cuRAND backend");
-  }
-
-  virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
-    throw oneapi::mkl::unimplemented("rng", "leapfrog",
-                                     "unsupported by cuRAND backend");
-  }
-
-  virtual ~philox4x32x10_impl() override { curandDestroyGenerator(engine_); }
-
- private:
-  curandGenerator_t engine_;
+private:
+    curandGenerator_t engine_;
 };
-#else  // cuRAND backend is currently not supported on Windows
+#else // cuRAND backend is currently not supported on Windows
 class philox4x32x10_impl : public oneapi::mkl::rng::detail::engine_impl {
- public:
-  philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+public:
+    philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  philox4x32x10_impl(cl::sycl::queue queue,
-                     std::initializer_list<std::uint64_t> seed)
-      : oneapi::mkl::rng::detail::engine_impl(queue) {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    philox4x32x10_impl(cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed)
+            : oneapi::mkl::rng::detail::engine_impl(queue) {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  philox4x32x10_impl(const philox4x32x10_impl* other)
-      : oneapi::mkl::rng::detail::engine_impl(*other) {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    philox4x32x10_impl(const philox4x32x10_impl* other)
+            : oneapi::mkl::rng::detail::engine_impl(*other) {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  // Buffers API
+    // Buffers API
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::uniform<
+                              std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::gaussian<
+                              double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const oneapi::mkl::rng::lognormal<
+                              double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
+                          std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<float, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, cl::sycl::buffer<double, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::int32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
+                          std::int64_t n, cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
-                        cl::sycl::buffer<std::uint32_t, 1>& r) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                          cl::sycl::buffer<std::uint32_t, 1>& r) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  // USM APIs
+    // USM APIs
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          std::int32_t, oneapi::mkl::rng::uniform_method::standard>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
+            distr,
+        std::int64_t n, std::int32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::uniform<
-          double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::gaussian<
-          double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::box_muller2>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
+            distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, float* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, float* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const oneapi::mkl::rng::lognormal<
-          double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-      std::int64_t n, double* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
+        std::int64_t n, double* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::int32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
-      std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
+        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual cl::sycl::event generate(
-      const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-      const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return cl::sycl::event{};
-  }
+    virtual cl::sycl::event generate(
+        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
+        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return cl::sycl::event{};
+    }
 
-  virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-    return nullptr;
-  }
+    virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+        return nullptr;
+    }
 
-  virtual void skip_ahead(std::uint64_t num_to_skip) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void skip_ahead(std::uint64_t num_to_skip) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void skip_ahead(
-      std::initializer_list<std::uint64_t> num_to_skip) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void skip_ahead(std::initializer_list<std::uint64_t> num_to_skip) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
-    throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
-  }
+    virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
+        throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
+    }
 
-  virtual ~philox4x32x10_impl() override {}
+    virtual ~philox4x32x10_impl() override {}
 };
 #endif
 
-oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
-    sycl::queue queue, std::uint64_t seed) {
-  return new philox4x32x10_impl(queue, seed);
+oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(sycl::queue queue, std::uint64_t seed) {
+    return new philox4x32x10_impl(queue, seed);
 }
 
 oneapi::mkl::rng::detail::engine_impl* create_philox4x32x10(
     cl::sycl::queue queue, std::initializer_list<std::uint64_t> seed) {
-  return new philox4x32x10_impl(queue, seed);
+    return new philox4x32x10_impl(queue, seed);
 }
 
-}  // namespace curand
-}  // namespace rng
-}  // namespace mkl
-}  // namespace oneapi
+} // namespace curand
+} // namespace rng
+} // namespace mkl
+} // namespace oneapi

--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -47,6 +47,9 @@ static inline void host_task(H &cgh, F f) {
 template <typename Engine, typename Distr>
 class kernel_name {};
 
+template <typename Engine, typename Distr>
+class kernel_name_usm {};
+
 } // namespace mklcpu
 } // namespace rng
 } // namespace mkl

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -321,7 +321,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -333,7 +333,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -345,7 +345,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -357,7 +357,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, stream, n, r, distr.a(),
                              distr.b());
             });
@@ -370,7 +370,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, stream, n, r, distr.a(),
                              distr.b());
             });
@@ -383,7 +383,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -396,7 +396,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -409,7 +409,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -422,7 +422,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -435,7 +435,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2, stream, n, r, distr.m(),
                                distr.s(), distr.displ(), distr.scale());
             });
@@ -448,7 +448,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2, stream, n, r, distr.m(),
                                distr.s(), distr.displ(), distr.scale());
             });
@@ -461,7 +461,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF, stream, n, r, distr.m(), distr.s(),
                                distr.displ(), distr.scale());
             });
@@ -474,7 +474,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF, stream, n, r, distr.m(), distr.s(),
                                distr.displ(), distr.scale());
             });
@@ -487,7 +487,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, n, r, distr.p());
             });
         });
@@ -499,7 +499,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, n,
                                reinterpret_cast<int32_t*>(r), distr.p());
             });
@@ -512,7 +512,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, stream, n, r, distr.lambda());
             });
         });
@@ -524,7 +524,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, stream, n,
                              reinterpret_cast<int32_t*>(r), distr.lambda());
             });
@@ -537,7 +537,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(
+            host_task<kernel_name_usm<mrg32k3a_impl, decltype(distr)>>(
                 cgh, [=]() { viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD, stream, n, r); });
         });
     }

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -323,7 +323,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -335,7 +335,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -347,7 +347,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 viRngUniform(VSL_RNG_METHOD_UNIFORM_STD, stream, n, r, distr.a(), distr.b());
             });
         });
@@ -359,7 +359,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, stream, n, r, distr.a(),
                              distr.b());
             });
@@ -372,7 +372,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE, stream, n, r, distr.a(),
                              distr.b());
             });
@@ -385,7 +385,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -398,7 +398,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -411,7 +411,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -424,7 +424,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF, stream, n, r, distr.mean(),
                               distr.stddev());
             });
@@ -437,7 +437,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2, stream, n, r, distr.m(),
                                distr.s(), distr.displ(), distr.scale());
             });
@@ -450,7 +450,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2, stream, n, r, distr.m(),
                                distr.s(), distr.displ(), distr.scale());
             });
@@ -463,7 +463,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF, stream, n, r, distr.m(), distr.s(),
                                distr.displ(), distr.scale());
             });
@@ -476,7 +476,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF, stream, n, r, distr.m(), distr.s(),
                                distr.displ(), distr.scale());
             });
@@ -489,7 +489,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, n, r, distr.p());
             });
         });
@@ -501,7 +501,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, n,
                                reinterpret_cast<int32_t*>(r), distr.p());
             });
@@ -514,7 +514,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, stream, n, r, distr.lambda());
             });
         });
@@ -526,7 +526,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM, stream, n,
                              reinterpret_cast<int32_t*>(r), distr.lambda());
             });
@@ -539,7 +539,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
-            host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(
+            host_task<kernel_name_usm<philox4x32x10_impl, decltype(distr)>>(
                 cgh, [=]() { viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD, stream, n, r); });
         });
     }


### PR DESCRIPTION
# Description

- [x] Fix mklcpu backend kernel names ([issue 89](https://github.com/oneapi-src/oneMKL/issues/89))
- [x] Apply clang-format to curand backend
- [x] Change c++14 to c++17 cmake to avoid llvm failures 

## All Submissions

- [x] Do all unit tests pass locally? 
[log_ct.txt](https://github.com/oneapi-src/oneMKL/files/6461199/log_ct.txt)
[log_rt.txt](https://github.com/oneapi-src/oneMKL/files/6461202/log_rt.txt)


- [x] Have you formatted the code using clang-format?
