### PR TITLE
[cublas] Add synchronization to the Iamin USM function

### DIFF
--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -923,6 +923,7 @@ cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float 
             CUBLAS_ERROR_FUNC(cublasSdot, err, handle, n, x_, incx, y_, incy, res_);
         });
     });
+    done.wait();
     result[0] = result[0] + sb;
     return done;
 }

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -1079,6 +1079,7 @@ inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const
             CUBLAS_ERROR_FUNC(func, err, handle, n, x_, incx, int_res_p_);
         });
     });
+    done.wait();
     result[0] = std::max((int64_t)(*int_res_p - 1), int64_t{ 0 });
     return done;
 }


### PR DESCRIPTION
# Description

This PR adds a missing synchronization for the `iamin` cublas USM function. 

I couldn't reproduce any issues regarding this with dpc++, however, this causes the iamin tests to fail when oneMKL is compelled by hipSYCL. Note that the same synchronization is present for the iamax USM function, which makes me believe that this has been left out by accident.



- [x] Do all unit tests pass locally? Attach a log. ~~[test.log](https://github.com/oneapi-src/oneMKL/files/6576178/test.log)~~  [test.log](https://github.com/oneapi-src/oneMKL/files/6587168/test.log)
- [x] Have you formatted the code using clang-format?

