### PR TITLE
Remove non standard function calls, and use qualified name for half

### DIFF
--- a/include/oneapi/mkl/blas.hxx
+++ b/include/oneapi/mkl/blas.hxx
@@ -261,11 +261,10 @@ static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose tran
                  c, ldc);
     gemm_postcondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
-
 static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                        std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                        std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+                        std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+                        std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+                        cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
     detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                  c, ldc);
@@ -273,15 +272,14 @@ static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose tran
 }
 
 static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                        std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-                        std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
+                        std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+                        std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
                         float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
     detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                  c, ldc);
     gemm_postcondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
-
 static inline void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
                               std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                               cl::sycl::buffer<float, 1> &a, std::int64_t lda,

--- a/include/oneapi/mkl/blas.hxx
+++ b/include/oneapi/mkl/blas.hxx
@@ -262,9 +262,11 @@ static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose tran
     gemm_postcondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
 }
 static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                        std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-                        std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
-                        cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
+                        std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+                        cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
+                        cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
+                        std::int64_t ldc) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
     detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                  c, ldc);
@@ -272,9 +274,10 @@ static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose tran
 }
 
 static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                        std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-                        std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
-                        float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+                        std::int64_t n, std::int64_t k, float alpha,
+                        cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+                        cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
     detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                  c, ldc);

--- a/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
@@ -416,14 +416,14 @@ static inline void gemm(backend_selector<backend::BACKEND> selector, transpose t
 
 static inline void gemm(backend_selector<backend::BACKEND> selector, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                        cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+                        cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc);
 
 static inline void gemm(backend_selector<backend::BACKEND> selector, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        float alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                        float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
                         cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 
 static inline void herk(backend_selector<backend::BACKEND> selector, uplo upper_lower,

--- a/include/oneapi/mkl/blas/detail/blas_loader.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_loader.hxx
@@ -398,13 +398,13 @@ ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, tran
                         cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
 ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                        cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+                        cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc);
 ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        float alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                        float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
                         cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 
 ONEMKL_EXPORT void syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,

--- a/include/oneapi/mkl/blas/detail/blas_loader.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_loader.hxx
@@ -398,9 +398,10 @@ ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, tran
                         cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
 ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
-                        cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc);
+                        cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+                        std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
+                        cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
+                        std::int64_t ldc);
 ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
                         float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,

--- a/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
@@ -743,11 +743,10 @@ void gemm(backend_selector<backend::cublas> selector, transpose transa, transpos
     gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
 }
-
 void gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::cublas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -757,8 +756,8 @@ void gemm(backend_selector<backend::cublas> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
@@ -767,7 +766,6 @@ void gemm(backend_selector<backend::cublas> selector, transpose transa, transpos
     gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
 }
-
 void syr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n, float alpha,
           cl::sycl::buffer<float, 1> &x, std::int64_t incx, cl::sycl::buffer<float, 1> &y,
           std::int64_t incy, cl::sycl::buffer<float, 1> &a, std::int64_t lda) {

--- a/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
@@ -744,8 +744,9 @@ void gemm(backend_selector<backend::cublas> selector, transpose transa, transpos
                        c, ldc);
 }
 void gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
@@ -756,8 +757,9 @@ void gemm(backend_selector<backend::cublas> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);

--- a/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
@@ -498,13 +498,13 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64
           cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+          std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc);
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 
 void hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,

--- a/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
@@ -745,8 +745,9 @@ void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
@@ -757,8 +758,9 @@ void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);

--- a/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
@@ -745,9 +745,9 @@ void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::mklcpu::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -757,8 +757,8 @@ void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);

--- a/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
@@ -745,8 +745,9 @@ void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
@@ -757,8 +758,9 @@ void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);

--- a/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
@@ -745,9 +745,9 @@ void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::mklgpu::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -757,8 +757,8 @@ void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);

--- a/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
@@ -745,8 +745,9 @@ void gemm(backend_selector<backend::netlib> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
@@ -757,8 +758,9 @@ void gemm(backend_selector<backend::netlib> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);

--- a/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
@@ -745,9 +745,9 @@ void gemm(backend_selector<backend::netlib> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::netlib::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -757,8 +757,8 @@ void gemm(backend_selector<backend::netlib> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);

--- a/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
@@ -49,14 +49,14 @@ ONEMKL_EXPORT void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
 
 ONEMKL_EXPORT void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                         oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                        std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                        std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+                        cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc);
 
 ONEMKL_EXPORT void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                         oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                        std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                        std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
                         cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 
 ONEMKL_EXPORT void symm(cl::sycl::queue &queue, oneapi::mkl::side left_right,

--- a/include/oneapi/mkl/blas/predicates.hxx
+++ b/include/oneapi/mkl/blas/predicates.hxx
@@ -1519,20 +1519,20 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 }
 
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                              std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                              cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                              cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                              cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+                              std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+                              cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                              cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+                              cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
 }
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                               std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                               cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                               cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                               cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+                               std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+                               cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                               cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+                               cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -1540,8 +1540,8 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                               std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                              cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                              cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                              cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                              cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
                               cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -1550,14 +1550,13 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                               cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                               cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                               cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                               cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
                                cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
 }
-
 inline void syr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               cl::sycl::buffer<float, 1> &x, std::int64_t incx,
                               cl::sycl::buffer<float, 1> &y, std::int64_t incy,
@@ -4749,11 +4748,10 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
     /* add postchecks to queue here for input args.  */
 #endif
 }
-
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                              std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                              const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                              half beta, half *c, std::int64_t ldc,
+                              std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+                              const cl::sycl::half *a, std::int64_t lda, const cl::sycl::half *b, std::int64_t ldb,
+                              cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -4761,9 +4759,9 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
 }
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                               std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                               const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                               half beta, half *c, std::int64_t ldc,
+                               std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+                               const cl::sycl::half *a, std::int64_t lda, const cl::sycl::half *b, std::int64_t ldb,
+                               cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */

--- a/include/oneapi/mkl/blas/predicates.hxx
+++ b/include/oneapi/mkl/blas/predicates.hxx
@@ -1521,8 +1521,9 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                               std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
                               cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
-                              cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
-                              cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
+                              cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
+                              cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
+                              std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -1531,8 +1532,9 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                                std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
                                cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
-                               cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
-                               cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
+                               cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
+                               cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
+                               std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4750,8 +4752,9 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 }
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                               std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
-                              const cl::sycl::half *a, std::int64_t lda, const cl::sycl::half *b, std::int64_t ldb,
-                              cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
+                              const cl::sycl::half *a, std::int64_t lda, const cl::sycl::half *b,
+                              std::int64_t ldb, cl::sycl::half beta, cl::sycl::half *c,
+                              std::int64_t ldc,
                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -4760,8 +4763,9 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                                std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
-                               const cl::sycl::half *a, std::int64_t lda, const cl::sycl::half *b, std::int64_t ldb,
-                               cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
+                               const cl::sycl::half *a, std::int64_t lda, const cl::sycl::half *b,
+                               std::int64_t ldb, cl::sycl::half beta, cl::sycl::half *c,
+                               std::int64_t ldc,
                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */

--- a/include/oneapi/mkl/detail/backend_selector.hpp
+++ b/include/oneapi/mkl/detail/backend_selector.hpp
@@ -27,6 +27,8 @@
 namespace oneapi {
 namespace mkl {
 
+using namespace cl;
+
 template <backend Backend>
 class backend_selector {
 public:

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -110,8 +110,10 @@ inline void gemm(Func func, DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C,
              transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);                              \
     }
 
-GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, cl::sycl::half, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F,
+                 CUDA_R_32F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, cl::sycl::half, cublasGemmEx, CUDA_R_16F,
+                 CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER
 
@@ -467,8 +469,9 @@ GEMM_LAUNCHER_USM(std::complex<double>, cublasZgemm)
 #undef GEMM_LAUNCHER_USM
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, cl::sycl::half alpha, const cl::sycl::half *a, std::int64_t lda,
-                     const cl::sycl::half *b, std::int64_t ldb, cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
+                     std::int64_t n, std::int64_t k, cl::sycl::half alpha, const cl::sycl::half *a,
+                     std::int64_t lda, const cl::sycl::half *b, std::int64_t ldb,
+                     cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for column_major layout");
 }
@@ -861,8 +864,10 @@ inline void gemm(Func func, DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C,
              transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);                              \
     }
 
-GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, cl::sycl::half, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F,
+                 CUDA_R_32F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, cl::sycl::half, cublasGemmEx, CUDA_R_16F,
+                 CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER
 
@@ -1067,8 +1072,9 @@ GEMM_LAUNCHER_USM(std::complex<double>, cublasZgemm)
 #undef GEMM_LAUNCHER_USM
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, cl::sycl::half alpha, const cl::sycl::half *a, std::int64_t lda,
-                     const cl::sycl::half *b, std::int64_t ldb, cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
+                     std::int64_t n, std::int64_t k, cl::sycl::half alpha, const cl::sycl::half *a,
+                     std::int64_t lda, const cl::sycl::half *b, std::int64_t ldb,
+                     cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for row_major layout");
 }

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -110,8 +110,8 @@ inline void gemm(Func func, DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C,
              transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);                              \
     }
 
-GEMM_EX_LAUNCHER(half, half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER(half, half, half, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, cl::sycl::half, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER
 
@@ -467,8 +467,8 @@ GEMM_LAUNCHER_USM(std::complex<double>, cublasZgemm)
 #undef GEMM_LAUNCHER_USM
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-                     const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+                     std::int64_t n, std::int64_t k, cl::sycl::half alpha, const cl::sycl::half *a, std::int64_t lda,
+                     const cl::sycl::half *b, std::int64_t ldb, cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for column_major layout");
 }
@@ -861,8 +861,8 @@ inline void gemm(Func func, DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C,
              transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);                              \
     }
 
-GEMM_EX_LAUNCHER(half, half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER(half, half, half, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, float, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
+GEMM_EX_LAUNCHER(cl::sycl::half, cl::sycl::half, cl::sycl::half, cublasGemmEx, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER
 
@@ -1067,8 +1067,8 @@ GEMM_LAUNCHER_USM(std::complex<double>, cublasZgemm)
 #undef GEMM_LAUNCHER_USM
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-                     const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+                     std::int64_t n, std::int64_t k, cl::sycl::half alpha, const cl::sycl::half *a, std::int64_t lda,
+                     const cl::sycl::half *b, std::int64_t ldb, cl::sycl::half beta, cl::sycl::half *c, std::int64_t ldc,
                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for row_major layout");
 }

--- a/src/blas/backends/mklcpu/mklcpu_level3.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cxx
@@ -98,8 +98,8 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-          cl::sycl::buffer<half, 1> &b, int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
+          int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
           int64_t ldc) {
     auto a_fp16 = a.reinterpret<fp16, 1>(a.get_range());
     auto b_fp16 = b.reinterpret<fp16, 1>(b.get_range());
@@ -142,8 +142,8 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-          cl::sycl::buffer<half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+          int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
           int64_t ldc) {
     auto a_fp16 = a.reinterpret<fp16, 1>(a.get_range());
     auto b_fp16 = b.reinterpret<fp16, 1>(b.get_range());

--- a/src/blas/backends/mklcpu/mklcpu_level3.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cxx
@@ -99,8 +99,8 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
           int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
-          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
-          int64_t ldc) {
+          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, int64_t ldc) {
     auto a_fp16 = a.reinterpret<fp16, 1>(a.get_range());
     auto b_fp16 = b.reinterpret<fp16, 1>(b.get_range());
     auto c_fp16 = c.reinterpret<fp16, 1>(c.get_range());
@@ -143,8 +143,8 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
           int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
-          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
-          int64_t ldc) {
+          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, float beta,
+          cl::sycl::buffer<float, 1> &c, int64_t ldc) {
     auto a_fp16 = a.reinterpret<fp16, 1>(a.get_range());
     auto b_fp16 = b.reinterpret<fp16, 1>(b.get_range());
     queue.submit([&](cl::sycl::handler &cgh) {

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -781,14 +781,16 @@ void cgemmt(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_UPLO upper_lower, MKL
             cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
 
 void hgemm(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa, MKL_TRANSPOSE transb,
-           int64_t m, int64_t n, int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
-           cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
-           int64_t ldc);
+           int64_t m, int64_t n, int64_t k, cl::sycl::half alpha,
+           cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
+           cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, cl::sycl::half beta,
+           cl::sycl::buffer<cl::sycl::half, 1> &c, int64_t ldc);
 
 void gemm_f16f16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                     MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
-                    cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b,
-                    int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
+                    cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
+                    cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, float beta,
+                    cl::sycl::buffer<float, 1> &c, int64_t ldc);
 
 cl::sycl::event gemm_s8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                   MKL_TRANSPOSE transb, CBLAS_OFFSET offsetc, int64_t m, int64_t n,

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -781,13 +781,13 @@ void cgemmt(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_UPLO upper_lower, MKL
             cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
 
 void hgemm(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa, MKL_TRANSPOSE transb,
-           int64_t m, int64_t n, int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-           cl::sycl::buffer<half, 1> &b, int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
+           int64_t m, int64_t n, int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
+           cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
            int64_t ldc);
 
 void gemm_f16f16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                     MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
-                    cl::sycl::buffer<half, 1> &a, int64_t lda, cl::sycl::buffer<half, 1> &b,
+                    cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b,
                     int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
 
 cl::sycl::event gemm_s8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,

--- a/src/blas/backends/mklgpu/mklgpu_level3.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level3.cxx
@@ -58,8 +58,9 @@ void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::tr
 }
 
 void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     ::oneapi::mkl::gpu::hgemm(queue, MAJOR, ::mkl::cblas_convert(transa),
                               ::mkl::cblas_convert(transb), m, n, k, alpha, a, lda, b, ldb, beta, c,
@@ -67,8 +68,9 @@ void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::tr
 }
 
 void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     ::oneapi::mkl::gpu::gemm_f16f16f32(queue, MAJOR, ::mkl::cblas_convert(transa),
                                        ::mkl::cblas_convert(transb), m, n, k, alpha, a, lda, b, ldb,

--- a/src/blas/backends/mklgpu/mklgpu_level3.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level3.cxx
@@ -58,17 +58,17 @@ void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::tr
 }
 
 void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     ::oneapi::mkl::gpu::hgemm(queue, MAJOR, ::mkl::cblas_convert(transa),
                               ::mkl::cblas_convert(transb), m, n, k, alpha, a, lda, b, ldb, beta, c,
                               ldc);
 }
 
 void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     ::oneapi::mkl::gpu::gemm_f16f16f32(queue, MAJOR, ::mkl::cblas_convert(transa),
                                        ::mkl::cblas_convert(transb), m, n, k, alpha, a, lda, b, ldb,

--- a/src/blas/backends/netlib/netlib_level3.cxx
+++ b/src/blas/backends/netlib/netlib_level3.cxx
@@ -92,9 +92,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -104,8 +104,8 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-          cl::sycl::buffer<half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+          int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
           int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");

--- a/src/blas/backends/netlib/netlib_level3.cxx
+++ b/src/blas/backends/netlib/netlib_level3.cxx
@@ -92,8 +92,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
@@ -105,8 +106,8 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
           int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a, int64_t lda,
-          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
-          int64_t ldc) {
+          cl::sycl::buffer<cl::sycl::half, 1> &b, int64_t ldb, float beta,
+          cl::sycl::buffer<float, 1> &c, int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -879,16 +879,18 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda,
                                                     b, ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha,
                                                              a, lda, b, ldb, beta, c, ldc);
@@ -3496,16 +3498,18 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
                                                  ldb, beta, c, ldc);
 }
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
           cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda, b,
                                                  ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha, a,
                                                           lda, b, ldb, beta, c, ldc);

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -879,16 +879,16 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda,
                                                     b, ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha,
                                                              a, lda, b, ldb, beta, c, ldc);
@@ -3495,18 +3495,17 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
     function_tables[libkey].row_major_zgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda, b,
                                                  ldb, beta, c, ldc);
 }
-
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, cl::sycl::half beta,
+          cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda, b,
                                                  ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha, a,
                                                           lda, b, ldb, beta, c, ldc);

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -569,15 +569,15 @@ typedef struct {
                                     cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*column_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                     oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                    std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                                    std::int64_t lda, cl::sycl::buffer<half, 1> &b,
-                                    std::int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
+                                    std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+                                    std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b,
+                                    std::int64_t ldb, cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
                                     std::int64_t ldc);
     void (*column_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                              oneapi::mkl::transpose transb, std::int64_t m,
                                              std::int64_t n, std::int64_t k, float alpha,
-                                             cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                                             cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
+                                             cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                                             cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
                                              float beta, cl::sycl::buffer<float, 1> &c,
                                              std::int64_t ldc);
     void (*column_major_chemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::side left_right,
@@ -2088,14 +2088,14 @@ typedef struct {
                                  cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*row_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                  oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                 std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                                 std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
-                                 half beta, cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                                 std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
+                                 std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
+                                 cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc);
     void (*row_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                           oneapi::mkl::transpose transb, std::int64_t m,
                                           std::int64_t n, std::int64_t k, float alpha,
-                                          cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                                          cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
+                                          cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                                          cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
                                           float beta, cl::sycl::buffer<float, 1> &c,
                                           std::int64_t ldc);
     void (*row_major_chemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::side left_right,

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -569,17 +569,19 @@ typedef struct {
                                     cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*column_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                     oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                    std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-                                    std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b,
-                                    std::int64_t ldb, cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
+                                    std::int64_t k, cl::sycl::half alpha,
+                                    cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                                    cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
+                                    cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
                                     std::int64_t ldc);
     void (*column_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                              oneapi::mkl::transpose transb, std::int64_t m,
                                              std::int64_t n, std::int64_t k, float alpha,
-                                             cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
-                                             cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
-                                             float beta, cl::sycl::buffer<float, 1> &c,
-                                             std::int64_t ldc);
+                                             cl::sycl::buffer<cl::sycl::half, 1> &a,
+                                             std::int64_t lda,
+                                             cl::sycl::buffer<cl::sycl::half, 1> &b,
+                                             std::int64_t ldb, float beta,
+                                             cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
     void (*column_major_chemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::side left_right,
                                     oneapi::mkl::uplo upper_lower, std::int64_t m, std::int64_t n,
                                     std::complex<float> alpha,
@@ -2088,9 +2090,11 @@ typedef struct {
                                  cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*row_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                  oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                 std::int64_t k, cl::sycl::half alpha, cl::sycl::buffer<cl::sycl::half, 1> &a,
-                                 std::int64_t lda, cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
-                                 cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c, std::int64_t ldc);
+                                 std::int64_t k, cl::sycl::half alpha,
+                                 cl::sycl::buffer<cl::sycl::half, 1> &a, std::int64_t lda,
+                                 cl::sycl::buffer<cl::sycl::half, 1> &b, std::int64_t ldb,
+                                 cl::sycl::half beta, cl::sycl::buffer<cl::sycl::half, 1> &c,
+                                 std::int64_t ldc);
     void (*row_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                           oneapi::mkl::transpose transb, std::int64_t m,
                                           std::int64_t n, std::int64_t k, float alpha,

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -33,6 +33,8 @@ namespace mkl {
 namespace rng {
 namespace mklcpu {
 
+using namespace cl;
+
 class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:
     mrg32k3a_impl(cl::sycl::queue queue, std::uint32_t seed)

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -33,6 +33,8 @@ namespace mkl {
 namespace rng {
 namespace mklcpu {
 
+using namespace cl;
+
 class philox4x32x10_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:
     philox4x32x10_impl(cl::sycl::queue queue, std::uint64_t seed)

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY_BATCH:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -186,7 +186,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -136,7 +136,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -181,7 +181,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -208,7 +208,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -263,7 +263,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -129,7 +129,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -173,7 +173,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -96,7 +96,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BIAS:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -142,7 +142,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BIAS:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -76,7 +76,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -224,11 +224,10 @@ template <typename fp>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fp *alpha, const fp *a, const int *lda,
                  const fp *b, const int *ldb, const fp *beta, fp *c, const int *ldc);
-
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
-          const int *n, const int *k, const half *alpha, const half *a, const int *lda,
-          const half *b, const int *ldb, const half *beta, half *c, const int *ldc) {
+          const int *n, const int *k, const cl::sycl::half *alpha, const cl::sycl::half *a, const int *lda,
+          const cl::sycl::half *b, const int *ldb, const cl::sycl::half *beta, cl::sycl::half *c, const int *ldc) {
     // Not supported in NETLIB. SGEMM is used as reference.
     int sizea, sizeb, sizec;
     const float alphaf = *alpha;
@@ -255,7 +254,6 @@ void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, c
     oneapi::mkl::aligned_free(bf);
     oneapi::mkl::aligned_free(cf);
 }
-
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const float *alpha, const float *a, const int *lda,
@@ -291,11 +289,10 @@ template <typename fpa, typename fpc>
 static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
                  const int *n, const int *k, const fpc *alpha, const fpa *a, const int *lda,
                  const fpa *b, const int *ldb, const fpc *beta, fpc *c, const int *ldc);
-
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
-          const int *n, const int *k, const float *alpha, const half *a, const int *lda,
-          const half *b, const int *ldb, const float *beta, float *c, const int *ldc) {
+          const int *n, const int *k, const float *alpha, const cl::sycl::half *a, const int *lda,
+          const cl::sycl::half *b, const int *ldb, const float *beta, float *c, const int *ldc) {
     // Not supported in NETLIB. SGEMM is used as reference.
     int sizea, sizeb;
     if (layout == CblasColMajor) {
@@ -314,7 +311,6 @@ void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, c
     oneapi::mkl::aligned_free(af);
     oneapi::mkl::aligned_free(bf);
 }
-
 template <typename fp>
 static void symm(CBLAS_LAYOUT layout, CBLAS_SIDE left_right, CBLAS_UPLO uplo, const int *m,
                  const int *n, const fp *alpha, const fp *a, const int *lda, const fp *b,

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -27,14 +27,17 @@
 #include <type_traits>
 
 #include <CL/sycl.hpp>
+#include "oneapi/mkl/detail/config.hpp"
 
 namespace std {
+//#ifdef ENABLE_HALF_ROUTINES
 static cl::sycl::half abs(cl::sycl::half v) {
     if (v < cl::sycl::half(0))
         return -v;
     else
         return v;
 }
+//#endif
 } // namespace std
 
 // Complex helpers.
@@ -140,12 +143,12 @@ template <>
 uint8_t rand_scalar() {
     return std::rand() % 128;
 }
-
+//#ifdef ENABLE_HALF_ROUTINES
 template <>
-half rand_scalar() {
-    return half(std::rand() % 32000) / half(32000) - half(0.5);
+cl::sycl::half rand_scalar() {
+    return cl::sycl::half(std::rand() % 32000) / cl::sycl::half(32000) - cl::sycl::half(0.5);
 }
-
+//#endif
 template <typename fp>
 static fp rand_scalar(int mag) {
     fp tmp = fp(mag) + fp(std::rand()) / fp(RAND_MAX) - fp(0.5);

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -103,7 +103,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -108,7 +108,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -67,7 +67,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -106,7 +106,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -107,7 +107,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -53,7 +53,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -73,7 +73,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -115,7 +115,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -68,7 +68,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -105,7 +105,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -66,7 +66,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -107,7 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -51,7 +51,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -67,7 +67,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -106,7 +106,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -76,7 +76,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -75,7 +75,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -122,7 +122,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -73,7 +73,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -70,7 +70,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -70,7 +70,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -72,7 +72,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -72,7 +72,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {
@@ -144,41 +144,39 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 
 class GemmTests
         : public ::testing::TestWithParam<std::tuple<cl::sycl::device*, oneapi::mkl::layout>> {};
-
 TEST_P(GemmTests, HalfHalfFloatPrecision) {
     float alpha(2.0);
     float beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }
 
 TEST_P(GemmTests, RealHalfPrecision) {
-    half alpha(2.0);
-    half beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, half>(
+    cl::sycl::half alpha(2.0);
+    cl::sycl::half beta(3.0);
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<cl::sycl::half, cl::sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }
-
 TEST_P(GemmTests, RealSinglePrecision) {
     float alpha(2.0);
     float beta(3.0);

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -78,7 +78,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -74,7 +74,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -78,7 +78,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -74,7 +74,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -73,7 +73,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/rng/include/engines_api_tests.hpp
+++ b/tests/unit_tests/rng/include/engines_api_tests.hpp
@@ -67,7 +67,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }
@@ -123,7 +123,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -79,15 +79,15 @@ public:
     // method to call any tests, switch between rt and ct
     template <typename... Args>
     int operator()(cl::sycl::device* dev, Args... args) {
-        auto exception_handler = [](sycl::exception_list exceptions) {
+        auto exception_handler = [](cl::sycl::exception_list exceptions) {
             for (std::exception_ptr const& e : exceptions) {
                 try {
                     std::rethrow_exception(e);
                 }
-                catch (sycl::exception const& e) {
+                catch (cl::sycl::exception const& e) {
                     std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                               << e.what() << std::endl
-                              << "OpenCL status: " << e.get_cl_code() << std::endl;
+                              << "OpenCL status: " << e.what() << std::endl;
                 }
             }
         };

--- a/tests/unit_tests/rng/include/skip_ahead_test.hpp
+++ b/tests/unit_tests/rng/include/skip_ahead_test.hpp
@@ -76,7 +76,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }
@@ -123,7 +123,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -44,6 +44,7 @@
 
 #define POISSON_ARGS 0.5
 
+using namespace cl;
 template <typename Distr, typename Engine>
 class statistics_test {
 public:
@@ -63,7 +64,7 @@ public:
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;
@@ -102,7 +103,7 @@ public:
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;


### PR DESCRIPTION
# Description
This replaces the `get_cl_code()` calls that are not part of the SYCL standard with the standardized `.what()` function calls. furthermore, it adds qualification for the half and other types where necessary. This PR as described in #99 necessary for adding support for using hipSYCL with oneMKL.


# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

