### PR TITLE
Conan: Update remotes

### DIFF
--- a/conan/remotes.txt
+++ b/conan/remotes.txt
@@ -1,2 +1,1 @@
-conan-center https://api.bintray.com/conan/conan/conan-center True
-conan-community https://api.bintray.com/conan/conan-community/conan True
+conan-center https://center.conan.io True


### PR DESCRIPTION
# Description

Bintray is now down, see e.g. https://blog.conan.io/2021/02/05/JFrog-announces-sunset-bintray.html

The new URL for the Conan Center is https://center.conan.io

For the same reason, the conan-community remote does not exist anymore, but almost all recipes are migrated to the Conan Center by now


# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
