### PR TITLE
Several minor fixes to copyrights, comments, code formatting

### DIFF
--- a/include/oneapi/mkl/lapack/detail/lapack_loader.hpp
+++ b/include/oneapi/mkl/lapack/detail/lapack_loader.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/lapack/backends/mklcpu/CMakeLists.txt
+++ b/src/lapack/backends/mklcpu/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2020 Intel Corporation
+# Copyright 2020-2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/lapack/backends/mklcpu/CMakeLists.txt
+++ b/src/lapack/backends/mklcpu/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties(${LIB_OBJ} PROPERTIES
 )
 target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ})
 
-#Set MKL libraries as not transitive for dynamic
+#Set oneMKL libraries as not transitive for dynamic
 if(BUILD_SHARED_LIBS)
   set_target_properties(${LIB_NAME} PROPERTIES
     INTERFACE_LINK_LIBRARIES ONEMKL::SYCL::SYCL

--- a/src/lapack/backends/mklcpu/mkl_lapack.cpp
+++ b/src/lapack/backends/mklcpu/mkl_lapack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/lapack/backends/mklgpu/CMakeLists.txt
+++ b/src/lapack/backends/mklgpu/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2020 Intel Corporation
+# Copyright 2020-2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/lapack/backends/mklgpu/CMakeLists.txt
+++ b/src/lapack/backends/mklgpu/CMakeLists.txt
@@ -44,7 +44,7 @@ set_target_properties(${LIB_OBJ} PROPERTIES
 )
 target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ})
 
-#Set libraries as not transitive for dynamic
+#Set oneMKL libraries as not transitive for dynamic
 if(BUILD_SHARED_LIBS)
   set_target_properties(${LIB_NAME} PROPERTIES
     INTERFACE_LINK_LIBRARIES ONEMKL::SYCL::SYCL

--- a/src/lapack/backends/mklgpu/mkl_lapack.cpp
+++ b/src/lapack/backends/mklgpu/mkl_lapack.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2020-2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/lapack/lapack_loader.cpp
+++ b/src/lapack/lapack_loader.cpp
@@ -1997,656 +1997,608 @@ sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
 }
 
 template <>
-std::int64_t gebrd_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, std::int64_t m,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t gebrd_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].sgebrd_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t gebrd_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, std::int64_t m,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t gebrd_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].dgebrd_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t gebrd_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      std::int64_t m,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, std::int64_t m,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].cgebrd_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t gebrd_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       std::int64_t m,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, std::int64_t m,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zgebrd_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t gerqf_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, std::int64_t m,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t gerqf_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].sgerqf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t gerqf_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, std::int64_t m,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t gerqf_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].dgerqf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t gerqf_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      std::int64_t m,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, std::int64_t m,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].cgerqf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t gerqf_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       std::int64_t m,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, std::int64_t m,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zgerqf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t geqrf_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, std::int64_t m,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t geqrf_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].sgeqrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t geqrf_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, std::int64_t m,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t geqrf_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].dgeqrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t geqrf_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      std::int64_t m,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, std::int64_t m,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].cgeqrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t geqrf_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       std::int64_t m,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, std::int64_t m,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zgeqrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t gesvd_scratchpad_size<float>(oneapi::mkl::device libkey,
+std::int64_t gesvd_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
+                                          std::int64_t m, std::int64_t n, std::int64_t lda,
+                                          std::int64_t ldu, std::int64_t ldvt) {
+    return function_tables[libkey].sgesvd_scratchpad_size_sycl(queue, jobu, jobvt, m, n, lda, ldu,
+                                                               ldvt);
+}
+template <>
+std::int64_t gesvd_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
+                                           std::int64_t m, std::int64_t n, std::int64_t lda,
+                                           std::int64_t ldu, std::int64_t ldvt) {
+    return function_tables[libkey].dgesvd_scratchpad_size_sycl(queue, jobu, jobvt, m, n, lda, ldu,
+                                                               ldvt);
+}
+template <>
+std::int64_t gesvd_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
                                                         sycl::queue &queue,
                                                         oneapi::mkl::jobsvd jobu,
                                                         oneapi::mkl::jobsvd jobvt, std::int64_t m,
                                                         std::int64_t n, std::int64_t lda,
                                                         std::int64_t ldu, std::int64_t ldvt) {
-    return function_tables[libkey].sgesvd_scratchpad_size_sycl(queue, jobu, jobvt, m, n, lda, ldu,
+    return function_tables[libkey].cgesvd_scratchpad_size_sycl(queue, jobu, jobvt, m, n, lda, ldu,
                                                                ldvt);
 }
 template <>
-std::int64_t gesvd_scratchpad_size<double>(oneapi::mkl::device libkey,
+std::int64_t gesvd_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
                                                          sycl::queue &queue,
                                                          oneapi::mkl::jobsvd jobu,
                                                          oneapi::mkl::jobsvd jobvt, std::int64_t m,
                                                          std::int64_t n, std::int64_t lda,
                                                          std::int64_t ldu, std::int64_t ldvt) {
-    return function_tables[libkey].dgesvd_scratchpad_size_sycl(queue, jobu, jobvt, m, n, lda, ldu,
-                                                               ldvt);
-}
-template <>
-std::int64_t gesvd_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::jobsvd jobu,
-    oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldu,
-    std::int64_t ldvt) {
-    return function_tables[libkey].cgesvd_scratchpad_size_sycl(queue, jobu, jobvt, m, n, lda, ldu,
-                                                               ldvt);
-}
-template <>
-std::int64_t gesvd_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::jobsvd jobu,
-    oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n, std::int64_t lda, std::int64_t ldu,
-    std::int64_t ldvt) {
     return function_tables[libkey].zgesvd_scratchpad_size_sycl(queue, jobu, jobvt, m, n, lda, ldu,
                                                                ldvt);
 }
 template <>
-std::int64_t getrf_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, std::int64_t m,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t getrf_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].sgetrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t getrf_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, std::int64_t m,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t getrf_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           std::int64_t m, std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].dgetrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t getrf_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      std::int64_t m,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, std::int64_t m,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].cgetrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
 std::int64_t getrf_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       std::int64_t m,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, std::int64_t m,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zgetrf_scratchpad_size_sycl(queue, m, n, lda);
 }
 template <>
-std::int64_t getri_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, std::int64_t n,
-                                                        std::int64_t lda) {
+std::int64_t getri_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].sgetri_scratchpad_size_sycl(queue, n, lda);
 }
 template <>
-std::int64_t getri_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, std::int64_t n,
-                                                         std::int64_t lda) {
+std::int64_t getri_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].dgetri_scratchpad_size_sycl(queue, n, lda);
 }
 template <>
 std::int64_t getri_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, std::int64_t n,
+                                                        std::int64_t lda) {
     return function_tables[libkey].cgetri_scratchpad_size_sycl(queue, n, lda);
 }
 template <>
 std::int64_t getri_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, std::int64_t n,
+                                                         std::int64_t lda) {
     return function_tables[libkey].zgetri_scratchpad_size_sycl(queue, n, lda);
 }
 template <>
-std::int64_t getrs_scratchpad_size<float>(oneapi::mkl::device libkey,
+std::int64_t getrs_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::transpose trans, std::int64_t n,
+                                          std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
+    return function_tables[libkey].sgetrs_scratchpad_size_sycl(queue, trans, n, nrhs, lda, ldb);
+}
+template <>
+std::int64_t getrs_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::transpose trans, std::int64_t n,
+                                           std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
+    return function_tables[libkey].dgetrs_scratchpad_size_sycl(queue, trans, n, nrhs, lda, ldb);
+}
+template <>
+std::int64_t getrs_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
                                                         sycl::queue &queue,
                                                         oneapi::mkl::transpose trans,
                                                         std::int64_t n, std::int64_t nrhs,
                                                         std::int64_t lda, std::int64_t ldb) {
-    return function_tables[libkey].sgetrs_scratchpad_size_sycl(queue, trans, n, nrhs, lda, ldb);
+    return function_tables[libkey].cgetrs_scratchpad_size_sycl(queue, trans, n, nrhs, lda, ldb);
 }
 template <>
-std::int64_t getrs_scratchpad_size<double>(oneapi::mkl::device libkey,
+std::int64_t getrs_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
                                                          sycl::queue &queue,
                                                          oneapi::mkl::transpose trans,
                                                          std::int64_t n, std::int64_t nrhs,
                                                          std::int64_t lda, std::int64_t ldb) {
-    return function_tables[libkey].dgetrs_scratchpad_size_sycl(queue, trans, n, nrhs, lda, ldb);
-}
-template <>
-std::int64_t getrs_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
-    return function_tables[libkey].cgetrs_scratchpad_size_sycl(queue, trans, n, nrhs, lda, ldb);
-}
-template <>
-std::int64_t getrs_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].zgetrs_scratchpad_size_sycl(queue, trans, n, nrhs, lda, ldb);
 }
 template <>
-std::int64_t heevd_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
-    std::int64_t n, std::int64_t lda) {
+std::int64_t heevd_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue, oneapi::mkl::job jobz,
+                                                        oneapi::mkl::uplo uplo, std::int64_t n,
+                                                        std::int64_t lda) {
     return function_tables[libkey].cheevd_scratchpad_size_sycl(queue, jobz, uplo, n, lda);
 }
 template <>
-std::int64_t heevd_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
-    std::int64_t n, std::int64_t lda) {
+std::int64_t heevd_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue, oneapi::mkl::job jobz,
+                                                         oneapi::mkl::uplo uplo, std::int64_t n,
+                                                         std::int64_t lda) {
     return function_tables[libkey].zheevd_scratchpad_size_sycl(queue, jobz, uplo, n, lda);
 }
 template <>
-std::int64_t hegvd_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
-    oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t lda, std::int64_t ldb) {
+std::int64_t hegvd_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue, std::int64_t itype,
+                                                        oneapi::mkl::job jobz,
+                                                        oneapi::mkl::uplo uplo, std::int64_t n,
+                                                        std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].chegvd_scratchpad_size_sycl(queue, itype, jobz, uplo, n, lda,
                                                                ldb);
 }
 template <>
-std::int64_t hegvd_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
-    oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t lda, std::int64_t ldb) {
+std::int64_t hegvd_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue, std::int64_t itype,
+                                                         oneapi::mkl::job jobz,
+                                                         oneapi::mkl::uplo uplo, std::int64_t n,
+                                                         std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].zhegvd_scratchpad_size_sycl(queue, itype, jobz, uplo, n, lda,
                                                                ldb);
 }
 template <>
 std::int64_t hetrd_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      oneapi::mkl::uplo uplo,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].chetrd_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t hetrd_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       oneapi::mkl::uplo uplo,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zhetrd_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t hetrf_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      oneapi::mkl::uplo uplo,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].chetrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t hetrf_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       oneapi::mkl::uplo uplo,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zhetrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t orgbr_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue,
-                                                        oneapi::mkl::generate vect, std::int64_t m,
-                                                        std::int64_t n, std::int64_t k,
-                                                        std::int64_t lda) {
+std::int64_t orgbr_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::generate vect, std::int64_t m,
+                                          std::int64_t n, std::int64_t k, std::int64_t lda) {
     return function_tables[libkey].sorgbr_scratchpad_size_sycl(queue, vect, m, n, k, lda);
 }
 template <>
-std::int64_t orgbr_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue,
-                                                         oneapi::mkl::generate vect, std::int64_t m,
-                                                         std::int64_t n, std::int64_t k,
-                                                         std::int64_t lda) {
+std::int64_t orgbr_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::generate vect, std::int64_t m,
+                                           std::int64_t n, std::int64_t k, std::int64_t lda) {
     return function_tables[libkey].dorgbr_scratchpad_size_sycl(queue, vect, m, n, k, lda);
 }
 template <>
-std::int64_t orgtr_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t orgtr_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::uplo uplo, std::int64_t n,
+                                          std::int64_t lda) {
     return function_tables[libkey].sorgtr_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t orgtr_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t orgtr_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::uplo uplo, std::int64_t n,
+                                           std::int64_t lda) {
     return function_tables[libkey].dorgtr_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t orgqr_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, std::int64_t m,
-                                                        std::int64_t n, std::int64_t k,
-                                                        std::int64_t lda) {
+std::int64_t orgqr_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          std::int64_t m, std::int64_t n, std::int64_t k,
+                                          std::int64_t lda) {
     return function_tables[libkey].sorgqr_scratchpad_size_sycl(queue, m, n, k, lda);
 }
 template <>
-std::int64_t orgqr_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, std::int64_t m,
-                                                         std::int64_t n, std::int64_t k,
-                                                         std::int64_t lda) {
+std::int64_t orgqr_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           std::int64_t m, std::int64_t n, std::int64_t k,
+                                           std::int64_t lda) {
     return function_tables[libkey].dorgqr_scratchpad_size_sycl(queue, m, n, k, lda);
 }
 template <>
-std::int64_t ormrq_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::side side,
-                                                        oneapi::mkl::transpose trans,
-                                                        std::int64_t m, std::int64_t n,
-                                                        std::int64_t k, std::int64_t lda,
-                                                        std::int64_t ldc) {
+std::int64_t ormrq_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::side side, oneapi::mkl::transpose trans,
+                                          std::int64_t m, std::int64_t n, std::int64_t k,
+                                          std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].sormrq_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t ormrq_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::side side,
-                                                         oneapi::mkl::transpose trans,
-                                                         std::int64_t m, std::int64_t n,
-                                                         std::int64_t k, std::int64_t lda,
-                                                         std::int64_t ldc) {
+std::int64_t ormrq_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::side side, oneapi::mkl::transpose trans,
+                                           std::int64_t m, std::int64_t n, std::int64_t k,
+                                           std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].dormrq_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t ormqr_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::side side,
-                                                        oneapi::mkl::transpose trans,
-                                                        std::int64_t m, std::int64_t n,
-                                                        std::int64_t k, std::int64_t lda,
-                                                        std::int64_t ldc) {
+std::int64_t ormqr_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::side side, oneapi::mkl::transpose trans,
+                                          std::int64_t m, std::int64_t n, std::int64_t k,
+                                          std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].sormqr_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t ormqr_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::side side,
-                                                         oneapi::mkl::transpose trans,
-                                                         std::int64_t m, std::int64_t n,
-                                                         std::int64_t k, std::int64_t lda,
-                                                         std::int64_t ldc) {
+std::int64_t ormqr_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::side side, oneapi::mkl::transpose trans,
+                                           std::int64_t m, std::int64_t n, std::int64_t k,
+                                           std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].dormqr_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t ormtr_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::side side,
-                                                        oneapi::mkl::uplo uplo,
-                                                        oneapi::mkl::transpose trans,
-                                                        std::int64_t m, std::int64_t n,
-                                                        std::int64_t lda, std::int64_t ldc) {
+std::int64_t ormtr_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::side side, oneapi::mkl::uplo uplo,
+                                          oneapi::mkl::transpose trans, std::int64_t m,
+                                          std::int64_t n, std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].sormtr_scratchpad_size_sycl(queue, side, uplo, trans, m, n, lda,
                                                                ldc);
 }
 template <>
-std::int64_t ormtr_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::side side,
-                                                         oneapi::mkl::uplo uplo,
-                                                         oneapi::mkl::transpose trans,
-                                                         std::int64_t m, std::int64_t n,
-                                                         std::int64_t lda, std::int64_t ldc) {
+std::int64_t ormtr_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::side side, oneapi::mkl::uplo uplo,
+                                           oneapi::mkl::transpose trans, std::int64_t m,
+                                           std::int64_t n, std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].dormtr_scratchpad_size_sycl(queue, side, uplo, trans, m, n, lda,
                                                                ldc);
 }
 template <>
-std::int64_t potrf_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t potrf_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::uplo uplo, std::int64_t n,
+                                          std::int64_t lda) {
     return function_tables[libkey].spotrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t potrf_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t potrf_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::uplo uplo, std::int64_t n,
+                                           std::int64_t lda) {
     return function_tables[libkey].dpotrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t potrf_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      oneapi::mkl::uplo uplo,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].cpotrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t potrf_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       oneapi::mkl::uplo uplo,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zpotrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t potrs_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                        std::int64_t n, std::int64_t nrhs,
-                                                        std::int64_t lda, std::int64_t ldb) {
+std::int64_t potrs_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
+                                          std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].spotrs_scratchpad_size_sycl(queue, uplo, n, nrhs, lda, ldb);
 }
 template <>
-std::int64_t potrs_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                         std::int64_t n, std::int64_t nrhs,
-                                                         std::int64_t lda, std::int64_t ldb) {
+std::int64_t potrs_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::uplo uplo, std::int64_t n,
+                                           std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].dpotrs_scratchpad_size_sycl(queue, uplo, n, nrhs, lda, ldb);
 }
 template <>
-std::int64_t potrs_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
+std::int64_t potrs_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                        std::int64_t n, std::int64_t nrhs,
+                                                        std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].cpotrs_scratchpad_size_sycl(queue, uplo, n, nrhs, lda, ldb);
 }
 template <>
-std::int64_t potrs_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
+std::int64_t potrs_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                         std::int64_t n, std::int64_t nrhs,
+                                                         std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].zpotrs_scratchpad_size_sycl(queue, uplo, n, nrhs, lda, ldb);
 }
 template <>
-std::int64_t potri_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t potri_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::uplo uplo, std::int64_t n,
+                                          std::int64_t lda) {
     return function_tables[libkey].spotri_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t potri_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t potri_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::uplo uplo, std::int64_t n,
+                                           std::int64_t lda) {
     return function_tables[libkey].dpotri_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t potri_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      oneapi::mkl::uplo uplo,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].cpotri_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t potri_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       oneapi::mkl::uplo uplo,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zpotri_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t sytrf_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t sytrf_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::uplo uplo, std::int64_t n,
+                                          std::int64_t lda) {
     return function_tables[libkey].ssytrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t sytrf_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t sytrf_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::uplo uplo, std::int64_t n,
+                                           std::int64_t lda) {
     return function_tables[libkey].dsytrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t sytrf_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      oneapi::mkl::uplo uplo,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].csytrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t sytrf_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       oneapi::mkl::uplo uplo,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zsytrf_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t syevd_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::job jobz,
-                                                        oneapi::mkl::uplo uplo, std::int64_t n,
-                                                        std::int64_t lda) {
+std::int64_t syevd_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
+                                          std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].ssyevd_scratchpad_size_sycl(queue, jobz, uplo, n, lda);
 }
 template <>
-std::int64_t syevd_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::job jobz,
-                                                         oneapi::mkl::uplo uplo, std::int64_t n,
-                                                         std::int64_t lda) {
+std::int64_t syevd_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
+                                           std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].dsyevd_scratchpad_size_sycl(queue, jobz, uplo, n, lda);
 }
 template <>
-std::int64_t sygvd_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, std::int64_t itype,
-                                                        oneapi::mkl::job jobz,
-                                                        oneapi::mkl::uplo uplo, std::int64_t n,
-                                                        std::int64_t lda, std::int64_t ldb) {
+std::int64_t sygvd_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          std::int64_t itype, oneapi::mkl::job jobz,
+                                          oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t lda,
+                                          std::int64_t ldb) {
     return function_tables[libkey].ssygvd_scratchpad_size_sycl(queue, itype, jobz, uplo, n, lda,
                                                                ldb);
 }
 template <>
-std::int64_t sygvd_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, std::int64_t itype,
-                                                         oneapi::mkl::job jobz,
-                                                         oneapi::mkl::uplo uplo, std::int64_t n,
-                                                         std::int64_t lda, std::int64_t ldb) {
+std::int64_t sygvd_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           std::int64_t itype, oneapi::mkl::job jobz,
+                                           oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t lda,
+                                           std::int64_t ldb) {
     return function_tables[libkey].dsygvd_scratchpad_size_sycl(queue, itype, jobz, uplo, n, lda,
                                                                ldb);
 }
 template <>
-std::int64_t sytrd_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                        std::int64_t n, std::int64_t lda) {
+std::int64_t sytrd_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::uplo uplo, std::int64_t n,
+                                          std::int64_t lda) {
     return function_tables[libkey].ssytrd_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t sytrd_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
-                                                         std::int64_t n, std::int64_t lda) {
+std::int64_t sytrd_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::uplo uplo, std::int64_t n,
+                                           std::int64_t lda) {
     return function_tables[libkey].dsytrd_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t trtrs_scratchpad_size<float>(oneapi::mkl::device libkey,
+std::int64_t trtrs_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                          oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
+                                          oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
+                                          std::int64_t lda, std::int64_t ldb) {
+    return function_tables[libkey].strtrs_scratchpad_size_sycl(queue, uplo, trans, diag, n, nrhs,
+                                                               lda, ldb);
+}
+template <>
+std::int64_t trtrs_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                           oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
+                                           oneapi::mkl::diag diag, std::int64_t n,
+                                           std::int64_t nrhs, std::int64_t lda, std::int64_t ldb) {
+    return function_tables[libkey].dtrtrs_scratchpad_size_sycl(queue, uplo, trans, diag, n, nrhs,
+                                                               lda, ldb);
+}
+template <>
+std::int64_t trtrs_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
                                                         oneapi::mkl::transpose trans,
                                                         oneapi::mkl::diag diag, std::int64_t n,
                                                         std::int64_t nrhs, std::int64_t lda,
                                                         std::int64_t ldb) {
-    return function_tables[libkey].strtrs_scratchpad_size_sycl(queue, uplo, trans, diag, n, nrhs,
+    return function_tables[libkey].ctrtrs_scratchpad_size_sycl(queue, uplo, trans, diag, n, nrhs,
                                                                lda, ldb);
 }
 template <>
-std::int64_t trtrs_scratchpad_size<double>(oneapi::mkl::device libkey,
+std::int64_t trtrs_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
                                                          sycl::queue &queue, oneapi::mkl::uplo uplo,
                                                          oneapi::mkl::transpose trans,
                                                          oneapi::mkl::diag diag, std::int64_t n,
                                                          std::int64_t nrhs, std::int64_t lda,
                                                          std::int64_t ldb) {
-    return function_tables[libkey].dtrtrs_scratchpad_size_sycl(queue, uplo, trans, diag, n, nrhs,
-                                                               lda, ldb);
-}
-template <>
-std::int64_t trtrs_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
-    std::int64_t lda, std::int64_t ldb) {
-    return function_tables[libkey].ctrtrs_scratchpad_size_sycl(queue, uplo, trans, diag, n, nrhs,
-                                                               lda, ldb);
-}
-template <>
-std::int64_t trtrs_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
-    std::int64_t lda, std::int64_t ldb) {
     return function_tables[libkey].ztrtrs_scratchpad_size_sycl(queue, uplo, trans, diag, n, nrhs,
                                                                lda, ldb);
 }
 template <>
-std::int64_t ungbr_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::generate vect, std::int64_t m,
-    std::int64_t n, std::int64_t k, std::int64_t lda) {
+std::int64_t ungbr_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue,
+                                                        oneapi::mkl::generate vect, std::int64_t m,
+                                                        std::int64_t n, std::int64_t k,
+                                                        std::int64_t lda) {
     return function_tables[libkey].cungbr_scratchpad_size_sycl(queue, vect, m, n, k, lda);
 }
 template <>
-std::int64_t ungbr_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::generate vect, std::int64_t m,
-    std::int64_t n, std::int64_t k, std::int64_t lda) {
+std::int64_t ungbr_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue,
+                                                         oneapi::mkl::generate vect, std::int64_t m,
+                                                         std::int64_t n, std::int64_t k,
+                                                         std::int64_t lda) {
     return function_tables[libkey].zungbr_scratchpad_size_sycl(queue, vect, m, n, k, lda);
 }
 template <>
-std::int64_t ungqr_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
-    std::int64_t lda) {
+std::int64_t ungqr_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue, std::int64_t m,
+                                                        std::int64_t n, std::int64_t k,
+                                                        std::int64_t lda) {
     return function_tables[libkey].cungqr_scratchpad_size_sycl(queue, m, n, k, lda);
 }
 template <>
-std::int64_t ungqr_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
-    std::int64_t lda) {
+std::int64_t ungqr_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue, std::int64_t m,
+                                                         std::int64_t n, std::int64_t k,
+                                                         std::int64_t lda) {
     return function_tables[libkey].zungqr_scratchpad_size_sycl(queue, m, n, k, lda);
 }
 template <>
 std::int64_t ungtr_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
-                                                                      sycl::queue &queue,
-                                                                      oneapi::mkl::uplo uplo,
-                                                                      std::int64_t n,
-                                                                      std::int64_t lda) {
+                                                        sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                        std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].cungtr_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
 std::int64_t ungtr_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
-                                                                       sycl::queue &queue,
-                                                                       oneapi::mkl::uplo uplo,
-                                                                       std::int64_t n,
-                                                                       std::int64_t lda) {
+                                                         sycl::queue &queue, oneapi::mkl::uplo uplo,
+                                                         std::int64_t n, std::int64_t lda) {
     return function_tables[libkey].zungtr_scratchpad_size_sycl(queue, uplo, n, lda);
 }
 template <>
-std::int64_t unmrq_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::side side,
-    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda,
-    std::int64_t ldc) {
+std::int64_t unmrq_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue, oneapi::mkl::side side,
+                                                        oneapi::mkl::transpose trans,
+                                                        std::int64_t m, std::int64_t n,
+                                                        std::int64_t k, std::int64_t lda,
+                                                        std::int64_t ldc) {
     return function_tables[libkey].cunmrq_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t unmrq_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::side side,
-    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda,
-    std::int64_t ldc) {
+std::int64_t unmrq_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue, oneapi::mkl::side side,
+                                                         oneapi::mkl::transpose trans,
+                                                         std::int64_t m, std::int64_t n,
+                                                         std::int64_t k, std::int64_t lda,
+                                                         std::int64_t ldc) {
     return function_tables[libkey].zunmrq_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t unmqr_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::side side,
-    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda,
-    std::int64_t ldc) {
+std::int64_t unmqr_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue, oneapi::mkl::side side,
+                                                        oneapi::mkl::transpose trans,
+                                                        std::int64_t m, std::int64_t n,
+                                                        std::int64_t k, std::int64_t lda,
+                                                        std::int64_t ldc) {
     return function_tables[libkey].cunmqr_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t unmqr_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::side side,
-    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda,
-    std::int64_t ldc) {
+std::int64_t unmqr_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue, oneapi::mkl::side side,
+                                                         oneapi::mkl::transpose trans,
+                                                         std::int64_t m, std::int64_t n,
+                                                         std::int64_t k, std::int64_t lda,
+                                                         std::int64_t ldc) {
     return function_tables[libkey].zunmqr_scratchpad_size_sycl(queue, side, trans, m, n, k, lda,
                                                                ldc);
 }
 template <>
-std::int64_t unmtr_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
-    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda,
-    std::int64_t ldc) {
+std::int64_t unmtr_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                        sycl::queue &queue, oneapi::mkl::side side,
+                                                        oneapi::mkl::uplo uplo,
+                                                        oneapi::mkl::transpose trans,
+                                                        std::int64_t m, std::int64_t n,
+                                                        std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].cunmtr_scratchpad_size_sycl(queue, side, uplo, trans, m, n, lda,
                                                                ldc);
 }
 template <>
-std::int64_t unmtr_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
-    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t lda,
-    std::int64_t ldc) {
+std::int64_t unmtr_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                         sycl::queue &queue, oneapi::mkl::side side,
+                                                         oneapi::mkl::uplo uplo,
+                                                         oneapi::mkl::transpose trans,
+                                                         std::int64_t m, std::int64_t n,
+                                                         std::int64_t lda, std::int64_t ldc) {
     return function_tables[libkey].zunmtr_scratchpad_size_sycl(queue, side, uplo, trans, m, n, lda,
                                                                ldc);
 }
 template <>
-std::int64_t getrf_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t stride_ipiv, std::int64_t batch_size) {
+std::int64_t getrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t m, std::int64_t n, std::int64_t lda,
+                                                std::int64_t stride_a, std::int64_t stride_ipiv,
+                                                std::int64_t batch_size) {
     return function_tables[libkey].sgetrf_batch_scratchpad_size_sycl(queue, m, n, lda, stride_a,
                                                                      stride_ipiv, batch_size);
 }
 template <>
-std::int64_t getrf_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t stride_ipiv, std::int64_t batch_size) {
+std::int64_t getrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t m, std::int64_t n, std::int64_t lda,
+                                                 std::int64_t stride_a, std::int64_t stride_ipiv,
+                                                 std::int64_t batch_size) {
     return function_tables[libkey].dgetrf_batch_scratchpad_size_sycl(queue, m, n, lda, stride_a,
                                                                      stride_ipiv, batch_size);
 }
@@ -2665,16 +2617,18 @@ std::int64_t getrf_batch_scratchpad_size<std::complex<double>>(
                                                                      stride_ipiv, batch_size);
 }
 template <>
-std::int64_t getri_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n, std::int64_t lda,
-    std::int64_t stride_a, std::int64_t stride_ipiv, std::int64_t batch_size) {
+std::int64_t getri_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t n, std::int64_t lda,
+                                                std::int64_t stride_a, std::int64_t stride_ipiv,
+                                                std::int64_t batch_size) {
     return function_tables[libkey].sgetri_batch_scratchpad_size_sycl(queue, n, lda, stride_a,
                                                                      stride_ipiv, batch_size);
 }
 template <>
-std::int64_t getri_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n, std::int64_t lda,
-    std::int64_t stride_a, std::int64_t stride_ipiv, std::int64_t batch_size) {
+std::int64_t getri_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t n, std::int64_t lda,
+                                                 std::int64_t stride_a, std::int64_t stride_ipiv,
+                                                 std::int64_t batch_size) {
     return function_tables[libkey].dgetri_batch_scratchpad_size_sycl(queue, n, lda, stride_a,
                                                                      stride_ipiv, batch_size);
 }
@@ -2693,18 +2647,22 @@ std::int64_t getri_batch_scratchpad_size<std::complex<double>>(
                                                                      stride_ipiv, batch_size);
 }
 template <>
-std::int64_t getrs_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t stride_a, std::int64_t stride_ipiv,
-    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+std::int64_t getrs_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                oneapi::mkl::transpose trans, std::int64_t n,
+                                                std::int64_t nrhs, std::int64_t lda,
+                                                std::int64_t stride_a, std::int64_t stride_ipiv,
+                                                std::int64_t ldb, std::int64_t stride_b,
+                                                std::int64_t batch_size) {
     return function_tables[libkey].sgetrs_batch_scratchpad_size_sycl(
         queue, trans, n, nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
 }
 template <>
-std::int64_t getrs_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t stride_a, std::int64_t stride_ipiv,
-    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+std::int64_t getrs_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 oneapi::mkl::transpose trans, std::int64_t n,
+                                                 std::int64_t nrhs, std::int64_t lda,
+                                                 std::int64_t stride_a, std::int64_t stride_ipiv,
+                                                 std::int64_t ldb, std::int64_t stride_b,
+                                                 std::int64_t batch_size) {
     return function_tables[libkey].dgetrs_batch_scratchpad_size_sycl(
         queue, trans, n, nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
 }
@@ -2725,16 +2683,18 @@ std::int64_t getrs_batch_scratchpad_size<std::complex<double>>(
         queue, trans, n, nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
 }
 template <>
-std::int64_t geqrf_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t stride_tau, std::int64_t batch_size) {
+std::int64_t geqrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t m, std::int64_t n, std::int64_t lda,
+                                                std::int64_t stride_a, std::int64_t stride_tau,
+                                                std::int64_t batch_size) {
     return function_tables[libkey].sgeqrf_batch_scratchpad_size_sycl(queue, m, n, lda, stride_a,
                                                                      stride_tau, batch_size);
 }
 template <>
-std::int64_t geqrf_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t stride_tau, std::int64_t batch_size) {
+std::int64_t geqrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t m, std::int64_t n, std::int64_t lda,
+                                                 std::int64_t stride_a, std::int64_t stride_tau,
+                                                 std::int64_t batch_size) {
     return function_tables[libkey].dgeqrf_batch_scratchpad_size_sycl(queue, m, n, lda, stride_a,
                                                                      stride_tau, batch_size);
 }
@@ -2753,16 +2713,18 @@ std::int64_t geqrf_batch_scratchpad_size<std::complex<double>>(
                                                                      stride_tau, batch_size);
 }
 template <>
-std::int64_t potrf_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size) {
+std::int64_t potrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                oneapi::mkl::uplo uplo, std::int64_t n,
+                                                std::int64_t lda, std::int64_t stride_a,
+                                                std::int64_t batch_size) {
     return function_tables[libkey].spotrf_batch_scratchpad_size_sycl(queue, uplo, n, lda, stride_a,
                                                                      batch_size);
 }
 template <>
-std::int64_t potrf_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size) {
+std::int64_t potrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 oneapi::mkl::uplo uplo, std::int64_t n,
+                                                 std::int64_t lda, std::int64_t stride_a,
+                                                 std::int64_t batch_size) {
     return function_tables[libkey].dpotrf_batch_scratchpad_size_sycl(queue, uplo, n, lda, stride_a,
                                                                      batch_size);
 }
@@ -2781,18 +2743,20 @@ std::int64_t potrf_batch_scratchpad_size<std::complex<double>>(
                                                                      batch_size);
 }
 template <>
-std::int64_t potrs_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t stride_a, std::int64_t ldb,
-    std::int64_t stride_b, std::int64_t batch_size) {
+std::int64_t potrs_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                oneapi::mkl::uplo uplo, std::int64_t n,
+                                                std::int64_t nrhs, std::int64_t lda,
+                                                std::int64_t stride_a, std::int64_t ldb,
+                                                std::int64_t stride_b, std::int64_t batch_size) {
     return function_tables[libkey].spotrs_batch_scratchpad_size_sycl(
         queue, uplo, n, nrhs, lda, stride_a, ldb, stride_b, batch_size);
 }
 template <>
-std::int64_t potrs_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
-    std::int64_t nrhs, std::int64_t lda, std::int64_t stride_a, std::int64_t ldb,
-    std::int64_t stride_b, std::int64_t batch_size) {
+std::int64_t potrs_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 oneapi::mkl::uplo uplo, std::int64_t n,
+                                                 std::int64_t nrhs, std::int64_t lda,
+                                                 std::int64_t stride_a, std::int64_t ldb,
+                                                 std::int64_t stride_b, std::int64_t batch_size) {
     return function_tables[libkey].dpotrs_batch_scratchpad_size_sycl(
         queue, uplo, n, nrhs, lda, stride_a, ldb, stride_b, batch_size);
 }
@@ -2813,16 +2777,18 @@ std::int64_t potrs_batch_scratchpad_size<std::complex<double>>(
         queue, uplo, n, nrhs, lda, stride_a, ldb, stride_b, batch_size);
 }
 template <>
-std::int64_t orgqr_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t stride_tau, std::int64_t batch_size) {
+std::int64_t orgqr_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t m, std::int64_t n, std::int64_t k,
+                                                std::int64_t lda, std::int64_t stride_a,
+                                                std::int64_t stride_tau, std::int64_t batch_size) {
     return function_tables[libkey].sorgqr_batch_scratchpad_size_sycl(queue, m, n, k, lda, stride_a,
                                                                      stride_tau, batch_size);
 }
 template <>
-std::int64_t orgqr_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
-    std::int64_t lda, std::int64_t stride_a, std::int64_t stride_tau, std::int64_t batch_size) {
+std::int64_t orgqr_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t m, std::int64_t n, std::int64_t k,
+                                                 std::int64_t lda, std::int64_t stride_a,
+                                                 std::int64_t stride_tau, std::int64_t batch_size) {
     return function_tables[libkey].dorgqr_batch_scratchpad_size_sycl(queue, m, n, k, lda, stride_a,
                                                                      stride_tau, batch_size);
 }
@@ -2841,82 +2807,88 @@ std::int64_t ungqr_batch_scratchpad_size<std::complex<double>>(
                                                                      stride_tau, batch_size);
 }
 template <>
-std::int64_t getrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                              sycl::queue &queue, std::int64_t *m,
-                                                              std::int64_t *n, std::int64_t *lda,
-                                                              std::int64_t group_count,
-                                                              std::int64_t *group_sizes) {
+std::int64_t getrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t *m, std::int64_t *n, std::int64_t *lda,
+                                                std::int64_t group_count,
+                                                std::int64_t *group_sizes) {
     return function_tables[libkey].sgetrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                               sycl::queue &queue, std::int64_t *m,
-                                                               std::int64_t *n, std::int64_t *lda,
-                                                               std::int64_t group_count,
-                                                               std::int64_t *group_sizes) {
+std::int64_t getrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t *m, std::int64_t *n,
+                                                 std::int64_t *lda, std::int64_t group_count,
+                                                 std::int64_t *group_sizes) {
     return function_tables[libkey].dgetrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getrf_batch_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *m, std::int64_t *n,
-    std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t getrf_batch_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                              sycl::queue &queue, std::int64_t *m,
+                                                              std::int64_t *n, std::int64_t *lda,
+                                                              std::int64_t group_count,
+                                                              std::int64_t *group_sizes) {
     return function_tables[libkey].cgetrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getrf_batch_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *m, std::int64_t *n,
-    std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t getrf_batch_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                               sycl::queue &queue, std::int64_t *m,
+                                                               std::int64_t *n, std::int64_t *lda,
+                                                               std::int64_t group_count,
+                                                               std::int64_t *group_sizes) {
     return function_tables[libkey].zgetrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getri_batch_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                              sycl::queue &queue, std::int64_t *n,
-                                                              std::int64_t *lda,
-                                                              std::int64_t group_count,
-                                                              std::int64_t *group_sizes) {
+std::int64_t getri_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t *n, std::int64_t *lda,
+                                                std::int64_t group_count,
+                                                std::int64_t *group_sizes) {
     return function_tables[libkey].sgetri_group_scratchpad_size_sycl(queue, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getri_batch_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                               sycl::queue &queue, std::int64_t *n,
-                                                               std::int64_t *lda,
-                                                               std::int64_t group_count,
-                                                               std::int64_t *group_sizes) {
+std::int64_t getri_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t *n, std::int64_t *lda,
+                                                 std::int64_t group_count,
+                                                 std::int64_t *group_sizes) {
     return function_tables[libkey].dgetri_group_scratchpad_size_sycl(queue, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getri_batch_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *n, std::int64_t *lda,
-    std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t getri_batch_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                              sycl::queue &queue, std::int64_t *n,
+                                                              std::int64_t *lda,
+                                                              std::int64_t group_count,
+                                                              std::int64_t *group_sizes) {
     return function_tables[libkey].cgetri_group_scratchpad_size_sycl(queue, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getri_batch_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *n, std::int64_t *lda,
-    std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t getri_batch_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                               sycl::queue &queue, std::int64_t *n,
+                                                               std::int64_t *lda,
+                                                               std::int64_t group_count,
+                                                               std::int64_t *group_sizes) {
     return function_tables[libkey].zgetri_group_scratchpad_size_sycl(queue, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t getrs_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n,
-    std::int64_t *nrhs, std::int64_t *lda, std::int64_t *ldb, std::int64_t group_count,
-    std::int64_t *group_sizes) {
+std::int64_t getrs_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                oneapi::mkl::transpose *trans, std::int64_t *n,
+                                                std::int64_t *nrhs, std::int64_t *lda,
+                                                std::int64_t *ldb, std::int64_t group_count,
+                                                std::int64_t *group_sizes) {
     return function_tables[libkey].sgetrs_group_scratchpad_size_sycl(queue, trans, n, nrhs, lda,
                                                                      ldb, group_count, group_sizes);
 }
 template <>
-std::int64_t getrs_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n,
-    std::int64_t *nrhs, std::int64_t *lda, std::int64_t *ldb, std::int64_t group_count,
-    std::int64_t *group_sizes) {
+std::int64_t getrs_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 oneapi::mkl::transpose *trans, std::int64_t *n,
+                                                 std::int64_t *nrhs, std::int64_t *lda,
+                                                 std::int64_t *ldb, std::int64_t group_count,
+                                                 std::int64_t *group_sizes) {
     return function_tables[libkey].dgetrs_group_scratchpad_size_sycl(queue, trans, n, nrhs, lda,
                                                                      ldb, group_count, group_sizes);
 }
@@ -2937,62 +2909,68 @@ std::int64_t getrs_batch_scratchpad_size<std::complex<double>>(
                                                                      ldb, group_count, group_sizes);
 }
 template <>
-std::int64_t geqrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey,
-                                                              sycl::queue &queue, std::int64_t *m,
-                                                              std::int64_t *n, std::int64_t *lda,
-                                                              std::int64_t group_count,
-                                                              std::int64_t *group_sizes) {
+std::int64_t geqrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t *m, std::int64_t *n, std::int64_t *lda,
+                                                std::int64_t group_count,
+                                                std::int64_t *group_sizes) {
     return function_tables[libkey].sgeqrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t geqrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey,
-                                                               sycl::queue &queue, std::int64_t *m,
-                                                               std::int64_t *n, std::int64_t *lda,
-                                                               std::int64_t group_count,
-                                                               std::int64_t *group_sizes) {
+std::int64_t geqrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t *m, std::int64_t *n,
+                                                 std::int64_t *lda, std::int64_t group_count,
+                                                 std::int64_t *group_sizes) {
     return function_tables[libkey].dgeqrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t geqrf_batch_scratchpad_size<std::complex<float>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *m, std::int64_t *n,
-    std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t geqrf_batch_scratchpad_size<std::complex<float>>(oneapi::mkl::device libkey,
+                                                              sycl::queue &queue, std::int64_t *m,
+                                                              std::int64_t *n, std::int64_t *lda,
+                                                              std::int64_t group_count,
+                                                              std::int64_t *group_sizes) {
     return function_tables[libkey].cgeqrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t geqrf_batch_scratchpad_size<std::complex<double>>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *m, std::int64_t *n,
-    std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t geqrf_batch_scratchpad_size<std::complex<double>>(oneapi::mkl::device libkey,
+                                                               sycl::queue &queue, std::int64_t *m,
+                                                               std::int64_t *n, std::int64_t *lda,
+                                                               std::int64_t group_count,
+                                                               std::int64_t *group_sizes) {
     return function_tables[libkey].zgeqrf_group_scratchpad_size_sycl(queue, m, n, lda, group_count,
                                                                      group_sizes);
 }
 template <>
-std::int64_t orgqr_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *m, std::int64_t *n,
-    std::int64_t *k, std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t orgqr_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                                                std::int64_t *lda, std::int64_t group_count,
+                                                std::int64_t *group_sizes) {
     return function_tables[libkey].sorgqr_group_scratchpad_size_sycl(queue, m, n, k, lda,
                                                                      group_count, group_sizes);
 }
 template <>
-std::int64_t orgqr_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *m, std::int64_t *n,
-    std::int64_t *k, std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t orgqr_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                                                 std::int64_t *lda, std::int64_t group_count,
+                                                 std::int64_t *group_sizes) {
     return function_tables[libkey].dorgqr_group_scratchpad_size_sycl(queue, m, n, k, lda,
                                                                      group_count, group_sizes);
 }
 template <>
-std::int64_t potrf_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
-    std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t potrf_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                oneapi::mkl::uplo *uplo, std::int64_t *n,
+                                                std::int64_t *lda, std::int64_t group_count,
+                                                std::int64_t *group_sizes) {
     return function_tables[libkey].spotrf_group_scratchpad_size_sycl(queue, uplo, n, lda,
                                                                      group_count, group_sizes);
 }
 template <>
-std::int64_t potrf_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
-    std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes) {
+std::int64_t potrf_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 oneapi::mkl::uplo *uplo, std::int64_t *n,
+                                                 std::int64_t *lda, std::int64_t group_count,
+                                                 std::int64_t *group_sizes) {
     return function_tables[libkey].dpotrf_group_scratchpad_size_sycl(queue, uplo, n, lda,
                                                                      group_count, group_sizes);
 }
@@ -3011,18 +2989,20 @@ std::int64_t potrf_batch_scratchpad_size<std::complex<double>>(
                                                                      group_count, group_sizes);
 }
 template <>
-std::int64_t potrs_batch_scratchpad_size<float>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
-    std::int64_t *nrhs, std::int64_t *lda, std::int64_t *ldb, std::int64_t group_count,
-    std::int64_t *group_sizes) {
+std::int64_t potrs_batch_scratchpad_size<float>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                oneapi::mkl::uplo *uplo, std::int64_t *n,
+                                                std::int64_t *nrhs, std::int64_t *lda,
+                                                std::int64_t *ldb, std::int64_t group_count,
+                                                std::int64_t *group_sizes) {
     return function_tables[libkey].spotrs_group_scratchpad_size_sycl(queue, uplo, n, nrhs, lda, ldb,
                                                                      group_count, group_sizes);
 }
 template <>
-std::int64_t potrs_batch_scratchpad_size<double>(
-    oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
-    std::int64_t *nrhs, std::int64_t *lda, std::int64_t *ldb, std::int64_t group_count,
-    std::int64_t *group_sizes) {
+std::int64_t potrs_batch_scratchpad_size<double>(oneapi::mkl::device libkey, sycl::queue &queue,
+                                                 oneapi::mkl::uplo *uplo, std::int64_t *n,
+                                                 std::int64_t *nrhs, std::int64_t *lda,
+                                                 std::int64_t *ldb, std::int64_t group_count,
+                                                 std::int64_t *group_sizes) {
     return function_tables[libkey].dpotrs_group_scratchpad_size_sycl(queue, uplo, n, nrhs, lda, ldb,
                                                                      group_count, group_sizes);
 }

--- a/tests/unit_tests/lapack/CMakeLists.txt
+++ b/tests/unit_tests/lapack/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2020 Intel Corporation
+# Copyright 2020-2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description

Few minor fixes to LAPACK sources: updated copyrights and comments for a few files and applied clang-formatting to one file.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? N/A - comment/white space changes only
- [x] Have you formatted the code using clang-format?

