### PR TITLE
Add option to disable half precision BLAS functions

### DIFF
--- a/src/blas/backends/cublas/CMakeLists.txt
+++ b/src/blas/backends/cublas/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(${LIB_OBJ} OBJECT
 )
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/src/include
           ${PROJECT_SOURCE_DIR}/src
 )
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})

--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -151,6 +151,11 @@ inline void gemm_batch(Func func, cl::sycl::queue &queue, transpose transa, tran
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, k, lda, ldb, ldc, stride_a, stride_b, stride_c, batch_size);
     queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, T>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<cl::sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<cl::sycl::access::mode::read_write>(cgh);
@@ -502,6 +507,11 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, k, lda, ldb, ldc, stride_a, stride_b, stride_c, batch_size);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, T>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -550,6 +560,11 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
         overflow_check(m[i], n[i], k[i], lda[i], ldb[i], ldc[i], group_size[i]);
     }
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, T>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);

--- a/src/blas/backends/cublas/cublas_helper.hpp
+++ b/src/blas/backends/cublas/cublas_helper.hpp
@@ -28,7 +28,9 @@
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <complex>
+
 #include "oneapi/mkl/types.hpp"
+#include "runtime_support_helper.hpp"
 
 namespace oneapi {
 namespace mkl {

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -81,6 +81,11 @@ inline void gemm(Func func, DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C,
     using cuDataType_C = typename CudaEquivalentType<T_C>::Type;
     overflow_check(m, n, k, lda, ldb, ldc);
     queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, T_A, T_B, T_C>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<cl::sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<cl::sycl::access::mode::read_write>(cgh);

--- a/src/blas/backends/mklcpu/CMakeLists.txt
+++ b/src/blas/backends/mklcpu/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${LIB_OBJ} OBJECT
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src
+          ${PROJECT_SOURCE_DIR}/src/include
           ${CMAKE_BINARY_DIR}/bin
           ${MKL_INCLUDE}
 )

--- a/src/blas/backends/mklcpu/mklcpu_batch.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_batch.cxx
@@ -636,6 +636,11 @@ void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int6
                 cl::sycl::buffer<half, 1> &b, int64_t ldb, int64_t stride_b, half beta,
                 cl::sycl::buffer<half, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
     queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<cl::sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<cl::sycl::access::mode::read_write>(cgh);
@@ -1974,6 +1979,11 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t group_count, int64_t *groupsize,
                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -2249,6 +2259,11 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            half beta, half *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);

--- a/src/blas/backends/mklcpu/mklcpu_common.hpp
+++ b/src/blas/backends/mklcpu/mklcpu_common.hpp
@@ -31,6 +31,7 @@
 
 #include "oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp"
 #include "oneapi/mkl/types.hpp"
+#include "runtime_support_helper.hpp"
 
 namespace oneapi {
 namespace mkl {

--- a/src/blas/backends/mklcpu/mklcpu_level3.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cpp
@@ -19,6 +19,7 @@
 
 #include <CL/sycl.hpp>
 
+#include "oneapi/mkl/exceptions.hpp"
 #include "mklcpu_common.hpp"
 #include "oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp"
 

--- a/src/blas/backends/mklcpu/mklcpu_level3.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cxx
@@ -102,8 +102,10 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
           cl::sycl::buffer<half, 1> &b, int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
           int64_t ldc) {
     queue.submit([&](cl::sycl::handler &cgh) {
-        if(!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)){
-            throw oneapi::mkl::unimplemented("blas", "cl::sycl::half", "half is not supported by the device or the sycl compiler");
+        if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
         }
         CBLAS_TRANSPOSE transa_ = cblas_convert(transa);
         CBLAS_TRANSPOSE transb_ = cblas_convert(transb);
@@ -147,10 +149,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
           int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
           cl::sycl::buffer<half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
           int64_t ldc) {
-    auto a_fp16 = a.reinterpret<fp16, 1>(a.get_range());
-    auto b_fp16 = b.reinterpret<fp16, 1>(b.get_range());
-    if(!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)){
-        throw oneapi::mkl::unimplemented("blas", "cl::sycl::half", "half is not supported by the device or the sycl compiler");
+    if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
+        throw oneapi::mkl::unimplemented(
+            "blas", "cl::sycl::half", "half is not supported by the device or the sycl compiler");
     }
     queue.submit([&](cl::sycl::handler &cgh) {
         CBLAS_TRANSPOSE transa_ = cblas_convert(transa);
@@ -160,11 +161,11 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
         auto accessor_c = c.get_access<cl::sycl::access::mode::read_write>(cgh);
         host_task<class mkl_kernel_gemm_f16f16f32>(cgh, [=]() {
             int64_t sizea, sizeb;
-#ifdef COLUMN_MAJOR 
+#ifdef COLUMN_MAJOR
             sizea = (transa == transpose::N) ? lda * k : lda * m;
             sizeb = (transb == transpose::N) ? ldb * n : ldb * k;
 #endif
-#ifdef ROW_MAJOR 
+#ifdef ROW_MAJOR
             sizea = (transa == transpose::N) ? lda * m : lda * k;
             sizeb = (transb == transpose::N) ? ldb * k : ldb * n;
 #endif
@@ -784,6 +785,11 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      int64_t ldb, half beta, half *c, int64_t ldc,
                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -829,6 +835,11 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      int64_t ldb, float beta, float *c, int64_t ldc,
                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
+        if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
+            throw oneapi::mkl::unimplemented(
+                "blas", "cl::sycl::half",
+                "half is not supported by the device or the sycl compiler");
+        }
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);

--- a/src/blas/backends/mklcpu/mklcpu_level3.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cxx
@@ -102,6 +102,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
           cl::sycl::buffer<half, 1> &b, int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
           int64_t ldc) {
     queue.submit([&](cl::sycl::handler &cgh) {
+        if(!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)){
+            throw oneapi::mkl::unimplemented("blas", "cl::sycl::half", "half is not supported by the device or the sycl compiler");
+        }
         CBLAS_TRANSPOSE transa_ = cblas_convert(transa);
         CBLAS_TRANSPOSE transb_ = cblas_convert(transb);
         float f32_alpha = (float)alpha;
@@ -144,6 +147,11 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
           int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
           cl::sycl::buffer<half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
           int64_t ldc) {
+    auto a_fp16 = a.reinterpret<fp16, 1>(a.get_range());
+    auto b_fp16 = b.reinterpret<fp16, 1>(b.get_range());
+    if(!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)){
+        throw oneapi::mkl::unimplemented("blas", "cl::sycl::half", "half is not supported by the device or the sycl compiler");
+    }
     queue.submit([&](cl::sycl::handler &cgh) {
         CBLAS_TRANSPOSE transa_ = cblas_convert(transa);
         CBLAS_TRANSPOSE transb_ = cblas_convert(transb);

--- a/src/blas/backends/mklgpu/CMakeLists.txt
+++ b/src/blas/backends/mklgpu/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(${LIB_OBJ} OBJECT
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src
+          ${PROJECT_SOURCE_DIR}/src/include
           ${CMAKE_BINARY_DIR}/bin
           ${MKL_INCLUDE}
 )

--- a/src/blas/backends/netlib/CMakeLists.txt
+++ b/src/blas/backends/netlib/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(${LIB_OBJ} OBJECT
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src
+          ${PROJECT_SOURCE_DIR}/src/include
           ${CMAKE_BINARY_DIR}/bin
           ${NETLIB_INCLUDE}
 )

--- a/src/include/runtime_support_helper.hpp
+++ b/src/include/runtime_support_helper.hpp
@@ -24,7 +24,7 @@
 #include <type_traits>
 
 // Utility function to verify that a given set of types is supported by the
-// device compiler combintiation
+// device compiler combination
 template <typename verify_type, typename T, typename... Ts>
 bool verify_support(cl::sycl::queue q, cl::sycl::aspect aspect) {
     bool has_aspect = q.get_device().has(aspect);

--- a/src/include/runtime_support_helper.hpp
+++ b/src/include/runtime_support_helper.hpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _ONEMKL_RUNTIME_SUPPORT_HELPER_HPP_
+#define _ONEMKL_RUNTIME_SUPPORT_HELPER_HPP_
+
+#include <CL/sycl.hpp>
+#include <type_traits>
+
+// Utility function to verify that a given set of types is supported by the
+// device compiler combintiation
+template <typename verify_type, typename T, typename... Ts>
+bool verify_support(cl::sycl::queue q, cl::sycl::aspect aspect) {
+    bool has_aspect = q.get_device().has(aspect);
+    if constexpr (sizeof...(Ts) > 0) {
+        if constexpr (std::is_same_v<verify_type, T>) {
+            return has_aspect && verify_support<verify_type, Ts...>(q, aspect);
+        }
+        else {
+            return true && verify_support<verify_type, Ts...>(q, aspect);
+        }
+    }
+    else {
+        if constexpr (std::is_same_v<verify_type, T>) {
+            return has_aspect;
+        }
+        else {
+            return true;
+        }
+    }
+}
+
+#endif //_ONEMKL_RUNTIME_SUPPORT_HELPER_HPP_


### PR DESCRIPTION
# Description
This PR adds functionality to disable the cuBLAS and MKLcpu BLAS functions, which take half-precision arguments. related to #99

# Checklist


- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
