### PR TITLE
Updated BLAS domain with exact copy-over from oneMKL spec per SME dir…

### DIFF
--- a/docs/domains/blas/axpy.rst
+++ b/docs/domains/blas/axpy.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_axpy:
 
 axpy
@@ -99,6 +103,26 @@ axpy (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_axpy_usm:
 
@@ -180,5 +204,26 @@ axpy (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/axpy_batch.rst
+++ b/docs/domains/blas/axpy_batch.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_axpy_batch:
 
 axpy_batch
@@ -23,6 +27,129 @@ operation adds a scalar-vector product to a vector.
       * -  ``double`` 
       * -  ``std::complex<float>`` 
       * -  ``std::complex<double>`` 
+
+.. _onemkl_blas_axpy_batch_buffer:
+
+axpy_batch (Buffer Version)
+---------------------------
+
+.. rubric:: Description
+
+The buffer version of ``axpy_batch`` supports only the strided API. 
+
+The strided API operation is defined as:
+::
+  
+   for i = 0 … batch_size – 1
+      X and Y are vectors at offset i * stridex, i * stridey in x and y
+      Y := alpha * X + Y
+   end for
+
+where:
+
+``alpha`` is scalar,
+
+``X`` and ``Y`` are vectors.
+   
+**Strided API**
+
+.. rubric:: Syntax
+ 
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       void axpy_batch(sycl::queue &queue,
+                       std::int64_t n,
+                       T alpha,
+                       sycl::buffer<T,
+                       1> &x,
+                       std::int64_t incx,
+                       std::int64_t stridex,
+                       sycl::buffer<T,
+                       1> &y,
+                       std::int64_t incy,
+                       std::int64_t stridey,
+                       std::int64_t batch_size)
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       void axpy_batch(sycl::queue &queue,
+                       std::int64_t n,
+                       T alpha,
+                       sycl::buffer<T,
+                       1> &x,
+                       std::int64_t incx,
+                       std::int64_t stridex,
+                       sycl::buffer<T,
+                       1> &y,
+                       std::int64_t incy,
+                       std::int64_t stridey,
+                       std::int64_t batch_size)
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   n
+      Number of elements in ``X`` and ``Y``.
+
+   alpha
+       Specifies the scalar ``alpha``.
+
+   x
+      Buffer holding input vectors ``X`` with size ``stridex`` * ``batch_size``.
+
+   incx 
+      Stride of vector ``X``.
+
+   stridex 
+      Stride between different ``X`` vectors.
+
+   y
+      Buffer holding input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
+
+   incy 
+      Stride of vector ``Y``.
+   
+   stridey 
+      Stride between different ``Y`` vectors.
+
+   batch_size 
+      Specifies the number of ``axpy`` operations to perform.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   y
+      Output buffer, overwritten by ``batch_size`` ``axpy`` operations of the form 
+      ``alpha`` * ``X`` + ``Y``.
+
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_axpy_batch_usm:
 
@@ -243,5 +370,26 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:**:ref:`blas-like-extensions`

--- a/docs/domains/blas/blas-level-1-routines.rst
+++ b/docs/domains/blas/blas-level-1-routines.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _blas-level-1-routines:
 
 BLAS Level 1 Routines

--- a/docs/domains/blas/blas-level-2-routines.rst
+++ b/docs/domains/blas/blas-level-2-routines.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _blas-level-2-routines:
 
 BLAS Level 2 Routines

--- a/docs/domains/blas/blas-level-3-routines.rst
+++ b/docs/domains/blas/blas-level-3-routines.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _blas-level-3-routines:
 
 BLAS Level 3 Routines

--- a/docs/domains/blas/blas-like-extensions.rst
+++ b/docs/domains/blas/blas-like-extensions.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _blas-like-extensions:
 
 BLAS-like Extensions

--- a/docs/domains/blas/blas.rst
+++ b/docs/domains/blas/blas.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas:
 
 BLAS Routines
@@ -13,3 +17,5 @@ oneMKL provides DPC++ interfaces to the Basic Linear Algebra Subprograms (BLAS) 
     blas-level-3-routines.rst
     blas-like-extensions.rst
 
+
+**Parent topic:** :ref:`onemkl_dense_linear_algebra`

--- a/docs/domains/blas/copy.rst
+++ b/docs/domains/blas/copy.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_copy:
 
 copy
@@ -85,6 +89,26 @@ copy (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_copy_usm:
 
@@ -155,5 +179,26 @@ copy (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/dot.rst
+++ b/docs/domains/blas/dot.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_dot:
 
 dot
@@ -100,6 +104,26 @@ dot (Buffer Version)
    result
       Buffer where the result (a scalar) will be stored.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_dot_usm:
 
@@ -178,5 +202,26 @@ dot (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/dotc.rst
+++ b/docs/domains/blas/dotc.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_dotc:
 
 dotc
@@ -88,6 +92,26 @@ dotc (Buffer Version)
    result
       The buffer where the result (a scalar) is stored.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_dotc_usm:
 
@@ -166,5 +190,26 @@ dotc (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/dotu.rst
+++ b/docs/domains/blas/dotu.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_dotu:
 
 dotu
@@ -88,6 +92,26 @@ dotu (Buffer Version)
    result
       Buffer where the result (a scalar) is stored.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_dotu_usm:
 
@@ -166,5 +190,26 @@ dotu (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/gbmv.rst
+++ b/docs/domains/blas/gbmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_gbmv:
 
 gbmv
@@ -154,6 +158,26 @@ gbmv (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_gbmv_usm:
 
@@ -281,5 +305,27 @@ gbmv (USM Version)
    .. rubric:: Return Values
 
    Output event to wait on to ensure computation is complete.
+
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/gemm.rst
+++ b/docs/domains/blas/gemm.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_gemm:
 
 gemm
@@ -247,6 +251,26 @@ gemm (Buffer Version)
    If ``beta`` = 0, matrix ``C`` does not need to be initialized before
    calling ``gemm``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_gemm_usm:
 
@@ -447,5 +471,25 @@ gemm (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/gemm_batch.rst
+++ b/docs/domains/blas/gemm_batch.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_gemm_batch:
 
 gemm_batch
@@ -186,7 +190,7 @@ of matrices in ``a``, ``b`` and ``c`` buffers is given by the ``batch_size`` par
       Buffer holding input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
 
    ldc
-      The leading dimension of the mattrices ``C``. It must be positive and at least
+      The leading dimension of the matrices ``C``. It must be positive and at least
       ``m`` if column major layout is used to store matrices or at
       least ``n`` if column major layout is used to store matrices.
 
@@ -212,6 +216,25 @@ of matrices in ``a``, ``b`` and ``c`` buffers is given by the ``batch_size`` par
    If ``beta`` = 0, matrix ``C`` does not need to be initialized before
    calling ``gemm_batch``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_gemm_batch_usm:
@@ -568,7 +591,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       Pointer to input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
 
    ldc
-      The leading dimension of the mattrices ``C``. It must be positive and at least
+      The leading dimension of the matrices ``C``. It must be positive and at least
       ``m`` if column major layout is used to store matrices or at
       least ``n`` if column major layout is used to store matrices.
 
@@ -603,5 +626,26 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/gemm_bias.rst
+++ b/docs/domains/blas/gemm_bias.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_gemm_bias:
 
 gemm_bias
@@ -46,8 +50,20 @@ op(``A``) is ``m`` x ``k``, op(``B``) is ``k`` x ``n``, and
        -  Tb 
        -  Tc 
      * -  ``float`` 
+       -  ``std::uint8_t`` 
+       -  ``std::uint8_t`` 
+       -  ``std::int32_t`` 
+     * -  ``float`` 
        -  ``std::int8_t`` 
        -  ``std::uint8_t`` 
+       -  ``std::int32_t`` 
+     * -  ``float`` 
+       -  ``std::uint8_t`` 
+       -  ``std::int8_t`` 
+       -  ``std::int32_t`` 
+     * -  ``float`` 
+       -  ``std::int8_t`` 
+       -  ``std::int8_t`` 
        -  ``std::int32_t`` 
 
 .. _onemkl_blas_gemm_bias_buffer:
@@ -267,5 +283,276 @@ gemm_bias (Buffer Version)
    If ``beta`` = 0, matrix ``C`` does not need to be initialized
    before calling ``gemm_bias``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
+
+.. _onemkl_blas_gemm_bias_usm:
+
+gemm_bias (USM Version)
+-----------------------
+
+.. rubric:: Syntax
+      
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event gemm_bias(sycl::queue &queue,
+                             onemkl::transpose transa,
+                             onemkl::transpose transb,
+                             onemkl::offset offset_type,
+                             std::int64_t m,
+                             std::int64_t n,
+                             std::int64_t k,
+                             Ts alpha,
+                             const Ta *a,
+                             std::int64_t lda,
+                             Ta ao,
+                             const Tb *b,
+                             std::int64_t ldb,
+                             Tb bo,
+                             Ts beta,
+                             Tc *c,
+                             std::int64_t ldc,
+                             const Tc *co,
+                             const sycl::vector_class<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event gemm_bias(sycl::queue &queue,
+                             onemkl::transpose transa,
+                             onemkl::transpose transb,
+                             onemkl::offset offset_type,
+                             std::int64_t m,
+                             std::int64_t n,
+                             std::int64_t k,
+                             Ts alpha,
+                             const Ta *a,
+                             std::int64_t lda,
+                             Ta ao,
+                             const Tb *b,
+                             std::int64_t ldb,
+                             Tb bo,
+                             Ts beta,
+                             Tc *c,
+                             std::int64_t ldc,
+                             const Tc *co,
+                             const sycl::vector_class<sycl::event> &dependencies = {})
+   }
+      
+.. container:: section
+   
+   .. rubric:: Input Parameters
+ 
+   queue
+      The queue where the routine should be executed.
+ 
+   transa
+      Specifies op(``A``), the transposition operation applied to
+      ``A``. See
+      :ref:`onemkl_datatypes` for
+      more details.
+ 
+   transb
+      Specifies op(``B``), the transposition operation applied to
+      ``B``. See
+      :ref:`onemkl_datatypes` for
+      more details.
+ 
+   offset_type
+      Specifies the form of ``C_offset`` used in the matrix
+      multiplication. See
+      :ref:`onemkl_datatypes` for
+      more details.
+ 
+   m
+      Number of rows of op(``A``) and ``C``. Must be at least zero.
+ 
+   n
+      Number of columns of op(``B``) and ``C``. Must be at least
+      zero.
+ 
+   k
+      Number of columns of op(``A``) and rows of op(``B``). Must be
+      at least zero.
+ 
+   alpha
+      Scaling factor for the matrix-matrix product.
+ 
+   a
+      Pointer to input matrix ``A``.
+ 
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``A`` not transposed
+           - ``A`` transposed
+         * - Column major
+           - ``A`` is an ``m``-by-``k`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``k``.
+           - ``A`` is an ``k``-by-``m`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``m``
+         * - Row major
+           - ``A`` is an ``m``-by-``k`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``m``.
+           - ``A`` is an ``k``-by-``m`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``k``
+ 
+      See :ref:`matrix-storage` for more details.
+ 
+   lda
+      The leading dimension of ``A``. It must be positive.
+
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``A`` not transposed
+           - ``A`` transposed
+         * - Column major
+           - ``lda`` must be at least ``m``.
+           - ``lda`` must be at least ``k``.
+         * - Row major
+           - ``lda`` must be at least ``k``.
+           - ``lda`` must be at least ``m``.
+ 
+   ao
+      Specifies the scalar offset value for matrix ``A``.
+ 
+   b
+      Pointer to input matrix ``B``.
+ 
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``B`` not transposed
+           - ``B`` transposed
+         * - Column major
+           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``.
+           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``k``
+         * - Row major
+           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``k``.
+           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``
+ 
+      See :ref:`matrix-storage` for more details.
+ 
+   ldb
+      The leading dimension of ``B``. It must be positive.
+
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``B`` not transposed
+           - ``B`` transposed
+         * - Column major
+           - ``ldb`` must be at least ``k``.
+           - ``ldb`` must be at least ``n``.
+         * - Row major
+           - ``ldb`` must be at least ``n``.
+           - ``ldb`` must be at least ``k``.
+ 
+   bo 
+      Specifies the scalar offset value for matrix ``B``.
+ 
+   beta
+      Scaling factor for matrix ``C``.
+ 
+   c
+      Pointer to input/output matrix ``C``. It must have a
+      size of at least ``ldc``\ \*\ ``n`` if column major layout is
+      used to store matrices or at least ``ldc``\ \*\ ``m`` if row
+      major layout is used to store matrices . See :ref:`matrix-storage` for more details.
+ 
+   ldc
+      The leading dimension of ``C``. It must be positive and at least
+      ``m`` if column major layout is used to store matrices or at
+      least ``n`` if column major layout is used to store matrices.
+
+   co
+      Pointer to offset values for matrix ``C``.
+ 
+ 
+      If ``offset_type`` = ``offset::fix``, the ``co`` array must have
+      size at least 1.
+ 
+ 
+      If ``offset_type`` = ``offset::col``, the ``co`` array must have
+      size at least ``max(1,m)``.
+ 
+ 
+      If ``offset_type`` = ``offset::row``, the ``co`` array must have
+      size at least ``max(1,n)``.
+
+   dependencies
+      List of events to wait for before starting computation, if any.
+      If omitted, defaults to no dependencies.
+ 
+.. container:: section
+ 
+   .. rubric:: Output Parameters
+ 
+   c
+      Pointer to the output matrix, overwritten by ``alpha`` * (op(``A``) -
+      ``A_offset``)*(op(``B``) - ``B_offset``) + ``beta`` * ``C`` + ``C_offset``.
+ 
+.. container:: section
+ 
+   .. rubric:: Notes
+ 
+   If ``beta`` = 0, matrix ``C`` does not need to be initialized
+   before calling ``gemm_bias``.
+
+.. container:: section
+
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/gemmt.rst
+++ b/docs/domains/blas/gemmt.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_gemmt:
 
 gemmt
@@ -218,6 +222,26 @@ gemmt (Buffer Version)
    If ``beta`` = 0, matrix ``C`` does not need to be initialized
    before calling gemmt.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_gemmt_usm:
 
@@ -414,5 +438,26 @@ gemmt (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/gemv.rst
+++ b/docs/domains/blas/gemv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_gemv:
 
 gemv
@@ -138,6 +142,26 @@ gemv (Buffer Version)
    y
       The buffer holding updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_gemv_usm:
 
@@ -257,5 +281,26 @@ gemv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/ger.rst
+++ b/docs/domains/blas/ger.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_ger:
 
 ger
@@ -121,6 +125,26 @@ ger (Buffer Version)
    a
       Buffer holding the updated matrix ``A``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_ger_usm:
 
@@ -221,6 +245,26 @@ ger (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/gerc.rst
+++ b/docs/domains/blas/gerc.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_gerc:
 
 gerc
@@ -123,6 +127,26 @@ gerc (Buffer Version)
    a
       Buffer holding the updated matrix ``A``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_gerc_usm:
 
@@ -223,5 +247,27 @@ gerc (USM Version)
    .. rubric:: Return Values
 
    Output event to wait on to ensure computation is complete.
+
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/geru.rst
+++ b/docs/domains/blas/geru.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_geru:
 
 geru
@@ -121,6 +125,26 @@ geru (Buffer Version)
    a
       Buffer holding the updated matrix ``A``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_geru_usm:
 
@@ -222,6 +246,26 @@ geru (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/hbmv.rst
+++ b/docs/domains/blas/hbmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_hbmv:
 
 hbmv
@@ -130,6 +134,26 @@ hbmv (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_hbmv_usm:
 
@@ -241,5 +265,26 @@ hbmv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/hemm.rst
+++ b/docs/domains/blas/hemm.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_hemm:
 
 hemm
@@ -170,6 +174,25 @@ hemm (Buffer Version)
    If ``beta`` = 0, matrix ``C`` does not need to be initialized before
    calling ``hemm``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_hemm_usm:
@@ -311,5 +334,26 @@ hemm (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/hemv.rst
+++ b/docs/domains/blas/hemv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_hemv:
 
 hemv
@@ -123,6 +127,25 @@ hemv (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_hemv_usm:
@@ -228,5 +251,26 @@ hemv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/her.rst
+++ b/docs/domains/blas/her.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_her:
 
 her
@@ -110,6 +114,26 @@ her (Buffer Version)
 
       The imaginary parts of the diagonal elements are set to zero.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_her_usm:
 
@@ -201,5 +225,26 @@ her (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/her2.rst
+++ b/docs/domains/blas/her2.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_her2:
 
 her2
@@ -122,6 +126,25 @@ her2 (Buffer Version)
 
       The imaginary parts of the diagonal elements are set to zero.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_her2_usm:
@@ -227,5 +250,26 @@ her2 (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/her2k.rst
+++ b/docs/domains/blas/her2k.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_her2k:
 
 her2k
@@ -213,6 +217,26 @@ her2k (Buffer Version)
    c
       Output buffer, overwritten by the updated ``C`` matrix.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_her2k_usm:
 
@@ -392,6 +416,26 @@ her2k (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/herk.rst
+++ b/docs/domains/blas/herk.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_herk:
 
 herk
@@ -164,6 +168,25 @@ herk (Buffer Version)
       ``alpha``\ \*op(``A``)*op(``A``)\ :sup:`T` + ``beta``\ \*\ ``C``.
       The imaginary parts of the diagonal elements are set to zero.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_herk_usm:
@@ -304,6 +327,26 @@ herk (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/hpmv.rst
+++ b/docs/domains/blas/hpmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_hpmv:
 
 hpmv
@@ -120,6 +124,25 @@ hpmv (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_hpmv_usm:
@@ -223,6 +246,26 @@ hpmv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/hpr.rst
+++ b/docs/domains/blas/hpr.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_hpr:
 
 hpr
@@ -107,6 +111,26 @@ hpr (Buffer Version)
 
       The imaginary parts of the diagonal elements are set to zero.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_hpr_usm:
 
@@ -196,6 +220,26 @@ hpr (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/hpr2.rst
+++ b/docs/domains/blas/hpr2.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_hpr2:
 
 hpr2
@@ -119,6 +123,25 @@ hpr2 (Buffer Version)
 
       The imaginary parts of the diagonal elements are set to zero.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_hpr2_usm:
@@ -222,5 +245,26 @@ hpr2 (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/iamax.rst
+++ b/docs/domains/blas/iamax.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_iamax:
 
 iamax
@@ -97,6 +101,26 @@ iamax (Buffer Version)
       The buffer where the zero-based index ``i`` of the maximal element
       is stored.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_iamax_usm:
 
@@ -163,5 +187,26 @@ iamax (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/iamin.rst
+++ b/docs/domains/blas/iamin.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_iamin:
 
 iamin
@@ -93,6 +97,26 @@ iamin (Buffer Version)
       Buffer where the zero-based index ``i`` of the minimum element
       will be stored.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_iamin_usm:
 
@@ -155,6 +179,26 @@ iamin (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/nrm2.rst
+++ b/docs/domains/blas/nrm2.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_nrm2:
 
 nrm2
@@ -87,6 +91,26 @@ nrm2 (Buffer Version)
       Buffer where the Euclidean norm of the vector ``x`` will be
       stored.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_nrm2_usm:
 
@@ -153,6 +177,26 @@ nrm2 (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/rot.rst
+++ b/docs/domains/blas/rot.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_rot:
 
 rot
@@ -114,6 +118,25 @@ rot (Buffer Version)
    y
       Buffer holding updated buffer ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_rot_usm:
@@ -204,5 +227,26 @@ rot (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/rotg.rst
+++ b/docs/domains/blas/rotg.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_rotg:
 
 rotg
@@ -99,6 +103,26 @@ rotg (Buffer Version)
       Buffer holding the parameter ``s`` associated with the Givens
       rotation.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_rotg_usm:
 
@@ -171,5 +195,26 @@ rotg (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/rotm.rst
+++ b/docs/domains/blas/rotm.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_rotm:
 
 rotm
@@ -138,6 +142,25 @@ rotm (Buffer Version)
    y
       Buffer holding updated buffer ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_rotm_usm:
@@ -262,5 +285,26 @@ rotm (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/rotmg.rst
+++ b/docs/domains/blas/rotmg.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_rotmg:
 
 rotmg
@@ -134,6 +138,25 @@ rotmg (Buffer Version)
       are assumed based on the value of ``flag`` and are not required to
       be set in the ``param`` vector.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_rotmg_usm:
@@ -253,5 +276,26 @@ rotmg (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/sbmv.rst
+++ b/docs/domains/blas/sbmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_sbmv:
 
 sbmv
@@ -130,6 +134,26 @@ sbmv (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_sbmv_usm:
 
@@ -240,5 +264,26 @@ sbmv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/scal.rst
+++ b/docs/domains/blas/scal.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_scal:
 
 scal
@@ -95,6 +99,26 @@ scal (Buffer Version)
    x
       Buffer holding updated buffer ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_scal_usm:
 
@@ -158,5 +182,26 @@ scal (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/sdsdot.rst
+++ b/docs/domains/blas/sdsdot.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_sdsdot:
 
 sdsdot
@@ -85,6 +89,26 @@ sdsdot (Buffer Version)
       Buffer where the result (a scalar) will be stored. If ``n`` < 0
       the result is ``sb``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_sdsdot_usm:
 
@@ -167,6 +191,26 @@ sdsdot (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/spmv.rst
+++ b/docs/domains/blas/spmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_spmv:
 
 spmv
@@ -117,6 +121,26 @@ spmv (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_spmv_usm:
 
@@ -216,5 +240,26 @@ spmv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/spr.rst
+++ b/docs/domains/blas/spr.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_spr:
 
 spr
@@ -103,6 +107,25 @@ spr (Buffer Version)
       triangular part of the symmetric matrix ``A`` if
       ``upper_lower``\ \=\ ``lower``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_spr_usm:
@@ -188,6 +211,26 @@ spr (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/spr2.rst
+++ b/docs/domains/blas/spr2.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_spr2:
 
 spr2
@@ -114,6 +118,26 @@ spr2 (Buffer Version)
       triangular part of the symmetric matrix ``A`` if
       ``upper_lower``\ \=\ ``lower``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_spr2_usm:
 
@@ -209,5 +233,26 @@ spr2 (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/swap.rst
+++ b/docs/domains/blas/swap.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_swap:
 
 swap
@@ -100,6 +104,25 @@ swap (Buffer Version)
       Buffer holding updated buffer ``y``, that is, the input vector
       ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_swap_usm:
@@ -180,5 +203,26 @@ swap (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-1-routines`

--- a/docs/domains/blas/symm.rst
+++ b/docs/domains/blas/symm.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_symm:
 
 symm
@@ -169,6 +173,26 @@ symm (Buffer Version)
    If ``beta`` = 0, matrix ``C`` does not need to be initialized before
    calling ``symm``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_symm_usm:
 
@@ -307,5 +331,26 @@ symm (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/symv.rst
+++ b/docs/domains/blas/symv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_symv:
 
 symv
@@ -120,6 +124,26 @@ symv (Buffer Version)
    y
       Buffer holding the updated vector ``y``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_symv_usm:
 
@@ -222,5 +246,26 @@ symv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/syr.rst
+++ b/docs/domains/blas/syr.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_syr:
 
 syr
@@ -109,6 +113,26 @@ syr (Buffer Version)
       triangular part of the symmetric matrix ``A`` if
       ``upper_lower``\ \=\ ``lower``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_syr_usm:
 
@@ -198,5 +222,26 @@ syr (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/syr2.rst
+++ b/docs/domains/blas/syr2.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_syr2:
 
 syr2
@@ -121,6 +125,25 @@ syr2 (Buffer Version)
       triangular part of the symmetric matrix ``A`` if
       ``upper_lower``\ \=\ ``lower``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_syr2_usm:
@@ -224,5 +247,26 @@ syr2 (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/syr2k.rst
+++ b/docs/domains/blas/syr2k.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_syr2k:
 
 syr2k
@@ -213,6 +217,25 @@ syr2k (Buffer Version)
    c
       Output buffer, overwritten by the updated ``C`` matrix.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_syr2k_usm:
@@ -393,5 +416,26 @@ syr2k (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/syrk.rst
+++ b/docs/domains/blas/syrk.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_syrk:
 
 syrk
@@ -159,6 +163,26 @@ syrk (Buffer Version)
       Output buffer, overwritten by
       ``alpha``\ \*op(``A``)*op(``A``)\ :sup:`T` + ``beta``\ \*\ ``C``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_syrk_usm:
 
@@ -292,5 +316,26 @@ syrk (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/tbmv.rst
+++ b/docs/domains/blas/tbmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_tbmv:
 
 tbmv
@@ -120,6 +124,25 @@ tbmv (Buffer Version)
    x
       Buffer holding the updated vector ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_tbmv_usm:
@@ -219,5 +242,26 @@ tbmv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/tbsv.rst
+++ b/docs/domains/blas/tbsv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_tbsv:
 
 tbsv
@@ -122,6 +126,25 @@ tbsv (Buffer Version)
    x
       Buffer holding the solution vector ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_tbsv_usm:
@@ -221,5 +244,26 @@ tbsv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/tpmv.rst
+++ b/docs/domains/blas/tpmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_tpmv:
 
 tpmv
@@ -108,6 +112,26 @@ tpmv (Buffer Version)
    x
       Buffer holding the updated vector ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_tpmv_usm:
 
@@ -195,5 +219,26 @@ tpmv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/tpsv.rst
+++ b/docs/domains/blas/tpsv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_tpsv:
 
 tpsv
@@ -113,6 +117,26 @@ tpsv (Buffer Version)
    x
       Buffer holding the solution vector ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_tpsv_usm:
 
@@ -203,5 +227,26 @@ tpsv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/trmm.rst
+++ b/docs/domains/blas/trmm.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_trmm:
 
 trmm
@@ -158,6 +162,25 @@ trmm (Buffer Version)
    If ``alpha`` = 0, matrix ``B`` is set to zero, and ``A`` and ``B`` do
    not need to be initialized at entry.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_trmm_usm:
@@ -284,5 +307,26 @@ trmm (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/trmv.rst
+++ b/docs/domains/blas/trmv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_trmv:
 
 trmv
@@ -114,6 +118,26 @@ trmv (Buffer Version)
    x
       Buffer holding the updated vector ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
 .. _onemkl_blas_trmv_usm:
 
@@ -206,5 +230,26 @@ trmv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/domains/blas/trsm.rst
+++ b/docs/domains/blas/trsm.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_trsm:
 
 trsm
@@ -156,6 +160,25 @@ trsm (Buffer Version)
    If ``alpha`` = 0, matrix ``B`` is set to zero, and ``A`` and ``B`` do
    not need to be initialized at entry.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_trsm_usm:
@@ -282,5 +305,26 @@ trsm (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-3-routines`

--- a/docs/domains/blas/trsm_batch.rst
+++ b/docs/domains/blas/trsm_batch.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_trsm_batch:
 
 trsm_batch
@@ -179,5 +183,365 @@ of matrices in ``a`` and ``b`` buffers are given by the ``batch_size`` parameter
 
    If ``alpha`` = 0, matrix ``B`` is set to zero and the matrices ``A``
    and ``B`` do not need to be initialized before calling ``trsm_batch``.
+
+
+trsm_batch (USM Version)
+---------------------------
+
+.. rubric:: Description
+
+The USM version of ``trsm_batch`` supports the group API and strided API. 
+
+The group API operation is defined as:
+::
+
+   idx = 0
+   for i = 0 … group_count – 1
+       for j = 0 … group_size – 1
+           A and B are matrices in a[idx] and b[idx]
+           if (left_right == onemkl::side::left) then
+               compute X such that op(A) * X = alpha[i] * B
+           else
+               compute X such that X * op(A) = alpha[i] * B
+           end if
+           B := X
+           idx = idx + 1
+       end for
+   end for     
+
+
+The strided API operation is defined as:
+::
+
+   for i = 0 … batch_size – 1
+       A and B are matrices at offset i * stridea and i * strideb in a and b.
+       if (left_right == onemkl::side::left) then
+           compute X such that op(A) * X = alpha * B
+       else
+           compute X such that X * op(A) = alpha * B
+       end if
+       B := X
+   end for
+
+   where:
+
+op(``A``) is one of op(``A``) = ``A``, or op(A) = ``A``\ :sup:`T`,
+or op(``A``) = ``A``\ :sup:`H`,
+
+``alpha`` is a scalar,
+
+``A`` is a triangular matrix,
+
+``B`` and ``X`` are ``m`` x ``n`` general matrices,
+
+``A`` is either ``m`` x ``m`` or ``n`` x ``n``,depending on whether
+it multiplies ``X`` on the left or right. On return, the matrix ``B``
+is overwritten by the solution matrix ``X``.
+
+For group API, ``a`` and ``b`` arrays contain the pointers for all the input matrices. 
+The total number of matrices in ``a`` and ``b`` are given by: 
+ 
+.. math::
+      
+      total\_batch\_count = \sum_{i=0}^{group\_count-1}group\_size[i]
+
+For strided API, ``a`` and ``b`` arrays contain all the input matrices. The total number of matrices 
+in ``a`` and ``b`` are given by the ``batch_size`` parameter.  
+
+**Group API**
+
+.. rubric:: Syntax
+      
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side *left_right,
+                              onemkl::uplo *upper_lower,
+                              onemkl::transpose *trans,
+                              onemkl::diag *unit_diag,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              T **b,
+                              std::int64_t *ldb,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const sycl::vector_class<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side *left_right,
+                              onemkl::uplo *upper_lower,
+                              onemkl::transpose *trans,
+                              onemkl::diag *unit_diag,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              T **b,
+                              std::int64_t *ldb,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const sycl::vector_class<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   left_right
+      Array of ``group_count`` ``onemkl::side`` values. ``left_right[i]`` specifies whether ``A`` multiplies
+      ``X`` on the left (``side::left``) or on the right
+      (``side::right``) for every ``trsm`` operation in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   upper_lower
+      Array of ``group_count`` ``onemkl::uplo`` values. ``upper_lower[i]`` specifies whether ``A`` is upper or lower
+      triangular for every matrix in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   trans
+      Array of ``group_count`` ``onemkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used
+      for every ``trsm`` operation in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   unit_diag
+      Array of ``group_count`` ``onemkl::diag`` values. ``unit_diag[i]`` specifies whether ``A`` is assumed to
+      be unit triangular (all diagonal elements are 1) for every matrix in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Array of ``group_count`` integers. ``m[i]`` specifies the
+      number of rows of ``B`` for every matrix in group ``i``. All entries must be at least zero.
+
+   n
+      Array of ``group_count`` integers. ``n[i]`` specifies the
+      number of columns of ``B`` for every matrix in group ``i``. All entries must be at least zero.
+
+   alpha
+      Array of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor in group ``i``.
+
+   a
+      Array of pointers to input matrices ``A`` with size ``total_batch_count``. See :ref:`matrix-storage` for more details.
+
+   lda
+      Array of ``group_count`` integers. ``lda[i]`` specifies the leading dimension of ``A`` for every matrix in group ``i``. 
+      All entries must be at least ``m``
+      if ``left_right`` is ``side::left``, and at least 
+      ``n`` if ``left_right`` is ``side::right``. All entries must be positive.
+
+   b
+      Array of pointers to input matrices ``B`` with size ``total_batch_count``. See :ref:`matrix-storage` for more details.
+
+   ldb
+      Array of ``group_count`` integers. ``ldb[i]`` specifies the
+      leading dimension of ``B`` for every matrix in group ``i``.  All
+      entries must be positive and at least ``m`` and positive if
+      column major layout is used to store matrices or at least ``n``
+      if row major layout is used to store matrices.
+
+   group_count
+      Specifies the number of groups. Must be at least 0.
+
+   group_size
+      Array of ``group_count`` integers. ``group_size[i]`` specifies the
+      number of ``trsm`` operations in group ``i``. All entries must be at least 0.
+
+   dependencies
+         List of events to wait for before starting computation, if any.
+         If omitted, defaults to no dependencies.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   b
+      Output buffer, overwritten by the ``total_batch_count`` solution
+      matrices ``X``.
+
+.. container:: section
+
+   .. rubric:: Notes
+
+   If ``alpha`` = 0, matrix ``B`` is set to zero and the matrices ``A``
+   and ``B`` do not need to be initialized before calling ``trsm_batch``.
+
+.. container:: section
+   
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side left_right,
+                              onemkl::uplo upper_lower,
+                              onemkl::transpose trans,
+                              onemkl::diag unit_diag,
+                              std::int64_t m,
+                              std::int64_t n,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              T *b,
+                              std::int64_t ldb,
+                              std::int64_t strideb,
+                              std::int64_t batch_size,
+                              const sycl::vector_class<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side left_right,
+                              onemkl::uplo upper_lower,
+                              onemkl::transpose trans,
+                              onemkl::diag unit_diag,
+                              std::int64_t m,
+                              std::int64_t n,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              T *b,
+                              std::int64_t ldb,
+                              std::int64_t strideb,
+                              std::int64_t batch_size,
+                              const sycl::vector_class<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   left_right
+      Specifies whether the matrices ``A`` multiply ``X`` on the left
+      (``side::left``) or on the right (``side::right``). See :ref:`onemkl_datatypes` for more details.
+
+   upper_lower
+      Specifies whether the matrices ``A`` are upper or lower
+      triangular. See :ref:`onemkl_datatypes` for more details.
+
+   trans
+      Specifies op(``A``), the transposition operation applied to the
+      matrices ``A``. See :ref:`onemkl_datatypes` for more details.
+
+   unit_diag
+      Specifies whether the matrices ``A`` are assumed to be unit
+      triangular (all diagonal elements are 1). See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Number of rows of the ``B`` matrices. Must be at least zero.
+
+   n
+      Number of columns of the ``B`` matrices. Must be at least zero.
+
+   alpha
+      Scaling factor for the solutions.
+
+   a
+      Pointer to input matrices ``A`` with size ``stridea`` * ``batch_size``.
+
+   lda
+      Leading dimension of the matrices ``A``. Must be at least ``m`` if
+      ``left_right`` = ``side::left``, and at least ``n`` if ``left_right`` =
+      ``side::right``. Must be positive.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   b
+      Pointer to input matrices ``B`` with size ``strideb`` * ``batch_size``.
+
+   ldb
+      Leading dimension of the matrices ``B``. It must be positive and at least
+      ``m`` if column major layout is used to store matrices or at
+      least ``n`` if row major layout is used to store matrices.
+
+   strideb
+      Stride between different ``B`` matrices. 
+
+   batch_size
+      Specifies the number of triangular linear systems to solve.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   b
+      Output matrices, overwritten by ``batch_size`` solution matrices
+      ``X``.
+
+.. container:: section
+
+   .. rubric:: Notes
+
+   If ``alpha`` = 0, matrix ``B`` is set to zero and the matrices ``A``
+   and ``B`` do not need to be initialized before calling ``trsm_batch``.
+
+.. container:: section
+   
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+   **Parent topic:** :ref:`blas-like-extensions`
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
+
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/trsv.rst
+++ b/docs/domains/blas/trsv.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
 .. _onemkl_blas_trsv:
 
 trsv
@@ -116,6 +120,25 @@ trsv (Buffer Version)
    x
       Buffer holding the solution vector ``x``.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
       
 
 .. _onemkl_blas_trsv_usm:
@@ -211,5 +234,26 @@ trsv (USM Version)
 
    Output event to wait on to ensure computation is complete.
 
+.. container:: section
+
+   .. rubric:: Throws
+
+   This routine shall throw the following exceptions if the associated condition is detected. An implementation may throw additional implementation-specific exception(s) in case of error conditions not covered here.
+
+   :ref:`oneapi::mkl::invalid_argument<onemkl_exception_invalid_argument>`
+       
+       
+   
+   :ref:`oneapi::mkl::unsupported_device<onemkl_exception_unsupported_device>`
+       
+
+   :ref:`oneapi::mkl::host_bad_alloc<onemkl_exception_host_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::device_bad_alloc<onemkl_exception_device_bad_alloc>`
+       
+
+   :ref:`oneapi::mkl::unimplemented<onemkl_exception_unimplemented>`
+      
 
    **Parent topic:** :ref:`blas-level-2-routines`

--- a/docs/exceptions.inc.rst
+++ b/docs/exceptions.inc.rst
@@ -1,0 +1,81 @@
+.. SPDX-FileCopyrightText: 2019-2020 Intel Corporation
+..
+.. SPDX-License-Identifier: CC-BY-4.0
+
+.. _onemkl_exceptions:
+
+Exceptions and Error Handling
+------------------------------
+
+oneMKL error handling relies on the mechanism of C++ exceptions. Should error occur, it will be propagated at the point of a function call where it is caught using standard C++ error handling mechanism.
+
+.. _onemkl_exception_classification:
+
+Exception classification
+++++++++++++++++++++++++
+
+Exception classification in oneMKL is aligned with C++ Standard Library classification. oneMKL introduces class that defines the base class in the hierarchy of oneMKL exception classes. All oneMKL routines throw exceptions inherited from this base class.
+In the hierarchy of oneMKL exceptions, ``oneapi::mkl::exception`` is the base class inherited from ``std::exception`` class. All other oneMKL exception classes are derived from this base class.
+
+This specification does not require implementations to perform error-checking. However, if an implementation does provide error-checking, it shall use the following exception classes. Additional implementation-specific exception classes can be used for exceptional conditions not fitting any of these classes.
+
+.. _onemkl_common_exceptions:
+
+Common exceptions
+*****************
+
+.. csv-table::
+    :header: "Exception class", "Description"
+    :widths: 40, 60
+
+    ".. _onemkl_exception:
+
+    ``oneapi::mkl::exception``", "Reports general unspecified problem"
+    ".. _onemkl_exception_unsupported_device:
+
+    ``oneapi::mkl::unsupported_device``", "Reports a problem when the routine is not supported on a specific device"
+    ".. _onemkl_exception_host_bad_alloc:
+
+    ``oneapi::mkl::host_bad_alloc``", "Reports a problem that occurred during memory allocation on the host"
+    ".. _onemkl_exception_device_bad_alloc:
+
+    ``oneapi::mkl::device_bad_alloc``", "Reports a problem that occurred during memory allocation on a specific device"
+    ".. _onemkl_exception_unimplemented:
+
+    ``oneapi::mkl::unimplemented``", "Reports a problem when a specific routine has not been implemented for the specified parameters"
+    ".. _onemkl_exception_invalid_argument:
+
+    ``oneapi::mkl::invalid_argument``", "Reports problem when arguments to the routine were rejected"
+    ".. _onemkl_exception_uninitialized:
+
+    ``oneapi::mkl::uninitialized``", "Reports problem when a handle (descriptor) has not been initialized"
+    ".. _onemkl_exception_computation_error:
+
+    ``oneapi::mkl::computation_error``", "Reports any computation errors that have occurred inside a oneMKL routine"
+    ".. _onemkl_exception_batch_error:
+
+    ``oneapi::mkl::batch_error``", "Reports errors that have occurred inside a batch oneMKL routine"
+
+
+.. _onemkl_lapack_specific_exceptions:
+
+LAPACK specific exceptions
+**************************
+
+.. csv-table::
+    :header: "Exception class", "Description"
+    :widths: 40, 60
+
+    ".. _onemkl_lapack_exception:
+
+    ``oneapi::mkl::lapack::exception``", "Base class for all LAPACK exceptions providing access to info code familiar to users of conventional LAPACK API. All LAPACK related exceptions can be handled with catch block for this class."
+    ".. _onemkl_lapack_exception_invalid_argument:
+    
+    ``oneapi::mkl::lapack::invalid_argument``", "Reports errors when arguments provided to the LAPACK subroutine are inconsistent or do not match expected values. Class extends base ``oneapi::mkl::invalid_argument`` with ability to access conventional status info code."
+    ".. _onemkl_lapack_exception_computation_error:
+    
+    ``oneapi::mkl::lapack::computation_error``", "Reports computation errors that have occurred during call to LAPACK subroutine. Class extends base ``oneapi::mkl::computation_error`` with ability to access conventional status info code familiar to LAPACK users."
+    ".. _onemkl_lapack_exception_batch_error:
+    
+    ``oneapi::mkl::lapack::batch_error``", "Reports errors that have occurred during batch LAPACK computations. Class extends base ``oneapi::mkl::batch_error`` with ability to access individual exception objects for each of the issues observed in a batch and an info code. The info code contains the number of errors that occurred in a batch. Positions of problems in a supplied batch that experienced issues during computations can be retrieved with `ids()` method, and list of particular exceptions can be obtained with `exceptions()` method of the exception object. Possible exceptions for a batch are documented for corresponding non-batch API."
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,3 +21,4 @@ oneMKL Interfaces is an open-source implementation of oneMKL Data Parallel C++ (
    domains/matrix-storage.rst
    domains/blas/blas.rst
    create_new_backend.rst
+   exceptions.inc.rst


### PR DESCRIPTION
…ection.

Added exceptions.inc.rst to oneMKL/docs to resolve cross references used in BLAS topics, and added exceptions.inc.rst to the index toctree.

Signed-off-by: John O'Connell <john.oconnell@intel.com>

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
