### PR TITLE
doc: enable cmake documentation only build from docs

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -16,7 +16,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
+cmake_minimum_required (VERSION 3.13)
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 find_package(Sphinx REQUIRED)
 
 # configured documentation tools and intermediate build results

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,15 @@
 This folder contains oneMKL documentation in reStructuredText (rST) format.
 
 The documentation build step is skipped by default.
-To enable building documentation:
+To enable building documentation from the main build:
 - Set `-o build_doc=True` when building with Conan. For more information see [Building with Conan](../README.md#building-with-conan)
 - Set `-DBUILD_DOC=ON` when building with CMake. For more information see [Building with CMake](../README.md#building-with-cmake)
+
+To build documentation only use following cmake command from the current folder:
+```bash
+# Inside <path to onemkl>/docs
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+Generated documentation can be found in `<path to onemkl>/docs/build/Documentation`


### PR DESCRIPTION
# Description

Current build system doesn't allow to build standalone documentation, this PR enables this option.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

