### PR TITLE
[cuBLAS] Fix deprecated API

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -97,7 +97,8 @@ void ContextCallback(void *userData) {
 }
 
 cublasHandle_t CublasScopedContextHandler::get_handle(const cl::sycl::queue &queue) {
-    auto piPlacedContext_ = reinterpret_cast<pi_context>(placedContext_.get());
+    auto piPlacedContext_ =
+        reinterpret_cast<pi_context>(cl::sycl::get_native<cl::sycl::backend::cuda>(placedContext_));
     CUstream streamId = get_stream(queue);
     cublasStatus_t err;
     auto it = handle_helper.cublas_handle_mapper_.find(piPlacedContext_);


### PR DESCRIPTION
# Description

This PR is replacing the deprecated API in cuBLAS backend with newer one.

Fixes # (GitHub issue)
No issue.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[cublas_gpu_test_api.log](https://github.com/oneapi-src/oneMKL/files/6517636/cublas_gpu_test_api.log)


- [x] Have you formatted the code using clang-format?

## New interfaces
N/A
## New features
N/A

## Bug fixes
N/A

