### PR TITLE
[cmake] temporary disable sycl 2020 deprecations warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ if(WIN32)
   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fsycl /nologo <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 endif()
 
+# Temporary disable sycl 2020 deprecations warnings
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSYCL2020_DISABLE_DEPRECATION_WARNINGS")
+
 ## Backends
 option(ENABLE_MKLCPU_BACKEND "" ON)
 option(ENABLE_MKLGPU_BACKEND "" ON)


### PR DESCRIPTION
# Description
Temporary disable deprecations warnings for sycl 2020 which happens in build with llvm compiler, as functionality is not yet available in dpcpp compiler, so can't switch to the new version. Example: get_count for sycl::buffer

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
