### PR TITLE
doc: add oneAPI logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # oneAPI Math Kernel Library (oneMKL) Interfaces
 
+<img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo">
+
 oneMKL interfaces are an open-source implementation of the oneMKL Data Parallel C++ (DPC++) interface according to the [oneMKL specification](https://spec.oneapi.com/versions/latest/elements/oneMKL/source/index.html). It works with multiple devices (backends) using device-specific libraries underneath.
+
+oneMKL is part of [oneAPI](https://oneapi.io).
+<br/><br/>
 
 <table>
     <thead>


### PR DESCRIPTION
Add oneAPI main page link and logo to README.

See the rendered document here: [link](https://github.com/mkrainiuk/oneMKL/blob/main/README.md)