### PR TITLE
Add missing include to mklcpu_batch.cpp

### DIFF
--- a/src/blas/backends/mklcpu/mklcpu_batch.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_batch.cpp
@@ -19,6 +19,7 @@
 
 #include <CL/sycl.hpp>
 
+#include "oneapi/mkl/exceptions.hpp"
 #include "mklcpu_common.hpp"
 #include "oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp"
 


### PR DESCRIPTION
# Description

This is a fix for the bug introduced in #102 that prevents compiling the blas domain. In #102 `exceptions.hpp` was not included even though it is used in this file.
