### PR TITLE
Add build instruction for CUDA backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ conan build ..
 
 2. Build and install all required [dependencies](#software-requirements). 
 
-### Building for MKL
+### Building for oneMKL
 
 - On Linux*
 ```bash

--- a/README.md
+++ b/README.md
@@ -561,9 +561,6 @@ With:
 -DENABLE_CURAND_BACKEND=True   \
 ```
 
-Note that enabling both the cuBLAS and cuRAND backends breaks building the
-tests.
-
 ### Build Options
 All options specified in the Conan section are available to CMake. You can specify these options using `-D<cmake_option>=<value>`.
 

--- a/README.md
+++ b/README.md
@@ -546,7 +546,6 @@ cmake .. -DENABLE_CUBLAS_BACKEND=True                      \
          -DENABLE_MKLCPU_BACKEND=False                     \   # disable Intel MKL CPU backend
          -DENABLE_MKLGPU_BACKEND=False                     \   # disable Intel MKL GPU backend
          [-DREF_BLAS_ROOT=<reference_blas_install_prefix>] \   # required only for testing
-         [-DREF_LAPACK_ROOT=<reference_lapack_install_prefix>] # required only for testing
 cmake --build .
 ctest
 cmake --install . --prefix <path_to_install_dir>

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ conan build ..
 
 2. Build and install all required [dependencies](#software-requirements). 
 
-Then:
+### Building for MKL
 
 - On Linux*
 ```bash
@@ -531,6 +531,36 @@ ninja
 ctest
 cmake --install . --prefix <path_to_install_dir>
 ```
+
+### Building for CUDA
+
+- On Linux*
+
+With the CUBLAS backend:
+
+```bash
+# Inside <path to onemkl>
+mkdir build && cd build
+export CXX=<path_to_dpcpp_compiler>/bin/dpcpp;
+cmake .. -DENABLE_CUBLAS_BACKEND=ON   \
+         -DENABLE_MKLCPU_BACKEND=OFF  \ # disable Intel MKL CPU backend
+         -DENABLE_MKLGPU_BACKEND=OFF    # disable Intel MKL GPU backend
+cmake --build .
+cmake --install . --prefix <path_to_install_dir>
+```
+
+To build with the CURAND backend instead simply replace:
+```bash
+-DENABLE_CUBLAS_BACKEND=ON   \
+```
+
+With:
+```bash
+-DENABLE_CURAND_BACKEND=ON   \
+```
+
+Note that enabling both the CUBLAS and CURAND backends breaks building the
+tests.
 
 ### Build Options
 All options specified in the Conan section are available to CMake. You can specify these options using `-D<cmake_option>=<value>`.

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ cmake --install . --prefix <path_to_install_dir>
 
 - On Linux*
 
-With the CUBLAS backend:
+With the cuBLAS backend:
 
 ```bash
 # Inside <path to onemkl>
@@ -549,7 +549,7 @@ cmake --build .
 cmake --install . --prefix <path_to_install_dir>
 ```
 
-To build with the CURAND backend instead simply replace:
+To build with the cuRAND backend instead simply replace:
 ```bash
 -DENABLE_CUBLAS_BACKEND=ON   \
 ```
@@ -559,7 +559,7 @@ With:
 -DENABLE_CURAND_BACKEND=ON   \
 ```
 
-Note that enabling both the CUBLAS and CURAND backends breaks building the
+Note that enabling both the cuBLAS and cuRAND backends breaks building the
 tests.
 
 ### Build Options

--- a/README.md
+++ b/README.md
@@ -542,21 +542,24 @@ With the cuBLAS backend:
 # Inside <path to onemkl>
 mkdir build && cd build
 export CXX=<path_to_dpcpp_compiler>/bin/dpcpp;
-cmake .. -DENABLE_CUBLAS_BACKEND=ON   \
-         -DENABLE_MKLCPU_BACKEND=OFF  \ # disable Intel MKL CPU backend
-         -DENABLE_MKLGPU_BACKEND=OFF    # disable Intel MKL GPU backend
+cmake .. -DENABLE_CUBLAS_BACKEND=True                      \
+         -DENABLE_MKLCPU_BACKEND=False                     \   # disable Intel MKL CPU backend
+         -DENABLE_MKLGPU_BACKEND=False                     \   # disable Intel MKL GPU backend
+         [-DREF_BLAS_ROOT=<reference_blas_install_prefix>] \   # required only for testing
+         [-DREF_LAPACK_ROOT=<reference_lapack_install_prefix>] # required only for testing
 cmake --build .
+ctest
 cmake --install . --prefix <path_to_install_dir>
 ```
 
 To build with the cuRAND backend instead simply replace:
 ```bash
--DENABLE_CUBLAS_BACKEND=ON   \
+-DENABLE_CUBLAS_BACKEND=True   \
 ```
 
 With:
 ```bash
--DENABLE_CURAND_BACKEND=ON   \
+-DENABLE_CURAND_BACKEND=True   \
 ```
 
 Note that enabling both the cuBLAS and cuRAND backends breaks building the


### PR DESCRIPTION
# Description

This adds CMake instructions to build oneMKL for CUBLAS and CURAND, the current instructions are a little confusing since they only mention MKL build so this is aiming to make them a little clearer when targeting other backends.