### PR TITLE
[cublas] set CUBLAS_POINTER_MODE_HOST after setting it to device

### DIFF
--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -56,6 +56,9 @@ inline void asum(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
             cublasStatus_t err;
             // ASUM does not support negative index
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, std::abs(incx), res_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -161,6 +164,9 @@ inline void rotg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T1, 1> &a,
             auto s_ = sc.get_mem<cuDataType1 *>(ih, s_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, a_, b_, c_, s_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -203,6 +209,9 @@ inline void rotm(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
             auto param_ = sc.get_mem<cuDataType *>(ih, param_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, y_, incy, param_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -273,6 +282,9 @@ inline void dot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T
             auto res_ = sc.get_mem<cuDataType *>(ih, res_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, y_, incy, res_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -310,12 +322,16 @@ inline void rot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
             // fault. When it is set to device it is users responsibility to
             // synchronise as the function is completely asynchronous.
-            // cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
             auto x_ = sc.get_mem<cuDataType1 *>(ih, x_acc);
             auto y_ = sc.get_mem<cuDataType1 *>(ih, y_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, y_, incy, (cuDataType2 *)&c,
                               (cuDataType3 *)&s);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }
@@ -355,6 +371,9 @@ void sdsdot(cl::sycl::queue &queue, int64_t n, float sb, cl::sycl::buffer<float,
             auto res_ = sc.get_mem<float *>(ih, res_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(cublasSdot, err, handle, n, x_, incx, y_, incy, res_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -396,6 +415,9 @@ inline void rotmg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T, 1> &d1,
             auto param_ = sc.get_mem<cuDataType *>(ih, param_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, d1_, d2_, x1_, y1_, param_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -443,6 +465,9 @@ inline void iamax(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
             // For negative incx, iamax returns 0. This behaviour is similar to that of
             // reference netlib BLAS.
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, int_res_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -526,6 +551,9 @@ inline void iamin(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
             // For negative incx, iamin returns 0. This behaviour is similar to that of
             // implemented as a reference IAMIN.
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, int_res_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
@@ -569,6 +597,9 @@ inline void nrm2(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
             cublasStatus_t err;
             // NRM2 does not support negative index
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, std::abs(incx), res_);
+            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
+            // to be set, therfore we need to reset this to the default value
+            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
             cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -56,6 +56,7 @@ inline void asum(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
             cublasStatus_t err;
             // ASUM does not support negative index
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, std::abs(incx), res_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }
@@ -160,6 +161,7 @@ inline void rotg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T1, 1> &a,
             auto s_ = sc.get_mem<cuDataType1 *>(ih, s_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, a_, b_, c_, s_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }
@@ -201,6 +203,7 @@ inline void rotm(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
             auto param_ = sc.get_mem<cuDataType *>(ih, param_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, y_, incy, param_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }
@@ -270,6 +273,7 @@ inline void dot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T
             auto res_ = sc.get_mem<cuDataType *>(ih, res_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, y_, incy, res_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }
@@ -351,6 +355,7 @@ void sdsdot(cl::sycl::queue &queue, int64_t n, float sb, cl::sycl::buffer<float,
             auto res_ = sc.get_mem<float *>(ih, res_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(cublasSdot, err, handle, n, x_, incx, y_, incy, res_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
     // Since SB is a host pointer we need to bring the result back to the host and
@@ -391,6 +396,7 @@ inline void rotmg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T, 1> &d1,
             auto param_ = sc.get_mem<cuDataType *>(ih, param_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, d1_, d2_, x1_, y1_, param_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }
@@ -437,6 +443,7 @@ inline void iamax(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
             // For negative incx, iamax returns 0. This behaviour is similar to that of
             // reference netlib BLAS.
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, int_res_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
     // This requires to bring the data to host, copy it, and return it back to
@@ -519,6 +526,7 @@ inline void iamin(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
             // For negative incx, iamin returns 0. This behaviour is similar to that of
             // implemented as a reference IAMIN.
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, int_res_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
     result.template get_access<cl::sycl::access::mode::write>()[0] =
@@ -561,6 +569,7 @@ inline void nrm2(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
             cublasStatus_t err;
             // NRM2 does not support negative index
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, std::abs(incx), res_);
+            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -317,21 +317,11 @@ inline void rot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T
         cgh.interop_task([=](cl::sycl::interop_handler ih) {
             auto sc = CublasScopedContextHandler(queue);
             auto handle = sc.get_handle(queue);
-            // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
-            // when the data is on buffer, it must be set to
-            // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
-            // fault. When it is set to device it is users responsibility to
-            // synchronise as the function is completely asynchronous.
-            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
             auto x_ = sc.get_mem<cuDataType1 *>(ih, x_acc);
             auto y_ = sc.get_mem<cuDataType1 *>(ih, y_acc);
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, y_, incy, (cuDataType2 *)&c,
                               (cuDataType3 *)&s);
-            // Higher level BLAS functions expect CUBLAS_POINTER_MODE_HOST
-            // to be set, therfore we need to reset this to the default value
-            // in order to avoid CUDA_ERROR_ILLEGAL_ADRESS errors
-            cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
         });
     });
 }


### PR DESCRIPTION
This PR is a solution proposal for issue #92 

# Description

I believe this is the most simplistic way to solve the issue described in #92. 

Fixes #92 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
* on CPU device: 
[cpu_tests.log](https://github.com/oneapi-src/oneMKL/files/6489583/cpu_tests.log)
* on GPU: see issue #93 
- [x] Have you formatted the code using clang-format?
- [ ] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
see #92 
