### PR TITLE
[RNG] Add work around in unit tests for hangs in cuRAND backend

### DIFF
--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -79,17 +79,6 @@ public:
     // method to call any tests, switch between rt and ct
     template <typename... Args>
     int operator()(cl::sycl::device* dev, Args... args) {
-        static sycl::device* previous_device = nullptr;
-        static sycl::context* context = nullptr;
-
-        if((previous_device != dev)) {
-            previous_device = dev;
-            if(context != nullptr) {
-                delete context;
-            }
-            context = new sycl::context(*dev);
-        }
-
         auto exception_handler = [](sycl::exception_list exceptions) {
             for (std::exception_ptr const& e : exceptions) {
                 try {
@@ -103,7 +92,22 @@ public:
             }
         };
 
+#ifdef ENABLE_CURAND_BACKEND // w/a for cuda backend hangs when there are several queues with different contexts
+        static sycl::device* previous_device = nullptr;
+        static sycl::context* context = nullptr;
+
+        if ((previous_device != dev)) {
+            previous_device = dev;
+            if (context != nullptr) {
+                delete context;
+            }
+            context = new sycl::context(*dev);
+        }
+
         cl::sycl::queue queue(*context, *dev, exception_handler);
+#else
+        cl::sycl::queue queue(*dev, exception_handler);
+#endif
 
 #ifdef CALL_RT_API
         test_(queue, args...);


### PR DESCRIPTION
# Description

llvm cuda backend has an issue with hangs, when creating multiple queues from one device, but different contexts in the same test. W/a is added.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
[rng_curand_testing.txt](https://github.com/oneapi-src/oneMKL/files/6867767/rng_curand_testing.txt)

- [x] Have you formatted the code using clang-format?

