### PR TITLE
Replace get_cl_code() with what()

### DIFF
--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -131,7 +131,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -87,8 +87,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -130,8 +130,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
@@ -139,7 +139,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
@@ -54,8 +54,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
@@ -138,8 +138,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY_BATCH:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -186,7 +186,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY_BATCH:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -185,8 +185,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY_BATCH:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -127,7 +127,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during COPY_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -126,8 +126,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during COPY_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -86,8 +86,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
@@ -137,7 +137,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during COPY_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
@@ -136,8 +136,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during COPY_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/copy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY_BATCH:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/copy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_usm.cpp
@@ -181,8 +181,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during COPY_BATCH:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/copy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_usm.cpp
@@ -182,7 +182,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during COPY_BATCH:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -148,7 +148,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DGMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -102,8 +102,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DGMM_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -147,8 +147,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DGMM_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -54,8 +54,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DGMM_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -154,8 +154,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DGMM_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -155,7 +155,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DGMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -220,7 +220,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DGMM_BATCH:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -219,8 +219,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DGMM_BATCH:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DGMM_BATCH:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -136,7 +136,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -181,7 +181,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -135,8 +135,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -180,8 +180,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -208,7 +208,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -207,8 +207,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -263,7 +263,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -262,8 +262,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BATCH:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -163,7 +163,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -117,8 +117,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -162,8 +162,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
@@ -167,8 +167,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
@@ -168,7 +168,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV_BATCH:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
@@ -238,8 +238,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV_BATCH:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
@@ -239,7 +239,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV_BATCH:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -168,7 +168,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYRK_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -167,8 +167,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYRK_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -123,8 +123,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -82,9 +82,9 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     beta = rand_scalar<fp>();
     upper_lower = (oneapi::mkl::uplo)(std::rand() % 2);
     if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-        trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
-                                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                                                : oneapi::mkl::transpose::conjtrans;
+        trans = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
+                : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                         : oneapi::mkl::transpose::conjtrans;
     }
     else {
         trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
@@ -190,7 +190,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYRK_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -189,8 +189,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYRK_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -102,10 +102,9 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
         beta[i] = rand_scalar<fp>();
         upper_lower[i] = (oneapi::mkl::uplo)(std::rand() % 2);
         if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-            trans[i] = (std::rand() % 2) == 0
-                           ? oneapi::mkl::transpose::nontrans
-                           : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                                    : oneapi::mkl::transpose::conjtrans;
+            trans[i] = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
+                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                                : oneapi::mkl::transpose::conjtrans;
         }
         else {
             trans[i] = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
@@ -239,7 +238,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYRK_BATCH:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK_BATCH:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -238,8 +238,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYRK_BATCH:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -129,7 +129,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -173,7 +173,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -128,8 +128,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -172,8 +172,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
@@ -177,7 +177,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
@@ -176,8 +176,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM_BATCH_STRIDE:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
@@ -250,8 +250,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM_BATCH:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
@@ -251,7 +251,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during TRSM_BATCH:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -96,7 +96,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BIAS:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -142,7 +142,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BIAS:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -95,8 +95,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BIAS:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -141,8 +141,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BIAS:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
@@ -146,8 +146,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BIAS:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
@@ -147,7 +147,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM_BIAS:\n"
                   << e.what() << std::endl;
-                  print_error_code(e);
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
@@ -55,8 +55,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM_BIAS:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -76,7 +76,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -75,8 +75,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -120,8 +120,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -119,8 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GEMMT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -121,8 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GEMMT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMMT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -122,8 +122,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMMT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -103,7 +103,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -101,8 +101,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during ASUM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ASUM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -64,8 +64,8 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -102,8 +102,8 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -110,8 +110,8 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ASUM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -109,8 +109,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during ASUM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ASUM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -107,8 +107,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPBY:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -67,8 +67,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPBY:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -106,9 +106,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during AXPBY:\n"
-                  << e.what() << std::endl;
-                  print_error_code(e);
+        std::cout << "Caught synchronous SYCL exception during AXPBY:\n" << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpby_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpby_usm.cpp
@@ -110,9 +110,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during AXPBY:\n"
-                  << e.what() << std::endl;
-                  print_error_code(e);
+        std::cout << "Caught synchronous SYCL exception during AXPBY:\n" << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpby_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpby_usm.cpp
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPBY:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << e.what() << std::endl;
+                  print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpby_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpby_usm.cpp
@@ -51,8 +51,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPBY:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -108,7 +108,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -106,8 +106,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during AXPY:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during AXPY:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -67,8 +67,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -107,8 +107,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -51,8 +51,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during AXPY:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during AXPY:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during AXPY:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during AXPY:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -67,7 +67,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -106,7 +106,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -66,8 +66,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -105,8 +105,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -104,8 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during COPY:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during COPY:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during COPY:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -110,8 +110,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during COPY:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -109,8 +109,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during COPY:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during COPY:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -107,7 +107,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -65,8 +65,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -106,8 +106,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -105,8 +105,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during DOT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during DOT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -109,8 +109,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during DOT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during DOT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during DOT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -110,8 +110,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during DOT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -67,8 +67,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -108,8 +108,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -107,8 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during DOTC:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during DOTC:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during DOTC:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during DOTC:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -51,8 +51,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTC:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTC:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -68,7 +68,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -67,8 +67,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -108,8 +108,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -107,8 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during DOTU:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during DOTU:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during DOTU:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during DOTU:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -51,8 +51,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during DOTU:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during DOTU:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -64,8 +64,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -103,8 +103,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -102,8 +102,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during IAMAX:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMAX:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -108,8 +108,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during IAMAX:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during IAMAX:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -65,7 +65,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -102,8 +102,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during IAMIN:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -64,8 +64,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -103,8 +103,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -108,8 +108,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during IAMIN:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during IAMIN:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during IAMIN:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -66,7 +66,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -104,7 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -102,8 +102,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during NRM2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during NRM2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -65,8 +65,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -103,8 +103,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -109,8 +109,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during NRM2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during NRM2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during NRM2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -110,8 +110,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during NRM2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -107,8 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during ROT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -68,8 +68,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -108,8 +108,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -53,7 +53,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during ROT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -52,8 +52,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -73,7 +73,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -115,7 +115,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -72,8 +72,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -114,8 +114,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -113,8 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during ROTG:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROTG:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -122,8 +122,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during ROTG:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROTG:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -51,8 +51,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTG:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -123,8 +123,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTG:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during ROTM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROTM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -70,8 +70,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -51,8 +51,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -113,8 +113,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -112,8 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during ROTM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROTM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -71,7 +71,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -110,8 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROTMG:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -70,8 +70,8 @@ int test(device* dev, oneapi::mkl::layout layout) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device* dev, oneapi::mkl::layout layout) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -52,7 +52,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -118,8 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during ROTMG:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -51,8 +51,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during ROTMG:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -119,8 +119,8 @@ int test(device *dev, oneapi::mkl::layout layout) {
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during ROTMG:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -68,7 +68,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -105,7 +105,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -67,8 +67,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -104,8 +104,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -103,8 +103,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SCAL:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SCAL:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -110,8 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SCAL:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SCAL:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SCAL:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SCAL:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -66,7 +66,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -107,7 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -105,8 +105,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SDSDOT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -65,8 +65,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -106,8 +106,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -51,7 +51,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -109,8 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SDSDOT:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -50,8 +50,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SDSDOT:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -110,8 +110,8 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SDSDOT:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -67,7 +67,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -106,7 +106,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -104,8 +104,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SWAP:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SWAP:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -66,8 +66,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -105,8 +105,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -52,7 +52,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -111,7 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -51,8 +51,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SWAP:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -110,8 +110,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SWAP:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -109,8 +109,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SWAP:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SWAP:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -76,7 +76,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -118,8 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -75,8 +75,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -119,8 +119,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -122,8 +122,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -121,8 +121,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -75,7 +75,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -74,8 +74,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -115,8 +115,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -114,8 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GEMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GEMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -122,7 +122,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -121,8 +121,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GEMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -120,8 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GEMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GEMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GER:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GER:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -71,8 +71,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -115,8 +115,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GER:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GER:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GER:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -116,8 +116,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GER:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -71,8 +71,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GERC:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GERC:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERC:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -116,8 +116,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERC:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -115,8 +115,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GERC:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GERC:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GERU:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GERU:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -71,8 +71,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -117,7 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -115,8 +115,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during GERU:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GERU:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during GERU:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -116,8 +116,8 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during GERU:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -73,7 +73,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -114,8 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -72,8 +72,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -115,8 +115,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -119,8 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -120,8 +120,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -71,8 +71,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HEMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HEMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -119,8 +119,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HEMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -118,8 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HEMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HEMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -70,7 +70,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -69,8 +69,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -108,8 +108,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HER:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HER:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HER2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HER2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -71,8 +71,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -119,8 +119,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -118,8 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HER2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HER2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -112,8 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HER:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HER:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HER:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -113,8 +113,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HER:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -70,8 +70,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HPMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HPMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -117,8 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HPMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HPMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -118,8 +118,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -70,7 +70,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -69,8 +69,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -108,8 +108,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HPR:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HPR:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HPR2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HPR2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -70,8 +70,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -116,8 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HPR2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HPR2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -117,8 +117,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -112,8 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during HPR:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HPR:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during HPR:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -113,8 +113,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during HPR:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -72,7 +72,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -71,8 +71,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -113,8 +113,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -112,8 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -119,8 +119,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -118,8 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SPMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SPMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -70,8 +70,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -118,8 +118,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -117,8 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SPMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SPMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -68,8 +68,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -108,8 +108,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -107,8 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SPR:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SPR:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -70,8 +70,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SPR2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SPR2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -116,8 +116,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SPR2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SPR2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -117,8 +117,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SPR:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SPR:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SPR:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SPR:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SYMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -70,8 +70,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -117,8 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SYMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -118,8 +118,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -69,7 +69,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -109,7 +109,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -107,8 +107,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SYR:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYR:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -68,8 +68,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -108,8 +108,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -71,7 +71,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -70,8 +70,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -110,8 +110,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SYR2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYR2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -118,8 +118,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR2:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -117,8 +117,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SYR2:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYR2:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -54,7 +54,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -111,8 +111,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const &e) {
-        std::cout << "Caught synchronous SYCL exception during SYR:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYR:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -53,8 +53,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const &e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const &e) {
         std::cout << "Caught synchronous SYCL exception during SYR:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented &e) {

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -72,7 +72,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -110,8 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -71,8 +71,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -119,8 +119,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -118,8 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -72,7 +72,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -112,7 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -71,8 +71,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -111,8 +111,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -110,8 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TBSV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TBSV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -118,8 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TBSV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TBSV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBSV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -119,8 +119,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBSV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -108,8 +108,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -69,8 +69,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TBMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -53,8 +53,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -115,8 +115,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -114,8 +114,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TBMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TBMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -69,8 +69,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -108,8 +108,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TPSV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TPSV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -116,7 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -53,8 +53,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TPSV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -115,8 +115,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TPSV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -114,8 +114,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TPSV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TPSV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -69,8 +69,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -108,8 +108,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -116,8 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRMV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRMV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -53,8 +53,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -117,8 +117,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -70,7 +70,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -110,7 +110,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -108,8 +108,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRSV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRSV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -69,8 +69,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -109,8 +109,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -118,7 +118,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -116,8 +116,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRSV:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRSV:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -53,8 +53,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSV:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -117,8 +117,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSV:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -122,8 +122,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during GEMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GEMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -78,8 +78,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -123,8 +123,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -124,8 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during GEMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during GEMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during GEMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -125,8 +125,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during GEMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -78,7 +78,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -77,8 +77,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -122,8 +122,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -121,8 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during HEMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HEMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -122,8 +122,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during HEMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HEMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HEMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -123,8 +123,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HEMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -78,8 +78,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -123,8 +123,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -122,8 +122,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during HER2K:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HER2K:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HER2K:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -125,8 +125,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HER2K:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -124,8 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during HER2K:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HER2K:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -74,7 +74,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -114,7 +114,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -112,8 +112,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during HERK:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HERK:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -73,8 +73,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -113,8 +113,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -119,8 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during HERK:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during HERK:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during HERK:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -120,8 +120,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during HERK:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -78,7 +78,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -121,8 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SYMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -77,8 +77,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -122,8 +122,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -124,7 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -123,8 +123,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -122,8 +122,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SYMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -74,7 +74,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -73,8 +73,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -118,8 +118,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -117,8 +117,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYR2K:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -121,7 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -119,8 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYR2K:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -53,8 +53,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYR2K:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -120,8 +120,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYR2K:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -73,7 +73,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -113,7 +113,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -111,8 +111,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SYRK:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYRK:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -72,8 +72,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -112,8 +112,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -54,7 +54,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -119,7 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -117,8 +117,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during SYRK:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during SYRK:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -53,8 +53,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during SYRK:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -118,8 +118,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during SYRK:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -121,8 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -78,8 +78,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -122,8 +122,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -124,8 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRMM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRMM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRMM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -125,8 +125,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRMM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -79,7 +79,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -121,8 +121,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRSM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRSM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -78,8 +78,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -122,8 +122,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -55,7 +55,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
                           << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << "OpenCL status: " << e.what() << std::endl;
             }
         }
     };
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
                   << e.what() << std::endl
-                  << "OpenCL status: " << e.get_cl_code() << std::endl;
+                  << "OpenCL status: " << e.what() << std::endl;
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -124,8 +124,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #endif
     }
     catch (exception const& e) {
-        std::cout << "Caught synchronous SYCL exception during TRSM:\n"
-                  << e.what() << std::endl;
+        std::cout << "Caught synchronous SYCL exception during TRSM:\n" << e.what() << std::endl;
         print_error_code(e);
     }
 

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -54,8 +54,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
             }
             catch (exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception during TRSM:\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.what() << std::endl;
+                          << e.what() << std::endl;
+                print_error_code(e);
             }
         }
     };
@@ -125,8 +125,8 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
     catch (exception const& e) {
         std::cout << "Caught synchronous SYCL exception during TRSM:\n"
-                  << e.what() << std::endl
-                  << "OpenCL status: " << e.what() << std::endl;
+                  << e.what() << std::endl;
+        print_error_code(e);
     }
 
     catch (const oneapi::mkl::unimplemented& e) {

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <tuple>
 #include <gtest/gtest.h>
+#include <CL/sycl.hpp>
 
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"
@@ -95,6 +96,8 @@
             }                                                                  \
         }                                                                      \
     } while (0);
+
+void print_error_code(cl::sycl::exception const& e);
 
 class DeviceNamePrint {
 public:

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -97,7 +97,7 @@
         }                                                                      \
     } while (0);
 
-void print_error_code(cl::sycl::exception const& e);
+void print_error_code(cl::sycl::exception const &e);
 
 class DeviceNamePrint {
 public:

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -77,7 +77,7 @@ private:
 
 } // anonymous namespace
 
-void print_error_code(cl::sycl::exception const& e){
+void print_error_code(cl::sycl::exception const& e) {
 #ifdef __HIPSYCL__
     std::cout << "Backend status: " << e.code() << std::endl;
 #else

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 #include <CL/sycl.hpp>
 #include <string>
+#include "test_helper.hpp"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"
 
@@ -75,6 +76,14 @@ private:
 }; // class TersePrinter
 
 } // anonymous namespace
+
+void print_error_code(cl::sycl::exception const& e){
+#ifdef __HIPSYCL__
+    std::cout << "Backend status: " << e.code() << std::endl;
+#else
+    std::cout << "OpenCL status: " << e.get_cl_code() << std::endl;
+#endif
+}
 
 int main(int argc, char** argv) {
     std::set<std::string> unique_devices;

--- a/tests/unit_tests/rng/include/engines_api_tests.hpp
+++ b/tests/unit_tests/rng/include/engines_api_tests.hpp
@@ -67,7 +67,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }
@@ -123,7 +123,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/engines_api_tests.hpp
+++ b/tests/unit_tests/rng/include/engines_api_tests.hpp
@@ -65,8 +65,7 @@ public:
             return;
         }
         catch (cl::sycl::exception const& e) {
-            std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl;
+            std::cout << "SYCL exception during generation" << std::endl << e.what() << std::endl;
             print_error_code(e);
             status = test_failed;
             return;
@@ -121,8 +120,7 @@ public:
             return;
         }
         catch (cl::sycl::exception const& e) {
-            std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl;
+            std::cout << "SYCL exception during generation" << std::endl << e.what() << std::endl;
             print_error_code(e);
             status = test_failed;
             return;

--- a/tests/unit_tests/rng/include/engines_api_tests.hpp
+++ b/tests/unit_tests/rng/include/engines_api_tests.hpp
@@ -66,8 +66,8 @@ public:
         }
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.what() << std::endl;
+                      << e.what() << std::endl;
+            print_error_code(e);
             status = test_failed;
             return;
         }
@@ -122,8 +122,8 @@ public:
         }
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.what() << std::endl;
+                      << e.what() << std::endl;
+            print_error_code(e);
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -87,7 +87,7 @@ public:
                 catch (sycl::exception const& e) {
                     std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
                               << e.what() << std::endl
-                              << "OpenCL status: " << e.get_cl_code() << std::endl;
+                              << "OpenCL status: " << e.what() << std::endl;
                 }
             }
         };

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -86,8 +86,8 @@ public:
                 }
                 catch (sycl::exception const& e) {
                     std::cout << "Caught asynchronous SYCL exception during ASUM:\n"
-                              << e.what() << std::endl
-                              << "OpenCL status: " << e.what() << std::endl;
+                              << e.what() << std::endl;
+                    print_error_code(e);
                 }
             }
         };

--- a/tests/unit_tests/rng/include/skip_ahead_test.hpp
+++ b/tests/unit_tests/rng/include/skip_ahead_test.hpp
@@ -76,7 +76,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }
@@ -123,7 +123,7 @@ public:
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/skip_ahead_test.hpp
+++ b/tests/unit_tests/rng/include/skip_ahead_test.hpp
@@ -74,8 +74,7 @@ public:
             return;
         }
         catch (cl::sycl::exception const& e) {
-            std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl;
+            std::cout << "SYCL exception during generation" << std::endl << e.what() << std::endl;
             print_error_code(e);
             status = test_failed;
             return;
@@ -121,8 +120,7 @@ public:
             return;
         }
         catch (cl::sycl::exception const& e) {
-            std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl;
+            std::cout << "SYCL exception during generation" << std::endl << e.what() << std::endl;
             print_error_code(e);
             status = test_failed;
             return;

--- a/tests/unit_tests/rng/include/skip_ahead_test.hpp
+++ b/tests/unit_tests/rng/include/skip_ahead_test.hpp
@@ -75,8 +75,8 @@ public:
         }
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.what() << std::endl;
+                      << e.what() << std::endl;
+            print_error_code(e);
             status = test_failed;
             return;
         }
@@ -122,8 +122,8 @@ public:
         }
         catch (cl::sycl::exception const& e) {
             std::cout << "SYCL exception during generation" << std::endl
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.what() << std::endl;
+                      << e.what() << std::endl;
+            print_error_code(e);
             status = test_failed;
             return;
         }

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -63,7 +63,7 @@ public:
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;
@@ -102,7 +102,7 @@ public:
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
                       << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << "OpenCL status: " << e.what() << std::endl;
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -62,8 +62,8 @@ public:
         }
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.what() << std::endl;
+                      << e.what() << std::endl;
+            print_error_code(e);
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;
@@ -101,8 +101,8 @@ public:
         }
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.what() << std::endl;
+                      << e.what() << std::endl;
+            print_error_code(e);
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;


### PR DESCRIPTION
# Description
`get_cl_code()` is not part of the SYCL standard, therefore this PR replaces it with `what()`

related to #99 

# Checklist

- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?


