### PR TITLE
all: replace unsupported sycl::vector_class with std::vector

### DIFF
--- a/docs/domains/blas/asum.rst
+++ b/docs/domains/blas/asum.rst
@@ -103,7 +103,7 @@ asum (USM Version)
                         const T *x,
                         std::int64_t incx,
                         T_res *result,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -113,7 +113,7 @@ asum (USM Version)
                         const T *x,
                         std::int64_t incx,
                         T_res *result,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/axpy.rst
+++ b/docs/domains/blas/axpy.rst
@@ -117,7 +117,7 @@ axpy (USM Version)
                         std::int64_t incx,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -129,7 +129,7 @@ axpy (USM Version)
                         std::int64_t incx,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/axpy_batch.rst
+++ b/docs/domains/blas/axpy_batch.rst
@@ -85,7 +85,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
                               std::int64_t *incy,
                               std::int64_t group_count,
                               std::int64_t *group_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -99,7 +99,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
                               std::int64_t *incy,
                               std::int64_t group_count,
                               std::int64_t *group_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section
@@ -173,7 +173,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
                               std::int64_t incy,
                               std::int64_t stridey,
                               std::int64_t batch_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -188,7 +188,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
                               std::int64_t incy,
                               std::int64_t stridey,
                               std::int64_t batch_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/copy.rst
+++ b/docs/domains/blas/copy.rst
@@ -102,7 +102,7 @@ copy (USM Version)
                         std::int64_t incx,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -113,7 +113,7 @@ copy (USM Version)
                         std::int64_t incx,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
    
 .. container:: section

--- a/docs/domains/blas/dot.rst
+++ b/docs/domains/blas/dot.rst
@@ -118,7 +118,7 @@ dot (USM Version)
                        const T *y,
                        std::int64_t incy,
                        T_res *result,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -130,7 +130,7 @@ dot (USM Version)
                        const T *y,
                        std::int64_t incy,
                        T_res *result,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/dotc.rst
+++ b/docs/domains/blas/dotc.rst
@@ -106,7 +106,7 @@ dotc (USM Version)
                  const T *y,
                  std::int64_t incy,
                  T *result,
-                 const sycl::vector_class<sycl::event> &dependencies = {})
+                 const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -118,7 +118,7 @@ dotc (USM Version)
                  const T *y,
                  std::int64_t incy,
                  T *result,
-                 const sycl::vector_class<sycl::event> &dependencies = {})
+                 const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/dotu.rst
+++ b/docs/domains/blas/dotu.rst
@@ -106,7 +106,7 @@ dotu (USM Version)
                         const T *y,
                         std::int64_t incy,
                         T *result,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -118,7 +118,7 @@ dotu (USM Version)
                         const T *y,
                         std::int64_t incy,
                         T *result,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/gbmv.rst
+++ b/docs/domains/blas/gbmv.rst
@@ -179,7 +179,7 @@ gbmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -198,7 +198,7 @@ gbmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/gemm.rst
+++ b/docs/domains/blas/gemm.rst
@@ -272,7 +272,7 @@ gemm (USM Version)
                         Ts beta,
                         Tc *c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -291,7 +291,7 @@ gemm (USM Version)
                         Ts beta,
                         Tc *c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/gemm_batch.rst
+++ b/docs/domains/blas/gemm_batch.rst
@@ -287,7 +287,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t *ldc,
                               std::int64_t group_count,
                               std::int64_t *group_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -308,7 +308,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t *ldc,
                               std::int64_t group_count,
                               std::int64_t *group_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section
@@ -463,7 +463,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t ldc,
                               std::int64_t stridec,
                               std::int64_t batch_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -486,7 +486,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t ldc,
                               std::int64_t stridec,
                               std::int64_t batch_size,
-                              const sycl::vector_class<sycl::event> &dependencies = {})
+                              const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/gemmt.rst
+++ b/docs/domains/blas/gemmt.rst
@@ -243,7 +243,7 @@ gemmt (USM Version)
                          T beta,
                          T* c,
                          std::int64_t ldc,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -262,7 +262,7 @@ gemmt (USM Version)
                          T beta,
                          T* c,
                          std::int64_t ldc,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/gemv.rst
+++ b/docs/domains/blas/gemv.rst
@@ -161,7 +161,7 @@ gemv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -178,7 +178,7 @@ gemv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/ger.rst
+++ b/docs/domains/blas/ger.rst
@@ -142,7 +142,7 @@ ger (USM Version)
                        std::int64_t incy,
                        T *a,
                        std::int64_t lda,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -157,7 +157,7 @@ ger (USM Version)
                        std::int64_t incy,
                        T *a,
                        std::int64_t lda,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/gerc.rst
+++ b/docs/domains/blas/gerc.rst
@@ -144,7 +144,7 @@ gerc (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -159,7 +159,7 @@ gerc (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/geru.rst
+++ b/docs/domains/blas/geru.rst
@@ -142,7 +142,7 @@ geru (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -157,7 +157,7 @@ geru (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/hbmv.rst
+++ b/docs/domains/blas/hbmv.rst
@@ -153,7 +153,7 @@ hbmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -170,7 +170,7 @@ hbmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/hemm.rst
+++ b/docs/domains/blas/hemm.rst
@@ -195,7 +195,7 @@ hemm (USM Version)
                         T beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -213,7 +213,7 @@ hemm (USM Version)
                         T beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/hemv.rst
+++ b/docs/domains/blas/hemv.rst
@@ -146,7 +146,7 @@ hemv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -162,7 +162,7 @@ hemv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/her.rst
+++ b/docs/domains/blas/her.rst
@@ -129,7 +129,7 @@ her (USM Version)
                        std::int64_t incx,
                        T *a,
                        std::int64_t lda,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -142,7 +142,7 @@ her (USM Version)
                        std::int64_t incx,
                        T *a,
                        std::int64_t lda,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/her2.rst
+++ b/docs/domains/blas/her2.rst
@@ -144,7 +144,7 @@ her2 (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -159,7 +159,7 @@ her2 (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/her2k.rst
+++ b/docs/domains/blas/her2k.rst
@@ -237,7 +237,7 @@ her2k (USM Version)
                          T_real beta,
                          T* c,
                          std::int64_t ldc,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -255,7 +255,7 @@ her2k (USM Version)
                          T_real beta,
                          T* c,
                          std::int64_t ldc,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/herk.rst
+++ b/docs/domains/blas/herk.rst
@@ -187,7 +187,7 @@ herk (USM Version)
                         T_real beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -203,7 +203,7 @@ herk (USM Version)
                         T_real beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/hpmv.rst
+++ b/docs/domains/blas/hpmv.rst
@@ -142,7 +142,7 @@ hpmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -157,7 +157,7 @@ hpmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/hpr.rst
+++ b/docs/domains/blas/hpr.rst
@@ -125,7 +125,7 @@ hpr (USM Version)
                        const T *x,
                        std::int64_t incx,
                        T *a,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -137,7 +137,7 @@ hpr (USM Version)
                        const T *x,
                        std::int64_t incx,
                        T *a,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/hpr2.rst
+++ b/docs/domains/blas/hpr2.rst
@@ -140,7 +140,7 @@ hpr2 (USM Version)
                         const T *y,
                         std::int64_t incy,
                         T *a,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -154,7 +154,7 @@ hpr2 (USM Version)
                         const T *y,
                         std::int64_t incy,
                         T *a,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/iamax.rst
+++ b/docs/domains/blas/iamax.rst
@@ -113,7 +113,7 @@ iamax (USM Version)
                          const T *x,
                          std::int64_t incx,
                          T_res *result,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -123,7 +123,7 @@ iamax (USM Version)
                          const T *x,
                          std::int64_t incx,
                          T_res *result,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/iamin.rst
+++ b/docs/domains/blas/iamin.rst
@@ -109,7 +109,7 @@ iamin (USM Version)
                          const T *x,
                          std::int64_t incx,
                          T_res *result,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -119,7 +119,7 @@ iamin (USM Version)
                          const T *x,
                          std::int64_t incx,
                          T_res *result,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/nrm2.rst
+++ b/docs/domains/blas/nrm2.rst
@@ -103,7 +103,7 @@ nrm2 (USM Version)
                         const T *x,
                         std::int64_t incx,
                         T_res *result,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -113,7 +113,7 @@ nrm2 (USM Version)
                         const T *x,
                         std::int64_t incx,
                         T_res *result,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/rot.rst
+++ b/docs/domains/blas/rot.rst
@@ -134,7 +134,7 @@ rot (USM Version)
                        std::int64_t incy,
                        T_scalar c,
                        T_scalar s,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -147,7 +147,7 @@ rot (USM Version)
                        std::int64_t incy,
                        T_scalar c,
                        T_scalar s,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/rotg.rst
+++ b/docs/domains/blas/rotg.rst
@@ -115,7 +115,7 @@ rotg (USM Version)
                         T *b,
                         T_real *c,
                         T *s,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -125,7 +125,7 @@ rotg (USM Version)
                         T *b,
                         T_real *c,
                         T *s,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/rotm.rst
+++ b/docs/domains/blas/rotm.rst
@@ -157,7 +157,7 @@ rotm (USM Version)
                         T *y,
                         std::int64_t incy,
                         T *param,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -169,7 +169,7 @@ rotm (USM Version)
                         T *y,
                         std::int64_t incy,
                         T *param,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
    
 .. container:: section

--- a/docs/domains/blas/rotmg.rst
+++ b/docs/domains/blas/rotmg.rst
@@ -152,7 +152,7 @@ rotmg (USM Version)
                          T *x1,
                          T *y1,
                          T *param,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -163,7 +163,7 @@ rotmg (USM Version)
                          T *x1,
                          T *y1,
                          T *param,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/sbmv.rst
+++ b/docs/domains/blas/sbmv.rst
@@ -153,7 +153,7 @@ sbmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -170,7 +170,7 @@ sbmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/scal.rst
+++ b/docs/domains/blas/scal.rst
@@ -111,7 +111,7 @@ scal (USM Version)
                         T_scalar alpha,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -121,7 +121,7 @@ scal (USM Version)
                         T_scalar alpha,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/sdsdot.rst
+++ b/docs/domains/blas/sdsdot.rst
@@ -104,7 +104,7 @@ sdsdot (USM Version)
                           const float *y,
                           std::int64_t incy,
                           float *result,
-                          const sycl::vector_class<sycl::event> &dependencies = {})
+                          const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -117,7 +117,7 @@ sdsdot (USM Version)
                           const float *y,
                           std::int64_t incy,
                           float *result,
-                          const sycl::vector_class<sycl::event> &dependencies = {})
+                          const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/spmv.rst
+++ b/docs/domains/blas/spmv.rst
@@ -138,7 +138,7 @@ spmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -153,7 +153,7 @@ spmv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
    
 .. container:: section

--- a/docs/domains/blas/spr.rst
+++ b/docs/domains/blas/spr.rst
@@ -122,7 +122,7 @@ spr (USM Version)
                        const T *x,
                        std::int64_t incx,
                        T *a,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -134,7 +134,7 @@ spr (USM Version)
                        const T *x,
                        std::int64_t incx,
                        T *a,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
    
 .. container:: section

--- a/docs/domains/blas/swap.rst
+++ b/docs/domains/blas/swap.rst
@@ -118,7 +118,7 @@ swap (USM Version)
                         std::int64_t incx,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -129,7 +129,7 @@ swap (USM Version)
                         std::int64_t incx,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
    
 .. container:: section

--- a/docs/domains/blas/symm.rst
+++ b/docs/domains/blas/symm.rst
@@ -193,7 +193,7 @@ symm (USM Version)
                         T beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -211,7 +211,7 @@ symm (USM Version)
                         T beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/symv.rst
+++ b/docs/domains/blas/symv.rst
@@ -142,7 +142,7 @@ symv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -158,7 +158,7 @@ symv (USM Version)
                         T beta,
                         T *y,
                         std::int64_t incy,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/syr.rst
+++ b/docs/domains/blas/syr.rst
@@ -128,7 +128,7 @@ syr (USM Version)
                        std::int64_t incx,
                        T *a,
                        std::int64_t lda,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -141,7 +141,7 @@ syr (USM Version)
                        std::int64_t incx,
                        T *a,
                        std::int64_t lda,
-                       const sycl::vector_class<sycl::event> &dependencies = {})
+                       const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/syr2.rst
+++ b/docs/domains/blas/syr2.rst
@@ -143,7 +143,7 @@ syr2 (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -158,7 +158,7 @@ syr2 (USM Version)
                         std::int64_t incy,
                         T *a,
                         std::int64_t lda,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/syr2k.rst
+++ b/docs/domains/blas/syr2k.rst
@@ -238,7 +238,7 @@ syr2k (USM Version)
                          T beta,
                          T* c,
                          std::int64_t ldc,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -256,7 +256,7 @@ syr2k (USM Version)
                          T beta,
                          T* c,
                          std::int64_t ldc,
-                         const sycl::vector_class<sycl::event> &dependencies = {})
+                         const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/syrk.rst
+++ b/docs/domains/blas/syrk.rst
@@ -181,7 +181,7 @@ syrk (USM Version)
                         T beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -197,7 +197,7 @@ syrk (USM Version)
                         T beta,
                         T* c,
                         std::int64_t ldc,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/tbmv.rst
+++ b/docs/domains/blas/tbmv.rst
@@ -142,7 +142,7 @@ tbmv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -157,7 +157,7 @@ tbmv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/tbsv.rst
+++ b/docs/domains/blas/tbsv.rst
@@ -144,7 +144,7 @@ tbsv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -159,7 +159,7 @@ tbsv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/tpmv.rst
+++ b/docs/domains/blas/tpmv.rst
@@ -127,7 +127,7 @@ tpmv (USM Version)
                         const T *a,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -140,7 +140,7 @@ tpmv (USM Version)
                         const T *a,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/tpsv.rst
+++ b/docs/domains/blas/tpsv.rst
@@ -133,7 +133,7 @@ tpsv (USM Version)
                         const T *a,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -147,7 +147,7 @@ tpsv (USM Version)
                         const T *a,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/trmm.rst
+++ b/docs/domains/blas/trmm.rst
@@ -181,7 +181,7 @@ trmm (USM Version)
                         std::int64_t lda,
                         T* b,
                         std::int64_t ldb,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -197,7 +197,7 @@ trmm (USM Version)
                         std::int64_t lda,
                         T* b,
                         std::int64_t ldb,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/trmv.rst
+++ b/docs/domains/blas/trmv.rst
@@ -134,7 +134,7 @@ trmv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -148,7 +148,7 @@ trmv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/trsm.rst
+++ b/docs/domains/blas/trsm.rst
@@ -180,7 +180,7 @@ trsm (USM Version)
                         std::int64_t lda,
                         T* b,
                         std::int64_t ldb,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -197,7 +197,7 @@ trsm (USM Version)
                         std::int64_t lda,
                         T* b,
                         std::int64_t ldb,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/docs/domains/blas/trsv.rst
+++ b/docs/domains/blas/trsv.rst
@@ -138,7 +138,7 @@ trsv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -153,7 +153,7 @@ trsv (USM Version)
                         std::int64_t lda,
                         T *x,
                         std::int64_t incx,
-                        const sycl::vector_class<sycl::event> &dependencies = {})
+                        const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section

--- a/include/oneapi/mkl/blas.hxx
+++ b/include/oneapi/mkl/blas.hxx
@@ -1938,7 +1938,7 @@ static inline void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose tran
 
 static inline cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    float *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
@@ -1947,7 +1947,7 @@ static inline cl::sycl::event asum(
 
 static inline cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    double *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
@@ -1956,7 +1956,7 @@ static inline cl::sycl::event asum(
 
 static inline cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
@@ -1965,7 +1965,7 @@ static inline cl::sycl::event asum(
 
 static inline cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
@@ -1974,7 +1974,7 @@ static inline cl::sycl::event asum(
 
 static inline cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
@@ -1984,7 +1984,7 @@ static inline cl::sycl::event axpy(
 static inline cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
     double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
@@ -1994,7 +1994,7 @@ static inline cl::sycl::event axpy(
 static inline cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
     std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
@@ -2004,7 +2004,7 @@ static inline cl::sycl::event axpy(
 static inline cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
@@ -2014,7 +2014,7 @@ static inline cl::sycl::event axpy(
 static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, double *alpha, const double **x, std::int64_t *incx,
     double **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2027,7 +2027,7 @@ static inline cl::sycl::event axpy_batch(
 static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x, std::int64_t *incx,
     float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2041,7 +2041,7 @@ static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2055,7 +2055,7 @@ static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2068,7 +2068,7 @@ static inline cl::sycl::event axpy_batch(
 static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
     std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2081,7 +2081,7 @@ static inline cl::sycl::event axpy_batch(
 static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
     std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2095,7 +2095,7 @@ static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
     std::int64_t incx, std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2109,7 +2109,7 @@ static inline cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2122,7 +2122,7 @@ static inline cl::sycl::event axpy_batch(
 static inline cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
     const float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2133,7 +2133,7 @@ static inline cl::sycl::event axpby(
 static inline cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
     const double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2144,7 +2144,7 @@ static inline cl::sycl::event axpby(
 static inline cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
     std::int64_t incx, const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2156,7 +2156,7 @@ static inline cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2166,7 +2166,7 @@ static inline cl::sycl::event axpby(
 
 static inline cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -2175,7 +2175,7 @@ static inline cl::sycl::event copy(
 
 static inline cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -2185,7 +2185,7 @@ static inline cl::sycl::event copy(
 static inline cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -2195,7 +2195,7 @@ static inline cl::sycl::event copy(
 static inline cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -2205,7 +2205,7 @@ static inline cl::sycl::event copy(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx, float **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2216,7 +2216,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx, double **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2227,7 +2227,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const std::complex<float> **x, std::int64_t *incx,
     std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2238,7 +2238,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const std::complex<double> **x, std::int64_t *incx,
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2249,7 +2249,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t stridex,
     float *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2261,7 +2261,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
     std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2273,7 +2273,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     std::int64_t stridex, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2285,7 +2285,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2297,7 +2297,7 @@ static inline cl::sycl::event copy_batch(
 static inline cl::sycl::event dot(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
     std::int64_t incy, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dot_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done = detail::dot(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
     dot_postcondition(queue, n, x, incx, y, incy, result, dependencies);
@@ -2307,7 +2307,7 @@ static inline cl::sycl::event dot(
 static inline cl::sycl::event dot(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, const double *y,
     std::int64_t incy, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dot_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done = detail::dot(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
     dot_postcondition(queue, n, x, incx, y, incy, result, dependencies);
@@ -2317,7 +2317,7 @@ static inline cl::sycl::event dot(
 static inline cl::sycl::event dot(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
     std::int64_t incy, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dot_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done = detail::dot(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
     dot_postcondition(queue, n, x, incx, y, incy, result, dependencies);
@@ -2327,7 +2327,7 @@ static inline cl::sycl::event dot(
 static inline cl::sycl::event dotc(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dotc_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotc(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2338,7 +2338,7 @@ static inline cl::sycl::event dotc(
 static inline cl::sycl::event dotc(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dotc_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotc(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2349,7 +2349,7 @@ static inline cl::sycl::event dotc(
 static inline cl::sycl::event dotu(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dotu_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotu(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2360,7 +2360,7 @@ static inline cl::sycl::event dotu(
 static inline cl::sycl::event dotu(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dotu_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotu(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2372,7 +2372,7 @@ static inline cl::sycl::event gbmv(
     cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
     std::int64_t ku, float alpha, const float *a, std::int64_t lda, const float *x,
     std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2386,7 +2386,7 @@ static inline cl::sycl::event gbmv(
     cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
     std::int64_t ku, double alpha, const double *a, std::int64_t lda, const double *x,
     std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2401,7 +2401,7 @@ static inline cl::sycl::event gbmv(
     std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2416,7 +2416,7 @@ static inline cl::sycl::event gbmv(
     std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2430,7 +2430,7 @@ static inline cl::sycl::event gemm(
     cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
     std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
     float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2444,7 +2444,7 @@ static inline cl::sycl::event gemm(
     cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
     std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *b,
     std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2459,7 +2459,7 @@ static inline cl::sycl::event gemm(
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2474,7 +2474,7 @@ static inline cl::sycl::event gemm(
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2488,7 +2488,7 @@ static inline cl::sycl::event gemm(
     cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
     std::int64_t k, half alpha, const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
     half beta, half *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2502,7 +2502,7 @@ static inline cl::sycl::event gemm(
     cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
     std::int64_t k, float alpha, const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
     float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2516,7 +2516,7 @@ static inline cl::sycl::event gemm(
     cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
     std::int64_t k, float alpha, const bfloat16 *a, std::int64_t lda, const bfloat16 *b,
     std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2530,7 +2530,7 @@ static inline cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, transpose *transa, transpose *transb, std::int64_t *m, std::int64_t *n,
     std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, const float **b,
     std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2545,7 +2545,7 @@ static inline cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, transpose *transa, transpose *transb, std::int64_t *m, std::int64_t *n,
     std::int64_t *k, double *alpha, const double **a, std::int64_t *lda, const double **b,
     std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2561,7 +2561,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
     const std::complex<float> **b, std::int64_t *ldb, std::complex<float> *beta,
     std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2577,7 +2577,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
     const std::complex<double> **b, std::int64_t *ldb, std::complex<double> *beta,
     std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2592,7 +2592,7 @@ static inline cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, transpose *transa, transpose *transb, std::int64_t *m, std::int64_t *n,
     std::int64_t *k, half *alpha, const half **a, std::int64_t *lda, const half **b,
     std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2608,7 +2608,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t k, float alpha, const float *a, std::int64_t lda, std::int64_t stride_a,
     const float *b, std::int64_t ldb, std::int64_t stride_b, float beta, float *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2624,7 +2624,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t k, double alpha, const double *a, std::int64_t lda, std::int64_t stride_a,
     const double *b, std::int64_t ldb, std::int64_t stride_b, double beta, double *c,
     std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2640,7 +2640,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::int64_t stride_a, const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2656,7 +2656,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stride_a, const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2672,7 +2672,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t k, half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
     const half *b, std::int64_t ldb, std::int64_t stride_b, half beta, half *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2687,7 +2687,7 @@ static inline cl::sycl::event gemmt(
     cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, std::int64_t n,
     std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
     float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2701,7 +2701,7 @@ static inline cl::sycl::event gemmt(
     cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, std::int64_t n,
     std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *b,
     std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2716,7 +2716,7 @@ static inline cl::sycl::event gemmt(
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2731,7 +2731,7 @@ static inline cl::sycl::event gemmt(
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2746,7 +2746,7 @@ static inline cl::sycl::event gemm_bias(
     std::int64_t n, std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
     std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo, float beta,
     std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2761,7 +2761,7 @@ static inline cl::sycl::event gemm_bias(
     std::int64_t n, std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
     std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo, float beta,
     std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2776,7 +2776,7 @@ static inline cl::sycl::event gemm_bias(
     std::int64_t n, std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
     std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo, float beta,
     std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2791,7 +2791,7 @@ static inline cl::sycl::event gemm_bias(
     std::int64_t n, std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
     std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo, float beta,
     std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2804,7 +2804,7 @@ static inline cl::sycl::event gemm_bias(
 static inline cl::sycl::event gemv(
     cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, float alpha,
     const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2815,7 +2815,7 @@ static inline cl::sycl::event gemv(
 static inline cl::sycl::event gemv(
     cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, double alpha,
     const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2828,7 +2828,7 @@ static inline cl::sycl::event gemv(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2841,7 +2841,7 @@ static inline cl::sycl::event gemv(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2853,7 +2853,7 @@ static inline cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, float alpha,
     const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
     std::int64_t stridex, float beta, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y,
                             incy, stridey, batch_size, dependencies);
     auto done =
@@ -2868,7 +2868,7 @@ static inline cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, double alpha,
     const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
     std::int64_t stridex, double beta, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y,
                             incy, stridey, batch_size, dependencies);
     auto done =
@@ -2884,7 +2884,7 @@ static inline cl::sycl::event gemv_batch(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y,
                             incy, stridey, batch_size, dependencies);
     auto done =
@@ -2900,7 +2900,7 @@ static inline cl::sycl::event gemv_batch(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stridea, const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y,
                             incy, stridey, batch_size, dependencies);
     auto done =
@@ -2915,7 +2915,7 @@ static inline cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, transpose *trans, std::int64_t *m, std::int64_t *n, float *alpha,
     const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float *beta, float **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2929,7 +2929,7 @@ static inline cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, transpose *trans, std::int64_t *m, std::int64_t *n, double *alpha,
     const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
     double **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2944,7 +2944,7 @@ static inline cl::sycl::event gemv_batch(
     std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
     std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2959,7 +2959,7 @@ static inline cl::sycl::event gemv_batch(
     std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> *beta,
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2973,7 +2973,7 @@ static inline cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n, const float *a,
     std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx, std::int64_t stridex,
     float *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -2987,7 +2987,7 @@ static inline cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n, const double *a,
     std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
     std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -3002,7 +3002,7 @@ static inline cl::sycl::event dgmm_batch(
     const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -3017,7 +3017,7 @@ static inline cl::sycl::event dgmm_batch(
     const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -3031,7 +3031,7 @@ static inline cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n, const float **a,
     std::int64_t *lda, const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3045,7 +3045,7 @@ static inline cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n, const double **a,
     std::int64_t *lda, const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3059,7 +3059,7 @@ static inline cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n,
     const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
     std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3073,7 +3073,7 @@ static inline cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n,
     const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
     std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3086,7 +3086,7 @@ static inline cl::sycl::event dgmm_batch(
 static inline cl::sycl::event ger(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     ger_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::ger(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                             dependencies);
@@ -3097,7 +3097,7 @@ static inline cl::sycl::event ger(
 static inline cl::sycl::event ger(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     ger_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::ger(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                             dependencies);
@@ -3109,7 +3109,7 @@ static inline cl::sycl::event gerc(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gerc_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::gerc(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3121,7 +3121,7 @@ static inline cl::sycl::event gerc(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     gerc_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::gerc(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3133,7 +3133,7 @@ static inline cl::sycl::event geru(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     geru_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::geru(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3145,7 +3145,7 @@ static inline cl::sycl::event geru(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     geru_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::geru(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3158,7 +3158,7 @@ static inline cl::sycl::event hbmv(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::hbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3173,7 +3173,7 @@ static inline cl::sycl::event hbmv(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::hbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3188,7 +3188,7 @@ static inline cl::sycl::event hemm(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hemm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::hemm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3203,7 +3203,7 @@ static inline cl::sycl::event hemm(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hemm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::hemm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3217,7 +3217,7 @@ static inline cl::sycl::event hemv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
     std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hemv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::hemv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3229,7 +3229,7 @@ static inline cl::sycl::event hemv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
     std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hemv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::hemv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3240,7 +3240,7 @@ static inline cl::sycl::event hemv(
 static inline cl::sycl::event her(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     her_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::her(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3251,7 +3251,7 @@ static inline cl::sycl::event her(
 static inline cl::sycl::event her(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     her_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::her(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3263,7 +3263,7 @@ static inline cl::sycl::event her2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     her2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::her2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3275,7 +3275,7 @@ static inline cl::sycl::event her2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     her2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::her2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3287,7 +3287,7 @@ static inline cl::sycl::event her2k(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, float beta, std::complex<float> *c,
-    std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
     her2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::her2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3301,7 +3301,7 @@ static inline cl::sycl::event her2k(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, double beta, std::complex<double> *c,
-    std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
     her2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::her2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3314,7 +3314,7 @@ static inline cl::sycl::event her2k(
 static inline cl::sycl::event herk(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     float alpha, const std::complex<float> *a, std::int64_t lda, float beta, std::complex<float> *c,
-    std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
     herk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::herk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -3326,7 +3326,7 @@ static inline cl::sycl::event herk(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     double alpha, const std::complex<double> *a, std::int64_t lda, double beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     herk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::herk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -3338,7 +3338,7 @@ static inline cl::sycl::event hpmv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *a, const std::complex<float> *x, std::int64_t incx,
     std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hpmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::hpmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3350,7 +3350,7 @@ static inline cl::sycl::event hpmv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *a, const std::complex<double> *x, std::int64_t incx,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hpmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::hpmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3361,7 +3361,7 @@ static inline cl::sycl::event hpmv(
 static inline cl::sycl::event hpr(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::hpr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3372,7 +3372,7 @@ static inline cl::sycl::event hpr(
 static inline cl::sycl::event hpr(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::hpr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3384,7 +3384,7 @@ static inline cl::sycl::event hpr2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::hpr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3396,7 +3396,7 @@ static inline cl::sycl::event hpr2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::hpr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3406,7 +3406,7 @@ static inline cl::sycl::event hpr2(
 
 static inline cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
@@ -3415,7 +3415,7 @@ static inline cl::sycl::event iamax(
 
 static inline cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
@@ -3424,7 +3424,7 @@ static inline cl::sycl::event iamax(
 
 static inline cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
@@ -3433,7 +3433,7 @@ static inline cl::sycl::event iamax(
 
 static inline cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
@@ -3442,7 +3442,7 @@ static inline cl::sycl::event iamax(
 
 static inline cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
@@ -3451,7 +3451,7 @@ static inline cl::sycl::event iamin(
 
 static inline cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
@@ -3460,7 +3460,7 @@ static inline cl::sycl::event iamin(
 
 static inline cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
@@ -3469,7 +3469,7 @@ static inline cl::sycl::event iamin(
 
 static inline cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
@@ -3478,7 +3478,7 @@ static inline cl::sycl::event iamin(
 
 static inline cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    float *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
@@ -3487,7 +3487,7 @@ static inline cl::sycl::event nrm2(
 
 static inline cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    double *result, const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
@@ -3496,7 +3496,7 @@ static inline cl::sycl::event nrm2(
 
 static inline cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
@@ -3505,7 +3505,7 @@ static inline cl::sycl::event nrm2(
 
 static inline cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
@@ -3515,7 +3515,7 @@ static inline cl::sycl::event nrm2(
 static inline cl::sycl::event rot(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
     std::complex<float> *y, std::int64_t incy, float c, float s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
@@ -3525,7 +3525,7 @@ static inline cl::sycl::event rot(
 static inline cl::sycl::event rot(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
     std::complex<double> *y, std::int64_t incy, double c, double s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
@@ -3535,7 +3535,7 @@ static inline cl::sycl::event rot(
 static inline cl::sycl::event rot(
     cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
     std::int64_t incy, float c, float s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
@@ -3545,7 +3545,7 @@ static inline cl::sycl::event rot(
 static inline cl::sycl::event rot(
     cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
     std::int64_t incy, double c, double s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
@@ -3554,7 +3554,7 @@ static inline cl::sycl::event rot(
 
 static inline cl::sycl::event rotg(
     cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
@@ -3563,7 +3563,7 @@ static inline cl::sycl::event rotg(
 
 static inline cl::sycl::event rotg(
     cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
@@ -3572,7 +3572,7 @@ static inline cl::sycl::event rotg(
 
 static inline cl::sycl::event rotg(
     cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
-    std::complex<float> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::complex<float> *s, const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
@@ -3581,7 +3581,7 @@ static inline cl::sycl::event rotg(
 
 static inline cl::sycl::event rotg(
     cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
-    std::complex<double> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
@@ -3591,7 +3591,7 @@ static inline cl::sycl::event rotg(
 static inline cl::sycl::event rotm(
     cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
     std::int64_t incy, float *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotm_precondition(queue, n, x, incx, y, incy, param, dependencies);
     auto done = detail::rotm(get_device_id(queue), queue, n, x, incx, y, incy, param, dependencies);
     rotm_postcondition(queue, n, x, incx, y, incy, param, dependencies);
@@ -3601,7 +3601,7 @@ static inline cl::sycl::event rotm(
 static inline cl::sycl::event rotm(
     cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
     std::int64_t incy, double *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotm_precondition(queue, n, x, incx, y, incy, param, dependencies);
     auto done = detail::rotm(get_device_id(queue), queue, n, x, incx, y, incy, param, dependencies);
     rotm_postcondition(queue, n, x, incx, y, incy, param, dependencies);
@@ -3610,7 +3610,7 @@ static inline cl::sycl::event rotm(
 
 static inline cl::sycl::event rotmg(
     cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotmg_precondition(queue, d1, d2, x1, y1, param, dependencies);
     auto done = detail::rotmg(get_device_id(queue), queue, d1, d2, x1, y1, param, dependencies);
     rotmg_postcondition(queue, d1, d2, x1, y1, param, dependencies);
@@ -3619,7 +3619,7 @@ static inline cl::sycl::event rotmg(
 
 static inline cl::sycl::event rotmg(
     cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotmg_precondition(queue, d1, d2, x1, y1, param, dependencies);
     auto done = detail::rotmg(get_device_id(queue), queue, d1, d2, x1, y1, param, dependencies);
     rotmg_postcondition(queue, d1, d2, x1, y1, param, dependencies);
@@ -3629,7 +3629,7 @@ static inline cl::sycl::event rotmg(
 static inline cl::sycl::event sbmv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k, float alpha,
     const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     sbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::sbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3642,7 +3642,7 @@ static inline cl::sycl::event sbmv(
 static inline cl::sycl::event sbmv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k, double alpha,
     const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     sbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::sbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3654,7 +3654,7 @@ static inline cl::sycl::event sbmv(
 
 static inline cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
@@ -3663,7 +3663,7 @@ static inline cl::sycl::event scal(
 
 static inline cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
@@ -3672,7 +3672,7 @@ static inline cl::sycl::event scal(
 
 static inline cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
@@ -3681,7 +3681,7 @@ static inline cl::sycl::event scal(
 
 static inline cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
@@ -3690,7 +3690,7 @@ static inline cl::sycl::event scal(
 
 static inline cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
@@ -3699,7 +3699,7 @@ static inline cl::sycl::event scal(
 
 static inline cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
@@ -3709,7 +3709,7 @@ static inline cl::sycl::event scal(
 static inline cl::sycl::event sdsdot(
     cl::sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
     const float *y, std::int64_t incy, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     sdsdot_precondition(queue, n, sb, x, incx, y, incy, result, dependencies);
     auto done =
         detail::sdsdot(get_device_id(queue), queue, n, sb, x, incx, y, incy, result, dependencies);
@@ -3720,7 +3720,7 @@ static inline cl::sycl::event sdsdot(
 static inline cl::sycl::event spmv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *a,
     const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     spmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::spmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3731,7 +3731,7 @@ static inline cl::sycl::event spmv(
 static inline cl::sycl::event spmv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *a,
     const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     spmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::spmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3741,7 +3741,7 @@ static inline cl::sycl::event spmv(
 
 static inline cl::sycl::event spr(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, float *a, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, float *a, const std::vector<cl::sycl::event> &dependencies = {}) {
     spr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::spr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3752,7 +3752,7 @@ static inline cl::sycl::event spr(
 static inline cl::sycl::event spr(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, double *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     spr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::spr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3763,7 +3763,7 @@ static inline cl::sycl::event spr(
 static inline cl::sycl::event spr2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     spr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::spr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3774,7 +3774,7 @@ static inline cl::sycl::event spr2(
 static inline cl::sycl::event spr2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     spr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::spr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3784,7 +3784,7 @@ static inline cl::sycl::event spr2(
 
 static inline cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -3793,7 +3793,7 @@ static inline cl::sycl::event swap(
 
 static inline cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -3803,7 +3803,7 @@ static inline cl::sycl::event swap(
 static inline cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -3813,7 +3813,7 @@ static inline cl::sycl::event swap(
 static inline cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
@@ -3823,7 +3823,7 @@ static inline cl::sycl::event swap(
 static inline cl::sycl::event symm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
-    float *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3836,7 +3836,7 @@ static inline cl::sycl::event symm(
 static inline cl::sycl::event symm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
-    double *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3851,7 +3851,7 @@ static inline cl::sycl::event symm(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3866,7 +3866,7 @@ static inline cl::sycl::event symm(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3879,7 +3879,7 @@ static inline cl::sycl::event symm(
 static inline cl::sycl::event symv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *a,
     std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     symv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::symv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3890,7 +3890,7 @@ static inline cl::sycl::event symv(
 static inline cl::sycl::event symv(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *a,
     std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     symv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::symv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3901,7 +3901,7 @@ static inline cl::sycl::event symv(
 static inline cl::sycl::event syr(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, float *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::syr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3912,7 +3912,7 @@ static inline cl::sycl::event syr(
 static inline cl::sycl::event syr(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, double *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::syr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3923,7 +3923,7 @@ static inline cl::sycl::event syr(
 static inline cl::sycl::event syr2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::syr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3934,7 +3934,7 @@ static inline cl::sycl::event syr2(
 static inline cl::sycl::event syr2(
     cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::syr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3945,7 +3945,7 @@ static inline cl::sycl::event syr2(
 static inline cl::sycl::event syr2k(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
-    float *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3958,7 +3958,7 @@ static inline cl::sycl::event syr2k(
 static inline cl::sycl::event syr2k(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     double alpha, const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
-    double *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3973,7 +3973,7 @@ static inline cl::sycl::event syr2k(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3988,7 +3988,7 @@ static inline cl::sycl::event syr2k(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -4001,7 +4001,7 @@ static inline cl::sycl::event syr2k(
 static inline cl::sycl::event syrk(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     float alpha, const float *a, std::int64_t lda, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4012,7 +4012,7 @@ static inline cl::sycl::event syrk(
 static inline cl::sycl::event syrk(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     double alpha, const double *a, std::int64_t lda, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4024,7 +4024,7 @@ static inline cl::sycl::event syrk(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4036,7 +4036,7 @@ static inline cl::sycl::event syrk(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4048,7 +4048,7 @@ static inline cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, std::int64_t *n, std::int64_t *k,
     float *alpha, const float **a, std::int64_t *lda, float *beta, float **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4062,7 +4062,7 @@ static inline cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, std::int64_t *n, std::int64_t *k,
     double *alpha, const double **a, std::int64_t *lda, double *beta, double **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4076,7 +4076,7 @@ static inline cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, std::int64_t *n, std::int64_t *k,
     std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
     std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4091,7 +4091,7 @@ static inline cl::sycl::event syrk_batch(
     std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
     std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4105,7 +4105,7 @@ static inline cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     float alpha, const float *a, std::int64_t lda, std::int64_t stride_a, float beta, float *c,
     std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4119,7 +4119,7 @@ static inline cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
     double alpha, const double *a, std::int64_t lda, std::int64_t stride_a, double beta, double *c,
     std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4134,7 +4134,7 @@ static inline cl::sycl::event syrk_batch(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4149,7 +4149,7 @@ static inline cl::sycl::event syrk_batch(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4162,7 +4162,7 @@ static inline cl::sycl::event syrk_batch(
 static inline cl::sycl::event tbmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4173,7 +4173,7 @@ static inline cl::sycl::event tbmv(
 static inline cl::sycl::event tbmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4184,7 +4184,7 @@ static inline cl::sycl::event tbmv(
 static inline cl::sycl::event tbmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4195,7 +4195,7 @@ static inline cl::sycl::event tbmv(
 static inline cl::sycl::event tbmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4206,7 +4206,7 @@ static inline cl::sycl::event tbmv(
 static inline cl::sycl::event tbsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4217,7 +4217,7 @@ static inline cl::sycl::event tbsv(
 static inline cl::sycl::event tbsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4228,7 +4228,7 @@ static inline cl::sycl::event tbsv(
 static inline cl::sycl::event tbsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4239,7 +4239,7 @@ static inline cl::sycl::event tbsv(
 static inline cl::sycl::event tbsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     std::int64_t k, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4250,7 +4250,7 @@ static inline cl::sycl::event tbsv(
 static inline cl::sycl::event tpmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4261,7 +4261,7 @@ static inline cl::sycl::event tpmv(
 static inline cl::sycl::event tpmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4272,7 +4272,7 @@ static inline cl::sycl::event tpmv(
 static inline cl::sycl::event tpmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4283,7 +4283,7 @@ static inline cl::sycl::event tpmv(
 static inline cl::sycl::event tpmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4294,7 +4294,7 @@ static inline cl::sycl::event tpmv(
 static inline cl::sycl::event tpsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4305,7 +4305,7 @@ static inline cl::sycl::event tpsv(
 static inline cl::sycl::event tpsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4316,7 +4316,7 @@ static inline cl::sycl::event tpsv(
 static inline cl::sycl::event tpsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4327,7 +4327,7 @@ static inline cl::sycl::event tpsv(
 static inline cl::sycl::event tpsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4338,7 +4338,7 @@ static inline cl::sycl::event tpsv(
 static inline cl::sycl::event trmm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-    std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4351,7 +4351,7 @@ static inline cl::sycl::event trmm(
 static inline cl::sycl::event trmm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-    std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4365,7 +4365,7 @@ static inline cl::sycl::event trmm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4379,7 +4379,7 @@ static inline cl::sycl::event trmm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4392,7 +4392,7 @@ static inline cl::sycl::event trmm(
 static inline cl::sycl::event trmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4403,7 +4403,7 @@ static inline cl::sycl::event trmv(
 static inline cl::sycl::event trmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4414,7 +4414,7 @@ static inline cl::sycl::event trmv(
 static inline cl::sycl::event trmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<float> *a, std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4425,7 +4425,7 @@ static inline cl::sycl::event trmv(
 static inline cl::sycl::event trmv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<double> *a, std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4436,7 +4436,7 @@ static inline cl::sycl::event trmv(
 static inline cl::sycl::event trsm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-    std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4449,7 +4449,7 @@ static inline cl::sycl::event trsm(
 static inline cl::sycl::event trsm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-    std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4463,7 +4463,7 @@ static inline cl::sycl::event trsm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4477,7 +4477,7 @@ static inline cl::sycl::event trsm(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4491,7 +4491,7 @@ static inline cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
     std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4506,7 +4506,7 @@ static inline cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
     std::int64_t stride_a, double *b, std::int64_t ldb, std::int64_t stride_b,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4522,7 +4522,7 @@ static inline cl::sycl::event trsm_batch(
     std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb,
     std::int64_t stride_b, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4538,7 +4538,7 @@ static inline cl::sycl::event trsm_batch(
     std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb,
     std::int64_t stride_b, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4553,7 +4553,7 @@ static inline cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans, diag *unit_diag,
     std::int64_t *m, std::int64_t *n, float *alpha, const float **a, std::int64_t *lda, float **b,
     std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             b, ldb, group_count, group_size, dependencies);
     auto done =
@@ -4568,7 +4568,7 @@ static inline cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans, diag *unit_diag,
     std::int64_t *m, std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
     double **b, std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             b, ldb, group_count, group_size, dependencies);
     auto done =
@@ -4583,7 +4583,7 @@ static inline cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans, diag *unit_diag,
     std::int64_t *m, std::int64_t *n, std::complex<float> *alpha, const std::complex<float> **a,
     std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             b, ldb, group_count, group_size, dependencies);
     auto done =
@@ -4598,7 +4598,7 @@ static inline cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans, diag *unit_diag,
     std::int64_t *m, std::int64_t *n, std::complex<double> *alpha, const std::complex<double> **a,
     std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             b, ldb, group_count, group_size, dependencies);
     auto done =
@@ -4612,7 +4612,7 @@ static inline cl::sycl::event trsm_batch(
 static inline cl::sycl::event trsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4623,7 +4623,7 @@ static inline cl::sycl::event trsv(
 static inline cl::sycl::event trsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4634,7 +4634,7 @@ static inline cl::sycl::event trsv(
 static inline cl::sycl::event trsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<float> *a, std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4645,7 +4645,7 @@ static inline cl::sycl::event trsv(
 static inline cl::sycl::event trsv(
     cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
     const std::complex<double> *a, std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {}) {
+    const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);

--- a/include/oneapi/mkl/blas.hxx
+++ b/include/oneapi/mkl/blas.hxx
@@ -1936,85 +1936,85 @@ static inline void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose tran
 
 // USM APIs
 
-static inline cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                   std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                   std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     asum_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::asum(get_device_id(queue), queue, n, x, incx, result, dependencies);
     asum_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                   const float *x, std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-    double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                   const double *x, std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
-    std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_precondition(queue, n, alpha, x, incx, y, incy, dependencies);
     auto done = detail::axpy(get_device_id(queue), queue, n, alpha, x, incx, y, incy, dependencies);
     axpy_postcondition(queue, n, alpha, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, double *alpha, const double **x, std::int64_t *incx,
-    double **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, double *alpha,
+                                         const double **x, std::int64_t *incx, double **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2024,10 +2024,11 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x, std::int64_t *incx,
-    float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, float *alpha,
+                                         const float **x, std::int64_t *incx, float **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2037,11 +2038,12 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
-    const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         std::complex<double> *alpha,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2051,11 +2053,12 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         std::complex<float> *alpha, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, y, incy,
@@ -2065,10 +2068,11 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                         const float *x, std::int64_t incx, std::int64_t stridex,
+                                         float *y, std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2078,10 +2082,11 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                         const double *x, std::int64_t incx, std::int64_t stridex,
+                                         double *y, std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2091,11 +2096,12 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
-    std::int64_t incx, std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         std::complex<float> alpha, const std::complex<float> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<float> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2105,11 +2111,12 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         std::complex<double> alpha, const std::complex<double> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<double> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     axpy_batch_precondition(queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = detail::axpy_batch(get_device_id(queue), queue, n, alpha, x, incx, stridex, y, incy,
@@ -2119,10 +2126,10 @@ static inline cl::sycl::event axpy_batch(
     return done;
 }
 
-static inline cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    const float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                    const float *x, std::int64_t incx, const float beta, float *y,
+                                    std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2130,10 +2137,10 @@ static inline cl::sycl::event axpby(
     return done;
 }
 
-static inline cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-    const double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                    const double *x, std::int64_t incx, const double beta,
+                                    double *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2141,10 +2148,11 @@ static inline cl::sycl::event axpby(
     return done;
 }
 
-static inline cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
-    std::int64_t incx, const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n,
+                                    std::complex<float> alpha, const std::complex<float> *x,
+                                    std::int64_t incx, const std::complex<float> beta,
+                                    std::complex<float> *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2152,11 +2160,11 @@ static inline cl::sycl::event axpby(
     return done;
 }
 
-static inline cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n,
+                                    std::complex<double> alpha, const std::complex<double> *x,
+                                    std::int64_t incx, const std::complex<double> beta,
+                                    std::complex<double> *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     axpby_precondition(queue, n, alpha, x, incx, beta, y, incy, dependencies);
     auto done =
         detail::axpby(get_device_id(queue), queue, n, alpha, x, incx, beta, y, incy, dependencies);
@@ -2164,48 +2172,48 @@ static inline cl::sycl::event axpby(
     return done;
 }
 
-static inline cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                   std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                   std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::copy(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     copy_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx, float **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const float **x,
+                                         std::int64_t *incx, float **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2213,10 +2221,10 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx, double **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const double **x,
+                                         std::int64_t *incx, double **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2224,10 +2232,11 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const std::complex<float> **x, std::int64_t *incx,
-    std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2235,10 +2244,11 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const std::complex<double> **x, std::int64_t *incx,
-    std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, y, incy, group_count, group_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, y, incy, group_count,
                                    group_size, dependencies);
@@ -2246,10 +2256,11 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t stridex,
-    float *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                         std::int64_t incx, std::int64_t stridex, float *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2258,10 +2269,11 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                         std::int64_t incx, std::int64_t stridex, double *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2270,10 +2282,12 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t stridex, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         const std::complex<float> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<float> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2282,10 +2296,12 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         const std::complex<double> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<double> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     copy_batch_precondition(queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
     auto done = detail::copy_batch(get_device_id(queue), queue, n, x, incx, stridex, y, incy,
                                    stridey, batch_size, dependencies);
@@ -2294,40 +2310,41 @@ static inline cl::sycl::event copy_batch(
     return done;
 }
 
-static inline cl::sycl::event dot(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
-    std::int64_t incy, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                  std::int64_t incx, const float *y, std::int64_t incy,
+                                  float *result,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     dot_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done = detail::dot(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
     dot_postcondition(queue, n, x, incx, y, incy, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event dot(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, const double *y,
-    std::int64_t incy, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                  std::int64_t incx, const double *y, std::int64_t incy,
+                                  double *result,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     dot_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done = detail::dot(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
     dot_postcondition(queue, n, x, incx, y, incy, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event dot(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
-    std::int64_t incy, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                  std::int64_t incx, const float *y, std::int64_t incy,
+                                  double *result,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     dot_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done = detail::dot(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
     dot_postcondition(queue, n, x, incx, y, incy, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event dotc(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     dotc_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotc(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2335,10 +2352,11 @@ static inline cl::sycl::event dotc(
     return done;
 }
 
-static inline cl::sycl::event dotc(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     dotc_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotc(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2346,10 +2364,11 @@ static inline cl::sycl::event dotc(
     return done;
 }
 
-static inline cl::sycl::event dotu(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     dotu_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotu(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2357,10 +2376,11 @@ static inline cl::sycl::event dotu(
     return done;
 }
 
-static inline cl::sycl::event dotu(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     dotu_precondition(queue, n, x, incx, y, incy, result, dependencies);
     auto done =
         detail::dotu(get_device_id(queue), queue, n, x, incx, y, incy, result, dependencies);
@@ -2368,11 +2388,11 @@ static inline cl::sycl::event dotu(
     return done;
 }
 
-static inline cl::sycl::event gbmv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
-    std::int64_t ku, float alpha, const float *a, std::int64_t lda, const float *x,
-    std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha,
+                                   const float *a, std::int64_t lda, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2382,11 +2402,11 @@ static inline cl::sycl::event gbmv(
     return done;
 }
 
-static inline cl::sycl::event gbmv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
-    std::int64_t ku, double alpha, const double *a, std::int64_t lda, const double *x,
-    std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
+                                   const double *a, std::int64_t lda, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2396,12 +2416,13 @@ static inline cl::sycl::event gbmv(
     return done;
 }
 
-static inline cl::sycl::event gbmv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
-    std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2411,12 +2432,13 @@ static inline cl::sycl::event gbmv(
     return done;
 }
 
-static inline cl::sycl::event gbmv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
-    std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gbmv_precondition(queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::gbmv(get_device_id(queue), queue, trans, m, n, kl, ku, alpha, a, lda, x,
@@ -2426,11 +2448,11 @@ static inline cl::sycl::event gbmv(
     return done;
 }
 
-static inline cl::sycl::event gemm(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
-    float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                   std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                                   const float *a, std::int64_t lda, const float *b,
+                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2440,11 +2462,11 @@ static inline cl::sycl::event gemm(
     return done;
 }
 
-static inline cl::sycl::event gemm(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *b,
-    std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                   std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
+                                   const double *a, std::int64_t lda, const double *b,
+                                   std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2454,12 +2476,13 @@ static inline cl::sycl::event gemm(
     return done;
 }
 
-static inline cl::sycl::event gemm(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                   std::int64_t m, std::int64_t n, std::int64_t k,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2469,12 +2492,13 @@ static inline cl::sycl::event gemm(
     return done;
 }
 
-static inline cl::sycl::event gemm(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                   std::int64_t m, std::int64_t n, std::int64_t k,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *b,
+                                   std::int64_t ldb, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2484,11 +2508,11 @@ static inline cl::sycl::event gemm(
     return done;
 }
 
-static inline cl::sycl::event gemm(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, half alpha, const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-    half beta, half *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                   std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
+                                   const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
+                                   half beta, half *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2498,11 +2522,11 @@ static inline cl::sycl::event gemm(
     return done;
 }
 
-static inline cl::sycl::event gemm(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, float alpha, const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-    float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                   std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                                   const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
+                                   float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2512,11 +2536,11 @@ static inline cl::sycl::event gemm(
     return done;
 }
 
-static inline cl::sycl::event gemm(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, float alpha, const bfloat16 *a, std::int64_t lda, const bfloat16 *b,
-    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                   std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                                   const bfloat16 *a, std::int64_t lda, const bfloat16 *b,
+                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b,
@@ -2526,11 +2550,13 @@ static inline cl::sycl::event gemm(
     return done;
 }
 
-static inline cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, transpose *transa, transpose *transb, std::int64_t *m, std::int64_t *n,
-    std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, const float **b,
-    std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa,
+                                         transpose *transb, std::int64_t *m, std::int64_t *n,
+                                         std::int64_t *k, float *alpha, const float **a,
+                                         std::int64_t *lda, const float **b, std::int64_t *ldb,
+                                         float *beta, float **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2541,11 +2567,13 @@ static inline cl::sycl::event gemm_batch(
     return done;
 }
 
-static inline cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, transpose *transa, transpose *transb, std::int64_t *m, std::int64_t *n,
-    std::int64_t *k, double *alpha, const double **a, std::int64_t *lda, const double **b,
-    std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa,
+                                         transpose *transb, std::int64_t *m, std::int64_t *n,
+                                         std::int64_t *k, double *alpha, const double **a,
+                                         std::int64_t *lda, const double **b, std::int64_t *ldb,
+                                         double *beta, double **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2588,11 +2616,13 @@ static inline cl::sycl::event gemm_batch(
     return done;
 }
 
-static inline cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, transpose *transa, transpose *transb, std::int64_t *m, std::int64_t *n,
-    std::int64_t *k, half *alpha, const half **a, std::int64_t *lda, const half **b,
-    std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa,
+                                         transpose *transb, std::int64_t *m, std::int64_t *n,
+                                         std::int64_t *k, half *alpha, const half **a,
+                                         std::int64_t *lda, const half **b, std::int64_t *ldb,
+                                         half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done =
@@ -2603,12 +2633,14 @@ static inline cl::sycl::event gemm_batch(
     return done;
 }
 
-static inline cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, float alpha, const float *a, std::int64_t lda, std::int64_t stride_a,
-    const float *b, std::int64_t ldb, std::int64_t stride_b, float beta, float *c, std::int64_t ldc,
-    std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                         std::int64_t m, std::int64_t n, std::int64_t k,
+                                         float alpha, const float *a, std::int64_t lda,
+                                         std::int64_t stride_a, const float *b, std::int64_t ldb,
+                                         std::int64_t stride_b, float beta, float *c,
+                                         std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2619,12 +2651,14 @@ static inline cl::sycl::event gemm_batch(
     return done;
 }
 
-static inline cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, double alpha, const double *a, std::int64_t lda, std::int64_t stride_a,
-    const double *b, std::int64_t ldb, std::int64_t stride_b, double beta, double *c,
-    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                         std::int64_t m, std::int64_t n, std::int64_t k,
+                                         double alpha, const double *a, std::int64_t lda,
+                                         std::int64_t stride_a, const double *b, std::int64_t ldb,
+                                         std::int64_t stride_b, double beta, double *c,
+                                         std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2667,12 +2701,13 @@ static inline cl::sycl::event gemm_batch(
     return done;
 }
 
-static inline cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,
-    std::int64_t k, half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
-    const half *b, std::int64_t ldb, std::int64_t stride_b, half beta, half *c, std::int64_t ldc,
-    std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                         std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
+                                         const half *a, std::int64_t lda, std::int64_t stride_a,
+                                         const half *b, std::int64_t ldb, std::int64_t stride_b,
+                                         half beta, half *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = detail::gemm_batch(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a,
@@ -2683,11 +2718,11 @@ static inline cl::sycl::event gemm_batch(
     return done;
 }
 
-static inline cl::sycl::event gemmt(
-    cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, std::int64_t n,
-    std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
-    float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
+                                    transpose transb, std::int64_t n, std::int64_t k, float alpha,
+                                    const float *a, std::int64_t lda, const float *b,
+                                    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2697,11 +2732,11 @@ static inline cl::sycl::event gemmt(
     return done;
 }
 
-static inline cl::sycl::event gemmt(
-    cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, std::int64_t n,
-    std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *b,
-    std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
+                                    transpose transb, std::int64_t n, std::int64_t k, double alpha,
+                                    const double *a, std::int64_t lda, const double *b,
+                                    std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2711,12 +2746,13 @@ static inline cl::sycl::event gemmt(
     return done;
 }
 
-static inline cl::sycl::event gemmt(
-    cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, std::int64_t n,
-    std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
+                                    transpose transb, std::int64_t n, std::int64_t k,
+                                    std::complex<float> alpha, const std::complex<float> *a,
+                                    std::int64_t lda, const std::complex<float> *b,
+                                    std::int64_t ldb, std::complex<float> beta,
+                                    std::complex<float> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2726,12 +2762,13 @@ static inline cl::sycl::event gemmt(
     return done;
 }
 
-static inline cl::sycl::event gemmt(
-    cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, std::int64_t n,
-    std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
+                                    transpose transb, std::int64_t n, std::int64_t k,
+                                    std::complex<double> alpha, const std::complex<double> *a,
+                                    std::int64_t lda, const std::complex<double> *b,
+                                    std::int64_t ldb, std::complex<double> beta,
+                                    std::complex<double> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemmt_precondition(queue, upper_lower, transa, transb, n, k, alpha, a, lda, b, ldb, beta, c,
                        ldc, dependencies);
     auto done = detail::gemmt(get_device_id(queue), queue, upper_lower, transa, transb, n, k, alpha,
@@ -2741,12 +2778,13 @@ static inline cl::sycl::event gemmt(
     return done;
 }
 
-static inline cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
-    std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo, float beta,
-    std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                        offset offsetc, std::int64_t m, std::int64_t n,
+                                        std::int64_t k, float alpha, const std::int8_t *a,
+                                        std::int64_t lda, std::int8_t ao, const std::uint8_t *b,
+                                        std::int64_t ldb, std::uint8_t bo, float beta,
+                                        std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2756,12 +2794,13 @@ static inline cl::sycl::event gemm_bias(
     return done;
 }
 
-static inline cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
-    std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo, float beta,
-    std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                        offset offsetc, std::int64_t m, std::int64_t n,
+                                        std::int64_t k, float alpha, const std::int8_t *a,
+                                        std::int64_t lda, std::int8_t ao, const std::int8_t *b,
+                                        std::int64_t ldb, std::int8_t bo, float beta,
+                                        std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2771,12 +2810,13 @@ static inline cl::sycl::event gemm_bias(
     return done;
 }
 
-static inline cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
-    std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo, float beta,
-    std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                        offset offsetc, std::int64_t m, std::int64_t n,
+                                        std::int64_t k, float alpha, const std::uint8_t *a,
+                                        std::int64_t lda, std::uint8_t ao, const std::int8_t *b,
+                                        std::int64_t ldb, std::int8_t bo, float beta,
+                                        std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2786,12 +2826,13 @@ static inline cl::sycl::event gemm_bias(
     return done;
 }
 
-static inline cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
-    std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo, float beta,
-    std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
+                                        offset offsetc, std::int64_t m, std::int64_t n,
+                                        std::int64_t k, float alpha, const std::uint8_t *a,
+                                        std::int64_t lda, std::uint8_t ao, const std::uint8_t *b,
+                                        std::int64_t ldb, std::uint8_t bo, float beta,
+                                        std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_bias_precondition(queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo,
                            beta, c, ldc, co, dependencies);
     auto done = detail::gemm_bias(get_device_id(queue), queue, transa, transb, offsetc, m, n, k,
@@ -2801,10 +2842,11 @@ static inline cl::sycl::event gemm_bias(
     return done;
 }
 
-static inline cl::sycl::event gemv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, float alpha,
-    const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                                   const float *x, std::int64_t incx, float beta, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2812,10 +2854,11 @@ static inline cl::sycl::event gemv(
     return done;
 }
 
-static inline cl::sycl::event gemv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, double alpha,
-    const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                                   const double *x, std::int64_t incx, double beta, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2823,12 +2866,13 @@ static inline cl::sycl::event gemv(
     return done;
 }
 
-static inline cl::sycl::event gemv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2836,12 +2880,13 @@ static inline cl::sycl::event gemv(
     return done;
 }
 
-static inline cl::sycl::event gemv(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::gemv(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx, beta,
                              y, incy, dependencies);
@@ -2849,11 +2894,13 @@ static inline cl::sycl::event gemv(
     return done;
 }
 
-static inline cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, float alpha,
-    const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
-    std::int64_t stridex, float beta, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                         std::int64_t n, float alpha, const float *a,
+                                         std::int64_t lda, std::int64_t stridea, const float *x,
+                                         std::int64_t incx, std::int64_t stridex, float beta,
+                                         float *y, std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y,
                             incy, stridey, batch_size, dependencies);
     auto done =
@@ -2864,11 +2911,13 @@ static inline cl::sycl::event gemv_batch(
     return done;
 }
 
-static inline cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n, double alpha,
-    const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
-    std::int64_t stridex, double beta, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t m,
+                                         std::int64_t n, double alpha, const double *a,
+                                         std::int64_t lda, std::int64_t stridea, const double *x,
+                                         std::int64_t incx, std::int64_t stridex, double beta,
+                                         double *y, std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y,
                             incy, stridey, batch_size, dependencies);
     auto done =
@@ -2911,11 +2960,12 @@ static inline cl::sycl::event gemv_batch(
     return done;
 }
 
-static inline cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, transpose *trans, std::int64_t *m, std::int64_t *n, float *alpha,
-    const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float *beta, float **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
+                                         std::int64_t *n, float *alpha, const float **a,
+                                         std::int64_t *lda, const float **x, std::int64_t *incx,
+                                         float *beta, float **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2925,11 +2975,12 @@ static inline cl::sycl::event gemv_batch(
     return done;
 }
 
-static inline cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, transpose *trans, std::int64_t *m, std::int64_t *n, double *alpha,
-    const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
-    double **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
+                                         std::int64_t *n, double *alpha, const double **a,
+                                         std::int64_t *lda, const double **x, std::int64_t *incx,
+                                         double *beta, double **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2939,12 +2990,14 @@ static inline cl::sycl::event gemv_batch(
     return done;
 }
 
-static inline cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, transpose *trans, std::int64_t *m, std::int64_t *n,
-    std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
-    std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
+                                         std::int64_t *n, std::complex<float> *alpha,
+                                         const std::complex<float> **a, std::int64_t *lda,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> *beta, std::complex<float> **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2954,12 +3007,14 @@ static inline cl::sycl::event gemv_batch(
     return done;
 }
 
-static inline cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, transpose *trans, std::int64_t *m, std::int64_t *n,
-    std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
-    const std::complex<double> **x, std::int64_t *incx, std::complex<double> *beta,
-    std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
+                                         std::int64_t *n, std::complex<double> *alpha,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> *beta, std::complex<double> **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     gemv_batch_precondition(queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
                             group_size, dependencies);
     auto done = detail::gemv_batch(get_device_id(queue), queue, trans, m, n, alpha, a, lda, x, incx,
@@ -2969,11 +3024,12 @@ static inline cl::sycl::event gemv_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n, const float *a,
-    std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx, std::int64_t stridex,
-    float *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m,
+                                         std::int64_t n, const float *a, std::int64_t lda,
+                                         std::int64_t stridea, const float *x, std::int64_t incx,
+                                         std::int64_t stridex, float *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -2983,11 +3039,12 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n, const double *a,
-    std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m,
+                                         std::int64_t n, const double *a, std::int64_t lda,
+                                         std::int64_t stridea, const double *x, std::int64_t incx,
+                                         std::int64_t stridex, double *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -2997,12 +3054,14 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n,
-    const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m,
+                                         std::int64_t n, const std::complex<float> *a,
+                                         std::int64_t lda, std::int64_t stridea,
+                                         const std::complex<float> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<float> *c,
+                                         std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -3012,12 +3071,14 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n,
-    const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m,
+                                         std::int64_t n, const std::complex<double> *a,
+                                         std::int64_t lda, std::int64_t stridea,
+                                         const std::complex<double> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<double> *c,
+                                         std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc,
                             stridec, batch_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, stridea,
@@ -3027,11 +3088,12 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n, const float **a,
-    std::int64_t *lda, const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
+                                         std::int64_t *n, const float **a, std::int64_t *lda,
+                                         const float **x, std::int64_t *incx, float **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3041,11 +3103,12 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n, const double **a,
-    std::int64_t *lda, const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
+                                         std::int64_t *n, const double **a, std::int64_t *lda,
+                                         const double **x, std::int64_t *incx, double **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3055,11 +3118,13 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n,
-    const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
-    std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
+                                         std::int64_t *n, const std::complex<float> **a,
+                                         std::int64_t *lda, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3069,11 +3134,13 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, side *left_right, std::int64_t *m, std::int64_t *n,
-    const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
-    std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
+                                         std::int64_t *n, const std::complex<double> **a,
+                                         std::int64_t *lda, const std::complex<double> **x,
+                                         std::int64_t *incx, std::complex<double> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     dgmm_batch_precondition(queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count,
                             group_size, dependencies);
     auto done = detail::dgmm_batch(get_device_id(queue), queue, left_right, m, n, a, lda, x, incx,
@@ -3083,10 +3150,10 @@ static inline cl::sycl::event dgmm_batch(
     return done;
 }
 
-static inline cl::sycl::event ger(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                  float alpha, const float *x, std::int64_t incx, const float *y,
+                                  std::int64_t incy, float *a, std::int64_t lda,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     ger_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::ger(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                             dependencies);
@@ -3094,10 +3161,10 @@ static inline cl::sycl::event ger(
     return done;
 }
 
-static inline cl::sycl::event ger(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                  double alpha, const double *x, std::int64_t incx, const double *y,
+                                  std::int64_t incy, double *a, std::int64_t lda,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     ger_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::ger(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                             dependencies);
@@ -3105,11 +3172,11 @@ static inline cl::sycl::event ger(
     return done;
 }
 
-static inline cl::sycl::event gerc(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, const std::complex<float> *y,
+                                   std::int64_t incy, std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gerc_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::gerc(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3117,11 +3184,11 @@ static inline cl::sycl::event gerc(
     return done;
 }
 
-static inline cl::sycl::event gerc(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, const std::complex<double> *y,
+                                   std::int64_t incy, std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     gerc_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::gerc(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3129,11 +3196,11 @@ static inline cl::sycl::event gerc(
     return done;
 }
 
-static inline cl::sycl::event geru(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, const std::complex<float> *y,
+                                   std::int64_t incy, std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     geru_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::geru(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3141,11 +3208,11 @@ static inline cl::sycl::event geru(
     return done;
 }
 
-static inline cl::sycl::event geru(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, const std::complex<double> *y,
+                                   std::int64_t incy, std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     geru_precondition(queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::geru(get_device_id(queue), queue, m, n, alpha, x, incx, y, incy, a, lda,
                              dependencies);
@@ -3153,12 +3220,13 @@ static inline cl::sycl::event geru(
     return done;
 }
 
-static inline cl::sycl::event hbmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::int64_t k, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::hbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3168,12 +3236,13 @@ static inline cl::sycl::event hbmv(
     return done;
 }
 
-static inline cl::sycl::event hbmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::int64_t k, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::hbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3183,12 +3252,13 @@ static inline cl::sycl::event hbmv(
     return done;
 }
 
-static inline cl::sycl::event hemm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hemm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::hemm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3198,12 +3268,13 @@ static inline cl::sycl::event hemm(
     return done;
 }
 
-static inline cl::sycl::event hemm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *b, std::int64_t ldb,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hemm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::hemm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3213,11 +3284,12 @@ static inline cl::sycl::event hemm(
     return done;
 }
 
-static inline cl::sycl::event hemv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
-    std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hemv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::hemv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3225,11 +3297,12 @@ static inline cl::sycl::event hemv(
     return done;
 }
 
-static inline cl::sycl::event hemv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
-    std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hemv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::hemv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3237,10 +3310,10 @@ static inline cl::sycl::event hemv(
     return done;
 }
 
-static inline cl::sycl::event her(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  float alpha, const std::complex<float> *x, std::int64_t incx,
+                                  std::complex<float> *a, std::int64_t lda,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     her_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::her(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3248,10 +3321,10 @@ static inline cl::sycl::event her(
     return done;
 }
 
-static inline cl::sycl::event her(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  double alpha, const std::complex<double> *x, std::int64_t incx,
+                                  std::complex<double> *a, std::int64_t lda,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     her_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::her(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3259,11 +3332,11 @@ static inline cl::sycl::event her(
     return done;
 }
 
-static inline cl::sycl::event her2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, const std::complex<float> *y,
+                                   std::int64_t incy, std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     her2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::her2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3271,11 +3344,11 @@ static inline cl::sycl::event her2(
     return done;
 }
 
-static inline cl::sycl::event her2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, const std::complex<double> *y,
+                                   std::int64_t incy, std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     her2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::her2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3283,11 +3356,12 @@ static inline cl::sycl::event her2(
     return done;
 }
 
-static inline cl::sycl::event her2k(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, float beta, std::complex<float> *c,
-    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                    std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                    const std::complex<float> *a, std::int64_t lda,
+                                    const std::complex<float> *b, std::int64_t ldb, float beta,
+                                    std::complex<float> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     her2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::her2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3297,11 +3371,12 @@ static inline cl::sycl::event her2k(
     return done;
 }
 
-static inline cl::sycl::event her2k(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, double beta, std::complex<double> *c,
-    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                    std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                    const std::complex<double> *a, std::int64_t lda,
+                                    const std::complex<double> *b, std::int64_t ldb, double beta,
+                                    std::complex<double> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     her2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::her2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3311,10 +3386,11 @@ static inline cl::sycl::event her2k(
     return done;
 }
 
-static inline cl::sycl::event herk(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    float alpha, const std::complex<float> *a, std::int64_t lda, float beta, std::complex<float> *c,
-    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   std::int64_t n, std::int64_t k, float alpha,
+                                   const std::complex<float> *a, std::int64_t lda, float beta,
+                                   std::complex<float> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     herk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::herk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -3322,11 +3398,11 @@ static inline cl::sycl::event herk(
     return done;
 }
 
-static inline cl::sycl::event herk(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    double alpha, const std::complex<double> *a, std::int64_t lda, double beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   std::int64_t n, std::int64_t k, double alpha,
+                                   const std::complex<double> *a, std::int64_t lda, double beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     herk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::herk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -3334,11 +3410,12 @@ static inline cl::sycl::event herk(
     return done;
 }
 
-static inline cl::sycl::event hpmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *a, const std::complex<float> *x, std::int64_t incx,
-    std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hpmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::hpmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3346,11 +3423,12 @@ static inline cl::sycl::event hpmv(
     return done;
 }
 
-static inline cl::sycl::event hpmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *a, const std::complex<double> *x, std::int64_t incx,
-    std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hpmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::hpmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3358,10 +3436,10 @@ static inline cl::sycl::event hpmv(
     return done;
 }
 
-static inline cl::sycl::event hpr(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  float alpha, const std::complex<float> *x, std::int64_t incx,
+                                  std::complex<float> *a,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::hpr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3369,10 +3447,10 @@ static inline cl::sycl::event hpr(
     return done;
 }
 
-static inline cl::sycl::event hpr(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  double alpha, const std::complex<double> *x, std::int64_t incx,
+                                  std::complex<double> *a,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::hpr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3380,11 +3458,11 @@ static inline cl::sycl::event hpr(
     return done;
 }
 
-static inline cl::sycl::event hpr2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *a,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, const std::complex<float> *y,
+                                   std::int64_t incy, std::complex<float> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::hpr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3392,11 +3470,11 @@ static inline cl::sycl::event hpr2(
     return done;
 }
 
-static inline cl::sycl::event hpr2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *a,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, const std::complex<double> *y,
+                                   std::int64_t incy, std::complex<double> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     hpr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::hpr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3404,232 +3482,232 @@ static inline cl::sycl::event hpr2(
     return done;
 }
 
-static inline cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<double> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamax_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamax_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<double> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     iamin_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
     iamin_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                   std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                   std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     nrm2_precondition(queue, n, x, incx, result, dependencies);
     auto done = detail::nrm2(get_device_id(queue), queue, n, x, incx, result, dependencies);
     nrm2_postcondition(queue, n, x, incx, result, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rot(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
-    std::complex<float> *y, std::int64_t incy, float c, float s,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
+                                  std::int64_t incx, std::complex<float> *y, std::int64_t incy,
+                                  float c, float s,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rot(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
-    std::complex<double> *y, std::int64_t incy, double c, double s,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
+                                  std::int64_t incx, std::complex<double> *y, std::int64_t incy,
+                                  double c, double s,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rot(
-    cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-    std::int64_t incy, float c, float s,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                  std::int64_t incx, float *y, std::int64_t incy, float c, float s,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rot(
-    cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-    std::int64_t incy, double c, double s,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                  std::int64_t incx, double *y, std::int64_t incy, double c,
+                                  double s, const std::vector<cl::sycl::event> &dependencies = {}) {
     rot_precondition(queue, n, x, incx, y, incy, c, s, dependencies);
     auto done = detail::rot(get_device_id(queue), queue, n, x, incx, y, incy, c, s, dependencies);
     rot_postcondition(queue, n, x, incx, y, incy, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotg(
-    cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotg(
-    cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c,
+                                   double *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotg(
-    cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
-    std::complex<float> *s, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a,
+                                   std::complex<float> *b, float *c, std::complex<float> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotg(
-    cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
-    std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a,
+                                   std::complex<double> *b, double *c, std::complex<double> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     rotg_precondition(queue, a, b, c, s, dependencies);
     auto done = detail::rotg(get_device_id(queue), queue, a, b, c, s, dependencies);
     rotg_postcondition(queue, a, b, c, s, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotm(
-    cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-    std::int64_t incy, float *param,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                   std::int64_t incx, float *y, std::int64_t incy, float *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     rotm_precondition(queue, n, x, incx, y, incy, param, dependencies);
     auto done = detail::rotm(get_device_id(queue), queue, n, x, incx, y, incy, param, dependencies);
     rotm_postcondition(queue, n, x, incx, y, incy, param, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotm(
-    cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-    std::int64_t incy, double *param,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                   std::int64_t incx, double *y, std::int64_t incy, double *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     rotm_precondition(queue, n, x, incx, y, incy, param, dependencies);
     auto done = detail::rotm(get_device_id(queue), queue, n, x, incx, y, incy, param, dependencies);
     rotm_postcondition(queue, n, x, incx, y, incy, param, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotmg(
-    cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1,
+                                    float y1, float *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotmg_precondition(queue, d1, d2, x1, y1, param, dependencies);
     auto done = detail::rotmg(get_device_id(queue), queue, d1, d2, x1, y1, param, dependencies);
     rotmg_postcondition(queue, d1, d2, x1, y1, param, dependencies);
     return done;
 }
 
-static inline cl::sycl::event rotmg(
-    cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1,
+                                    double y1, double *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     rotmg_precondition(queue, d1, d2, x1, y1, param, dependencies);
     auto done = detail::rotmg(get_device_id(queue), queue, d1, d2, x1, y1, param, dependencies);
     rotmg_postcondition(queue, d1, d2, x1, y1, param, dependencies);
     return done;
 }
 
-static inline cl::sycl::event sbmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k, float alpha,
-    const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                                   const float *x, std::int64_t incx, float beta, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     sbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::sbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3639,10 +3717,11 @@ static inline cl::sycl::event sbmv(
     return done;
 }
 
-static inline cl::sycl::event sbmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k, double alpha,
-    const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                                   const double *x, std::int64_t incx, double beta, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     sbmv_precondition(queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = detail::sbmv(get_device_id(queue), queue, upper_lower, n, k, alpha, a, lda, x, incx,
@@ -3652,64 +3731,66 @@ static inline cl::sycl::event sbmv(
     return done;
 }
 
-static inline cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
     return done;
 }
 
-static inline cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
     return done;
 }
 
-static inline cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<float> alpha, std::complex<float> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
     return done;
 }
 
-static inline cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<double> alpha, std::complex<double> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
     return done;
 }
 
-static inline cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
     return done;
 }
 
-static inline cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     scal_precondition(queue, n, alpha, x, incx, dependencies);
     auto done = detail::scal(get_device_id(queue), queue, n, alpha, x, incx, dependencies);
     scal_postcondition(queue, n, alpha, x, incx, dependencies);
     return done;
 }
 
-static inline cl::sycl::event sdsdot(
-    cl::sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
-    const float *y, std::int64_t incy, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event sdsdot(cl::sycl::queue &queue, std::int64_t n, float sb,
+                                     const float *x, std::int64_t incx, const float *y,
+                                     std::int64_t incy, float *result,
+                                     const std::vector<cl::sycl::event> &dependencies = {}) {
     sdsdot_precondition(queue, n, sb, x, incx, y, incy, result, dependencies);
     auto done =
         detail::sdsdot(get_device_id(queue), queue, n, sb, x, incx, y, incy, result, dependencies);
@@ -3717,10 +3798,10 @@ static inline cl::sycl::event sdsdot(
     return done;
 }
 
-static inline cl::sycl::event spmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *a,
-    const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   float alpha, const float *a, const float *x, std::int64_t incx,
+                                   float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     spmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::spmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3728,10 +3809,10 @@ static inline cl::sycl::event spmv(
     return done;
 }
 
-static inline cl::sycl::event spmv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *a,
-    const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   double alpha, const double *a, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     spmv_precondition(queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
     auto done = detail::spmv(get_device_id(queue), queue, upper_lower, n, alpha, a, x, incx, beta,
                              y, incy, dependencies);
@@ -3739,9 +3820,9 @@ static inline cl::sycl::event spmv(
     return done;
 }
 
-static inline cl::sycl::event spr(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, float *a, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  float alpha, const float *x, std::int64_t incx, float *a,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     spr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::spr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3749,10 +3830,9 @@ static inline cl::sycl::event spr(
     return done;
 }
 
-static inline cl::sycl::event spr(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, double *a,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  double alpha, const double *x, std::int64_t incx, double *a,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     spr_precondition(queue, upper_lower, n, alpha, x, incx, a, dependencies);
     auto done =
         detail::spr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, dependencies);
@@ -3760,10 +3840,10 @@ static inline cl::sycl::event spr(
     return done;
 }
 
-static inline cl::sycl::event spr2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   float alpha, const float *x, std::int64_t incx, const float *y,
+                                   std::int64_t incy, float *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     spr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::spr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3771,10 +3851,10 @@ static inline cl::sycl::event spr2(
     return done;
 }
 
-static inline cl::sycl::event spr2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   double alpha, const double *x, std::int64_t incx,
+                                   const double *y, std::int64_t incy, double *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     spr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, dependencies);
     auto done = detail::spr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, dependencies);
@@ -3782,48 +3862,47 @@ static inline cl::sycl::event spr2(
     return done;
 }
 
-static inline cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                   std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                   std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     swap_precondition(queue, n, x, incx, y, incy, dependencies);
     auto done = detail::swap(get_device_id(queue), queue, n, x, incx, y, incy, dependencies);
     swap_postcondition(queue, n, x, incx, y, incy, dependencies);
     return done;
 }
 
-static inline cl::sycl::event symm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
-    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   std::int64_t m, std::int64_t n, float alpha, const float *a,
+                                   std::int64_t lda, const float *b, std::int64_t ldb, float beta,
+                                   float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3833,10 +3912,11 @@ static inline cl::sycl::event symm(
     return done;
 }
 
-static inline cl::sycl::event symm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
-    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   std::int64_t m, std::int64_t n, double alpha, const double *a,
+                                   std::int64_t lda, const double *b, std::int64_t ldb, double beta,
+                                   double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3846,12 +3926,13 @@ static inline cl::sycl::event symm(
     return done;
 }
 
-static inline cl::sycl::event symm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3861,12 +3942,13 @@ static inline cl::sycl::event symm(
     return done;
 }
 
-static inline cl::sycl::event symm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *b, std::int64_t ldb,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     symm_precondition(queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
     auto done = detail::symm(get_device_id(queue), queue, left_right, upper_lower, m, n, alpha, a,
@@ -3876,10 +3958,10 @@ static inline cl::sycl::event symm(
     return done;
 }
 
-static inline cl::sycl::event symv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *a,
-    std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   float alpha, const float *a, std::int64_t lda, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     symv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::symv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3887,10 +3969,10 @@ static inline cl::sycl::event symv(
     return done;
 }
 
-static inline cl::sycl::event symv(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *a,
-    std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   double alpha, const double *a, std::int64_t lda, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     symv_precondition(queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
     auto done = detail::symv(get_device_id(queue), queue, upper_lower, n, alpha, a, lda, x, incx,
                              beta, y, incy, dependencies);
@@ -3898,10 +3980,10 @@ static inline cl::sycl::event symv(
     return done;
 }
 
-static inline cl::sycl::event syr(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, float *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  float alpha, const float *x, std::int64_t incx, float *a,
+                                  std::int64_t lda,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     syr_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::syr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3909,10 +3991,10 @@ static inline cl::sycl::event syr(
     return done;
 }
 
-static inline cl::sycl::event syr(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, double *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                  double alpha, const double *x, std::int64_t incx, double *a,
+                                  std::int64_t lda,
+                                  const std::vector<cl::sycl::event> &dependencies = {}) {
     syr_precondition(queue, upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = detail::syr(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, a, lda,
                             dependencies);
@@ -3920,10 +4002,10 @@ static inline cl::sycl::event syr(
     return done;
 }
 
-static inline cl::sycl::event syr2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   float alpha, const float *x, std::int64_t incx, const float *y,
+                                   std::int64_t incy, float *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::syr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3931,10 +4013,10 @@ static inline cl::sycl::event syr2(
     return done;
 }
 
-static inline cl::sycl::event syr2(
-    cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
+                                   double alpha, const double *x, std::int64_t incx,
+                                   const double *y, std::int64_t incy, double *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2_precondition(queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = detail::syr2(get_device_id(queue), queue, upper_lower, n, alpha, x, incx, y, incy,
                              a, lda, dependencies);
@@ -3942,10 +4024,11 @@ static inline cl::sycl::event syr2(
     return done;
 }
 
-static inline cl::sycl::event syr2k(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
-    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                    std::int64_t n, std::int64_t k, float alpha, const float *a,
+                                    std::int64_t lda, const float *b, std::int64_t ldb, float beta,
+                                    float *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3955,10 +4038,11 @@ static inline cl::sycl::event syr2k(
     return done;
 }
 
-static inline cl::sycl::event syr2k(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    double alpha, const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
-    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                    std::int64_t n, std::int64_t k, double alpha, const double *a,
+                                    std::int64_t lda, const double *b, std::int64_t ldb,
+                                    double beta, double *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3968,12 +4052,13 @@ static inline cl::sycl::event syr2k(
     return done;
 }
 
-static inline cl::sycl::event syr2k(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                    std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                    const std::complex<float> *a, std::int64_t lda,
+                                    const std::complex<float> *b, std::int64_t ldb,
+                                    std::complex<float> beta, std::complex<float> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3983,12 +4068,13 @@ static inline cl::sycl::event syr2k(
     return done;
 }
 
-static inline cl::sycl::event syr2k(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                    std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                    const std::complex<double> *a, std::int64_t lda,
+                                    const std::complex<double> *b, std::int64_t ldb,
+                                    std::complex<double> beta, std::complex<double> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     syr2k_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                        dependencies);
     auto done = detail::syr2k(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
@@ -3998,10 +4084,10 @@ static inline cl::sycl::event syr2k(
     return done;
 }
 
-static inline cl::sycl::event syrk(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    float alpha, const float *a, std::int64_t lda, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   std::int64_t n, std::int64_t k, float alpha, const float *a,
+                                   std::int64_t lda, float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4009,10 +4095,10 @@ static inline cl::sycl::event syrk(
     return done;
 }
 
-static inline cl::sycl::event syrk(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    double alpha, const double *a, std::int64_t lda, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   std::int64_t n, std::int64_t k, double alpha, const double *a,
+                                   std::int64_t lda, double beta, double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4020,11 +4106,12 @@ static inline cl::sycl::event syrk(
     return done;
 }
 
-static inline cl::sycl::event syrk(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4032,11 +4119,12 @@ static inline cl::sycl::event syrk(
     return done;
 }
 
-static inline cl::sycl::event syrk(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
     auto done = detail::syrk(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a, lda,
                              beta, c, ldc, dependencies);
@@ -4044,11 +4132,12 @@ static inline cl::sycl::event syrk(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, std::int64_t *n, std::int64_t *k,
-    float *alpha, const float **a, std::int64_t *lda, float *beta, float **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower,
+                                         transpose *trans, std::int64_t *n, std::int64_t *k,
+                                         float *alpha, const float **a, std::int64_t *lda,
+                                         float *beta, float **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4058,11 +4147,12 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, std::int64_t *n, std::int64_t *k,
-    double *alpha, const double **a, std::int64_t *lda, double *beta, double **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower,
+                                         transpose *trans, std::int64_t *n, std::int64_t *k,
+                                         double *alpha, const double **a, std::int64_t *lda,
+                                         double *beta, double **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4072,11 +4162,13 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, std::int64_t *n, std::int64_t *k,
-    std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
-    std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower,
+                                         transpose *trans, std::int64_t *n, std::int64_t *k,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         std::int64_t *lda, std::complex<float> *beta,
+                                         std::complex<float> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4086,12 +4178,14 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, std::int64_t *n, std::int64_t *k,
-    std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
-    std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower,
+                                         transpose *trans, std::int64_t *n, std::int64_t *k,
+                                         std::complex<double> *alpha,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         std::complex<double> *beta, std::complex<double> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                             group_count, group_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4101,11 +4195,12 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    float alpha, const float *a, std::int64_t lda, std::int64_t stride_a, float beta, float *c,
-    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                         std::int64_t n, std::int64_t k, float alpha,
+                                         const float *a, std::int64_t lda, std::int64_t stride_a,
+                                         float beta, float *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4115,11 +4210,12 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    double alpha, const double *a, std::int64_t lda, std::int64_t stride_a, double beta, double *c,
-    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                         std::int64_t n, std::int64_t k, double alpha,
+                                         const double *a, std::int64_t lda, std::int64_t stride_a,
+                                         double beta, double *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4129,12 +4225,13 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                         std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<float> beta,
+                                         std::complex<float> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4144,12 +4241,13 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n, std::int64_t k,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                         std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<double> beta,
+                                         std::complex<double> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     syrk_batch_precondition(queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
                             stride_c, batch_size, dependencies);
     auto done = detail::syrk_batch(get_device_id(queue), queue, upper_lower, trans, n, k, alpha, a,
@@ -4159,10 +4257,10 @@ static inline cl::sycl::event syrk_batch(
     return done;
 }
 
-static inline cl::sycl::event tbmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
+                                   std::int64_t lda, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4170,10 +4268,10 @@ static inline cl::sycl::event tbmv(
     return done;
 }
 
-static inline cl::sycl::event tbmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4181,10 +4279,11 @@ static inline cl::sycl::event tbmv(
     return done;
 }
 
-static inline cl::sycl::event tbmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4192,10 +4291,11 @@ static inline cl::sycl::event tbmv(
     return done;
 }
 
-static inline cl::sycl::event tbmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbmv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4203,10 +4303,10 @@ static inline cl::sycl::event tbmv(
     return done;
 }
 
-static inline cl::sycl::event tbsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
+                                   std::int64_t lda, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4214,10 +4314,10 @@ static inline cl::sycl::event tbsv(
     return done;
 }
 
-static inline cl::sycl::event tbsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4225,10 +4325,11 @@ static inline cl::sycl::event tbsv(
     return done;
 }
 
-static inline cl::sycl::event tbsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4236,10 +4337,11 @@ static inline cl::sycl::event tbsv(
     return done;
 }
 
-static inline cl::sycl::event tbsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    std::int64_t k, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tbsv_precondition(queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
     auto done = detail::tbsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, k, a,
                              lda, x, incx, dependencies);
@@ -4247,10 +4349,10 @@ static inline cl::sycl::event tbsv(
     return done;
 }
 
-static inline cl::sycl::event tpmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const float *a, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4258,10 +4360,10 @@ static inline cl::sycl::event tpmv(
     return done;
 }
 
-static inline cl::sycl::event tpmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const double *a, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4269,10 +4371,10 @@ static inline cl::sycl::event tpmv(
     return done;
 }
 
-static inline cl::sycl::event tpmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4280,10 +4382,10 @@ static inline cl::sycl::event tpmv(
     return done;
 }
 
-static inline cl::sycl::event tpmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpmv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4291,10 +4393,10 @@ static inline cl::sycl::event tpmv(
     return done;
 }
 
-static inline cl::sycl::event tpsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const float *a, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4302,10 +4404,10 @@ static inline cl::sycl::event tpsv(
     return done;
 }
 
-static inline cl::sycl::event tpsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const double *a, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4313,10 +4415,10 @@ static inline cl::sycl::event tpsv(
     return done;
 }
 
-static inline cl::sycl::event tpsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4324,10 +4426,10 @@ static inline cl::sycl::event tpsv(
     return done;
 }
 
-static inline cl::sycl::event tpsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     tpsv_precondition(queue, upper_lower, trans, unit_diag, n, a, x, incx, dependencies);
     auto done = detail::tpsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, x,
                              incx, dependencies);
@@ -4335,10 +4437,11 @@ static inline cl::sycl::event tpsv(
     return done;
 }
 
-static inline cl::sycl::event trmm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   float alpha, const float *a, std::int64_t lda, float *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4348,10 +4451,11 @@ static inline cl::sycl::event trmm(
     return done;
 }
 
-static inline cl::sycl::event trmm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   double alpha, const double *a, std::int64_t lda, double *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4361,11 +4465,11 @@ static inline cl::sycl::event trmm(
     return done;
 }
 
-static inline cl::sycl::event trmm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4375,11 +4479,11 @@ static inline cl::sycl::event trmm(
     return done;
 }
 
-static inline cl::sycl::event trmm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trmm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4389,10 +4493,10 @@ static inline cl::sycl::event trmm(
     return done;
 }
 
-static inline cl::sycl::event trmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4400,10 +4504,10 @@ static inline cl::sycl::event trmv(
     return done;
 }
 
-static inline cl::sycl::event trmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4411,10 +4515,10 @@ static inline cl::sycl::event trmv(
     return done;
 }
 
-static inline cl::sycl::event trmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<float> *a, std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4422,10 +4526,10 @@ static inline cl::sycl::event trmv(
     return done;
 }
 
-static inline cl::sycl::event trmv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<double> *a, std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trmv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trmv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4433,10 +4537,11 @@ static inline cl::sycl::event trmv(
     return done;
 }
 
-static inline cl::sycl::event trsm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   float alpha, const float *a, std::int64_t lda, float *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4446,10 +4551,11 @@ static inline cl::sycl::event trsm(
     return done;
 }
 
-static inline cl::sycl::event trsm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-    std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   double alpha, const double *a, std::int64_t lda, double *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4459,11 +4565,11 @@ static inline cl::sycl::event trsm(
     return done;
 }
 
-static inline cl::sycl::event trsm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4473,11 +4579,11 @@ static inline cl::sycl::event trsm(
     return done;
 }
 
-static inline cl::sycl::event trsm(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb,
                       dependencies);
     auto done = detail::trsm(get_device_id(queue), queue, left_right, upper_lower, trans, unit_diag,
@@ -4487,11 +4593,13 @@ static inline cl::sycl::event trsm(
     return done;
 }
 
-static inline cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
-    std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                         transpose trans, diag unit_diag, std::int64_t m,
+                                         std::int64_t n, float alpha, const float *a,
+                                         std::int64_t lda, std::int64_t stride_a, float *b,
+                                         std::int64_t ldb, std::int64_t stride_b,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4502,11 +4610,13 @@ static inline cl::sycl::event trsm_batch(
     return done;
 }
 
-static inline cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-    std::int64_t stride_a, double *b, std::int64_t ldb, std::int64_t stride_b,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                         transpose trans, diag unit_diag, std::int64_t m,
+                                         std::int64_t n, double alpha, const double *a,
+                                         std::int64_t lda, std::int64_t stride_a, double *b,
+                                         std::int64_t ldb, std::int64_t stride_b,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4517,12 +4627,14 @@ static inline cl::sycl::event trsm_batch(
     return done;
 }
 
-static inline cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb,
-    std::int64_t stride_b, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                         transpose trans, diag unit_diag, std::int64_t m,
+                                         std::int64_t n, std::complex<float> alpha,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<float> *b,
+                                         std::int64_t ldb, std::int64_t stride_b,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4533,12 +4645,14 @@ static inline cl::sycl::event trsm_batch(
     return done;
 }
 
-static inline cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb,
-    std::int64_t stride_b, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
+                                         transpose trans, diag unit_diag, std::int64_t m,
+                                         std::int64_t n, std::complex<double> alpha,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<double> *b,
+                                         std::int64_t ldb, std::int64_t stride_b,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = detail::trsm_batch(get_device_id(queue), queue, left_right, upper_lower, trans,
@@ -4549,11 +4663,13 @@ static inline cl::sycl::event trsm_batch(
     return done;
 }
 
-static inline cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans, diag *unit_diag,
-    std::int64_t *m, std::int64_t *n, float *alpha, const float **a, std::int64_t *lda, float **b,
-    std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right,
+                                         uplo *upper_lower, transpose *trans, diag *unit_diag,
+                                         std::int64_t *m, std::int64_t *n, float *alpha,
+                                         const float **a, std::int64_t *lda, float **b,
+                                         std::int64_t *ldb, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             b, ldb, group_count, group_size, dependencies);
     auto done =
@@ -4564,11 +4680,13 @@ static inline cl::sycl::event trsm_batch(
     return done;
 }
 
-static inline cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans, diag *unit_diag,
-    std::int64_t *m, std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
-    double **b, std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right,
+                                         uplo *upper_lower, transpose *trans, diag *unit_diag,
+                                         std::int64_t *m, std::int64_t *n, double *alpha,
+                                         const double **a, std::int64_t *lda, double **b,
+                                         std::int64_t *ldb, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {}) {
     trsm_batch_precondition(queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
                             b, ldb, group_count, group_size, dependencies);
     auto done =
@@ -4609,10 +4727,10 @@ static inline cl::sycl::event trsm_batch(
     return done;
 }
 
-static inline cl::sycl::event trsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4620,10 +4738,10 @@ static inline cl::sycl::event trsv(
     return done;
 }
 
-static inline cl::sycl::event trsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4631,10 +4749,10 @@ static inline cl::sycl::event trsv(
     return done;
 }
 
-static inline cl::sycl::event trsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<float> *a, std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);
@@ -4642,10 +4760,10 @@ static inline cl::sycl::event trsv(
     return done;
 }
 
-static inline cl::sycl::event trsv(
-    cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, std::int64_t n,
-    const std::complex<double> *a, std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {}) {
+static inline cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {}) {
     trsv_precondition(queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
     auto done = detail::trsv(get_device_id(queue), queue, upper_lower, trans, unit_diag, n, a, lda,
                              x, incx, dependencies);

--- a/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
@@ -1086,527 +1086,527 @@ static inline void symv(backend_selector<backend::BACKEND> selector, uplo upper_
 static inline cl::sycl::event syr2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
     const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
     const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event scal(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, float *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event scal(
     backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, double *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event scal(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event scal(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event scal(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event scal(
     backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
                                   float *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
                                   double *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hpmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
     std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hpmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
     std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta, float *c,
-    std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta, double *c,
-    std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, float *beta,
     float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
     double *beta, double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
     std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
     std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, float alpha, const float *a, std::int64_t lda, std::int64_t stride_a,
     float beta, float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, double alpha, const double *a, std::int64_t lda, std::int64_t stride_a,
     double beta, double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syrk_batch(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event her2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event her2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                                   std::int64_t incy, float c, float s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   std::complex<double> *x, std::int64_t incx,
                                   std::complex<double> *y, std::int64_t incy, double c, double s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   float *x, std::int64_t incx, float *y, std::int64_t incy, float c,
                                   float s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   double *x, std::int64_t incx, double *y, std::int64_t incy,
                                   double c, double s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, float *alpha, const float **x,
     std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, double *alpha, const double **x,
     std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, std::complex<float> *alpha,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, std::complex<double> *alpha,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpby(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, const float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpby(
     backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, const double *x,
     std::int64_t incx, const double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpby(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event axpby(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gerc(
     backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gerc(
     backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr2k(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
     float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr2k(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *b,
     std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr2k(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr2k(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
     double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
     std::int64_t incx, std::int64_t stridex, float beta, float *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
     std::int64_t incx, std::int64_t stridex, double beta, double *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stridea, const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
     float *alpha, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
     float *beta, float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
     double *alpha, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
     double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
     std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
     std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
     std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> *beta,
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
     const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
     std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
     const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
     std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
     const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
     const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
     const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
     const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
     const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
     std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dgmm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
     const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
     std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event her(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, float alpha, const std::complex<float> *x,
                                   std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event her(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, double alpha, const std::complex<double> *x,
                                   std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hpr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, float alpha, const std::complex<float> *x,
                                   std::int64_t incx, std::complex<float> *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hpr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, double alpha, const std::complex<double> *x,
                                   std::int64_t incx, std::complex<double> *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamin(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamin(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamin(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamin(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
     std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
     std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
@@ -1614,7 +1614,7 @@ static inline cl::sycl::event gemm_batch(
     const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
     std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
@@ -1622,28 +1622,28 @@ static inline cl::sycl::event gemm_batch(
     const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **b,
     std::int64_t *ldb, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
     std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     std::int64_t stride_a, const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
     float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     std::int64_t stride_a, const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
     double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
@@ -1651,7 +1651,7 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t lda, std::int64_t stride_a, const std::complex<float> *b, std::int64_t ldb,
     std::int64_t stride_b, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
@@ -1659,682 +1659,682 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t lda, std::int64_t stride_a, const std::complex<double> *b, std::int64_t ldb,
     std::int64_t stride_b, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
     std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
     std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
     half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
     const float *a, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
     const double *a, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event swap(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event swap(
     backend_selector<backend::BACKEND> selector, std::int64_t n, double *x, std::int64_t incx,
-    double *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event swap(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> *x,
     std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event swap(
     backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> *x,
     std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event geru(
     backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event geru(
     backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event nrm2(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event nrm2(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event nrm2(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event nrm2(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
     std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda, const half *b,
     std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda, const half *b,
     std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
     std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a, std::int64_t lda,
     const bfloat16 *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event herk(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda, float beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event herk(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda, double beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event ger(backend_selector<backend::BACKEND> selector, std::int64_t m,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
                                   const float *y, std::int64_t incy, float *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event ger(backend_selector<backend::BACKEND> selector, std::int64_t m,
                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
                                   const double *y, std::int64_t incy, double *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
-    float *b, std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-    double *b, std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
     int64_t stride_a, float *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
     int64_t stride_a, double *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     int64_t lda, int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-    int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     int64_t lda, int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-    int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha, const float **a,
     int64_t *lda, float **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha, const double **a,
     int64_t *lda, double **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<float> *alpha,
     const std::complex<float> **a, int64_t *lda, std::complex<float> **b, int64_t *ldb,
     int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsm_batch(
     backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<double> *alpha,
     const std::complex<double> **a, int64_t *lda, std::complex<double> **b, int64_t *ldb,
     int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dotu(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dotu(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
-    std::complex<double> *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::complex<double> *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hemm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
     std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hemm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
     std::int64_t n, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hpr2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hpr2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gbmv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda, const float *x,
     std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gbmv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
     const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gbmv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gbmv(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event symm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
     std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
     float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event symm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
     std::int64_t n, double alpha, const double *a, std::int64_t lda, const double *b,
     std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event symm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
     std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event symm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
     std::int64_t n, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dotc(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dotc(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
-    std::complex<double> *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::complex<double> *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
                                   float *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
                                   double *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
-    float *b, std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-    double *b, std::int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trmm(
     backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotmg(
     backend_selector<backend::BACKEND> selector, float *d1, float *d2, float *x1, float y1,
-    float *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *param, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotmg(
     backend_selector<backend::BACKEND> selector, double *d1, double *d2, double *x1, double y1,
-    double *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *param, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tpsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event trsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    double *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, const float **x,
     std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, const double **x,
     std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, const std::complex<float> **x,
     std::int64_t *incx, std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t *n, const std::complex<double> **x,
     std::int64_t *incx, std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
     std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
     std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event copy_batch(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, std::int64_t stridex, std::complex<double> *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hemv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event hemv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemmt(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemmt(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, double alpha, const double *a,
     std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemmt(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemmt(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
     std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_bias(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, offset offsetc,
     int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a, int64_t lda, std::int8_t ao,
     const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, int64_t ldc,
-    const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_bias(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, offset offsetc,
     int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a, int64_t lda, std::int8_t ao,
     const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, int64_t ldc,
-    const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_bias(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, offset offsetc,
     int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a, int64_t lda,
     std::uint8_t ao, const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta, std::int32_t *c,
     int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_bias(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, offset offsetc,
     int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a, int64_t lda,
     std::uint8_t ao, const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
     std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event sbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
     float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event sbmv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
     double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
     double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event asum(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event asum(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event asum(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event asum(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event tbsv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
     std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spr2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
     const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spr2(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
     const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamax(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamax(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamax(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event iamax(
     backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotm(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float *x, std::int64_t incx,
     float *y, std::int64_t incy, float *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotm(
     backend_selector<backend::BACKEND> selector, std::int64_t n, double *x, std::int64_t incx,
     double *y, std::int64_t incy, double *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotg(
     backend_selector<backend::BACKEND> selector, float *a, float *b, float *c, float *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotg(
     backend_selector<backend::BACKEND> selector, double *a, double *b, double *c, double *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotg(
     backend_selector<backend::BACKEND> selector, std::complex<float> *a, std::complex<float> *b,
     float *c, std::complex<float> *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rotg(
     backend_selector<backend::BACKEND> selector, std::complex<double> *a, std::complex<double> *b,
     double *c, std::complex<double> *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event sdsdot(
     backend_selector<backend::BACKEND> selector, std::int64_t n, float sb, const float *x,
     std::int64_t incx, const float *y, std::int64_t incy, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event her2k(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *b, std::int64_t ldb, float beta, std::complex<float> *c,
-    std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event her2k(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *b, std::int64_t ldb, double beta, std::complex<double> *c,
-    std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   const float *x, std::int64_t incx, const float *y,
                                   std::int64_t incy, float *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   const double *x, std::int64_t incx, const double *y,
                                   std::int64_t incy, double *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   const float *x, std::int64_t incx, const float *y,
                                   std::int64_t incy, double *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event symv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
     const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event symv(
     backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
     const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
@@ -1083,205 +1083,231 @@ static inline void symv(backend_selector<backend::BACKEND> selector, uplo upper_
 
 // USM APIs
 
-static inline cl::sycl::event syr2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
-    const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syr2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
+                                   const float *y, std::int64_t incy, float *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syr2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
-    const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syr2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
+                                   const double *y, std::int64_t incy, double *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event scal(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, float *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event scal(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   float alpha, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event scal(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, double *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event scal(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   double alpha, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event scal(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event scal(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   std::complex<float> alpha, std::complex<float> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event scal(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event scal(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   std::complex<double> alpha, std::complex<double> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event scal(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event scal(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   float alpha, std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event scal(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event scal(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   double alpha, std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const float *a,
+                                   std::int64_t lda, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const float *a,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const double *a,
+                                   double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<float> *a, std::complex<float> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<double> *a, std::complex<double> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
-                                  float *a,
-                                  const std::vector<cl::sycl::event> &dependencies = {});
+                                  float *a, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
-                                  double *a,
-                                  const std::vector<cl::sycl::event> &dependencies = {});
+                                  double *a, const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hpmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
-    std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hpmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hpmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
-    std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hpmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta, float *c,
-    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, std::int64_t n, std::int64_t k, float alpha,
+                                   const float *a, std::int64_t lda, float beta, float *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta, double *c,
-    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, std::int64_t n, std::int64_t k, double alpha,
+                                   const double *a, std::int64_t lda, double beta, double *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, std::int64_t n, std::int64_t k,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> beta,
+                                   std::complex<float> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, std::int64_t n, std::int64_t k,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, float *beta,
-    float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, float *alpha, const float **a,
+                                         std::int64_t *lda, float *beta, float **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
-    double *beta, double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, double *alpha, const double **a,
+                                         std::int64_t *lda, double *beta, double **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
-    std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, std::complex<float> *alpha,
+                                         const std::complex<float> **a, std::int64_t *lda,
+                                         std::complex<float> *beta, std::complex<float> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
-    std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, std::complex<double> *alpha,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         std::complex<double> *beta, std::complex<double> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, float alpha, const float *a, std::int64_t lda, std::int64_t stride_a,
-    float beta, float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, float alpha, const float *a,
+                                         std::int64_t lda, std::int64_t stride_a, float beta,
+                                         float *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, double alpha, const double *a, std::int64_t lda, std::int64_t stride_a,
-    double beta, double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, double alpha, const double *a,
+                                         std::int64_t lda, std::int64_t stride_a, double beta,
+                                         double *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, std::complex<float> alpha,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<float> beta,
+                                         std::complex<float> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syrk_batch(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syrk_batch(backend_selector<backend::BACKEND> selector,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, std::complex<double> alpha,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<double> beta,
+                                         std::complex<double> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event her2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event her2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event her2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event her2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
@@ -1295,176 +1321,198 @@ static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, s
 
 static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   float *x, std::int64_t incx, float *y, std::int64_t incy, float c,
-                                  float s,
-                                  const std::vector<cl::sycl::event> &dependencies = {});
+                                  float s, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event rot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   double *x, std::int64_t incx, double *y, std::int64_t incy,
                                   double c, double s,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   float alpha, const float *x, std::int64_t incx, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   double alpha, const double *x, std::int64_t incx, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, float *alpha, const float **x,
-    std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, float *alpha, const float **x,
+                                         std::int64_t *incx, float **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, double *alpha, const double **x,
-    std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, double *alpha, const double **x,
+                                         std::int64_t *incx, double **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, std::complex<float> *alpha,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, std::complex<float> *alpha,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, std::complex<double> *alpha,
-    const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, std::complex<double> *alpha,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, float alpha, const float *x,
+                                         std::int64_t incx, std::int64_t stridex, float *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, double alpha, const double *x,
+                                         std::int64_t incx, std::int64_t stridex, double *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, std::complex<float> alpha,
+                                         const std::complex<float> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<float> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, std::complex<double> alpha,
+                                         const std::complex<double> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<double> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpby(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, const float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpby(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    float alpha, const float *x, std::int64_t incx,
+                                    const float beta, float *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpby(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, double alpha, const double *x,
-    std::int64_t incx, const double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpby(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    double alpha, const double *x, std::int64_t incx,
+                                    const double beta, double *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpby(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpby(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    std::complex<float> alpha, const std::complex<float> *x,
+                                    std::int64_t incx, const std::complex<float> beta,
+                                    std::complex<float> *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event axpby(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event axpby(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    std::complex<double> alpha, const std::complex<double> *x,
+                                    std::int64_t incx, const std::complex<double> beta,
+                                    std::complex<double> *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gerc(
-    backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gerc(backend_selector<backend::BACKEND> selector, std::int64_t m,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gerc(
-    backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gerc(backend_selector<backend::BACKEND> selector, std::int64_t m,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syr2k(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
-    float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syr2k(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose trans, std::int64_t n, std::int64_t k, float alpha,
+                                    const float *a, std::int64_t lda, const float *b,
+                                    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syr2k(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *b,
-    std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syr2k(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose trans, std::int64_t n, std::int64_t k, double alpha,
+                                    const double *a, std::int64_t lda, const double *b,
+                                    std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syr2k(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syr2k(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<float> alpha, const std::complex<float> *a,
+                                    std::int64_t lda, const std::complex<float> *b,
+                                    std::int64_t ldb, std::complex<float> beta,
+                                    std::complex<float> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event syr2k(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event syr2k(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<double> alpha, const std::complex<double> *a,
+                                    std::int64_t lda, const std::complex<double> *b,
+                                    std::int64_t ldb, std::complex<double> beta,
+                                    std::complex<double> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, float alpha, const float *a,
+                                   std::int64_t lda, const float *x, std::int64_t incx, float beta,
+                                   float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
-    double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, double alpha, const double *a,
+                                   std::int64_t lda, const double *x, std::int64_t incx,
+                                   double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv_batch(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
-    std::int64_t incx, std::int64_t stridex, float beta, float *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose trans, std::int64_t m, std::int64_t n,
+                                         float alpha, const float *a, std::int64_t lda,
+                                         std::int64_t stridea, const float *x, std::int64_t incx,
+                                         std::int64_t stridex, float beta, float *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv_batch(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
-    std::int64_t incx, std::int64_t stridex, double beta, double *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose trans, std::int64_t m, std::int64_t n,
+                                         double alpha, const double *a, std::int64_t lda,
+                                         std::int64_t stridea, const double *x, std::int64_t incx,
+                                         std::int64_t stridex, double beta, double *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
@@ -1480,24 +1528,30 @@ static inline cl::sycl::event gemv_batch(
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv_batch(
-    backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
-    float *alpha, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
-    float *beta, float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose *trans, std::int64_t *m, std::int64_t *n,
+                                         float *alpha, const float **a, std::int64_t *lda,
+                                         const float **x, std::int64_t *incx, float *beta,
+                                         float **y, std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv_batch(
-    backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
-    double *alpha, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
-    double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose *trans, std::int64_t *m, std::int64_t *n,
+                                         double *alpha, const double **a, std::int64_t *lda,
+                                         const double **x, std::int64_t *incx, double *beta,
+                                         double **y, std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemv_batch(
-    backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
-    std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
-    std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemv_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose *trans, std::int64_t *m, std::int64_t *n,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         std::int64_t *lda, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> *beta,
+                                         std::complex<float> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemv_batch(
     backend_selector<backend::BACKEND> selector, transpose *trans, std::int64_t *m, std::int64_t *n,
@@ -1506,55 +1560,69 @@ static inline cl::sycl::event gemv_batch(
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
     std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
-    const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
-    std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const float *a, std::int64_t lda, std::int64_t stridea,
+                                         const float *x, std::int64_t incx, std::int64_t stridex,
+                                         float *c, std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
-    const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const double *a, std::int64_t lda, std::int64_t stridea,
+                                         const double *x, std::int64_t incx, std::int64_t stridex,
+                                         double *c, std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
-    const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stridea, const std::complex<float> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<float> *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, std::int64_t m, std::int64_t n,
-    const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stridea, const std::complex<double> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<double> *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
-    const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const float **a, std::int64_t *lda, const float **x,
+                                         std::int64_t *incx, float **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
-    const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const double **a, std::int64_t *lda, const double **x,
+                                         std::int64_t *incx, double **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
-    const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
-    std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const std::complex<float> **a, std::int64_t *lda,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dgmm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, std::int64_t *m, std::int64_t *n,
-    const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
-    std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dgmm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event her(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, float alpha, const std::complex<float> *x,
@@ -1576,45 +1644,51 @@ static inline cl::sycl::event hpr(backend_selector<backend::BACKEND> selector, u
                                   std::int64_t incx, std::complex<double> *a,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamin(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const float *x, std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamin(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const double *x, std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamin(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamin(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const std::complex<double> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(
-    backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
-    std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, float *alpha,
+                                         const float **a, std::int64_t *lda, const float **b,
+                                         std::int64_t *ldb, float *beta, float **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(
-    backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
-    std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, double *alpha,
+                                         const double **a, std::int64_t *lda, const double **b,
+                                         std::int64_t *ldb, double *beta, double **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(
-    backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<float> *alpha,
-    const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
-    std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         std::int64_t *lda, const std::complex<float> **b,
+                                         std::int64_t *ldb, std::complex<float> *beta,
+                                         std::complex<float> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
@@ -1624,26 +1698,31 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t group_count, std::int64_t *group_size,
     const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(
-    backend_selector<backend::BACKEND> selector, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
-    std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, half *alpha,
+                                         const half **a, std::int64_t *lda, const half **b,
+                                         std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    std::int64_t stride_a, const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
-    float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose transa, transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, float alpha,
+                                         const float *a, std::int64_t lda, std::int64_t stride_a,
+                                         const float *b, std::int64_t ldb, std::int64_t stride_b,
+                                         float beta, float *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    std::int64_t stride_a, const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
-    double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose transa, transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, double alpha,
+                                         const double *a, std::int64_t lda, std::int64_t stride_a,
+                                         const double *b, std::int64_t ldb, std::int64_t stride_b,
+                                         double beta, double *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_batch(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
@@ -1661,126 +1740,131 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t stride_c, std::int64_t batch_size,
     const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-    std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-    half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
+                                         transpose transa, transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, half alpha, const half *a,
+                                         std::int64_t lda, std::int64_t stride_a, const half *b,
+                                         std::int64_t ldb, std::int64_t stride_b, half beta,
+                                         half *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event spmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
-    const float *a, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event spmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *a, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event spmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
-    const double *a, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event spmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *a, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event swap(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event swap(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   float *x, std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event swap(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, double *x, std::int64_t incx,
-    double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event swap(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   double *x, std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event swap(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<float> *x,
-    std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event swap(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event swap(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, std::complex<double> *x,
-    std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event swap(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event geru(
-    backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event geru(backend_selector<backend::BACKEND> selector, std::int64_t m,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event geru(
-    backend_selector<backend::BACKEND> selector, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event geru(backend_selector<backend::BACKEND> selector, std::int64_t m,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event nrm2(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event nrm2(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event nrm2(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event nrm2(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event nrm2(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    float *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event nrm2(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const float *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event nrm2(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    double *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event nrm2(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const double *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
-    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
+                                   transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                                   float alpha, const float *a, std::int64_t lda, const float *b,
+                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
+                                   transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                                   double alpha, const double *a, std::int64_t lda, const double *b,
+                                   std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
+                                   transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
+                                   transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *b,
+                                   std::int64_t ldb, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda, const half *b,
-    std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
+                                   transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                                   half alpha, const half *a, std::int64_t lda, const half *b,
+                                   std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda, const half *b,
-    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
+                                   transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                                   float alpha, const half *a, std::int64_t lda, const half *b,
+                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
-    std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a, std::int64_t lda,
-    const bfloat16 *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
+                                   transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                                   float alpha, const bfloat16 *a, std::int64_t lda,
+                                   const bfloat16 *b, std::int64_t ldb, float beta, float *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event herk(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda, float beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event herk(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, std::int64_t n, std::int64_t k, float alpha,
+                                   const std::complex<float> *a, std::int64_t lda, float beta,
+                                   std::complex<float> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event herk(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda, double beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event herk(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, std::int64_t n, std::int64_t k, double alpha,
+                                   const std::complex<double> *a, std::int64_t lda, double beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event ger(backend_selector<backend::BACKEND> selector, std::int64_t m,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
@@ -1792,197 +1876,224 @@ static inline cl::sycl::event ger(backend_selector<backend::BACKEND> selector, s
                                   const double *y, std::int64_t incy, double *a, std::int64_t lda,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
-    float *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, float alpha, const float *a,
+                                   std::int64_t lda, float *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-    double *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, double alpha, const double *a,
+                                   std::int64_t lda, double *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-    int64_t stride_a, float *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n, float alpha,
+                                         const float *a, int64_t lda, int64_t stride_a, float *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
-    int64_t stride_a, double *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n, double alpha,
+                                         const double *a, int64_t lda, int64_t stride_a, double *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    int64_t lda, int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-    int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n,
+                                         std::complex<float> alpha, const std::complex<float> *a,
+                                         int64_t lda, int64_t stride_a, std::complex<float> *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    int64_t lda, int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-    int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n,
+                                         std::complex<double> alpha, const std::complex<double> *a,
+                                         int64_t lda, int64_t stride_a, std::complex<double> *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha, const float **a,
-    int64_t *lda, float **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n, float *alpha,
+                                         const float **a, int64_t *lda, float **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha, const double **a,
-    int64_t *lda, double **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n, double *alpha,
+                                         const double **a, int64_t *lda, double **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<float> *alpha,
-    const std::complex<float> **a, int64_t *lda, std::complex<float> **b, int64_t *ldb,
-    int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         int64_t *lda, std::complex<float> **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsm_batch(
-    backend_selector<backend::BACKEND> selector, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<double> *alpha,
-    const std::complex<double> **a, int64_t *lda, std::complex<double> **b, int64_t *ldb,
-    int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsm_batch(backend_selector<backend::BACKEND> selector,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n,
+                                         std::complex<double> *alpha,
+                                         const std::complex<double> **a, int64_t *lda,
+                                         std::complex<double> **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dotu(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dotu(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dotu(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
-    std::complex<double> *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dotu(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hemm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
-    std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hemm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hemm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
-    std::int64_t n, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hemm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *b,
+                                   std::int64_t ldb, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hpr2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hpr2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hpr2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hpr2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gbmv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda, const float *x,
-    std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gbmv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   float alpha, const float *a, std::int64_t lda, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gbmv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
-    const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gbmv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   double alpha, const double *a, std::int64_t lda, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gbmv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gbmv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gbmv(
-    backend_selector<backend::BACKEND> selector, transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gbmv(backend_selector<backend::BACKEND> selector, transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const float *a, std::int64_t lda, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const double *a, std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event symm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
-    std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
-    float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event symm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, std::int64_t m, std::int64_t n, float alpha,
+                                   const float *a, std::int64_t lda, const float *b,
+                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event symm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
-    std::int64_t n, double alpha, const double *a, std::int64_t lda, const double *b,
-    std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event symm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, std::int64_t m, std::int64_t n, double alpha,
+                                   const double *a, std::int64_t lda, const double *b,
+                                   std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event symm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
-    std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event symm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event symm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, std::int64_t m,
-    std::int64_t n, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event symm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *b,
+                                   std::int64_t ldb, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dotc(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dotc(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event dotc(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
-    std::complex<double> *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event dotc(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event syr(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
@@ -1994,175 +2105,201 @@ static inline cl::sycl::event syr(backend_selector<backend::BACKEND> selector, u
                                   double *a, std::int64_t lda,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
-    float *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, float alpha, const float *a,
+                                   std::int64_t lda, float *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-    double *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, double alpha, const double *a,
+                                   std::int64_t lda, double *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trmm(
-    backend_selector<backend::BACKEND> selector, side left_right, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trmm(backend_selector<backend::BACKEND> selector, side left_right,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotmg(
-    backend_selector<backend::BACKEND> selector, float *d1, float *d2, float *x1, float y1,
-    float *param, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotmg(backend_selector<backend::BACKEND> selector, float *d1,
+                                    float *d2, float *x1, float y1, float *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotmg(
-    backend_selector<backend::BACKEND> selector, double *d1, double *d2, double *x1, double y1,
-    double *param, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotmg(backend_selector<backend::BACKEND> selector, double *d1,
+                                    double *d2, double *x1, double y1, double *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const float *a,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const double *a,
+                                   double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<float> *a, std::complex<float> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tpsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tpsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<double> *a, std::complex<double> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const float *a,
+                                   std::int64_t lda, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event trsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event trsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const float *x, std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const double *x, std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, const float **x,
-    std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, const float **x, std::int64_t *incx,
+                                         float **y, std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, const double **x,
-    std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, const double **x, std::int64_t *incx,
+                                         double **y, std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, const std::complex<float> **x,
-    std::int64_t *incx, std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t *n, const std::complex<double> **x,
-    std::int64_t *incx, std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t *n, const std::complex<double> **x,
+                                         std::int64_t *incx, std::complex<double> **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, const float *x, std::int64_t incx,
+                                         std::int64_t stridex, float *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, const double *x, std::int64_t incx,
+                                         std::int64_t stridex, double *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, const std::complex<float> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<float> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event copy_batch(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, std::int64_t stridex, std::complex<double> *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event copy_batch(backend_selector<backend::BACKEND> selector,
+                                         std::int64_t n, const std::complex<double> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<double> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hemv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hemv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event hemv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event hemv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemmt(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemmt(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose transa, transpose transb, std::int64_t n,
+                                    std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                                    const float *b, std::int64_t ldb, float beta, float *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemmt(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, double alpha, const double *a,
-    std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemmt(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose transa, transpose transb, std::int64_t n,
+                                    std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                                    const double *b, std::int64_t ldb, double beta, double *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemmt(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
-    std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemmt(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose transa, transpose transb, std::int64_t n,
+                                    std::int64_t k, std::complex<float> alpha,
+                                    const std::complex<float> *a, std::int64_t lda,
+                                    const std::complex<float> *b, std::int64_t ldb,
+                                    std::complex<float> beta, std::complex<float> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemmt(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
-    std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemmt(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose transa, transpose transb, std::int64_t n,
+                                    std::int64_t k, std::complex<double> alpha,
+                                    const std::complex<double> *a, std::int64_t lda,
+                                    const std::complex<double> *b, std::int64_t ldb,
+                                    std::complex<double> beta, std::complex<double> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm_bias(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, offset offsetc,
@@ -2180,139 +2317,143 @@ static inline cl::sycl::event gemm_bias(
     backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, offset offsetc,
     int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a, int64_t lda,
     std::uint8_t ao, const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta, std::int32_t *c,
-    int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
+    int64_t ldc, const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_bias(
-    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, offset offsetc,
-    int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a, int64_t lda,
-    std::uint8_t ao, const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
-    std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_bias(backend_selector<backend::BACKEND> selector,
+                                        transpose transa, transpose transb, offset offsetc,
+                                        int64_t m, int64_t n, int64_t k, float alpha,
+                                        const std::uint8_t *a, int64_t lda, std::uint8_t ao,
+                                        const std::uint8_t *b, int64_t ldb, std::uint8_t bo,
+                                        float beta, std::int32_t *c, int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event sbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
-    float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event sbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, float alpha, const float *a,
+                                   std::int64_t lda, const float *x, std::int64_t incx, float beta,
+                                   float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event sbmv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, std::int64_t k,
-    double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
-    double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event sbmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, double alpha, const double *a,
+                                   std::int64_t lda, const double *x, std::int64_t incx,
+                                   double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event asum(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event asum(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event asum(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event asum(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event asum(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    float *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event asum(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const float *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event asum(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    double *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event asum(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   const double *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const float *a, std::int64_t lda, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const double *a, std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event tbsv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, diag unit_diag,
-    std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event tbsv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event spr2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
-    const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event spr2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
+                                   const float *y, std::int64_t incy, float *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event spr2(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
-    const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event spr2(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
+                                   const double *y, std::int64_t incy, double *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamax(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const float *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const float *x, std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamax(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const double *x, std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamax(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<float> *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event iamax(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, const std::complex<double> *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                    const std::complex<double> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotm(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float *x, std::int64_t incx,
-    float *y, std::int64_t incy, float *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotm(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   float *x, std::int64_t incx, float *y, std::int64_t incy,
+                                   float *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotm(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, double *x, std::int64_t incx,
-    double *y, std::int64_t incy, double *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotm(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                   double *x, std::int64_t incx, double *y, std::int64_t incy,
+                                   double *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotg(
-    backend_selector<backend::BACKEND> selector, float *a, float *b, float *c, float *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotg(backend_selector<backend::BACKEND> selector, float *a, float *b,
+                                   float *c, float *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotg(
-    backend_selector<backend::BACKEND> selector, double *a, double *b, double *c, double *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotg(backend_selector<backend::BACKEND> selector, double *a,
+                                   double *b, double *c, double *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotg(
-    backend_selector<backend::BACKEND> selector, std::complex<float> *a, std::complex<float> *b,
-    float *c, std::complex<float> *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotg(backend_selector<backend::BACKEND> selector,
+                                   std::complex<float> *a, std::complex<float> *b, float *c,
+                                   std::complex<float> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event rotg(
-    backend_selector<backend::BACKEND> selector, std::complex<double> *a, std::complex<double> *b,
-    double *c, std::complex<double> *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event rotg(backend_selector<backend::BACKEND> selector,
+                                   std::complex<double> *a, std::complex<double> *b, double *c,
+                                   std::complex<double> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event sdsdot(
-    backend_selector<backend::BACKEND> selector, std::int64_t n, float sb, const float *x,
-    std::int64_t incx, const float *y, std::int64_t incy, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event sdsdot(backend_selector<backend::BACKEND> selector, std::int64_t n,
+                                     float sb, const float *x, std::int64_t incx, const float *y,
+                                     std::int64_t incy, float *result,
+                                     const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event her2k(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *b, std::int64_t ldb, float beta, std::complex<float> *c,
-    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event her2k(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<float> alpha, const std::complex<float> *a,
+                                    std::int64_t lda, const std::complex<float> *b,
+                                    std::int64_t ldb, float beta, std::complex<float> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event her2k(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, transpose trans, std::int64_t n,
-    std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *b, std::int64_t ldb, double beta, std::complex<double> *c,
-    std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event her2k(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                    transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<double> alpha, const std::complex<double> *a,
+                                    std::int64_t lda, const std::complex<double> *b,
+                                    std::int64_t ldb, double beta, std::complex<double> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event dot(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                   const float *x, std::int64_t incx, const float *y,
@@ -2329,12 +2470,14 @@ static inline cl::sycl::event dot(backend_selector<backend::BACKEND> selector, s
                                   std::int64_t incy, double *result,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event symv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, float alpha,
-    const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event symv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                                   const float *x, std::int64_t incx, float beta, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event symv(
-    backend_selector<backend::BACKEND> selector, uplo upper_lower, std::int64_t n, double alpha,
-    const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event symv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                                   const double *x, std::int64_t incx, double beta, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/blas/detail/blas_loader.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_loader.hxx
@@ -960,75 +960,81 @@ ONEMKL_EXPORT void rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue,
 
 // USM APIs
 
-ONEMKL_EXPORT cl::sycl::event herk(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
-    float beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event herk(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda,
-    double beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event herk(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, std::int64_t n,
+                                   std::int64_t k, float alpha, const std::complex<float> *a,
+                                   std::int64_t lda, float beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event herk(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, std::int64_t n,
+                                   std::int64_t k, double alpha, const std::complex<double> *a,
+                                   std::int64_t lda, double beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event scal(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event scal(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event scal(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event scal(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event scal(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event scal(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, float alpha, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, double alpha, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, float alpha, std::complex<float> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, double alpha, std::complex<double> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const float *a, std::int64_t lda, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const double *a, std::int64_t lda, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const float *a, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const double *a, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, float alpha, const float *x,
@@ -1039,25 +1045,31 @@ ONEMKL_EXPORT cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &q
                                   std::int64_t incx, double *a,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
-    std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
-    std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<float> *alpha,
-    const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
-    std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, float *alpha,
+                                         const float **a, std::int64_t *lda, const float **b,
+                                         std::int64_t *ldb, float *beta, float **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, double *alpha,
+                                         const double **a, std::int64_t *lda, const double **b,
+                                         std::int64_t *ldb, double *beta, double **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         std::int64_t *lda, const std::complex<float> **b,
+                                         std::int64_t *ldb, std::complex<float> *beta,
+                                         std::complex<float> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<double> *alpha,
@@ -1065,24 +1077,29 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     std::int64_t *ldb, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
     const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
-    std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    std::int64_t stride_a, const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
-    float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    std::int64_t stride_a, const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
-    double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose *transa, transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, half *alpha,
+                                         const half **a, std::int64_t *lda, const half **b,
+                                         std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose transa, transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, float alpha,
+                                         const float *a, std::int64_t lda, std::int64_t stride_a,
+                                         const float *b, std::int64_t ldb, std::int64_t stride_b,
+                                         float beta, float *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose transa, transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, double alpha,
+                                         const double *a, std::int64_t lda, std::int64_t stride_a,
+                                         const double *b, std::int64_t ldb, std::int64_t stride_b,
+                                         double beta, double *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
@@ -1097,101 +1114,129 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-    std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-    half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose transa, transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, half alpha, const half *a,
+                                         std::int64_t lda, std::int64_t stride_a, const half *b,
+                                         std::int64_t ldb, std::int64_t stride_b, half beta,
+                                         half *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
-    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta,
-    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, std::int64_t n,
+                                   std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                                   float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, std::int64_t n,
+                                   std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                                   double beta, double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, std::int64_t n,
+                                   std::int64_t k, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, std::int64_t n,
+                                   std::int64_t k, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, float *beta,
-    float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
-    double *beta, double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
-    std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
-    std::int64_t *n, std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
-    std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, float *alpha, const float **a,
+                                         std::int64_t *lda, float *beta, float **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, double *alpha, const double **a,
+                                         std::int64_t *lda, double *beta, double **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, std::complex<float> *alpha,
+                                         const std::complex<float> **a, std::int64_t *lda,
+                                         std::complex<float> *beta, std::complex<float> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo *upper_lower, transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, std::complex<double> *alpha,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         std::complex<double> *beta, std::complex<double> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    std::int64_t stride_a, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    std::int64_t stride_a, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
-    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
-    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, float alpha, const float *a,
+                                         std::int64_t lda, std::int64_t stride_a, float beta,
+                                         float *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, double alpha, const double *a,
+                                         std::int64_t lda, std::int64_t stride_a, double beta,
+                                         double *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, std::complex<float> alpha,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<float> beta,
+                                         std::complex<float> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         uplo upper_lower, transpose trans, std::int64_t n,
+                                         std::int64_t k, std::complex<double> alpha,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<double> beta,
+                                         std::complex<double> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event her2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event her2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event hbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::int64_t k,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::int64_t k,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, std::complex<float> *x, std::int64_t incx,
@@ -1210,149 +1255,179 @@ ONEMKL_EXPORT cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &q
                                   std::int64_t incy, double c, double s,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event axpy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
-    const double *x, std::int64_t incx, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
+                                   float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
+                                   double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, float *alpha,
-    const float **x, std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, double *alpha,
-    const double **x, std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
-    std::complex<double> *alpha, const std::complex<double> **x, std::int64_t *incx,
-    std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
-    const double *x, std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, float *alpha, const float **x,
+                                         std::int64_t *incx, float **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, double *alpha, const double **x,
+                                         std::int64_t *incx, double **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, std::complex<float> *alpha,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, std::complex<double> *alpha,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, float alpha, const float *x,
+                                         std::int64_t incx, std::int64_t stridex, float *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, double alpha, const double *x,
+                                         std::int64_t incx, std::int64_t stridex, double *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, std::complex<float> alpha,
+                                         const std::complex<float> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<float> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, std::complex<double> alpha,
+                                         const std::complex<double> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<double> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event axpby(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
-    std::int64_t incx, const float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpby(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
-    const double *x, std::int64_t incx, const double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpby(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event axpby(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, float alpha, const float *x, std::int64_t incx,
+                                    const float beta, float *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, double alpha, const double *x,
+                                    std::int64_t incx, const double beta, double *y,
+                                    std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, std::complex<float> alpha,
+                                    const std::complex<float> *x, std::int64_t incx,
+                                    const std::complex<float> beta, std::complex<float> *y,
+                                    std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, std::complex<double> alpha,
+                                    const std::complex<double> *x, std::int64_t incx,
+                                    const std::complex<double> beta, std::complex<double> *y,
+                                    std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gerc(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gerc(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gerc(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gerc(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
-    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose trans, std::int64_t n,
+                                    std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                                    const float *b, std::int64_t ldb, float beta, float *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose trans, std::int64_t n,
+                                    std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                                    const double *b, std::int64_t ldb, double beta, double *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose trans, std::int64_t n,
+                                    std::int64_t k, std::complex<float> alpha,
+                                    const std::complex<float> *a, std::int64_t lda,
+                                    const std::complex<float> *b, std::int64_t ldb,
+                                    std::complex<float> beta, std::complex<float> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose trans, std::int64_t n,
+                                    std::int64_t k, std::complex<double> alpha,
+                                    const std::complex<double> *a, std::int64_t lda,
+                                    const std::complex<double> *b, std::int64_t ldb,
+                                    std::complex<double> beta, std::complex<double> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
-    std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, double alpha, const double *a, std::int64_t lda, const double *x,
-    std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n, float alpha,
+                                   const float *a, std::int64_t lda, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n, double alpha,
+                                   const double *a, std::int64_t lda, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, float alpha, const float *a, std::int64_t lda, std::int64_t stridea,
-    const float *x, std::int64_t incx, std::int64_t stridex, float beta, float *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, double alpha, const double *a, std::int64_t lda, std::int64_t stridea,
-    const double *x, std::int64_t incx, std::int64_t stridex, double beta, double *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose trans, std::int64_t m, std::int64_t n,
+                                         float alpha, const float *a, std::int64_t lda,
+                                         std::int64_t stridea, const float *x, std::int64_t incx,
+                                         std::int64_t stridex, float beta, float *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose trans, std::int64_t m, std::int64_t n,
+                                         double alpha, const double *a, std::int64_t lda,
+                                         std::int64_t stridea, const double *x, std::int64_t incx,
+                                         std::int64_t stridex, double beta, double *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
@@ -1365,22 +1440,28 @@ ONEMKL_EXPORT cl::sycl::event gemv_batch(
     std::int64_t stridea, const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
-    std::int64_t *n, float *alpha, const float **a, std::int64_t *lda, const float **x,
-    std::int64_t *incx, float *beta, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
-    std::int64_t *n, double *alpha, const double **a, std::int64_t *lda, const double **x,
-    std::int64_t *incx, double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
-    std::int64_t *n, std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
-    std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose *trans, std::int64_t *m, std::int64_t *n,
+                                         float *alpha, const float **a, std::int64_t *lda,
+                                         const float **x, std::int64_t *incx, float *beta,
+                                         float **y, std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose *trans, std::int64_t *m, std::int64_t *n,
+                                         double *alpha, const double **a, std::int64_t *lda,
+                                         const double **x, std::int64_t *incx, double *beta,
+                                         double **y, std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         transpose *trans, std::int64_t *m, std::int64_t *n,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         std::int64_t *lda, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> *beta,
+                                         std::complex<float> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
     std::int64_t *n, std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
@@ -1388,50 +1469,62 @@ ONEMKL_EXPORT cl::sycl::event gemv_batch(
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
     std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
-    std::int64_t n, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
-    std::int64_t incx, std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
-    std::int64_t n, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
-    std::int64_t incx, std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
-    std::int64_t n, const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
-    std::int64_t n, const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
-    std::int64_t *n, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
-    float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
-    std::int64_t *n, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
-    double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
-    std::int64_t *n, const std::complex<float> **a, std::int64_t *lda,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
-    std::int64_t *n, const std::complex<double> **a, std::int64_t *lda,
-    const std::complex<double> **x, std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const float *a, std::int64_t lda, std::int64_t stridea,
+                                         const float *x, std::int64_t incx, std::int64_t stridex,
+                                         float *c, std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const double *a, std::int64_t lda, std::int64_t stridea,
+                                         const double *x, std::int64_t incx, std::int64_t stridex,
+                                         double *c, std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stridea, const std::complex<float> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<float> *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, std::int64_t m, std::int64_t n,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stridea, const std::complex<double> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<double> *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const float **a, std::int64_t *lda, const float **x,
+                                         std::int64_t *incx, float **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const double **a, std::int64_t *lda, const double **x,
+                                         std::int64_t *incx, double **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const std::complex<float> **a, std::int64_t *lda,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, std::int64_t *m, std::int64_t *n,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, float alpha,
@@ -1455,188 +1548,216 @@ ONEMKL_EXPORT cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &q
                                   std::complex<double> *a,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event iamin(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event iamin(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event iamin(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event iamin(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const float *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const double *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const std::complex<double> *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hpmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
-    std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event hpmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
-    std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event spmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    float alpha, const float *a, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event spmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    double alpha, const double *a, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, float alpha, const float *a,
+                                   const float *x, std::int64_t incx, float beta, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, double alpha, const double *a,
+                                   const double *x, std::int64_t incx, double beta, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotmg(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-    float *param, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event rotmg(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, double *d1, double *d2, double *x1,
-    double y1, double *param, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotmg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *d1,
+                                    float *d2, float *x1, float y1, float *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotmg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *d1,
+                                    double *d2, double *x1, double y1, double *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event swap(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event swap(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
-    std::int64_t incx, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event swap(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
-    std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event swap(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
-    std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, float *x, std::int64_t incx, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, double *x, std::int64_t incx, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event geru(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event geru(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event geru(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event geru(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
-    std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
-    std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<float> *x, std::int64_t incx,
+                                   float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<double> *x, std::int64_t incx,
+                                   double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const float *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const double *x, std::int64_t incx,
+                                   double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, double alpha, const double *a,
-    std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
-    std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
-    transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
-    std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose transa, transpose transb,
+                                    std::int64_t n, std::int64_t k, float alpha, const float *a,
+                                    std::int64_t lda, const float *b, std::int64_t ldb, float beta,
+                                    float *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose transa, transpose transb,
+                                    std::int64_t n, std::int64_t k, double alpha, const double *a,
+                                    std::int64_t lda, const double *b, std::int64_t ldb,
+                                    double beta, double *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose transa, transpose transb,
+                                    std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                    const std::complex<float> *a, std::int64_t lda,
+                                    const std::complex<float> *b, std::int64_t ldb,
+                                    std::complex<float> beta, std::complex<float> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose transa, transpose transb,
+                                    std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                    const std::complex<double> *a, std::int64_t lda,
+                                    const std::complex<double> *b, std::int64_t ldb,
+                                    std::complex<double> beta, std::complex<double> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
-    std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
-    std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-    const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
-    const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
-    std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose transa, transpose transb, std::int64_t m,
+                                   std::int64_t n, std::int64_t k, float alpha, const float *a,
+                                   std::int64_t lda, const float *b, std::int64_t ldb, float beta,
+                                   float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose transa, transpose transb, std::int64_t m,
+                                   std::int64_t n, std::int64_t k, double alpha, const double *a,
+                                   std::int64_t lda, const double *b, std::int64_t ldb, double beta,
+                                   double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose transa, transpose transb, std::int64_t m,
+                                   std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose transa, transpose transb, std::int64_t m,
+                                   std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *b, std::int64_t ldb,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose transa, transpose transb, std::int64_t m,
+                                   std::int64_t n, std::int64_t k, half alpha, const half *a,
+                                   std::int64_t lda, const half *b, std::int64_t ldb, half beta,
+                                   half *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose transa, transpose transb, std::int64_t m,
+                                   std::int64_t n, std::int64_t k, float alpha, const half *a,
+                                   std::int64_t lda, const half *b, std::int64_t ldb, float beta,
+                                   float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose transa, transpose transb, std::int64_t m,
+                                   std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
+                                   std::int64_t lda, const bfloat16 *b, std::int64_t ldb,
+                                   float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_bias(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a, int64_t lda,
-    std::int8_t ao, const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
-    std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                        transpose transa, transpose transb, offset offsetc,
+                                        int64_t m, int64_t n, int64_t k, float alpha,
+                                        const std::int8_t *a, int64_t lda, std::int8_t ao,
+                                        const std::uint8_t *b, int64_t ldb, std::uint8_t bo,
+                                        float beta, std::int32_t *c, int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a, int64_t lda,
     std::int8_t ao, const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta, std::int32_t *c,
-    int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_bias(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a,
-    int64_t lda, std::uint8_t ao, const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta,
-    std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_bias(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-    offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a,
-    int64_t lda, std::uint8_t ao, const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
-    std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
+    int64_t ldc, const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                        transpose transa, transpose transb, offset offsetc,
+                                        int64_t m, int64_t n, int64_t k, float alpha,
+                                        const std::uint8_t *a, int64_t lda, std::uint8_t ao,
+                                        const std::int8_t *b, int64_t ldb, std::int8_t bo,
+                                        float beta, std::int32_t *c, int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                        transpose transa, transpose transb, offset offsetc,
+                                        int64_t m, int64_t n, int64_t k, float alpha,
+                                        const std::uint8_t *a, int64_t lda, std::uint8_t ao,
+                                        const std::uint8_t *b, int64_t ldb, std::uint8_t bo,
+                                        float beta, std::int32_t *c, int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    float alpha, const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event syr2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    double alpha, const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, float alpha, const float *x,
+                                   std::int64_t incx, const float *y, std::int64_t incy, float *a,
+                                   std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, double alpha, const double *x,
+                                   std::int64_t incx, const double *y, std::int64_t incy, double *a,
+                                   std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t m, std::int64_t n, float alpha, const float *x,
@@ -1649,182 +1770,213 @@ ONEMKL_EXPORT cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &q
                                   std::int64_t lda,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
-    std::int64_t lda, float *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
-    std::int64_t lda, double *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+                                   const float *a, std::int64_t lda, float *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+                                   const double *a, std::int64_t lda, double *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-    int64_t stride_a, float *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
-    int64_t lda, int64_t stride_a, double *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-    const std::complex<float> *a, int64_t lda, int64_t stride_a, std::complex<float> *b,
-    int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-    const std::complex<double> *a, int64_t lda, int64_t stride_a, std::complex<double> *b,
-    int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha, const float **a,
-    int64_t *lda, float **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha, const double **a,
-    int64_t *lda, double **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<float> *alpha,
-    const std::complex<float> **a, int64_t *lda, std::complex<float> **b, int64_t *ldb,
-    int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-    transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<double> *alpha,
-    const std::complex<double> **a, int64_t *lda, std::complex<double> **b, int64_t *ldb,
-    int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n, float alpha,
+                                         const float *a, int64_t lda, int64_t stride_a, float *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n, double alpha,
+                                         const double *a, int64_t lda, int64_t stride_a, double *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n,
+                                         std::complex<float> alpha, const std::complex<float> *a,
+                                         int64_t lda, int64_t stride_a, std::complex<float> *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side left_right, uplo upper_lower, transpose trans,
+                                         diag unit_diag, int64_t m, int64_t n,
+                                         std::complex<double> alpha, const std::complex<double> *a,
+                                         int64_t lda, int64_t stride_a, std::complex<double> *b,
+                                         int64_t ldb, int64_t stride_b, int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n, float *alpha,
+                                         const float **a, int64_t *lda, float **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n, double *alpha,
+                                         const double **a, int64_t *lda, double **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         int64_t *lda, std::complex<float> **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         side *left_right, uplo *upper_lower, transpose *trans,
+                                         diag *unit_diag, int64_t *m, int64_t *n,
+                                         std::complex<double> *alpha,
+                                         const std::complex<double> **a, int64_t *lda,
+                                         std::complex<double> **b, int64_t *ldb,
+                                         int64_t group_count, int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dotu(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dotu(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event hemm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, std::int64_t m,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, std::int64_t m,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *b, std::int64_t ldb,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hpr2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event hpr2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda,
-    const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha, const double *a,
-    std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
-    std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
-    std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
-    std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
+                                   std::int64_t ku, float alpha, const float *a, std::int64_t lda,
+                                   const float *x, std::int64_t incx, float beta, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
+                                   std::int64_t ku, double alpha, const double *a, std::int64_t lda,
+                                   const double *x, std::int64_t incx, double beta, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
+                                   std::int64_t ku, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   transpose trans, std::int64_t m, std::int64_t n, std::int64_t kl,
+                                   std::int64_t ku, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b,
-    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event symm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-    const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event symm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event symm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, std::int64_t m,
+                                   std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                                   const float *b, std::int64_t ldb, float beta, float *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, std::int64_t m,
+                                   std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                                   const double *b, std::int64_t ldb, double beta, double *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, std::int64_t m,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, std::int64_t m,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *b, std::int64_t ldb,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dotc(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event dotc(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, float alpha, const float *x,
@@ -1835,222 +1987,240 @@ ONEMKL_EXPORT cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &q
                                   std::int64_t incx, double *a, std::int64_t lda,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trmm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
-    std::int64_t lda, float *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trmm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
-    std::int64_t lda, double *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trmm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trmm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
-    transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+                                   const float *a, std::int64_t lda, float *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+                                   const double *a, std::int64_t lda, double *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   side left_right, uplo upper_lower, transpose trans,
+                                   diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event symv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
-    double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, float alpha, const float *a,
+                                   std::int64_t lda, const float *x, std::int64_t incx, float beta,
+                                   float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, double alpha, const double *a,
+                                   std::int64_t lda, const double *x, std::int64_t incx,
+                                   double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const float *a, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const double *a, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event trsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const float *a, std::int64_t lda, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const double *a, std::int64_t lda, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event copy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
-    std::int64_t incx, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
-    std::int64_t incx, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const float *x, std::int64_t incx, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const double *x, std::int64_t incx, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, const float **x,
-    std::int64_t *incx, float **y, std::int64_t *incy, int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, const double **x,
-    std::int64_t *incx, double **y, std::int64_t *incy, int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
-    int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
-    const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
-    std::int64_t *incy, int64_t group_count, int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, const float **x, std::int64_t *incx,
+                                         float **y, std::int64_t *incy, int64_t group_count,
+                                         int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, const double **x, std::int64_t *incx,
+                                         double **y, std::int64_t *incy, int64_t group_count,
+                                         int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> **y,
+                                         std::int64_t *incy, int64_t group_count,
+                                         int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t *n, const std::complex<double> **x,
+                                         std::int64_t *incx, std::complex<double> **y,
+                                         std::int64_t *incy, int64_t group_count,
+                                         int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
-    std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
-    std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, const float *x, std::int64_t incx,
+                                         std::int64_t stridex, float *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, const double *x, std::int64_t incx,
+                                         std::int64_t stridex, double *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, const std::complex<float> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<float> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                         std::int64_t n, const std::complex<double> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<double> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hemv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event hemv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event iamax(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event iamax(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
-    std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event iamax(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event iamax(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const float *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const double *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    std::int64_t n, const std::complex<double> *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event sbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *x,
-    std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event sbmv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *x,
-    std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::int64_t k, float alpha,
+                                   const float *a, std::int64_t lda, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, std::int64_t k, double alpha,
+                                   const double *a, std::int64_t lda, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event asum(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<float> *x, std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event asum(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
-    const std::complex<double> *x, std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event asum(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
-    std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event asum(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
-    std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<float> *x, std::int64_t incx,
+                                   float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const std::complex<double> *x, std::int64_t incx,
+                                   double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const float *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, const double *x, std::int64_t incx,
+                                   double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, transpose trans, diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event spr2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    float alpha, const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event spr2(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
-    double alpha, const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, float alpha, const float *x,
+                                   std::int64_t incx, const float *y, std::int64_t incy, float *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   uplo upper_lower, std::int64_t n, double alpha, const double *x,
+                                   std::int64_t incx, const double *y, std::int64_t incy, double *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
-    float *y, std::int64_t incy, float *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event rotm(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
-    std::int64_t incx, double *y, std::int64_t incy, double *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, float *x, std::int64_t incx, float *y,
+                                   std::int64_t incy, float *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::int64_t n, double *x, std::int64_t incx, double *y,
+                                   std::int64_t incy, double *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, const float *x, std::int64_t incx, const float *y,
@@ -2065,35 +2235,37 @@ ONEMKL_EXPORT cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &q
                                   std::int64_t incy, double *result,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event sdsdot(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
-    std::int64_t incx, const float *y, std::int64_t incy, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event sdsdot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                     std::int64_t n, float sb, const float *x, std::int64_t incx,
+                                     const float *y, std::int64_t incy, float *result,
+                                     const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event her2k(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event her2k(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, double beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose trans, std::int64_t n,
+                                    std::int64_t k, std::complex<float> alpha,
+                                    const std::complex<float> *a, std::int64_t lda,
+                                    const std::complex<float> *b, std::int64_t ldb, float beta,
+                                    std::complex<float> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                    uplo upper_lower, transpose trans, std::int64_t n,
+                                    std::int64_t k, std::complex<double> alpha,
+                                    const std::complex<double> *a, std::int64_t lda,
+                                    const std::complex<double> *b, std::int64_t ldb, double beta,
+                                    std::complex<double> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotg(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event rotg(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event rotg(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<float> *a,
-    std::complex<float> *b, float *c, std::complex<float> *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event rotg(
-    oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<double> *a,
-    std::complex<double> *b, double *c, std::complex<double> *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *a,
+                                   float *b, float *c, float *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *a,
+                                   double *b, double *c, double *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::complex<float> *a, std::complex<float> *b, float *c,
+                                   std::complex<float> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue,
+                                   std::complex<double> *a, std::complex<double> *b, double *c,
+                                   std::complex<double> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/blas/detail/blas_loader.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_loader.hxx
@@ -964,1136 +964,1136 @@ ONEMKL_EXPORT cl::sycl::event herk(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
     float beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event herk(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda,
     double beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event scal(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event scal(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event scal(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event scal(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event scal(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event scal(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tpmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tpmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tpmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, float alpha, const float *x,
                                   std::int64_t incx, float *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, double alpha, const double *x,
                                   std::int64_t incx, double *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
     std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
     std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<float> *alpha,
     const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
     std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<double> *alpha,
     const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **b,
     std::int64_t *ldb, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa, transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
     std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     std::int64_t stride_a, const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
     float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     std::int64_t stride_a, const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
     double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
     const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
     const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
     std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
     half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
-    float *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta,
-    double *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, float *beta,
     float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
     double *beta, double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
     std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
     std::int64_t *n, std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
     std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     std::int64_t stride_a, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     std::int64_t stride_a, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
     std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
     std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event her2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event hbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, std::complex<float> *x, std::int64_t incx,
                                   std::complex<float> *y, std::int64_t incy, float c, float s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, std::complex<double> *x, std::int64_t incx,
                                   std::complex<double> *y, std::int64_t incy, double c, double s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, float *x, std::int64_t incx, float *y,
                                   std::int64_t incy, float c, float s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, double *x, std::int64_t incx, double *y,
                                   std::int64_t incy, double c, double s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
     const double *x, std::int64_t incx, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, float *alpha,
     const float **x, std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, double *alpha,
     const double **x, std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
     std::complex<double> *alpha, const std::complex<double> **x, std::int64_t *incx,
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
     const double *x, std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpby(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
     std::int64_t incx, const float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpby(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double alpha,
     const double *x, std::int64_t incx, const double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpby(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event axpby(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gerc(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gerc(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2k(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
     std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syr2k(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syr2k(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syr2k(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
     std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, double alpha, const double *a, std::int64_t lda, const double *x,
     std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, float alpha, const float *a, std::int64_t lda, std::int64_t stridea,
     const float *x, std::int64_t incx, std::int64_t stridex, float beta, float *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, double alpha, const double *a, std::int64_t lda, std::int64_t stridea,
     const double *x, std::int64_t incx, std::int64_t stridex, double beta, double *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::int64_t stridea, const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<float> beta, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stridea, const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
     std::int64_t *n, float *alpha, const float **a, std::int64_t *lda, const float **x,
     std::int64_t *incx, float *beta, float **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
     std::int64_t *n, double *alpha, const double **a, std::int64_t *lda, const double **x,
     std::int64_t *incx, double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
     std::int64_t *n, std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
     std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
     std::int64_t *n, std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> *beta,
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
     std::int64_t n, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
     std::int64_t incx, std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
     std::int64_t n, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
     std::int64_t incx, std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
     std::int64_t n, const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, std::int64_t m,
     std::int64_t n, const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
     std::int64_t *n, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
     float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
     std::int64_t *n, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
     double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
     std::int64_t *n, const std::complex<float> **a, std::int64_t *lda,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, std::int64_t *m,
     std::int64_t *n, const std::complex<double> **a, std::int64_t *lda,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, float alpha,
                                   const std::complex<float> *x, std::int64_t incx,
                                   std::complex<float> *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, double alpha,
                                   const std::complex<double> *x, std::int64_t incx,
                                   std::complex<double> *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, float alpha,
                                   const std::complex<float> *x, std::int64_t incx,
                                   std::complex<float> *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, double alpha,
                                   const std::complex<double> *x, std::int64_t incx,
                                   std::complex<double> *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamin(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event iamin(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event iamin(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event iamin(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
     std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event hpmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
     std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     float alpha, const float *a, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event spmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     double alpha, const double *a, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotmg(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-    float *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *param, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rotmg(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, double *d1, double *d2, double *x1,
-    double y1, double *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double y1, double *param, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event swap(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event swap(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
     std::int64_t incx, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event swap(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
     std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event swap(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
     std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event geru(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event geru(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event nrm2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event nrm2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event nrm2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
     std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event nrm2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
     std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemmt(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemmt(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, double alpha, const double *a,
     std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemmt(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemmt(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose transa,
     transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
     std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
     std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
     const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
     const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
     std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a, int64_t lda,
     std::int8_t ao, const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
     std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a, int64_t lda,
     std::int8_t ao, const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta, std::int32_t *c,
     int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a,
     int64_t lda, std::uint8_t ao, const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta,
     std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
     offset offsetc, int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a,
     int64_t lda, std::uint8_t ao, const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
     std::int32_t *c, int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     float alpha, const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syr2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     double alpha, const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t m, std::int64_t n, float alpha, const float *x,
                                   std::int64_t incx, const float *y, std::int64_t incy, float *a,
                                   std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t m, std::int64_t n, double alpha, const double *x,
                                   std::int64_t incx, const double *y, std::int64_t incy, double *a,
                                   std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
     std::int64_t lda, float *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
     std::int64_t lda, double *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
     int64_t stride_a, float *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
     int64_t lda, int64_t stride_a, double *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
     const std::complex<float> *a, int64_t lda, int64_t stride_a, std::complex<float> *b,
     int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
     const std::complex<double> *a, int64_t lda, int64_t stride_a, std::complex<double> *b,
     int64_t ldb, int64_t stride_b, int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha, const float **a,
     int64_t *lda, float **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha, const double **a,
     int64_t *lda, double **b, int64_t *ldb, int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<float> *alpha,
     const std::complex<float> **a, int64_t *lda, std::complex<float> **b, int64_t *ldb,
     int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
     transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, std::complex<double> *alpha,
     const std::complex<double> **a, int64_t *lda, std::complex<double> **b, int64_t *ldb,
     int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dotu(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dotu(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event hemm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpr2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event hpr2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda,
     const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha, const double *a,
     std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
     std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans, std::int64_t m,
     std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
     std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b,
     std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event symm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
     const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event symm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event symm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dotc(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dotc(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, float alpha, const float *x,
                                   std::int64_t incx, float *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   uplo upper_lower, std::int64_t n, double alpha, const double *x,
                                   std::int64_t incx, double *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
     std::int64_t lda, float *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trmm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
     std::int64_t lda, double *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trmm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trmm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right, uplo upper_lower,
     transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event symv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
     double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tpsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tpsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tpsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event trsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
     std::int64_t incx, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
     std::int64_t incx, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, const float **x,
     std::int64_t *incx, float **y, std::int64_t *incy, int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n, const double **x,
     std::int64_t *incx, double **y, std::int64_t *incy, int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
     int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
     std::int64_t *incy, int64_t group_count, int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
     std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
     std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hemv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event hemv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamax(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event iamax(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
     std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event iamax(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event iamax(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event sbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *x,
     std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event sbmv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *x,
     std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event asum(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<float> *x, std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event asum(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
     const std::complex<double> *x, std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event asum(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const float *x,
     std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event asum(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, const double *x,
     std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tbsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tbsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event tbsv(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     float alpha, const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event spr2(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
     double alpha, const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
     float *y, std::int64_t incy, float *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rotm(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
     std::int64_t incx, double *y, std::int64_t incy, double *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, const float *x, std::int64_t incx, const float *y,
                                   std::int64_t incy, float *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, const double *x, std::int64_t incx,
                                   const double *y, std::int64_t incy, double *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                   std::int64_t n, const float *x, std::int64_t incx, const float *y,
                                   std::int64_t incy, double *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event sdsdot(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
     std::int64_t incx, const float *y, std::int64_t incy, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her2k(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event her2k(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, double beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotg(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rotg(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rotg(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<float> *a,
     std::complex<float> *b, float *c, std::complex<float> *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event rotg(
     oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<double> *a,
     std::complex<double> *b, double *c, std::complex<double> *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
@@ -2113,8 +2113,7 @@ cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2126,8 +2125,7 @@ cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2446,8 +2444,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo uppe
 cl::sycl::event her2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2460,8 +2457,7 @@ cl::sycl::event her2(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event her2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2699,8 +2695,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
 
 cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2710,8 +2705,7 @@ cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2744,8 +2738,7 @@ cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n
 cl::sycl::event gerc(backend_selector<backend::cublas> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2756,8 +2749,7 @@ cl::sycl::event gerc(backend_selector<backend::cublas> selector, std::int64_t m,
 cl::sycl::event gerc(backend_selector<backend::cublas> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2782,8 +2774,7 @@ cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_low
 cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2798,8 +2789,7 @@ cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -3162,8 +3152,7 @@ cl::sycl::event her(backend_selector<backend::cublas> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
-                    std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3173,8 +3162,7 @@ cl::sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
-                    std::complex<double> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3439,8 +3427,7 @@ cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3450,8 +3437,7 @@ cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3462,8 +3448,7 @@ cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event geru(backend_selector<backend::cublas> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3474,8 +3459,7 @@ cl::sycl::event geru(backend_selector<backend::cublas> selector, std::int64_t m,
 cl::sycl::event geru(backend_selector<backend::cublas> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3526,8 +3510,7 @@ cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3541,8 +3524,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3557,8 +3539,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3573,8 +3554,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3588,8 +3568,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3603,8 +3582,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3618,8 +3596,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3957,8 +3934,7 @@ cl::sycl::event hemm(backend_selector<backend::cublas> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3973,8 +3949,7 @@ cl::sycl::event hemm(backend_selector<backend::cublas> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4014,8 +3989,7 @@ cl::sycl::event hpr2(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans, std::int64_t m,
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4045,8 +4019,7 @@ cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4061,8 +4034,7 @@ cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4142,8 +4114,7 @@ cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right
 cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4158,8 +4129,7 @@ cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4174,8 +4144,7 @@ cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4287,8 +4256,7 @@ cl::sycl::event trmm(backend_selector<backend::cublas> selector, side left_right
 }
 
 cl::sycl::event rotmg(backend_selector<backend::cublas> selector, float *d1, float *d2, float *x1,
-                      float y1, float *param,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      float y1, float *param, const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4358,8 +4326,7 @@ cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4371,8 +4338,7 @@ cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4430,8 +4396,7 @@ cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4441,8 +4406,7 @@ cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);

--- a/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
@@ -2028,7 +2028,7 @@ void symv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int
 cl::sycl::event syr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2041,7 +2041,7 @@ cl::sycl::event syr2(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event syr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2053,7 +2053,7 @@ cl::sycl::event syr2(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n, float alpha,
                      float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2063,7 +2063,7 @@ cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n, double alpha,
                      double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2073,7 +2073,7 @@ cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<float> alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2083,7 +2083,7 @@ cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<double> alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2093,7 +2093,7 @@ cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n, float alpha,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2103,7 +2103,7 @@ cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n, double alpha,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2114,7 +2114,7 @@ cl::sycl::event scal(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2127,7 +2127,7 @@ cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2140,7 +2140,7 @@ cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2153,7 +2153,7 @@ cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2165,7 +2165,7 @@ cl::sycl::event trmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2177,7 +2177,7 @@ cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2190,7 +2190,7 @@ cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2203,7 +2203,7 @@ cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2215,7 +2215,7 @@ cl::sycl::event tpmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event spr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2225,7 +2225,7 @@ cl::sycl::event spr(backend_selector<backend::cublas> selector, uplo upper_lower
 
 cl::sycl::event spr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2237,7 +2237,7 @@ cl::sycl::event hpmv(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2251,7 +2251,7 @@ cl::sycl::event hpmv(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2264,7 +2264,7 @@ cl::sycl::event hpmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk(
@@ -2277,7 +2277,7 @@ cl::sycl::event syrk(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk(
@@ -2291,7 +2291,7 @@ cl::sycl::event syrk(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk(
@@ -2305,7 +2305,7 @@ cl::sycl::event syrk(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk(
@@ -2319,7 +2319,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, float *alpha,
                            const float **a, std::int64_t *lda, float *beta, float **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2334,7 +2334,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, double *alpha,
                            const double **a, std::int64_t *lda, double *beta, double **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2350,7 +2350,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo *upp
                            std::complex<float> *alpha, const std::complex<float> **a,
                            std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2366,7 +2366,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo *upp
                            std::complex<double> *alpha, const std::complex<double> **a,
                            std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2382,7 +2382,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo uppe
                            const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2398,7 +2398,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo uppe
                            const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2415,7 +2415,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2432,7 +2432,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::cublas> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syrk_batch(
@@ -2447,7 +2447,7 @@ cl::sycl::event her2(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2461,7 +2461,7 @@ cl::sycl::event her2(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2475,7 +2475,7 @@ cl::sycl::event hbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2490,7 +2490,7 @@ cl::sycl::event hbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2504,7 +2504,7 @@ cl::sycl::event hbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n,
                     std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2515,7 +2515,7 @@ cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n,
                     std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2525,7 +2525,7 @@ cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n, float *x,
                     std::int64_t incx, float *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2535,7 +2535,7 @@ cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n, 
 
 cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n, double *x,
                     std::int64_t incx, double *y, std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2545,7 +2545,7 @@ cl::sycl::event rot(backend_selector<backend::cublas> selector, std::int64_t n, 
 
 cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n, float alpha,
                      const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2555,7 +2555,7 @@ cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2566,7 +2566,7 @@ cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2577,7 +2577,7 @@ cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2588,7 +2588,7 @@ cl::sycl::event axpy(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int64_t *n,
                            float *alpha, const float **x, std::int64_t *incx, float **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(
@@ -2601,7 +2601,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int64_t *n,
                            double *alpha, const double **x, std::int64_t *incx, double **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(
@@ -2615,7 +2615,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
                            std::complex<float> *alpha, const std::complex<float> **x,
                            std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(
@@ -2629,7 +2629,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
                            std::complex<double> *alpha, const std::complex<double> **x,
                            std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(
@@ -2642,7 +2642,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int64_t n, float alpha,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2656,7 +2656,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int64_t n, double alpha,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2671,7 +2671,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
                            std::complex<float> alpha, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2686,7 +2686,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
                            std::complex<double> alpha, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2700,7 +2700,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::cublas> selector, std::int6
 cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2711,7 +2711,7 @@ cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2722,7 +2722,7 @@ cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n,
                       std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                       const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2733,7 +2733,7 @@ cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::cublas> selector, std::int64_t n,
                       std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                       const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2745,7 +2745,7 @@ cl::sycl::event gerc(backend_selector<backend::cublas> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2757,7 +2757,7 @@ cl::sycl::event gerc(backend_selector<backend::cublas> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2768,7 +2768,7 @@ cl::sycl::event gerc(backend_selector<backend::cublas> selector, std::int64_t m,
 cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                       const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2783,7 +2783,7 @@ cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2799,7 +2799,7 @@ cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_low
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2815,7 +2815,7 @@ cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2829,7 +2829,7 @@ cl::sycl::event syr2k(backend_selector<backend::cublas> selector, uplo upper_low
 cl::sycl::event gemv(backend_selector<backend::cublas> selector, transpose trans, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2842,7 +2842,7 @@ cl::sycl::event gemv(backend_selector<backend::cublas> selector, transpose trans
 cl::sycl::event gemv(backend_selector<backend::cublas> selector, transpose trans, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2856,7 +2856,7 @@ cl::sycl::event gemv(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2870,7 +2870,7 @@ cl::sycl::event gemv(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2885,7 +2885,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const float *x,
                            std::int64_t incx, std::int64_t stridex, float beta, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(
@@ -2901,7 +2901,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const double *x,
                            std::int64_t incx, std::int64_t stridex, double beta, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(
@@ -2918,7 +2918,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(
@@ -2935,7 +2935,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(
@@ -2951,7 +2951,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t *lda, const float **x, std::int64_t *incx, float *beta,
                            float **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2967,7 +2967,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
                            double **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2984,7 +2984,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3001,7 +3001,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::cublas> selector, transpose
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3017,7 +3017,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side left
                            std::int64_t stridea, const float *x, std::int64_t incx,
                            std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(
@@ -3033,7 +3033,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side left
                            std::int64_t stridea, const double *x, std::int64_t incx,
                            std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(
@@ -3049,7 +3049,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(
@@ -3065,7 +3065,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(
@@ -3080,7 +3080,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const float **a, std::int64_t *lda,
                            const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3095,7 +3095,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const double **a, std::int64_t *lda,
                            const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3111,7 +3111,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side *lef
                            std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3127,7 +3127,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side *lef
                            std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3141,7 +3141,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::cublas> selector, side *lef
 cl::sycl::event her(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3152,7 +3152,7 @@ cl::sycl::event her(backend_selector<backend::cublas> selector, uplo upper_lower
 cl::sycl::event her(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3163,7 +3163,7 @@ cl::sycl::event her(backend_selector<backend::cublas> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3174,7 +3174,7 @@ cl::sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3184,7 +3184,7 @@ cl::sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower
 
 cl::sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3194,7 +3194,7 @@ cl::sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3204,7 +3204,7 @@ cl::sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3214,7 +3214,7 @@ cl::sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3227,7 +3227,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            float *alpha, const float **a, std::int64_t *lda, const float **b,
                            std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3243,7 +3243,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            double *alpha, const double **a, std::int64_t *lda, const double **b,
                            std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3260,7 +3260,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3277,7 +3277,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3293,7 +3293,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            half *alpha, const half **a, std::int64_t *lda, const half **b,
                            std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3310,7 +3310,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3327,7 +3327,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3345,7 +3345,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3363,7 +3363,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3380,7 +3380,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
                            const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
                            half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_batch(
@@ -3394,7 +3394,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
 cl::sycl::event spmv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, const float *x, std::int64_t incx, float beta,
                      float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3407,7 +3407,7 @@ cl::sycl::event spmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event spmv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, const double *x, std::int64_t incx, double beta,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3419,7 +3419,7 @@ cl::sycl::event spmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3429,7 +3429,7 @@ cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3440,7 +3440,7 @@ cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3451,7 +3451,7 @@ cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::cublas> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3463,7 +3463,7 @@ cl::sycl::event geru(backend_selector<backend::cublas> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3475,7 +3475,7 @@ cl::sycl::event geru(backend_selector<backend::cublas> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3485,7 +3485,7 @@ cl::sycl::event geru(backend_selector<backend::cublas> selector, std::int64_t m,
 
 cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3495,7 +3495,7 @@ cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3505,7 +3505,7 @@ cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3515,7 +3515,7 @@ cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::cublas> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3527,7 +3527,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3542,7 +3542,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3558,7 +3558,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3574,7 +3574,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3589,7 +3589,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3604,7 +3604,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3619,7 +3619,7 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3635,7 +3635,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::cublas> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_bias(
@@ -3651,7 +3651,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::cublas> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_bias(
@@ -3667,7 +3667,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::cublas> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_bias(
@@ -3683,7 +3683,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::cublas> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemm_bias(
@@ -3697,7 +3697,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::cublas> selector, transpose 
 cl::sycl::event herk(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a,
                      std::int64_t lda, float beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::herk(
@@ -3710,7 +3710,7 @@ cl::sycl::event herk(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event herk(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
                      std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::herk(
@@ -3723,7 +3723,7 @@ cl::sycl::event herk(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event ger(backend_selector<backend::cublas> selector, std::int64_t m, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, const float *y,
                     std::int64_t incy, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3734,7 +3734,7 @@ cl::sycl::event ger(backend_selector<backend::cublas> selector, std::int64_t m, 
 cl::sycl::event ger(backend_selector<backend::cublas> selector, std::int64_t m, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, const double *y,
                     std::int64_t incy, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3745,7 +3745,7 @@ cl::sycl::event ger(backend_selector<backend::cublas> selector, std::int64_t m, 
 cl::sycl::event trsm(backend_selector<backend::cublas> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3759,7 +3759,7 @@ cl::sycl::event trsm(backend_selector<backend::cublas> selector, side left_right
 cl::sycl::event trsm(backend_selector<backend::cublas> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3774,7 +3774,7 @@ cl::sycl::event trsm(backend_selector<backend::cublas> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3789,7 +3789,7 @@ cl::sycl::event trsm(backend_selector<backend::cublas> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3805,7 +3805,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side left
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3821,7 +3821,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side left
                            std::int64_t n, double alpha, const double *a, std::int64_t lda,
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3837,7 +3837,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side left
                            std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3854,7 +3854,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side left
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3870,7 +3870,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side *lef
                            std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
                            float **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3886,7 +3886,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side *lef
                            std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
                            double **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3903,7 +3903,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side *lef
                            const std::complex<float> **a, std::int64_t *lda,
                            std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3920,7 +3920,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side *lef
                            const std::complex<double> **a, std::int64_t *lda,
                            std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsm_batch(
@@ -3934,7 +3934,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::cublas> selector, side *lef
 cl::sycl::event dotu(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3945,7 +3945,7 @@ cl::sycl::event dotu(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event dotu(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3958,7 +3958,7 @@ cl::sycl::event hemm(backend_selector<backend::cublas> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3974,7 +3974,7 @@ cl::sycl::event hemm(backend_selector<backend::cublas> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3988,7 +3988,7 @@ cl::sycl::event hemm(backend_selector<backend::cublas> selector, side left_right
 cl::sycl::event hpr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4001,7 +4001,7 @@ cl::sycl::event hpr2(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event hpr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4015,7 +4015,7 @@ cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4030,7 +4030,7 @@ cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4046,7 +4046,7 @@ cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4062,7 +4062,7 @@ cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4076,7 +4076,7 @@ cl::sycl::event gbmv(backend_selector<backend::cublas> selector, transpose trans
 cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbmv(
@@ -4089,7 +4089,7 @@ cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbmv(
@@ -4102,7 +4102,7 @@ cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbmv(
@@ -4115,7 +4115,7 @@ cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbmv(
@@ -4128,7 +4128,7 @@ cl::sycl::event tbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
                      const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4143,7 +4143,7 @@ cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4159,7 +4159,7 @@ cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4175,7 +4175,7 @@ cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4189,7 +4189,7 @@ cl::sycl::event symm(backend_selector<backend::cublas> selector, side left_right
 cl::sycl::event dotc(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4200,7 +4200,7 @@ cl::sycl::event dotc(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event dotc(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4210,7 +4210,7 @@ cl::sycl::event dotc(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event syr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4220,7 +4220,7 @@ cl::sycl::event syr(backend_selector<backend::cublas> selector, uplo upper_lower
 
 cl::sycl::event syr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4231,7 +4231,7 @@ cl::sycl::event syr(backend_selector<backend::cublas> selector, uplo upper_lower
 cl::sycl::event trmm(backend_selector<backend::cublas> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4245,7 +4245,7 @@ cl::sycl::event trmm(backend_selector<backend::cublas> selector, side left_right
 cl::sycl::event trmm(backend_selector<backend::cublas> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4260,7 +4260,7 @@ cl::sycl::event trmm(backend_selector<backend::cublas> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4275,7 +4275,7 @@ cl::sycl::event trmm(backend_selector<backend::cublas> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4288,7 +4288,7 @@ cl::sycl::event trmm(backend_selector<backend::cublas> selector, side left_right
 
 cl::sycl::event rotmg(backend_selector<backend::cublas> selector, float *d1, float *d2, float *x1,
                       float y1, float *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4298,7 +4298,7 @@ cl::sycl::event rotmg(backend_selector<backend::cublas> selector, float *d1, flo
 
 cl::sycl::event rotmg(backend_selector<backend::cublas> selector, double *d1, double *d2,
                       double *x1, double y1, double *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4308,7 +4308,7 @@ cl::sycl::event rotmg(backend_selector<backend::cublas> selector, double *d1, do
 
 cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4320,7 +4320,7 @@ cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4333,7 +4333,7 @@ cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4346,7 +4346,7 @@ cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4359,7 +4359,7 @@ cl::sycl::event tpsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4372,7 +4372,7 @@ cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4385,7 +4385,7 @@ cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4398,7 +4398,7 @@ cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4410,7 +4410,7 @@ cl::sycl::event trsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4420,7 +4420,7 @@ cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4431,7 +4431,7 @@ cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4442,7 +4442,7 @@ cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4453,7 +4453,7 @@ cl::sycl::event copy(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int64_t *n,
                            const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4466,7 +4466,7 @@ cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int64_t *n,
                            const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4480,7 +4480,7 @@ cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int6
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4494,7 +4494,7 @@ cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int6
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4507,7 +4507,7 @@ cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int64_t n,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4520,7 +4520,7 @@ cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int64_t n,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4534,7 +4534,7 @@ cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int6
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4548,7 +4548,7 @@ cl::sycl::event copy_batch(backend_selector<backend::cublas> selector, std::int6
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::copy_batch(
@@ -4562,7 +4562,7 @@ cl::sycl::event hemv(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hemv(
@@ -4576,7 +4576,7 @@ cl::sycl::event hemv(backend_selector<backend::cublas> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::hemv(
@@ -4590,7 +4590,7 @@ cl::sycl::event gemmt(backend_selector<backend::cublas> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4605,7 +4605,7 @@ cl::sycl::event gemmt(backend_selector<backend::cublas> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       double alpha, const double *a, std::int64_t lda, const double *b,
                       std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4621,7 +4621,7 @@ cl::sycl::event gemmt(backend_selector<backend::cublas> selector, uplo upper_low
                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                       const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4637,7 +4637,7 @@ cl::sycl::event gemmt(backend_selector<backend::cublas> selector, uplo upper_low
                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4651,7 +4651,7 @@ cl::sycl::event gemmt(backend_selector<backend::cublas> selector, uplo upper_low
 cl::sycl::event sbmv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4665,7 +4665,7 @@ cl::sycl::event sbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event sbmv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4678,7 +4678,7 @@ cl::sycl::event sbmv(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4688,7 +4688,7 @@ cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4698,7 +4698,7 @@ cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4708,7 +4708,7 @@ cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4719,7 +4719,7 @@ cl::sycl::event asum(backend_selector<backend::cublas> selector, std::int64_t n,
 cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbsv(
@@ -4732,7 +4732,7 @@ cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbsv(
@@ -4745,7 +4745,7 @@ cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbsv(
@@ -4758,7 +4758,7 @@ cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::tbsv(
@@ -4771,7 +4771,7 @@ cl::sycl::event tbsv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4784,7 +4784,7 @@ cl::sycl::event spr2(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4796,7 +4796,7 @@ cl::sycl::event spr2(backend_selector<backend::cublas> selector, uplo upper_lowe
 
 cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4806,7 +4806,7 @@ cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4816,7 +4816,7 @@ cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4826,7 +4826,7 @@ cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4836,7 +4836,7 @@ cl::sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n
 
 cl::sycl::event rotm(backend_selector<backend::cublas> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4846,7 +4846,7 @@ cl::sycl::event rotm(backend_selector<backend::cublas> selector, std::int64_t n,
 
 cl::sycl::event rotm(backend_selector<backend::cublas> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4855,7 +4855,7 @@ cl::sycl::event rotm(backend_selector<backend::cublas> selector, std::int64_t n,
 }
 
 cl::sycl::event rotg(backend_selector<backend::cublas> selector, float *a, float *b, float *c,
-                     float *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::cublas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4864,7 +4864,7 @@ cl::sycl::event rotg(backend_selector<backend::cublas> selector, float *a, float
 }
 
 cl::sycl::event rotg(backend_selector<backend::cublas> selector, double *a, double *b, double *c,
-                     double *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::cublas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4874,7 +4874,7 @@ cl::sycl::event rotg(backend_selector<backend::cublas> selector, double *a, doub
 
 cl::sycl::event rotg(backend_selector<backend::cublas> selector, std::complex<float> *a,
                      std::complex<float> *b, float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::cublas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4884,7 +4884,7 @@ cl::sycl::event rotg(backend_selector<backend::cublas> selector, std::complex<fl
 
 cl::sycl::event rotg(backend_selector<backend::cublas> selector, std::complex<double> *a,
                      std::complex<double> *b, double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::cublas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4894,7 +4894,7 @@ cl::sycl::event rotg(backend_selector<backend::cublas> selector, std::complex<do
 
 cl::sycl::event sdsdot(backend_selector<backend::cublas> selector, std::int64_t n, float sb,
                        const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                       float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       float *result, const std::vector<cl::sycl::event> &dependencies) {
     sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y,
                                                          incy, result, dependencies);
@@ -4906,7 +4906,7 @@ cl::sycl::event her2k(backend_selector<backend::cublas> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4922,7 +4922,7 @@ cl::sycl::event her2k(backend_selector<backend::cublas> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, double beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4935,7 +4935,7 @@ cl::sycl::event her2k(backend_selector<backend::cublas> selector, uplo upper_low
 
 cl::sycl::event dot(backend_selector<backend::cublas> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4945,7 +4945,7 @@ cl::sycl::event dot(backend_selector<backend::cublas> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::cublas> selector, std::int64_t n, const double *x,
                     std::int64_t incx, const double *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4955,7 +4955,7 @@ cl::sycl::event dot(backend_selector<backend::cublas> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::cublas> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4966,7 +4966,7 @@ cl::sycl::event dot(backend_selector<backend::cublas> selector, std::int64_t n, 
 cl::sycl::event symv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::symv(
@@ -4979,7 +4979,7 @@ cl::sycl::event symv(backend_selector<backend::cublas> selector, uplo upper_lowe
 cl::sycl::event symv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::cublas::MAJOR::symv(

--- a/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
@@ -885,12 +885,10 @@ cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const std::complex<
                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                     float *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     float *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                     double *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     double *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
@@ -902,13 +900,11 @@ cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, double alpha, const
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x,
                            std::int64_t *incx, float **y, std::int64_t *incy,
@@ -1061,12 +1057,10 @@ cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n, const std::complex<
                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                       std::int64_t incx, std::int64_t *result,
@@ -1077,12 +1071,10 @@ cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const std::complex
                       const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                       std::int64_t incx, std::int64_t *result,
@@ -1101,12 +1093,10 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const std::complex<
                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                     float *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     float *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                     double *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     double *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                     std::int64_t incx, std::complex<float> *y, std::int64_t incy, float c, float s,
@@ -1147,20 +1137,16 @@ cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, double *x, std::int
                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                      float *param,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      float *param, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1,
-                      double *param,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      double *param, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                      std::complex<float> *x, std::int64_t incx,
@@ -1171,20 +1157,17 @@ cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, std::complex<double
                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event sdsdot(cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
                        std::int64_t incx, const float *y, std::int64_t incy, float *result,
                        const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                      double *y, std::int64_t incy,
@@ -1201,28 +1184,24 @@ cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<double
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      float alpha, const float *a, std::int64_t lda, const float *x,
@@ -1358,8 +1337,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_
 
 cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha,
                     const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-                    std::int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, const double *y, std::int64_t incy,
@@ -1369,26 +1347,22 @@ cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, doub
 cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
@@ -1416,25 +1390,21 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                     const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-                    std::int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                     const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-                    std::int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a,
@@ -1478,13 +1448,11 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, s
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                      const float *a, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                      const double *a, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                     const float *x, std::int64_t incx, float *a,
@@ -1522,8 +1490,7 @@ cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, do
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                      const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, const double *y, std::int64_t incy,
@@ -1532,13 +1499,11 @@ cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, d
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
@@ -1552,13 +1517,11 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
@@ -1580,13 +1543,11 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const float *a, float *x, std::int64_t incx,
@@ -1598,13 +1559,11 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
@@ -1612,8 +1571,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::int64_t lda,
@@ -1631,8 +1589,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::int64_t lda,
@@ -1652,22 +1609,19 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
@@ -1682,8 +1636,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
@@ -1754,14 +1707,12 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
                            std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
@@ -1850,14 +1801,12 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
@@ -1872,14 +1821,12 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                            transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
@@ -2020,15 +1967,13 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       std::int64_t n, std::int64_t k, std::complex<double> alpha,

--- a/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
@@ -878,387 +878,387 @@ void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offse
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                      float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                      double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x,
                            std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, double *alpha, const double **x,
                            std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                            std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                            std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                       std::int64_t incx, const float beta, float *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                       std::int64_t incx, const double beta, double *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                       const std::complex<float> *x, std::int64_t incx,
                       const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                       const std::complex<double> *x, std::int64_t incx,
                       const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                      float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const float **x,
                            std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const double **x,
                            std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const std::complex<float> **x,
                            std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const std::complex<double> **x,
                            std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const float *x,
                            std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const double *x,
                            std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                     const float *y, std::int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                     const double *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                     const float *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                      float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                      double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                     std::int64_t incx, std::complex<float> *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                     std::int64_t incx, std::complex<double> *y, std::int64_t incy, double c,
-                    double s, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    double s, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b,
                      float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b,
                      double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                      std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                      double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
                       float *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1,
                       double *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event sdsdot(cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
                        std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                       const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                       const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                      std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                      std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                            float alpha, const float *a, std::int64_t lda, std::int64_t stridea,
                            const float *x, std::int64_t incx, std::int64_t stridex, float beta,
                            float *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                            double alpha, const double *a, std::int64_t lda, std::int64_t stridea,
                            const double *x, std::int64_t incx, std::int64_t stridex, double beta,
                            double *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a,
@@ -1266,7 +1266,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t
                            std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a,
@@ -1274,19 +1274,19 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, std::int64_t
                            std::int64_t incx, std::int64_t stridex, std::complex<double> beta,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
                            std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
                            const float **x, std::int64_t *incx, float *beta, float **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
                            std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
                            const double **x, std::int64_t *incx, double *beta, double **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
                            std::int64_t *n, std::complex<float> *alpha,
@@ -1294,7 +1294,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_t *m,
                            std::int64_t *n, std::complex<double> *alpha,
@@ -1302,652 +1302,652 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, std::int64_
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n,
                            const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
                            std::int64_t incx, std::int64_t stridex, float *c, std::int64_t ldc,
                            std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n,
                            const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
                            std::int64_t incx, std::int64_t stridex, double *c, std::int64_t ldc,
                            std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n,
                            const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, std::int64_t m, std::int64_t n,
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
                            std::int64_t *n, const float **a, std::int64_t *lda, const float **x,
                            std::int64_t *incx, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
                            std::int64_t *n, const double **a, std::int64_t *lda, const double **x,
                            std::int64_t *incx, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
                            std::int64_t *n, const std::complex<float> **a, std::int64_t *lda,
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, std::int64_t *m,
                            std::int64_t *n, const std::complex<double> **a, std::int64_t *lda,
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha,
                     const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
                     std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, const double *y, std::int64_t incy,
                     double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                     const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
                     std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                     const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
                     std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                     const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                     const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k,
                      float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, std::int64_t k,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                      const float *a, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                      const double *a, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                     const float *x, std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                      const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, const double *y, std::int64_t incy,
-                     double *a, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     double *a, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                      float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                     const float *x, std::int64_t incx, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                    const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                      const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, const double *y, std::int64_t incy,
                      double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<double> *a, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      std::int64_t n, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
                      const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
                      const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
                      float beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda,
                      double beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                       double beta, std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b,
                      std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
                      float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta,
                      double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
                            std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
                            std::int64_t *lda, float *beta, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
                            std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
                            std::int64_t *lda, double *beta, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
                            std::int64_t *n, std::int64_t *k, std::complex<float> *alpha,
                            const std::complex<float> **a, std::int64_t *lda,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans,
                            std::int64_t *n, std::int64_t *k, std::complex<double> *alpha,
                            const std::complex<double> **a, std::int64_t *lda,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                            std::int64_t n, std::int64_t k, float alpha, const float *a,
                            std::int64_t lda, std::int64_t stride_a, float beta, float *c,
                            std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                            std::int64_t n, std::int64_t k, double alpha, const double *a,
                            std::int64_t lda, std::int64_t stride_a, double beta, double *c,
                            std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                            std::int64_t n, std::int64_t k, std::complex<float> alpha,
                            const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
                            std::int64_t stride_c, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                            std::int64_t n, std::int64_t k, std::complex<double> alpha,
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
                            std::int64_t stride_c, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, double alpha, const double *a, std::int64_t lda,
                       const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                       std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                     const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                            transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                            float alpha, const float *a, std::int64_t lda, std::int64_t stride_a,
                            float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                            transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                            double alpha, const double *a, std::int64_t lda, std::int64_t stride_a,
                            double *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                            transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                            transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<double> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
                            transpose *trans, diag *unit_diag, std::int64_t *m, std::int64_t *n,
                            float *alpha, const float **a, std::int64_t *lda, float **b,
                            std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
                            transpose *trans, diag *unit_diag, std::int64_t *m, std::int64_t *n,
                            double *alpha, const double **a, std::int64_t *lda, double **b,
                            std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
                            transpose *trans, diag *unit_diag, std::int64_t *m, std::int64_t *n,
                            std::complex<float> *alpha, const std::complex<float> **a,
                            std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
                            transpose *trans, diag *unit_diag, std::int64_t *m, std::int64_t *n,
                            std::complex<double> *alpha, const std::complex<double> **a,
                            std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,
                            std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha,
                            const float **a, std::int64_t *lda, const float **b, std::int64_t *ldb,
                            float *beta, float **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,
                            std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha,
                            const double **a, std::int64_t *lda, const double **b, std::int64_t *ldb,
                            double *beta, double **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,
                            std::int64_t *m, std::int64_t *n, std::int64_t *k,
@@ -1955,7 +1955,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,
                            std::int64_t *m, std::int64_t *n, std::int64_t *k,
@@ -1963,21 +1963,21 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,
                            std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha,
                            const half **a, std::int64_t *lda, const half **b, std::int64_t *ldb,
                            half *beta, half **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
                            std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                            const float *a, std::int64_t lda, std::int64_t stride_a, const float *b,
                            std::int64_t ldb, std::int64_t stride_b, float beta, float *c,
                            std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
                            std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
@@ -1985,7 +1985,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
                            std::int64_t m, std::int64_t n, std::int64_t k,
@@ -1994,7 +1994,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
                            std::int64_t m, std::int64_t n, std::int64_t k,
@@ -2003,64 +2003,64 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
                            std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
                            const half *a, std::int64_t lda, std::int64_t stride_a, const half *b,
                            std::int64_t ldb, std::int64_t stride_b, half beta, half *c,
                            std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                           const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                       const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       std::int64_t n, std::int64_t k, std::complex<double> alpha,
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
                           offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
                           float alpha, const std::int8_t *a, std::int64_t lda, std::int8_t ao,
                           const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo, float beta,
                           std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                          const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
                           offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
                           float alpha, const std::int8_t *a, std::int64_t lda, std::int8_t ao,
                           const std::int8_t *b, std::int64_t ldb, std::int8_t bo, float beta,
                           std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                          const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
                           offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
                           float alpha, const std::uint8_t *a, std::int64_t lda, std::uint8_t ao,
                           const std::int8_t *b, std::int64_t ldb, std::int8_t bo, float beta,
                           std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                          const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
                           offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
                           float alpha, const std::uint8_t *a, std::int64_t lda, std::uint8_t ao,
                           const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo, float beta,
                           std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                          const std::vector<cl::sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
@@ -2030,7 +2030,7 @@ void symv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int
 cl::sycl::event syr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2043,7 +2043,7 @@ cl::sycl::event syr2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event syr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2055,7 +2055,7 @@ cl::sycl::event syr2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n, float alpha,
                      float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2065,7 +2065,7 @@ cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n, double alpha,
                      double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2075,7 +2075,7 @@ cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<float> alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2085,7 +2085,7 @@ cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<double> alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2095,7 +2095,7 @@ cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n, float alpha,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2105,7 +2105,7 @@ cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n, double alpha,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2116,7 +2116,7 @@ cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2129,7 +2129,7 @@ cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2142,7 +2142,7 @@ cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2155,7 +2155,7 @@ cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2167,7 +2167,7 @@ cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2179,7 +2179,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2192,7 +2192,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2205,7 +2205,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2217,7 +2217,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event spr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2227,7 +2227,7 @@ cl::sycl::event spr(backend_selector<backend::mklcpu> selector, uplo upper_lower
 
 cl::sycl::event spr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2239,7 +2239,7 @@ cl::sycl::event hpmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2253,7 +2253,7 @@ cl::sycl::event hpmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2266,7 +2266,7 @@ cl::sycl::event hpmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk(
@@ -2279,7 +2279,7 @@ cl::sycl::event syrk(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk(
@@ -2293,7 +2293,7 @@ cl::sycl::event syrk(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk(
@@ -2307,7 +2307,7 @@ cl::sycl::event syrk(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk(
@@ -2321,7 +2321,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, float *alpha,
                            const float **a, std::int64_t *lda, float *beta, float **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2336,7 +2336,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, double *alpha,
                            const double **a, std::int64_t *lda, double *beta, double **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2352,7 +2352,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo *upp
                            std::complex<float> *alpha, const std::complex<float> **a,
                            std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2368,7 +2368,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo *upp
                            std::complex<double> *alpha, const std::complex<double> **a,
                            std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2384,7 +2384,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo uppe
                            const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2400,7 +2400,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo uppe
                            const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2417,7 +2417,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2434,7 +2434,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syrk_batch(
@@ -2449,7 +2449,7 @@ cl::sycl::event her2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2463,7 +2463,7 @@ cl::sycl::event her2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2477,7 +2477,7 @@ cl::sycl::event hbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2492,7 +2492,7 @@ cl::sycl::event hbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2506,7 +2506,7 @@ cl::sycl::event hbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n,
                     std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2517,7 +2517,7 @@ cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n,
                     std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2527,7 +2527,7 @@ cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n, float *x,
                     std::int64_t incx, float *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2537,7 +2537,7 @@ cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n, 
 
 cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n, double *x,
                     std::int64_t incx, double *y, std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2547,7 +2547,7 @@ cl::sycl::event rot(backend_selector<backend::mklcpu> selector, std::int64_t n, 
 
 cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n, float alpha,
                      const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2557,7 +2557,7 @@ cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2568,7 +2568,7 @@ cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2579,7 +2579,7 @@ cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2590,7 +2590,7 @@ cl::sycl::event axpy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int64_t *n,
                            float *alpha, const float **x, std::int64_t *incx, float **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(
@@ -2603,7 +2603,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int64_t *n,
                            double *alpha, const double **x, std::int64_t *incx, double **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(
@@ -2617,7 +2617,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            std::complex<float> *alpha, const std::complex<float> **x,
                            std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(
@@ -2631,7 +2631,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            std::complex<double> *alpha, const std::complex<double> **x,
                            std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(
@@ -2644,7 +2644,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int64_t n, float alpha,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2658,7 +2658,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int64_t n, double alpha,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2673,7 +2673,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            std::complex<float> alpha, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2688,7 +2688,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            std::complex<double> alpha, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2702,7 +2702,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
 cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2713,7 +2713,7 @@ cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2724,7 +2724,7 @@ cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n,
                       std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                       const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2735,7 +2735,7 @@ cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n,
                       std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                       const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2747,7 +2747,7 @@ cl::sycl::event gerc(backend_selector<backend::mklcpu> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2759,7 +2759,7 @@ cl::sycl::event gerc(backend_selector<backend::mklcpu> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2770,7 +2770,7 @@ cl::sycl::event gerc(backend_selector<backend::mklcpu> selector, std::int64_t m,
 cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                       const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2785,7 +2785,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2801,7 +2801,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_low
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2817,7 +2817,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2831,7 +2831,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_low
 cl::sycl::event gemv(backend_selector<backend::mklcpu> selector, transpose trans, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2844,7 +2844,7 @@ cl::sycl::event gemv(backend_selector<backend::mklcpu> selector, transpose trans
 cl::sycl::event gemv(backend_selector<backend::mklcpu> selector, transpose trans, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2858,7 +2858,7 @@ cl::sycl::event gemv(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2872,7 +2872,7 @@ cl::sycl::event gemv(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2887,7 +2887,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const float *x,
                            std::int64_t incx, std::int64_t stridex, float beta, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(
@@ -2903,7 +2903,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const double *x,
                            std::int64_t incx, std::int64_t stridex, double beta, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(
@@ -2920,7 +2920,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(
@@ -2937,7 +2937,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(
@@ -2953,7 +2953,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t *lda, const float **x, std::int64_t *incx, float *beta,
                            float **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2969,7 +2969,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
                            double **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2986,7 +2986,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3003,7 +3003,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklcpu> selector, transpose
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3019,7 +3019,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side left
                            std::int64_t stridea, const float *x, std::int64_t incx,
                            std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(
@@ -3035,7 +3035,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side left
                            std::int64_t stridea, const double *x, std::int64_t incx,
                            std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(
@@ -3051,7 +3051,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(
@@ -3067,7 +3067,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(
@@ -3082,7 +3082,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const float **a, std::int64_t *lda,
                            const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3097,7 +3097,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const double **a, std::int64_t *lda,
                            const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3113,7 +3113,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3129,7 +3129,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3143,7 +3143,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklcpu> selector, side *lef
 cl::sycl::event her(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3154,7 +3154,7 @@ cl::sycl::event her(backend_selector<backend::mklcpu> selector, uplo upper_lower
 cl::sycl::event her(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3165,7 +3165,7 @@ cl::sycl::event her(backend_selector<backend::mklcpu> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3176,7 +3176,7 @@ cl::sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3186,7 +3186,7 @@ cl::sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower
 
 cl::sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3196,7 +3196,7 @@ cl::sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3206,7 +3206,7 @@ cl::sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3216,7 +3216,7 @@ cl::sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3229,7 +3229,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            float *alpha, const float **a, std::int64_t *lda, const float **b,
                            std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3245,7 +3245,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            double *alpha, const double **a, std::int64_t *lda, const double **b,
                            std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3262,7 +3262,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3279,7 +3279,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3295,7 +3295,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            half *alpha, const half **a, std::int64_t *lda, const half **b,
                            std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3312,7 +3312,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3329,7 +3329,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3347,7 +3347,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3365,7 +3365,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3382,7 +3382,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
                            const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
                            half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(
@@ -3396,7 +3396,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
 cl::sycl::event spmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, const float *x, std::int64_t incx, float beta,
                      float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3409,7 +3409,7 @@ cl::sycl::event spmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event spmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, const double *x, std::int64_t incx, double beta,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3421,7 +3421,7 @@ cl::sycl::event spmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3431,7 +3431,7 @@ cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3442,7 +3442,7 @@ cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3453,7 +3453,7 @@ cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3465,7 +3465,7 @@ cl::sycl::event geru(backend_selector<backend::mklcpu> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3477,7 +3477,7 @@ cl::sycl::event geru(backend_selector<backend::mklcpu> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3487,7 +3487,7 @@ cl::sycl::event geru(backend_selector<backend::mklcpu> selector, std::int64_t m,
 
 cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3497,7 +3497,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3507,7 +3507,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3517,7 +3517,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3529,7 +3529,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3544,7 +3544,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3560,7 +3560,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3576,7 +3576,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3591,7 +3591,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3606,7 +3606,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3621,7 +3621,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3637,7 +3637,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklcpu> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_bias(
@@ -3653,7 +3653,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklcpu> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_bias(
@@ -3669,7 +3669,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklcpu> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_bias(
@@ -3685,7 +3685,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklcpu> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemm_bias(
@@ -3699,7 +3699,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklcpu> selector, transpose 
 cl::sycl::event herk(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a,
                      std::int64_t lda, float beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::herk(
@@ -3712,7 +3712,7 @@ cl::sycl::event herk(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event herk(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
                      std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::herk(
@@ -3725,7 +3725,7 @@ cl::sycl::event herk(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event ger(backend_selector<backend::mklcpu> selector, std::int64_t m, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, const float *y,
                     std::int64_t incy, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3736,7 +3736,7 @@ cl::sycl::event ger(backend_selector<backend::mklcpu> selector, std::int64_t m, 
 cl::sycl::event ger(backend_selector<backend::mklcpu> selector, std::int64_t m, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, const double *y,
                     std::int64_t incy, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3747,7 +3747,7 @@ cl::sycl::event ger(backend_selector<backend::mklcpu> selector, std::int64_t m, 
 cl::sycl::event trsm(backend_selector<backend::mklcpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3761,7 +3761,7 @@ cl::sycl::event trsm(backend_selector<backend::mklcpu> selector, side left_right
 cl::sycl::event trsm(backend_selector<backend::mklcpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3776,7 +3776,7 @@ cl::sycl::event trsm(backend_selector<backend::mklcpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3791,7 +3791,7 @@ cl::sycl::event trsm(backend_selector<backend::mklcpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3807,7 +3807,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side left
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3823,7 +3823,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side left
                            std::int64_t n, double alpha, const double *a, std::int64_t lda,
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3839,7 +3839,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side left
                            std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3856,7 +3856,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side left
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3872,7 +3872,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
                            float **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3888,7 +3888,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
                            double **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3905,7 +3905,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            const std::complex<float> **a, std::int64_t *lda,
                            std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3922,7 +3922,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side *lef
                            const std::complex<double> **a, std::int64_t *lda,
                            std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsm_batch(
@@ -3936,7 +3936,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklcpu> selector, side *lef
 cl::sycl::event dotu(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3947,7 +3947,7 @@ cl::sycl::event dotu(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event dotu(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3960,7 +3960,7 @@ cl::sycl::event hemm(backend_selector<backend::mklcpu> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3976,7 +3976,7 @@ cl::sycl::event hemm(backend_selector<backend::mklcpu> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3990,7 +3990,7 @@ cl::sycl::event hemm(backend_selector<backend::mklcpu> selector, side left_right
 cl::sycl::event hpr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4003,7 +4003,7 @@ cl::sycl::event hpr2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event hpr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4017,7 +4017,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4032,7 +4032,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4048,7 +4048,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4064,7 +4064,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4078,7 +4078,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans
 cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbmv(
@@ -4091,7 +4091,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbmv(
@@ -4104,7 +4104,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbmv(
@@ -4117,7 +4117,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbmv(
@@ -4130,7 +4130,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
                      const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4145,7 +4145,7 @@ cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4161,7 +4161,7 @@ cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4177,7 +4177,7 @@ cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4191,7 +4191,7 @@ cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right
 cl::sycl::event dotc(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4202,7 +4202,7 @@ cl::sycl::event dotc(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event dotc(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4212,7 +4212,7 @@ cl::sycl::event dotc(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event syr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4222,7 +4222,7 @@ cl::sycl::event syr(backend_selector<backend::mklcpu> selector, uplo upper_lower
 
 cl::sycl::event syr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4233,7 +4233,7 @@ cl::sycl::event syr(backend_selector<backend::mklcpu> selector, uplo upper_lower
 cl::sycl::event trmm(backend_selector<backend::mklcpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4247,7 +4247,7 @@ cl::sycl::event trmm(backend_selector<backend::mklcpu> selector, side left_right
 cl::sycl::event trmm(backend_selector<backend::mklcpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4262,7 +4262,7 @@ cl::sycl::event trmm(backend_selector<backend::mklcpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4277,7 +4277,7 @@ cl::sycl::event trmm(backend_selector<backend::mklcpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4290,7 +4290,7 @@ cl::sycl::event trmm(backend_selector<backend::mklcpu> selector, side left_right
 
 cl::sycl::event rotmg(backend_selector<backend::mklcpu> selector, float *d1, float *d2, float *x1,
                       float y1, float *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4300,7 +4300,7 @@ cl::sycl::event rotmg(backend_selector<backend::mklcpu> selector, float *d1, flo
 
 cl::sycl::event rotmg(backend_selector<backend::mklcpu> selector, double *d1, double *d2,
                       double *x1, double y1, double *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4310,7 +4310,7 @@ cl::sycl::event rotmg(backend_selector<backend::mklcpu> selector, double *d1, do
 
 cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4322,7 +4322,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4335,7 +4335,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4348,7 +4348,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4361,7 +4361,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4374,7 +4374,7 @@ cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4387,7 +4387,7 @@ cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4400,7 +4400,7 @@ cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4412,7 +4412,7 @@ cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4422,7 +4422,7 @@ cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4433,7 +4433,7 @@ cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4444,7 +4444,7 @@ cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4455,7 +4455,7 @@ cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int64_t *n,
                            const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4468,7 +4468,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int64_t *n,
                            const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4482,7 +4482,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4496,7 +4496,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4509,7 +4509,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int64_t n,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4522,7 +4522,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int64_t n,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4536,7 +4536,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4550,7 +4550,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklcpu> selector, std::int6
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy_batch(
@@ -4564,7 +4564,7 @@ cl::sycl::event hemv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hemv(
@@ -4578,7 +4578,7 @@ cl::sycl::event hemv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hemv(
@@ -4592,7 +4592,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklcpu> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4607,7 +4607,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklcpu> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       double alpha, const double *a, std::int64_t lda, const double *b,
                       std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4623,7 +4623,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklcpu> selector, uplo upper_low
                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                       const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4639,7 +4639,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklcpu> selector, uplo upper_low
                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4653,7 +4653,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklcpu> selector, uplo upper_low
 cl::sycl::event sbmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4667,7 +4667,7 @@ cl::sycl::event sbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event sbmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4680,7 +4680,7 @@ cl::sycl::event sbmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4690,7 +4690,7 @@ cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4700,7 +4700,7 @@ cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4710,7 +4710,7 @@ cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4721,7 +4721,7 @@ cl::sycl::event asum(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbsv(
@@ -4734,7 +4734,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbsv(
@@ -4747,7 +4747,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbsv(
@@ -4760,7 +4760,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::tbsv(
@@ -4773,7 +4773,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4786,7 +4786,7 @@ cl::sycl::event spr2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4798,7 +4798,7 @@ cl::sycl::event spr2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4808,7 +4808,7 @@ cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4818,7 +4818,7 @@ cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4828,7 +4828,7 @@ cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4838,7 +4838,7 @@ cl::sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event rotm(backend_selector<backend::mklcpu> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4848,7 +4848,7 @@ cl::sycl::event rotm(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event rotm(backend_selector<backend::mklcpu> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4857,7 +4857,7 @@ cl::sycl::event rotm(backend_selector<backend::mklcpu> selector, std::int64_t n,
 }
 
 cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, float *a, float *b, float *c,
-                     float *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklcpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4866,7 +4866,7 @@ cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, float *a, float
 }
 
 cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, double *a, double *b, double *c,
-                     double *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklcpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4876,7 +4876,7 @@ cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, double *a, doub
 
 cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, std::complex<float> *a,
                      std::complex<float> *b, float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklcpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4886,7 +4886,7 @@ cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, std::complex<fl
 
 cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, std::complex<double> *a,
                      std::complex<double> *b, double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklcpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4896,7 +4896,7 @@ cl::sycl::event rotg(backend_selector<backend::mklcpu> selector, std::complex<do
 
 cl::sycl::event sdsdot(backend_selector<backend::mklcpu> selector, std::int64_t n, float sb,
                        const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                       float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       float *result, const std::vector<cl::sycl::event> &dependencies) {
     sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y,
                                                          incy, result, dependencies);
@@ -4908,7 +4908,7 @@ cl::sycl::event her2k(backend_selector<backend::mklcpu> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4924,7 +4924,7 @@ cl::sycl::event her2k(backend_selector<backend::mklcpu> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, double beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4937,7 +4937,7 @@ cl::sycl::event her2k(backend_selector<backend::mklcpu> selector, uplo upper_low
 
 cl::sycl::event dot(backend_selector<backend::mklcpu> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4947,7 +4947,7 @@ cl::sycl::event dot(backend_selector<backend::mklcpu> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::mklcpu> selector, std::int64_t n, const double *x,
                     std::int64_t incx, const double *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4957,7 +4957,7 @@ cl::sycl::event dot(backend_selector<backend::mklcpu> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::mklcpu> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4968,7 +4968,7 @@ cl::sycl::event dot(backend_selector<backend::mklcpu> selector, std::int64_t n, 
 cl::sycl::event symv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::symv(
@@ -4981,7 +4981,7 @@ cl::sycl::event symv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event symv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::symv(

--- a/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
@@ -2115,8 +2115,7 @@ cl::sycl::event scal(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2128,8 +2127,7 @@ cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event trmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2448,8 +2446,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklcpu> selector, uplo uppe
 cl::sycl::event her2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2462,8 +2459,7 @@ cl::sycl::event her2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event her2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2701,8 +2697,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklcpu> selector, std::int6
 
 cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2712,8 +2707,7 @@ cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n
 
 cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2746,8 +2740,7 @@ cl::sycl::event axpby(backend_selector<backend::mklcpu> selector, std::int64_t n
 cl::sycl::event gerc(backend_selector<backend::mklcpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2758,8 +2751,7 @@ cl::sycl::event gerc(backend_selector<backend::mklcpu> selector, std::int64_t m,
 cl::sycl::event gerc(backend_selector<backend::mklcpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2784,8 +2776,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_low
 cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2800,8 +2791,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklcpu> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -3164,8 +3154,7 @@ cl::sycl::event her(backend_selector<backend::mklcpu> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
-                    std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3175,8 +3164,7 @@ cl::sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
-                    std::complex<double> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3441,8 +3429,7 @@ cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3452,8 +3439,7 @@ cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3464,8 +3450,7 @@ cl::sycl::event swap(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event geru(backend_selector<backend::mklcpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3476,8 +3461,7 @@ cl::sycl::event geru(backend_selector<backend::mklcpu> selector, std::int64_t m,
 cl::sycl::event geru(backend_selector<backend::mklcpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3528,8 +3512,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklcpu> selector, std::int64_t n,
 cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3543,8 +3526,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3559,8 +3541,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3575,8 +3556,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3590,8 +3570,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3605,8 +3584,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3620,8 +3598,7 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3959,8 +3936,7 @@ cl::sycl::event hemm(backend_selector<backend::mklcpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3975,8 +3951,7 @@ cl::sycl::event hemm(backend_selector<backend::mklcpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4016,8 +3991,7 @@ cl::sycl::event hpr2(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans, std::int64_t m,
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4047,8 +4021,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4063,8 +4036,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklcpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4144,8 +4116,7 @@ cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right
 cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4160,8 +4131,7 @@ cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4176,8 +4146,7 @@ cl::sycl::event symm(backend_selector<backend::mklcpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4289,8 +4258,7 @@ cl::sycl::event trmm(backend_selector<backend::mklcpu> selector, side left_right
 }
 
 cl::sycl::event rotmg(backend_selector<backend::mklcpu> selector, float *d1, float *d2, float *x1,
-                      float y1, float *param,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      float y1, float *param, const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4360,8 +4328,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4373,8 +4340,7 @@ cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::mklcpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4432,8 +4398,7 @@ cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4443,8 +4408,7 @@ cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::mklcpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklcpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);

--- a/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
@@ -2030,7 +2030,7 @@ void symv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int
 cl::sycl::event syr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2043,7 +2043,7 @@ cl::sycl::event syr2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event syr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2055,7 +2055,7 @@ cl::sycl::event syr2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n, float alpha,
                      float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2065,7 +2065,7 @@ cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n, double alpha,
                      double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2075,7 +2075,7 @@ cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<float> alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2085,7 +2085,7 @@ cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<double> alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2095,7 +2095,7 @@ cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n, float alpha,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2105,7 +2105,7 @@ cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n, double alpha,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2116,7 +2116,7 @@ cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2129,7 +2129,7 @@ cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2142,7 +2142,7 @@ cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2155,7 +2155,7 @@ cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2167,7 +2167,7 @@ cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2179,7 +2179,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2192,7 +2192,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2205,7 +2205,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2217,7 +2217,7 @@ cl::sycl::event tpmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event spr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2227,7 +2227,7 @@ cl::sycl::event spr(backend_selector<backend::mklgpu> selector, uplo upper_lower
 
 cl::sycl::event spr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2239,7 +2239,7 @@ cl::sycl::event hpmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2253,7 +2253,7 @@ cl::sycl::event hpmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2266,7 +2266,7 @@ cl::sycl::event hpmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk(
@@ -2279,7 +2279,7 @@ cl::sycl::event syrk(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk(
@@ -2293,7 +2293,7 @@ cl::sycl::event syrk(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk(
@@ -2307,7 +2307,7 @@ cl::sycl::event syrk(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk(
@@ -2321,7 +2321,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, float *alpha,
                            const float **a, std::int64_t *lda, float *beta, float **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2336,7 +2336,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, double *alpha,
                            const double **a, std::int64_t *lda, double *beta, double **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2352,7 +2352,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo *upp
                            std::complex<float> *alpha, const std::complex<float> **a,
                            std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2368,7 +2368,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo *upp
                            std::complex<double> *alpha, const std::complex<double> **a,
                            std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2384,7 +2384,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo uppe
                            const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2400,7 +2400,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo uppe
                            const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2417,7 +2417,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2434,7 +2434,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syrk_batch(
@@ -2449,7 +2449,7 @@ cl::sycl::event her2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2463,7 +2463,7 @@ cl::sycl::event her2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2477,7 +2477,7 @@ cl::sycl::event hbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2492,7 +2492,7 @@ cl::sycl::event hbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2506,7 +2506,7 @@ cl::sycl::event hbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n,
                     std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2517,7 +2517,7 @@ cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n,
                     std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2527,7 +2527,7 @@ cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n, float *x,
                     std::int64_t incx, float *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2537,7 +2537,7 @@ cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n, 
 
 cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n, double *x,
                     std::int64_t incx, double *y, std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2547,7 +2547,7 @@ cl::sycl::event rot(backend_selector<backend::mklgpu> selector, std::int64_t n, 
 
 cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n, float alpha,
                      const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2557,7 +2557,7 @@ cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2568,7 +2568,7 @@ cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2579,7 +2579,7 @@ cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2590,7 +2590,7 @@ cl::sycl::event axpy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int64_t *n,
                            float *alpha, const float **x, std::int64_t *incx, float **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(
@@ -2603,7 +2603,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int64_t *n,
                            double *alpha, const double **x, std::int64_t *incx, double **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(
@@ -2617,7 +2617,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            std::complex<float> *alpha, const std::complex<float> **x,
                            std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(
@@ -2631,7 +2631,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            std::complex<double> *alpha, const std::complex<double> **x,
                            std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(
@@ -2644,7 +2644,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int64_t n, float alpha,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2658,7 +2658,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int64_t n, double alpha,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2673,7 +2673,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            std::complex<float> alpha, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2688,7 +2688,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            std::complex<double> alpha, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2702,7 +2702,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
 cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2713,7 +2713,7 @@ cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2724,7 +2724,7 @@ cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n,
                       std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                       const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2735,7 +2735,7 @@ cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n,
                       std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                       const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2747,7 +2747,7 @@ cl::sycl::event gerc(backend_selector<backend::mklgpu> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2759,7 +2759,7 @@ cl::sycl::event gerc(backend_selector<backend::mklgpu> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2770,7 +2770,7 @@ cl::sycl::event gerc(backend_selector<backend::mklgpu> selector, std::int64_t m,
 cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                       const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2785,7 +2785,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2801,7 +2801,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_low
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2817,7 +2817,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2831,7 +2831,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_low
 cl::sycl::event gemv(backend_selector<backend::mklgpu> selector, transpose trans, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2844,7 +2844,7 @@ cl::sycl::event gemv(backend_selector<backend::mklgpu> selector, transpose trans
 cl::sycl::event gemv(backend_selector<backend::mklgpu> selector, transpose trans, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2858,7 +2858,7 @@ cl::sycl::event gemv(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2872,7 +2872,7 @@ cl::sycl::event gemv(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2887,7 +2887,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const float *x,
                            std::int64_t incx, std::int64_t stridex, float beta, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(
@@ -2903,7 +2903,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const double *x,
                            std::int64_t incx, std::int64_t stridex, double beta, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(
@@ -2920,7 +2920,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(
@@ -2937,7 +2937,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(
@@ -2953,7 +2953,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t *lda, const float **x, std::int64_t *incx, float *beta,
                            float **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2969,7 +2969,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
                            double **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2986,7 +2986,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3003,7 +3003,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::mklgpu> selector, transpose
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3019,7 +3019,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side left
                            std::int64_t stridea, const float *x, std::int64_t incx,
                            std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(
@@ -3035,7 +3035,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side left
                            std::int64_t stridea, const double *x, std::int64_t incx,
                            std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(
@@ -3051,7 +3051,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(
@@ -3067,7 +3067,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(
@@ -3082,7 +3082,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const float **a, std::int64_t *lda,
                            const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3097,7 +3097,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const double **a, std::int64_t *lda,
                            const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3113,7 +3113,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3129,7 +3129,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3143,7 +3143,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::mklgpu> selector, side *lef
 cl::sycl::event her(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3154,7 +3154,7 @@ cl::sycl::event her(backend_selector<backend::mklgpu> selector, uplo upper_lower
 cl::sycl::event her(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3165,7 +3165,7 @@ cl::sycl::event her(backend_selector<backend::mklgpu> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3176,7 +3176,7 @@ cl::sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3186,7 +3186,7 @@ cl::sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower
 
 cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3196,7 +3196,7 @@ cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3206,7 +3206,7 @@ cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3216,7 +3216,7 @@ cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3229,7 +3229,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            half *alpha, const half **a, std::int64_t *lda, const half **b,
                            std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3245,7 +3245,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            float *alpha, const float **a, std::int64_t *lda, const float **b,
                            std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3261,7 +3261,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            double *alpha, const double **a, std::int64_t *lda, const double **b,
                            std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3278,7 +3278,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3295,7 +3295,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3312,7 +3312,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
                            half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3329,7 +3329,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3346,7 +3346,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3364,7 +3364,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3382,7 +3382,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(
@@ -3396,7 +3396,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
 cl::sycl::event spmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, const float *x, std::int64_t incx, float beta,
                      float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3409,7 +3409,7 @@ cl::sycl::event spmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event spmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, const double *x, std::int64_t incx, double beta,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3421,7 +3421,7 @@ cl::sycl::event spmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3431,7 +3431,7 @@ cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3442,7 +3442,7 @@ cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3453,7 +3453,7 @@ cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3465,7 +3465,7 @@ cl::sycl::event geru(backend_selector<backend::mklgpu> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3477,7 +3477,7 @@ cl::sycl::event geru(backend_selector<backend::mklgpu> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3487,7 +3487,7 @@ cl::sycl::event geru(backend_selector<backend::mklgpu> selector, std::int64_t m,
 
 cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3497,7 +3497,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3507,7 +3507,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3517,7 +3517,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3529,7 +3529,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3544,7 +3544,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3560,7 +3560,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3576,7 +3576,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3591,7 +3591,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3606,7 +3606,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3621,7 +3621,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3637,7 +3637,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklgpu> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_bias(
@@ -3653,7 +3653,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklgpu> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_bias(
@@ -3669,7 +3669,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklgpu> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_bias(
@@ -3685,7 +3685,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklgpu> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemm_bias(
@@ -3699,7 +3699,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::mklgpu> selector, transpose 
 cl::sycl::event herk(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a,
                      std::int64_t lda, float beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::herk(
@@ -3712,7 +3712,7 @@ cl::sycl::event herk(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event herk(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
                      std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::herk(
@@ -3725,7 +3725,7 @@ cl::sycl::event herk(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event ger(backend_selector<backend::mklgpu> selector, std::int64_t m, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, const float *y,
                     std::int64_t incy, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3736,7 +3736,7 @@ cl::sycl::event ger(backend_selector<backend::mklgpu> selector, std::int64_t m, 
 cl::sycl::event ger(backend_selector<backend::mklgpu> selector, std::int64_t m, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, const double *y,
                     std::int64_t incy, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3747,7 +3747,7 @@ cl::sycl::event ger(backend_selector<backend::mklgpu> selector, std::int64_t m, 
 cl::sycl::event trsm(backend_selector<backend::mklgpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3761,7 +3761,7 @@ cl::sycl::event trsm(backend_selector<backend::mklgpu> selector, side left_right
 cl::sycl::event trsm(backend_selector<backend::mklgpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3776,7 +3776,7 @@ cl::sycl::event trsm(backend_selector<backend::mklgpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3791,7 +3791,7 @@ cl::sycl::event trsm(backend_selector<backend::mklgpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3807,7 +3807,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side left
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3823,7 +3823,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side left
                            std::int64_t n, double alpha, const double *a, std::int64_t lda,
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3839,7 +3839,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side left
                            std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3856,7 +3856,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side left
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3872,7 +3872,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
                            float **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3888,7 +3888,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
                            double **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3905,7 +3905,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            const std::complex<float> **a, std::int64_t *lda,
                            std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3922,7 +3922,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side *lef
                            const std::complex<double> **a, std::int64_t *lda,
                            std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsm_batch(
@@ -3936,7 +3936,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::mklgpu> selector, side *lef
 cl::sycl::event dotu(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3947,7 +3947,7 @@ cl::sycl::event dotu(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event dotu(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3960,7 +3960,7 @@ cl::sycl::event hemm(backend_selector<backend::mklgpu> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3976,7 +3976,7 @@ cl::sycl::event hemm(backend_selector<backend::mklgpu> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3990,7 +3990,7 @@ cl::sycl::event hemm(backend_selector<backend::mklgpu> selector, side left_right
 cl::sycl::event hpr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4003,7 +4003,7 @@ cl::sycl::event hpr2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event hpr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4017,7 +4017,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4032,7 +4032,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4048,7 +4048,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4064,7 +4064,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4078,7 +4078,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans
 cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbmv(
@@ -4091,7 +4091,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbmv(
@@ -4104,7 +4104,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbmv(
@@ -4117,7 +4117,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbmv(
@@ -4130,7 +4130,7 @@ cl::sycl::event tbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
                      const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4145,7 +4145,7 @@ cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4161,7 +4161,7 @@ cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4177,7 +4177,7 @@ cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4191,7 +4191,7 @@ cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right
 cl::sycl::event dotc(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4202,7 +4202,7 @@ cl::sycl::event dotc(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event dotc(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4212,7 +4212,7 @@ cl::sycl::event dotc(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event syr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4222,7 +4222,7 @@ cl::sycl::event syr(backend_selector<backend::mklgpu> selector, uplo upper_lower
 
 cl::sycl::event syr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4233,7 +4233,7 @@ cl::sycl::event syr(backend_selector<backend::mklgpu> selector, uplo upper_lower
 cl::sycl::event trmm(backend_selector<backend::mklgpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4247,7 +4247,7 @@ cl::sycl::event trmm(backend_selector<backend::mklgpu> selector, side left_right
 cl::sycl::event trmm(backend_selector<backend::mklgpu> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4262,7 +4262,7 @@ cl::sycl::event trmm(backend_selector<backend::mklgpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4277,7 +4277,7 @@ cl::sycl::event trmm(backend_selector<backend::mklgpu> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4290,7 +4290,7 @@ cl::sycl::event trmm(backend_selector<backend::mklgpu> selector, side left_right
 
 cl::sycl::event rotmg(backend_selector<backend::mklgpu> selector, float *d1, float *d2, float *x1,
                       float y1, float *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4300,7 +4300,7 @@ cl::sycl::event rotmg(backend_selector<backend::mklgpu> selector, float *d1, flo
 
 cl::sycl::event rotmg(backend_selector<backend::mklgpu> selector, double *d1, double *d2,
                       double *x1, double y1, double *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4310,7 +4310,7 @@ cl::sycl::event rotmg(backend_selector<backend::mklgpu> selector, double *d1, do
 
 cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4322,7 +4322,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4335,7 +4335,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4348,7 +4348,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4361,7 +4361,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4374,7 +4374,7 @@ cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4387,7 +4387,7 @@ cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4400,7 +4400,7 @@ cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4412,7 +4412,7 @@ cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4422,7 +4422,7 @@ cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4433,7 +4433,7 @@ cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4444,7 +4444,7 @@ cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4455,7 +4455,7 @@ cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int64_t *n,
                            const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4468,7 +4468,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int64_t *n,
                            const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4482,7 +4482,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4496,7 +4496,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4509,7 +4509,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int64_t n,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4522,7 +4522,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int64_t n,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4536,7 +4536,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4550,7 +4550,7 @@ cl::sycl::event copy_batch(backend_selector<backend::mklgpu> selector, std::int6
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy_batch(
@@ -4564,7 +4564,7 @@ cl::sycl::event hemv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hemv(
@@ -4578,7 +4578,7 @@ cl::sycl::event hemv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hemv(
@@ -4592,7 +4592,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklgpu> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4607,7 +4607,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklgpu> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       double alpha, const double *a, std::int64_t lda, const double *b,
                       std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4623,7 +4623,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklgpu> selector, uplo upper_low
                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                       const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4639,7 +4639,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklgpu> selector, uplo upper_low
                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4653,7 +4653,7 @@ cl::sycl::event gemmt(backend_selector<backend::mklgpu> selector, uplo upper_low
 cl::sycl::event sbmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4667,7 +4667,7 @@ cl::sycl::event sbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event sbmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4680,7 +4680,7 @@ cl::sycl::event sbmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4690,7 +4690,7 @@ cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4700,7 +4700,7 @@ cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4710,7 +4710,7 @@ cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4721,7 +4721,7 @@ cl::sycl::event asum(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbsv(
@@ -4734,7 +4734,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbsv(
@@ -4747,7 +4747,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbsv(
@@ -4760,7 +4760,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::tbsv(
@@ -4773,7 +4773,7 @@ cl::sycl::event tbsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4786,7 +4786,7 @@ cl::sycl::event spr2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4798,7 +4798,7 @@ cl::sycl::event spr2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4808,7 +4808,7 @@ cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4818,7 +4818,7 @@ cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4828,7 +4828,7 @@ cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4838,7 +4838,7 @@ cl::sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event rotm(backend_selector<backend::mklgpu> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4848,7 +4848,7 @@ cl::sycl::event rotm(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event rotm(backend_selector<backend::mklgpu> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4857,7 +4857,7 @@ cl::sycl::event rotm(backend_selector<backend::mklgpu> selector, std::int64_t n,
 }
 
 cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, float *a, float *b, float *c,
-                     float *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklgpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4866,7 +4866,7 @@ cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, float *a, float
 }
 
 cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, double *a, double *b, double *c,
-                     double *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklgpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4876,7 +4876,7 @@ cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, double *a, doub
 
 cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, std::complex<float> *a,
                      std::complex<float> *b, float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklgpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4886,7 +4886,7 @@ cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, std::complex<fl
 
 cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, std::complex<double> *a,
                      std::complex<double> *b, double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::mklgpu::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4896,7 +4896,7 @@ cl::sycl::event rotg(backend_selector<backend::mklgpu> selector, std::complex<do
 
 cl::sycl::event sdsdot(backend_selector<backend::mklgpu> selector, std::int64_t n, float sb,
                        const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                       float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       float *result, const std::vector<cl::sycl::event> &dependencies) {
     sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y,
                                                          incy, result, dependencies);
@@ -4908,7 +4908,7 @@ cl::sycl::event her2k(backend_selector<backend::mklgpu> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4924,7 +4924,7 @@ cl::sycl::event her2k(backend_selector<backend::mklgpu> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, double beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4937,7 +4937,7 @@ cl::sycl::event her2k(backend_selector<backend::mklgpu> selector, uplo upper_low
 
 cl::sycl::event dot(backend_selector<backend::mklgpu> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4947,7 +4947,7 @@ cl::sycl::event dot(backend_selector<backend::mklgpu> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::mklgpu> selector, std::int64_t n, const double *x,
                     std::int64_t incx, const double *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4957,7 +4957,7 @@ cl::sycl::event dot(backend_selector<backend::mklgpu> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::mklgpu> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4968,7 +4968,7 @@ cl::sycl::event dot(backend_selector<backend::mklgpu> selector, std::int64_t n, 
 cl::sycl::event symv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::symv(
@@ -4981,7 +4981,7 @@ cl::sycl::event symv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event symv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::symv(

--- a/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
@@ -2115,8 +2115,7 @@ cl::sycl::event scal(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2128,8 +2127,7 @@ cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event trmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2448,8 +2446,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::mklgpu> selector, uplo uppe
 cl::sycl::event her2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2462,8 +2459,7 @@ cl::sycl::event her2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event her2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2701,8 +2697,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::mklgpu> selector, std::int6
 
 cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2712,8 +2707,7 @@ cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2746,8 +2740,7 @@ cl::sycl::event axpby(backend_selector<backend::mklgpu> selector, std::int64_t n
 cl::sycl::event gerc(backend_selector<backend::mklgpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2758,8 +2751,7 @@ cl::sycl::event gerc(backend_selector<backend::mklgpu> selector, std::int64_t m,
 cl::sycl::event gerc(backend_selector<backend::mklgpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2784,8 +2776,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_low
 cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2800,8 +2791,7 @@ cl::sycl::event syr2k(backend_selector<backend::mklgpu> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -3164,8 +3154,7 @@ cl::sycl::event her(backend_selector<backend::mklgpu> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
-                    std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3175,8 +3164,7 @@ cl::sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
-                    std::complex<double> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3441,8 +3429,7 @@ cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3452,8 +3439,7 @@ cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3464,8 +3450,7 @@ cl::sycl::event swap(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event geru(backend_selector<backend::mklgpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3476,8 +3461,7 @@ cl::sycl::event geru(backend_selector<backend::mklgpu> selector, std::int64_t m,
 cl::sycl::event geru(backend_selector<backend::mklgpu> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3528,8 +3512,7 @@ cl::sycl::event nrm2(backend_selector<backend::mklgpu> selector, std::int64_t n,
 cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3543,8 +3526,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3559,8 +3541,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3575,8 +3556,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3590,8 +3570,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3605,8 +3584,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3620,8 +3598,7 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3959,8 +3936,7 @@ cl::sycl::event hemm(backend_selector<backend::mklgpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3975,8 +3951,7 @@ cl::sycl::event hemm(backend_selector<backend::mklgpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4016,8 +3991,7 @@ cl::sycl::event hpr2(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans, std::int64_t m,
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4047,8 +4021,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4063,8 +4036,7 @@ cl::sycl::event gbmv(backend_selector<backend::mklgpu> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4144,8 +4116,7 @@ cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right
 cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4160,8 +4131,7 @@ cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4176,8 +4146,7 @@ cl::sycl::event symm(backend_selector<backend::mklgpu> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4289,8 +4258,7 @@ cl::sycl::event trmm(backend_selector<backend::mklgpu> selector, side left_right
 }
 
 cl::sycl::event rotmg(backend_selector<backend::mklgpu> selector, float *d1, float *d2, float *x1,
-                      float y1, float *param,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      float y1, float *param, const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4360,8 +4328,7 @@ cl::sycl::event tpsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4373,8 +4340,7 @@ cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::mklgpu> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4432,8 +4398,7 @@ cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4443,8 +4408,7 @@ cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::mklgpu> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::mklgpu::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);

--- a/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
@@ -2115,8 +2115,7 @@ cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2128,8 +2127,7 @@ cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2448,8 +2446,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo uppe
 cl::sycl::event her2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2462,8 +2459,7 @@ cl::sycl::event her2(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event her2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2701,8 +2697,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
 
 cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2712,8 +2707,7 @@ cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2746,8 +2740,7 @@ cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n
 cl::sycl::event gerc(backend_selector<backend::netlib> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2758,8 +2751,7 @@ cl::sycl::event gerc(backend_selector<backend::netlib> selector, std::int64_t m,
 cl::sycl::event gerc(backend_selector<backend::netlib> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2784,8 +2776,7 @@ cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_low
 cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2800,8 +2791,7 @@ cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -3164,8 +3154,7 @@ cl::sycl::event her(backend_selector<backend::netlib> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
-                    std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3175,8 +3164,7 @@ cl::sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower
 
 cl::sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
-                    std::complex<double> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3441,8 +3429,7 @@ cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3452,8 +3439,7 @@ cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3464,8 +3450,7 @@ cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event geru(backend_selector<backend::netlib> selector, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3476,8 +3461,7 @@ cl::sycl::event geru(backend_selector<backend::netlib> selector, std::int64_t m,
 cl::sycl::event geru(backend_selector<backend::netlib> selector, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3528,8 +3512,7 @@ cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3543,8 +3526,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3559,8 +3541,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3575,8 +3556,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3590,8 +3570,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3605,8 +3584,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3620,8 +3598,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
 cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3959,8 +3936,7 @@ cl::sycl::event hemm(backend_selector<backend::netlib> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3975,8 +3951,7 @@ cl::sycl::event hemm(backend_selector<backend::netlib> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4016,8 +3991,7 @@ cl::sycl::event hpr2(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans, std::int64_t m,
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4047,8 +4021,7 @@ cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4063,8 +4036,7 @@ cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4144,8 +4116,7 @@ cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right
 cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4160,8 +4131,7 @@ cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4176,8 +4146,7 @@ cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4289,8 +4258,7 @@ cl::sycl::event trmm(backend_selector<backend::netlib> selector, side left_right
 }
 
 cl::sycl::event rotmg(backend_selector<backend::netlib> selector, float *d1, float *d2, float *x1,
-                      float y1, float *param,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      float y1, float *param, const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4360,8 +4328,7 @@ cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4373,8 +4340,7 @@ cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4432,8 +4398,7 @@ cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4443,8 +4408,7 @@ cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);

--- a/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
@@ -2030,7 +2030,7 @@ void symv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int
 cl::sycl::event syr2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2043,7 +2043,7 @@ cl::sycl::event syr2(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event syr2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -2055,7 +2055,7 @@ cl::sycl::event syr2(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n, float alpha,
                      float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2065,7 +2065,7 @@ cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n, double alpha,
                      double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2075,7 +2075,7 @@ cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<float> alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2085,7 +2085,7 @@ cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<double> alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2095,7 +2095,7 @@ cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n, float alpha,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2105,7 +2105,7 @@ cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n, double alpha,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                        dependencies);
@@ -2116,7 +2116,7 @@ cl::sycl::event scal(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2129,7 +2129,7 @@ cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2142,7 +2142,7 @@ cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2155,7 +2155,7 @@ cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmv(selector.get_queue(), upper_lower, trans,
@@ -2167,7 +2167,7 @@ cl::sycl::event trmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2179,7 +2179,7 @@ cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2192,7 +2192,7 @@ cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2205,7 +2205,7 @@ cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2217,7 +2217,7 @@ cl::sycl::event tpmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event spr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2227,7 +2227,7 @@ cl::sycl::event spr(backend_selector<backend::netlib> selector, uplo upper_lower
 
 cl::sycl::event spr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -2239,7 +2239,7 @@ cl::sycl::event hpmv(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2253,7 +2253,7 @@ cl::sycl::event hpmv(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2266,7 +2266,7 @@ cl::sycl::event hpmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk(
@@ -2279,7 +2279,7 @@ cl::sycl::event syrk(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event syrk(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk(
@@ -2293,7 +2293,7 @@ cl::sycl::event syrk(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk(
@@ -2307,7 +2307,7 @@ cl::sycl::event syrk(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk(
@@ -2321,7 +2321,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, float *alpha,
                            const float **a, std::int64_t *lda, float *beta, float **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2336,7 +2336,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo *upp
                            transpose *trans, std::int64_t *n, std::int64_t *k, double *alpha,
                            const double **a, std::int64_t *lda, double *beta, double **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2352,7 +2352,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo *upp
                            std::complex<float> *alpha, const std::complex<float> **a,
                            std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2368,7 +2368,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo *upp
                            std::complex<double> *alpha, const std::complex<double> **a,
                            std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2384,7 +2384,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo uppe
                            const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2400,7 +2400,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo uppe
                            const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2417,7 +2417,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2434,7 +2434,7 @@ cl::sycl::event syrk_batch(backend_selector<backend::netlib> selector, uplo uppe
                            std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syrk_batch(
@@ -2449,7 +2449,7 @@ cl::sycl::event her2(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2463,7 +2463,7 @@ cl::sycl::event her2(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2477,7 +2477,7 @@ cl::sycl::event hbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2492,7 +2492,7 @@ cl::sycl::event hbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2506,7 +2506,7 @@ cl::sycl::event hbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n,
                     std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2517,7 +2517,7 @@ cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n,
                     std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2527,7 +2527,7 @@ cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n, float *x,
                     std::int64_t incx, float *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2537,7 +2537,7 @@ cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n, 
 
 cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n, double *x,
                     std::int64_t incx, double *y, std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                       s, dependencies);
@@ -2547,7 +2547,7 @@ cl::sycl::event rot(backend_selector<backend::netlib> selector, std::int64_t n, 
 
 cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n, float alpha,
                      const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2557,7 +2557,7 @@ cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2568,7 +2568,7 @@ cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2579,7 +2579,7 @@ cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                        incy, dependencies);
@@ -2590,7 +2590,7 @@ cl::sycl::event axpy(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int64_t *n,
                            float *alpha, const float **x, std::int64_t *incx, float **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(
@@ -2603,7 +2603,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int64_t *n,
                            double *alpha, const double **x, std::int64_t *incx, double **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(
@@ -2617,7 +2617,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
                            std::complex<float> *alpha, const std::complex<float> **x,
                            std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(
@@ -2631,7 +2631,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
                            std::complex<double> *alpha, const std::complex<double> **x,
                            std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(
@@ -2644,7 +2644,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int64_t n, float alpha,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2658,7 +2658,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
 cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int64_t n, double alpha,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2673,7 +2673,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
                            std::complex<float> alpha, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2688,7 +2688,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
                            std::complex<double> alpha, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2702,7 +2702,7 @@ cl::sycl::event axpy_batch(backend_selector<backend::netlib> selector, std::int6
 cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n, float alpha,
                       const float *x, std::int64_t incx, const float beta, float *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2713,7 +2713,7 @@ cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n, double alpha,
                       const double *x, std::int64_t incx, const double beta, double *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2724,7 +2724,7 @@ cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n,
                       std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                       const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2735,7 +2735,7 @@ cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n
 cl::sycl::event axpby(backend_selector<backend::netlib> selector, std::int64_t n,
                       std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                       const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                         beta, y, incy, dependencies);
@@ -2747,7 +2747,7 @@ cl::sycl::event gerc(backend_selector<backend::netlib> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2759,7 +2759,7 @@ cl::sycl::event gerc(backend_selector<backend::netlib> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -2770,7 +2770,7 @@ cl::sycl::event gerc(backend_selector<backend::netlib> selector, std::int64_t m,
 cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                       std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                       const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2785,7 +2785,7 @@ cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, double alpha, const double *a,
                       std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2801,7 +2801,7 @@ cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_low
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2817,7 +2817,7 @@ cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2831,7 +2831,7 @@ cl::sycl::event syr2k(backend_selector<backend::netlib> selector, uplo upper_low
 cl::sycl::event gemv(backend_selector<backend::netlib> selector, transpose trans, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2844,7 +2844,7 @@ cl::sycl::event gemv(backend_selector<backend::netlib> selector, transpose trans
 cl::sycl::event gemv(backend_selector<backend::netlib> selector, transpose trans, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2858,7 +2858,7 @@ cl::sycl::event gemv(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2872,7 +2872,7 @@ cl::sycl::event gemv(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2887,7 +2887,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const float *x,
                            std::int64_t incx, std::int64_t stridex, float beta, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(
@@ -2903,7 +2903,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t lda, std::int64_t stridea, const double *x,
                            std::int64_t incx, std::int64_t stridex, double beta, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(
@@ -2920,7 +2920,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(
@@ -2937,7 +2937,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(
@@ -2953,7 +2953,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t *lda, const float **x, std::int64_t *incx, float *beta,
                            float **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2969,7 +2969,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
                            double **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -2986,7 +2986,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3003,7 +3003,7 @@ cl::sycl::event gemv_batch(backend_selector<backend::netlib> selector, transpose
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemv_batch(selector.get_queue(), trans, m, n,
@@ -3019,7 +3019,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side left
                            std::int64_t stridea, const float *x, std::int64_t incx,
                            std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(
@@ -3035,7 +3035,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side left
                            std::int64_t stridea, const double *x, std::int64_t incx,
                            std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(
@@ -3051,7 +3051,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(
@@ -3067,7 +3067,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side left
                            std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(
@@ -3082,7 +3082,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const float **a, std::int64_t *lda,
                            const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3097,7 +3097,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side *lef
                            std::int64_t *m, std::int64_t *n, const double **a, std::int64_t *lda,
                            const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3113,7 +3113,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side *lef
                            std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3129,7 +3129,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side *lef
                            std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n,
@@ -3143,7 +3143,7 @@ cl::sycl::event dgmm_batch(backend_selector<backend::netlib> selector, side *lef
 cl::sycl::event her(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3154,7 +3154,7 @@ cl::sycl::event her(backend_selector<backend::netlib> selector, uplo upper_lower
 cl::sycl::event her(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -3165,7 +3165,7 @@ cl::sycl::event her(backend_selector<backend::netlib> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3176,7 +3176,7 @@ cl::sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower
 cl::sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, dependencies);
@@ -3186,7 +3186,7 @@ cl::sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower
 
 cl::sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3196,7 +3196,7 @@ cl::sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3206,7 +3206,7 @@ cl::sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3216,7 +3216,7 @@ cl::sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3229,7 +3229,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            float *alpha, const float **a, std::int64_t *lda, const float **b,
                            std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3245,7 +3245,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            double *alpha, const double **a, std::int64_t *lda, const double **b,
                            std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3262,7 +3262,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3279,7 +3279,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3295,7 +3295,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            half *alpha, const half **a, std::int64_t *lda, const half **b,
                            std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3312,7 +3312,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3329,7 +3329,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3347,7 +3347,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3365,7 +3365,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3382,7 +3382,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
                            const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
                            half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_batch(
@@ -3396,7 +3396,7 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
 cl::sycl::event spmv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, const float *x, std::int64_t incx, float beta,
                      float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3409,7 +3409,7 @@ cl::sycl::event spmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event spmv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, const double *x, std::int64_t incx, double beta,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3421,7 +3421,7 @@ cl::sycl::event spmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3431,7 +3431,7 @@ cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3442,7 +3442,7 @@ cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3453,7 +3453,7 @@ cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event swap(backend_selector<backend::netlib> selector, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -3465,7 +3465,7 @@ cl::sycl::event geru(backend_selector<backend::netlib> selector, std::int64_t m,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3477,7 +3477,7 @@ cl::sycl::event geru(backend_selector<backend::netlib> selector, std::int64_t m,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3487,7 +3487,7 @@ cl::sycl::event geru(backend_selector<backend::netlib> selector, std::int64_t m,
 
 cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3497,7 +3497,7 @@ cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3507,7 +3507,7 @@ cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3517,7 +3517,7 @@ cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event nrm2(backend_selector<backend::netlib> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -3529,7 +3529,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3544,7 +3544,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3560,7 +3560,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3576,7 +3576,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3591,7 +3591,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3606,7 +3606,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
                      std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3621,7 +3621,7 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3637,7 +3637,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::netlib> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_bias(
@@ -3653,7 +3653,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::netlib> selector, transpose 
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_bias(
@@ -3669,7 +3669,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::netlib> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_bias(
@@ -3685,7 +3685,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::netlib> selector, transpose 
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemm_bias(
@@ -3699,7 +3699,7 @@ cl::sycl::event gemm_bias(backend_selector<backend::netlib> selector, transpose 
 cl::sycl::event herk(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a,
                      std::int64_t lda, float beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::herk(
@@ -3712,7 +3712,7 @@ cl::sycl::event herk(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event herk(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
                      std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::herk(
@@ -3725,7 +3725,7 @@ cl::sycl::event herk(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event ger(backend_selector<backend::netlib> selector, std::int64_t m, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, const float *y,
                     std::int64_t incy, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3736,7 +3736,7 @@ cl::sycl::event ger(backend_selector<backend::netlib> selector, std::int64_t m, 
 cl::sycl::event ger(backend_selector<backend::netlib> selector, std::int64_t m, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, const double *y,
                     std::int64_t incy, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y,
                                                       incy, a, lda, dependencies);
@@ -3747,7 +3747,7 @@ cl::sycl::event ger(backend_selector<backend::netlib> selector, std::int64_t m, 
 cl::sycl::event trsm(backend_selector<backend::netlib> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3761,7 +3761,7 @@ cl::sycl::event trsm(backend_selector<backend::netlib> selector, side left_right
 cl::sycl::event trsm(backend_selector<backend::netlib> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3776,7 +3776,7 @@ cl::sycl::event trsm(backend_selector<backend::netlib> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3791,7 +3791,7 @@ cl::sycl::event trsm(backend_selector<backend::netlib> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3807,7 +3807,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side left
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3823,7 +3823,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side left
                            std::int64_t n, double alpha, const double *a, std::int64_t lda,
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3839,7 +3839,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side left
                            std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3856,7 +3856,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side left
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3872,7 +3872,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side *lef
                            std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
                            float **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3888,7 +3888,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side *lef
                            std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
                            double **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3905,7 +3905,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side *lef
                            const std::complex<float> **a, std::int64_t *lda,
                            std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3922,7 +3922,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side *lef
                            const std::complex<double> **a, std::int64_t *lda,
                            std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsm_batch(
@@ -3936,7 +3936,7 @@ cl::sycl::event trsm_batch(backend_selector<backend::netlib> selector, side *lef
 cl::sycl::event dotu(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3947,7 +3947,7 @@ cl::sycl::event dotu(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event dotu(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -3960,7 +3960,7 @@ cl::sycl::event hemm(backend_selector<backend::netlib> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3976,7 +3976,7 @@ cl::sycl::event hemm(backend_selector<backend::netlib> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3990,7 +3990,7 @@ cl::sycl::event hemm(backend_selector<backend::netlib> selector, side left_right
 cl::sycl::event hpr2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4003,7 +4003,7 @@ cl::sycl::event hpr2(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event hpr2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4017,7 +4017,7 @@ cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4032,7 +4032,7 @@ cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans
                      std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4048,7 +4048,7 @@ cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4064,7 +4064,7 @@ cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4078,7 +4078,7 @@ cl::sycl::event gbmv(backend_selector<backend::netlib> selector, transpose trans
 cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbmv(
@@ -4091,7 +4091,7 @@ cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbmv(
@@ -4104,7 +4104,7 @@ cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbmv(
@@ -4117,7 +4117,7 @@ cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbmv(
@@ -4130,7 +4130,7 @@ cl::sycl::event tbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right, uplo upper_lower,
                      std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
                      const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4145,7 +4145,7 @@ cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4161,7 +4161,7 @@ cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4177,7 +4177,7 @@ cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4191,7 +4191,7 @@ cl::sycl::event symm(backend_selector<backend::netlib> selector, side left_right
 cl::sycl::event dotc(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4202,7 +4202,7 @@ cl::sycl::event dotc(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event dotc(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4212,7 +4212,7 @@ cl::sycl::event dotc(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event syr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     float alpha, const float *x, std::int64_t incx, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4222,7 +4222,7 @@ cl::sycl::event syr(backend_selector<backend::netlib> selector, uplo upper_lower
 
 cl::sycl::event syr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                     double alpha, const double *x, std::int64_t incx, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                       x, incx, a, lda, dependencies);
@@ -4233,7 +4233,7 @@ cl::sycl::event syr(backend_selector<backend::netlib> selector, uplo upper_lower
 cl::sycl::event trmm(backend_selector<backend::netlib> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
                      const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4247,7 +4247,7 @@ cl::sycl::event trmm(backend_selector<backend::netlib> selector, side left_right
 cl::sycl::event trmm(backend_selector<backend::netlib> selector, side left_right, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4262,7 +4262,7 @@ cl::sycl::event trmm(backend_selector<backend::netlib> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4277,7 +4277,7 @@ cl::sycl::event trmm(backend_selector<backend::netlib> selector, side left_right
                      transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4290,7 +4290,7 @@ cl::sycl::event trmm(backend_selector<backend::netlib> selector, side left_right
 
 cl::sycl::event rotmg(backend_selector<backend::netlib> selector, float *d1, float *d2, float *x1,
                       float y1, float *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4300,7 +4300,7 @@ cl::sycl::event rotmg(backend_selector<backend::netlib> selector, float *d1, flo
 
 cl::sycl::event rotmg(backend_selector<backend::netlib> selector, double *d1, double *d2,
                       double *x1, double y1, double *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param,
                                                         dependencies);
@@ -4310,7 +4310,7 @@ cl::sycl::event rotmg(backend_selector<backend::netlib> selector, double *d1, do
 
 cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4322,7 +4322,7 @@ cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4335,7 +4335,7 @@ cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4348,7 +4348,7 @@ cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4361,7 +4361,7 @@ cl::sycl::event tpsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4374,7 +4374,7 @@ cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4387,7 +4387,7 @@ cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4400,7 +4400,7 @@ cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::trsv(selector.get_queue(), upper_lower, trans,
@@ -4412,7 +4412,7 @@ cl::sycl::event trsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4422,7 +4422,7 @@ cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4433,7 +4433,7 @@ cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4444,7 +4444,7 @@ cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                        dependencies);
@@ -4455,7 +4455,7 @@ cl::sycl::event copy(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int64_t *n,
                            const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4468,7 +4468,7 @@ cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int64_t *n,
                            const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4482,7 +4482,7 @@ cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int6
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4496,7 +4496,7 @@ cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int6
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4509,7 +4509,7 @@ cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int64_t n,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4522,7 +4522,7 @@ cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int6
 cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int64_t n,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4536,7 +4536,7 @@ cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int6
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4550,7 +4550,7 @@ cl::sycl::event copy_batch(backend_selector<backend::netlib> selector, std::int6
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::copy_batch(
@@ -4564,7 +4564,7 @@ cl::sycl::event hemv(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hemv(
@@ -4578,7 +4578,7 @@ cl::sycl::event hemv(backend_selector<backend::netlib> selector, uplo upper_lowe
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::hemv(
@@ -4592,7 +4592,7 @@ cl::sycl::event gemmt(backend_selector<backend::netlib> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4607,7 +4607,7 @@ cl::sycl::event gemmt(backend_selector<backend::netlib> selector, uplo upper_low
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       double alpha, const double *a, std::int64_t lda, const double *b,
                       std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4623,7 +4623,7 @@ cl::sycl::event gemmt(backend_selector<backend::netlib> selector, uplo upper_low
                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                       const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4639,7 +4639,7 @@ cl::sycl::event gemmt(backend_selector<backend::netlib> selector, uplo upper_low
                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4653,7 +4653,7 @@ cl::sycl::event gemmt(backend_selector<backend::netlib> selector, uplo upper_low
 cl::sycl::event sbmv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4667,7 +4667,7 @@ cl::sycl::event sbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event sbmv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      std::int64_t k, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4680,7 +4680,7 @@ cl::sycl::event sbmv(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4690,7 +4690,7 @@ cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4700,7 +4700,7 @@ cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n, const float *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4710,7 +4710,7 @@ cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n, const double *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                        dependencies);
@@ -4721,7 +4721,7 @@ cl::sycl::event asum(backend_selector<backend::netlib> selector, std::int64_t n,
 cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbsv(
@@ -4734,7 +4734,7 @@ cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbsv(
@@ -4747,7 +4747,7 @@ cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbsv(
@@ -4760,7 +4760,7 @@ cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lower, transpose trans,
                      diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::tbsv(
@@ -4773,7 +4773,7 @@ cl::sycl::event tbsv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4786,7 +4786,7 @@ cl::sycl::event spr2(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event spr2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, const double *y,
                      std::int64_t incy, double *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4798,7 +4798,7 @@ cl::sycl::event spr2(backend_selector<backend::netlib> selector, uplo upper_lowe
 
 cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n, const float *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4808,7 +4808,7 @@ cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n, const double *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4818,7 +4818,7 @@ cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4828,7 +4828,7 @@ cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4838,7 +4838,7 @@ cl::sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n
 
 cl::sycl::event rotm(backend_selector<backend::netlib> selector, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4848,7 +4848,7 @@ cl::sycl::event rotm(backend_selector<backend::netlib> selector, std::int64_t n,
 
 cl::sycl::event rotm(backend_selector<backend::netlib> selector, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                        param, dependencies);
@@ -4857,7 +4857,7 @@ cl::sycl::event rotm(backend_selector<backend::netlib> selector, std::int64_t n,
 }
 
 cl::sycl::event rotg(backend_selector<backend::netlib> selector, float *a, float *b, float *c,
-                     float *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::netlib::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4866,7 +4866,7 @@ cl::sycl::event rotg(backend_selector<backend::netlib> selector, float *a, float
 }
 
 cl::sycl::event rotg(backend_selector<backend::netlib> selector, double *a, double *b, double *c,
-                     double *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *s, const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::netlib::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4876,7 +4876,7 @@ cl::sycl::event rotg(backend_selector<backend::netlib> selector, double *a, doub
 
 cl::sycl::event rotg(backend_selector<backend::netlib> selector, std::complex<float> *a,
                      std::complex<float> *b, float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::netlib::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4886,7 +4886,7 @@ cl::sycl::event rotg(backend_selector<backend::netlib> selector, std::complex<fl
 
 cl::sycl::event rotg(backend_selector<backend::netlib> selector, std::complex<double> *a,
                      std::complex<double> *b, double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::netlib::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4896,7 +4896,7 @@ cl::sycl::event rotg(backend_selector<backend::netlib> selector, std::complex<do
 
 cl::sycl::event sdsdot(backend_selector<backend::netlib> selector, std::int64_t n, float sb,
                        const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                       float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       float *result, const std::vector<cl::sycl::event> &dependencies) {
     sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y,
                                                          incy, result, dependencies);
@@ -4908,7 +4908,7 @@ cl::sycl::event her2k(backend_selector<backend::netlib> selector, uplo upper_low
                       std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4924,7 +4924,7 @@ cl::sycl::event her2k(backend_selector<backend::netlib> selector, uplo upper_low
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, double beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4937,7 +4937,7 @@ cl::sycl::event her2k(backend_selector<backend::netlib> selector, uplo upper_low
 
 cl::sycl::event dot(backend_selector<backend::netlib> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4947,7 +4947,7 @@ cl::sycl::event dot(backend_selector<backend::netlib> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::netlib> selector, std::int64_t n, const double *x,
                     std::int64_t incx, const double *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4957,7 +4957,7 @@ cl::sycl::event dot(backend_selector<backend::netlib> selector, std::int64_t n, 
 
 cl::sycl::event dot(backend_selector<backend::netlib> selector, std::int64_t n, const float *x,
                     std::int64_t incx, const float *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                       result, dependencies);
@@ -4968,7 +4968,7 @@ cl::sycl::event dot(backend_selector<backend::netlib> selector, std::int64_t n, 
 cl::sycl::event symv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::symv(
@@ -4981,7 +4981,7 @@ cl::sycl::event symv(backend_selector<backend::netlib> selector, uplo upper_lowe
 cl::sycl::event symv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::netlib::MAJOR::symv(

--- a/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
@@ -1065,309 +1065,363 @@ ONEMKL_EXPORT void gemm_bias(cl::sycl::queue &queue, oneapi::mkl::transpose tran
 
 // USM APIs
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                   oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                                   std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                                   const float *b, std::int64_t ldb, float beta, float *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                   oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                                   std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                                   const double *b, std::int64_t ldb, double beta, double *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
-    std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                   oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                                   std::int64_t k, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
-    std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                   oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                                   std::int64_t k, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *b, std::int64_t ldb,
+                                   std::complex<double> beta, std::complex<double> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-    const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                   oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                                   std::int64_t k, half alpha, const half *a, std::int64_t lda,
+                                   const half *b, std::int64_t ldb, half beta, half *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
-    const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                   oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                                   std::int64_t k, float alpha, const half *a, std::int64_t lda,
+                                   const half *b, std::int64_t ldb, float beta, float *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
-    std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                   oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                                   std::int64_t k, float alpha, const bfloat16 *a, std::int64_t lda,
+                                   const bfloat16 *b, std::int64_t ldb, float beta, float *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-    const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::uint8_t *b, std::int64_t ldb,
-    std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_bias(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                        oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc,
+                                        std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                                        const std::int8_t *a, std::int64_t lda, std::int8_t ao,
+                                        const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
+                                        float beta, std::int32_t *c, std::int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-    const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::int8_t *b, std::int64_t ldb,
-    std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_bias(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                        oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc,
+                                        std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                                        const std::int8_t *a, std::int64_t lda, std::int8_t ao,
+                                        const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
+                                        float beta, std::int32_t *c, std::int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-    const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::int8_t *b,
-    std::int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-    const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_bias(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                        oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc,
+                                        std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                                        const std::uint8_t *a, std::int64_t lda, std::uint8_t ao,
+                                        const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
+                                        float beta, std::int32_t *c, std::int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_bias(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-    const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::uint8_t *b,
-    std::int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-    const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_bias(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                        oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc,
+                                        std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                                        const std::uint8_t *a, std::int64_t lda, std::uint8_t ao,
+                                        const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
+                                        float beta, std::int32_t *c, std::int64_t ldc,
+                                        const std::int32_t *co,
+                                        const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b,
-    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   float alpha, const float *a, std::int64_t lda, const float *b,
+                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-    const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   double alpha, const double *a, std::int64_t lda, const double *b,
+                                   std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *b,
+                                   std::int64_t ldb, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hemm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
+                                   std::complex<float> beta, std::complex<float> *c,
+                                   std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hemm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *b,
+                                   std::int64_t ldb, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
-    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                   float alpha, const float *a, std::int64_t lda, float beta,
+                                   float *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta,
-    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                   double alpha, const double *a, std::int64_t lda, double beta,
+                                   double *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> beta,
+                                   std::complex<float> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> beta,
+                                   std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
-    std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, float *beta,
-    float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                                         oneapi::mkl::transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, float *alpha, const float **a,
+                                         std::int64_t *lda, float *beta, float **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
-    std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
-    double *beta, double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                                         oneapi::mkl::transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, double *alpha, const double **a,
+                                         std::int64_t *lda, double *beta, double **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
-    std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
-    std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                                         oneapi::mkl::transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, std::complex<float> *alpha,
+                                         const std::complex<float> **a, std::int64_t *lda,
+                                         std::complex<float> *beta, std::complex<float> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
-    std::int64_t *n, std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
-    std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                                         oneapi::mkl::transpose *trans, std::int64_t *n,
+                                         std::int64_t *k, std::complex<double> *alpha,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         std::complex<double> *beta, std::complex<double> **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    std::int64_t stride_a, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                         oneapi::mkl::transpose trans, std::int64_t n,
+                                         std::int64_t k, float alpha, const float *a,
+                                         std::int64_t lda, std::int64_t stride_a, float beta,
+                                         float *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    std::int64_t stride_a, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                         oneapi::mkl::transpose trans, std::int64_t n,
+                                         std::int64_t k, double alpha, const double *a,
+                                         std::int64_t lda, std::int64_t stride_a, double beta,
+                                         double *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
-    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                         oneapi::mkl::transpose trans, std::int64_t n,
+                                         std::int64_t k, std::complex<float> alpha,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<float> beta,
+                                         std::complex<float> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syrk_batch(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
-    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syrk_batch(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                         oneapi::mkl::transpose trans, std::int64_t n,
+                                         std::int64_t k, std::complex<double> alpha,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stride_a, std::complex<double> beta,
+                                         std::complex<double> *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event herk(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
-    float beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event herk(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                   float alpha, const std::complex<float> *a, std::int64_t lda,
+                                   float beta, std::complex<float> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event herk(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda,
-    double beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event herk(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                   double alpha, const std::complex<double> *a, std::int64_t lda,
+                                   double beta, std::complex<double> *c, std::int64_t ldc,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
-    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                    float alpha, const float *a, std::int64_t lda, const float *b,
+                                    std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                    double alpha, const double *a, std::int64_t lda,
+                                    const double *b, std::int64_t ldb, double beta, double *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<float> alpha, const std::complex<float> *a,
+                                    std::int64_t lda, const std::complex<float> *b,
+                                    std::int64_t ldb, std::complex<float> beta,
+                                    std::complex<float> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2k(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2k(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<double> alpha, const std::complex<double> *a,
+                                    std::int64_t lda, const std::complex<double> *b,
+                                    std::int64_t ldb, std::complex<double> beta,
+                                    std::complex<double> *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event her2k(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
-    std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2k(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<float> alpha, const std::complex<float> *a,
+                                    std::int64_t lda, const std::complex<float> *b,
+                                    std::int64_t ldb, float beta, std::complex<float> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event her2k(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, double beta,
-    std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2k(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                                    std::complex<double> alpha, const std::complex<double> *a,
+                                    std::int64_t lda, const std::complex<double> *b,
+                                    std::int64_t ldb, double beta, std::complex<double> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trmm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   float alpha, const float *a, std::int64_t lda, float *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trmm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   double alpha, const double *a, std::int64_t lda, double *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trmm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trmm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trmm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   float alpha, const float *a, std::int64_t lda, float *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   double alpha, const double *a, std::int64_t lda, double *b,
+                                   std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *b, std::int64_t ldb,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                   oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                                   oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, std::int64_t stride_a, float *b,
-    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                         oneapi::mkl::uplo upper_lower,
+                                         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                         std::int64_t m, std::int64_t n, float alpha,
+                                         const float *a, std::int64_t lda, std::int64_t stride_a,
+                                         float *b, std::int64_t ldb, std::int64_t stride_b,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-    oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, std::int64_t stride_a, double *b,
-    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                         oneapi::mkl::uplo upper_lower,
+                                         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                         std::int64_t m, std::int64_t n, double alpha,
+                                         const double *a, std::int64_t lda, std::int64_t stride_a,
+                                         double *b, std::int64_t ldb, std::int64_t stride_b,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -1383,19 +1437,23 @@ ONEMKL_EXPORT cl::sycl::event trsm_batch(
     std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
-    oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
-    float *alpha, const float **a, std::int64_t *lda, float **b, std::int64_t *ldb,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(cl::sycl::queue &queue, oneapi::mkl::side *left_right,
+                                         oneapi::mkl::uplo *upper_lower,
+                                         oneapi::mkl::transpose *trans,
+                                         oneapi::mkl::diag *unit_diag, std::int64_t *m,
+                                         std::int64_t *n, float *alpha, const float **a,
+                                         std::int64_t *lda, float **b, std::int64_t *ldb,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event trsm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
-    oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
-    double *alpha, const double **a, std::int64_t *lda, double **b, std::int64_t *ldb,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event trsm_batch(cl::sycl::queue &queue, oneapi::mkl::side *left_right,
+                                         oneapi::mkl::uplo *upper_lower,
+                                         oneapi::mkl::transpose *trans,
+                                         oneapi::mkl::diag *unit_diag, std::int64_t *m,
+                                         std::int64_t *n, double *alpha, const double **a,
+                                         std::int64_t *lda, double **b, std::int64_t *ldb,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
@@ -1411,44 +1469,49 @@ ONEMKL_EXPORT cl::sycl::event trsm_batch(
     std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
     const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, float alpha, const float *a,
+                                   std::int64_t lda, const float *x, std::int64_t incx, float beta,
+                                   float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
-    double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, double alpha, const double *a,
+                                   std::int64_t lda, const double *x, std::int64_t incx,
+                                   double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    float alpha, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
-    std::int64_t incx, std::int64_t stridex, float beta, float *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                         std::int64_t m, std::int64_t n, float alpha,
+                                         const float *a, std::int64_t lda, std::int64_t stridea,
+                                         const float *x, std::int64_t incx, std::int64_t stridex,
+                                         float beta, float *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    double alpha, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
-    std::int64_t incx, std::int64_t stridex, double beta, double *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                         std::int64_t m, std::int64_t n, double alpha,
+                                         const double *a, std::int64_t lda, std::int64_t stridea,
+                                         const double *x, std::int64_t incx, std::int64_t stridex,
+                                         double beta, double *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -1464,24 +1527,30 @@ ONEMKL_EXPORT cl::sycl::event gemv_batch(
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
-    float *alpha, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
-    float *beta, float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *trans,
+                                         std::int64_t *m, std::int64_t *n, float *alpha,
+                                         const float **a, std::int64_t *lda, const float **x,
+                                         std::int64_t *incx, float *beta, float **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
-    double *alpha, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
-    double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *trans,
+                                         std::int64_t *m, std::int64_t *n, double *alpha,
+                                         const double **a, std::int64_t *lda, const double **x,
+                                         std::int64_t *incx, double *beta, double **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemv_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
-    std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
-    std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemv_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *trans,
+                                         std::int64_t *m, std::int64_t *n,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         std::int64_t *lda, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> *beta,
+                                         std::complex<float> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
@@ -1490,81 +1559,97 @@ ONEMKL_EXPORT cl::sycl::event gemv_batch(
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
     std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
-    const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
-    std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                         std::int64_t m, std::int64_t n, const float *a,
+                                         std::int64_t lda, std::int64_t stridea, const float *x,
+                                         std::int64_t incx, std::int64_t stridex, float *c,
+                                         std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
-    const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                         std::int64_t m, std::int64_t n, const double *a,
+                                         std::int64_t lda, std::int64_t stridea, const double *x,
+                                         std::int64_t incx, std::int64_t stridex, double *c,
+                                         std::int64_t ldc, std::int64_t stridec,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
-    const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                         std::int64_t m, std::int64_t n,
+                                         const std::complex<float> *a, std::int64_t lda,
+                                         std::int64_t stridea, const std::complex<float> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<float> *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
-    const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
-    std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side left_right,
+                                         std::int64_t m, std::int64_t n,
+                                         const std::complex<double> *a, std::int64_t lda,
+                                         std::int64_t stridea, const std::complex<double> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<double> *c, std::int64_t ldc,
+                                         std::int64_t stridec, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
-    const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side *left_right,
+                                         std::int64_t *m, std::int64_t *n, const float **a,
+                                         std::int64_t *lda, const float **x, std::int64_t *incx,
+                                         float **c, std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
-    const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side *left_right,
+                                         std::int64_t *m, std::int64_t *n, const double **a,
+                                         std::int64_t *lda, const double **x, std::int64_t *incx,
+                                         double **c, std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
-    const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
-    std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side *left_right,
+                                         std::int64_t *m, std::int64_t *n,
+                                         const std::complex<float> **a, std::int64_t *lda,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event dgmm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
-    const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
-    std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event dgmm_batch(cl::sycl::queue &queue, oneapi::mkl::side *left_right,
+                                         std::int64_t *m, std::int64_t *n,
+                                         const std::complex<double> **a, std::int64_t *lda,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda, const float *x,
-    std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   float alpha, const float *a, std::int64_t lda, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
-    const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   double alpha, const double *a, std::int64_t lda, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
-    std::int64_t lda, const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   std::complex<float> alpha, const std::complex<float> *a,
+                                   std::int64_t lda, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gbmv(
-    cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-    std::int64_t kl, std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
-    std::int64_t lda, const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gbmv(cl::sycl::queue &queue, oneapi::mkl::transpose trans,
+                                   std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                   std::complex<double> alpha, const std::complex<double> *a,
+                                   std::int64_t lda, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                                   float alpha, const float *x, std::int64_t incx, const float *y,
@@ -1576,57 +1661,61 @@ ONEMKL_EXPORT cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::i
                                   std::int64_t incy, double *a, std::int64_t lda,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gerc(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, const std::complex<float> *y,
+                                   std::int64_t incy, std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gerc(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, const std::complex<double> *y,
+                                   std::int64_t incy, std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event geru(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-    const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-    std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, const std::complex<float> *y,
+                                   std::int64_t incy, std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event geru(
-    cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-    std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, const std::complex<double> *y,
+                                   std::int64_t incy, std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hemv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-    const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, std::int64_t lda,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> beta, std::complex<float> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hemv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hemv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, std::int64_t lda,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> beta, std::complex<double> *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const std::complex<float> *x,
@@ -1638,29 +1727,33 @@ ONEMKL_EXPORT cl::sycl::event her(cl::sycl::queue &queue, oneapi::mkl::uplo uppe
                                   std::int64_t incx, std::complex<double> *a, std::int64_t lda,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event her2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event her2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event her2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hpmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
-    std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *a, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> beta,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hpmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
-    std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *a, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> beta,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const std::complex<float> *x,
@@ -1672,38 +1765,43 @@ ONEMKL_EXPORT cl::sycl::event hpr(cl::sycl::queue &queue, oneapi::mkl::uplo uppe
                                   std::int64_t incx, std::complex<double> *a,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hpr2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpr2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<float> alpha,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event hpr2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-    std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event hpr2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::complex<double> alpha,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event sbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-    float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event sbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, float alpha, const float *a,
+                                   std::int64_t lda, const float *x, std::int64_t incx, float beta,
+                                   float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event sbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-    double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
-    double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event sbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, std::int64_t k, double alpha, const double *a,
+                                   std::int64_t lda, const double *x, std::int64_t incx,
+                                   double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-    const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                                   const float *x, std::int64_t incx, float beta, float *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event symv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-    const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event symv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                                   const double *x, std::int64_t incx, double beta, double *y,
+                                   std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
@@ -1715,386 +1813,417 @@ ONEMKL_EXPORT cl::sycl::event syr(cl::sycl::queue &queue, oneapi::mkl::uplo uppe
                                   double *a, std::int64_t lda,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-    const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
+                                   const float *y, std::int64_t incy, float *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event syr2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-    const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event syr2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
+                                   const double *y, std::int64_t incy, double *a, std::int64_t lda,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event spmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-    const float *a, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event spmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *a, const float *x,
+                                   std::int64_t incx, float beta, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event spmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-    const double *a, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event spmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *a, const double *x,
+                                   std::int64_t incx, double beta, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
-                                  float *a,
-                                  const std::vector<cl::sycl::event> &dependencies = {});
+                                  float *a, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
-                                  double *a,
-                                  const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event spr2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-    const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event spr2(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-    const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
-    float *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda,
-    double *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
-    std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
-    std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
-    float *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda,
-    double *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
-    std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tbsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
-    std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event tpsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trmv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
-    std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event trsv(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-    oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
-    std::complex<double> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event dotc(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event dotc(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event dotu(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event dotu(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamax(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event iamin(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event asum(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-    double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
-    std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x, std::int64_t *incx,
-    float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, double *alpha, const double **x, std::int64_t *incx,
-    double **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
-    const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
-    const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
-    std::int64_t incx, std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
-    std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpy_batch(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
-    std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    const float beta, float *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-    const double beta, double *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
-    std::int64_t incx, const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event axpby(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-    const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx, float **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx, double **y,
-    std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const std::complex<float> **x, std::int64_t *incx,
-    std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t *n, const std::complex<double> **x, std::int64_t *incx,
-    std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t stridex,
-    float *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t stridex, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-
-ONEMKL_EXPORT cl::sycl::event copy_batch(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
+                                  double *a, const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event spr2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
+                                   const float *y, std::int64_t incy, float *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event spr2(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
+                                   const double *y, std::int64_t incy, double *a,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
+                                   float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const double *a,
+                                   std::int64_t lda, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<float> *a,
+                                   std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tbsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, std::int64_t k, const std::complex<double> *a,
+                                   std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const float *a, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const double *a, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const float *a, float *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const double *a, double *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event tpsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const float *a, std::int64_t lda, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const double *a, std::int64_t lda, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trmv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const float *a, std::int64_t lda, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const double *a, std::int64_t lda, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<float> *a, std::int64_t lda,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event trsv(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                   oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag,
+                                   std::int64_t n, const std::complex<double> *a, std::int64_t lda,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   const std::complex<float> *y, std::int64_t incy,
+                                   std::complex<float> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   const std::complex<double> *y, std::int64_t incy,
+                                   std::complex<double> *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<double> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                    std::int64_t incx, std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<float> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n,
+                                    const std::complex<double> *x, std::int64_t incx,
+                                    std::int64_t *result,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                   std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                   std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                   const float *x, std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                   const double *x, std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<float> alpha, const std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<double> alpha, const std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, float *alpha,
+                                         const float **x, std::int64_t *incx, float **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n, double *alpha,
+                                         const double **x, std::int64_t *incx, double **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         std::complex<float> *alpha, const std::complex<float> **x,
+                                         std::int64_t *incx, std::complex<float> **y,
+                                         std::int64_t *incy, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         std::complex<double> *alpha,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                         const float *x, std::int64_t incx, std::int64_t stridex,
+                                         float *y, std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                         const double *x, std::int64_t incx, std::int64_t stridex,
+                                         double *y, std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         std::complex<float> alpha, const std::complex<float> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<float> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         std::complex<double> alpha, const std::complex<double> *x,
+                                         std::int64_t incx, std::int64_t stridex,
+                                         std::complex<double> *y, std::int64_t incy,
+                                         std::int64_t stridey, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                    const float *x, std::int64_t incx, const float beta, float *y,
+                                    std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                    const double *x, std::int64_t incx, const double beta,
+                                    double *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n,
+                                    std::complex<float> alpha, const std::complex<float> *x,
+                                    std::int64_t incx, const std::complex<float> beta,
+                                    std::complex<float> *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n,
+                                    std::complex<double> alpha, const std::complex<double> *x,
+                                    std::int64_t incx, const std::complex<double> beta,
+                                    std::complex<double> *y, std::int64_t incy,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                   std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                   std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx,
+                                   std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx,
+                                   std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const float **x,
+                                         std::int64_t *incx, float **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n, const double **x,
+                                         std::int64_t *incx, double **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         const std::complex<float> **x, std::int64_t *incx,
+                                         std::complex<float> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t *n,
+                                         const std::complex<double> **x, std::int64_t *incx,
+                                         std::complex<double> **y, std::int64_t *incy,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                         std::int64_t incx, std::int64_t stridex, float *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                         std::int64_t incx, std::int64_t stridex, double *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         const std::complex<float> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<float> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
+
+ONEMKL_EXPORT cl::sycl::event copy_batch(cl::sycl::queue &queue, std::int64_t n,
+                                         const std::complex<double> *x, std::int64_t incx,
+                                         std::int64_t stridex, std::complex<double> *y,
+                                         std::int64_t incy, std::int64_t stridey,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                   std::int64_t incx, const float *y, std::int64_t incy,
@@ -2106,31 +2235,31 @@ ONEMKL_EXPORT cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const 
                                   double *result,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event sdsdot(
-    cl::sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
-    const float *y, std::int64_t incy, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event sdsdot(cl::sycl::queue &queue, std::int64_t n, float sb,
+                                     const float *x, std::int64_t incx, const float *y,
+                                     std::int64_t incy, float *result,
+                                     const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                   std::int64_t incx, const float *y, std::int64_t incy,
                                   double *result,
                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<float> *x, std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n,
+                                   const std::complex<double> *x, std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const float *x,
+                                   std::int64_t incx, float *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event nrm2(
-    cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const double *x,
+                                   std::int64_t incx, double *result,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                                   std::int64_t incx, std::complex<float> *y, std::int64_t incy,
@@ -2148,106 +2277,108 @@ ONEMKL_EXPORT cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, float 
 
 ONEMKL_EXPORT cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, double *x,
                                   std::int64_t incx, double *y, std::int64_t incy, double c,
-                                  double s,
-                                  const std::vector<cl::sycl::event> &dependencies = {});
+                                  double s, const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotg(
-    cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotg(
-    cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c,
+                                   double *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotg(
-    cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
-    std::complex<float> *s, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a,
+                                   std::complex<float> *b, float *c, std::complex<float> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotg(
-    cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
-    std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a,
+                                   std::complex<double> *b, double *c, std::complex<double> *s,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotm(
-    cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-    std::int64_t incy, float *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                   std::int64_t incx, float *y, std::int64_t incy, float *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotm(
-    cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-    std::int64_t incy, double *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                   std::int64_t incx, double *y, std::int64_t incy, double *param,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotmg(
-    cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1,
+                                    float y1, float *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event rotmg(
-    cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1,
+                                    double y1, double *param,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, std::complex<float> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<float> alpha, std::complex<float> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n,
+                                   std::complex<double> alpha, std::complex<double> *x,
+                                   std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x, std::int64_t incx,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                   std::complex<float> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event scal(
-    cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha,
+                                   std::complex<double> *x, std::int64_t incx,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                   std::int64_t incx, float *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                   std::int64_t incx, double *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
-    std::complex<float> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
+                                   std::int64_t incx, std::complex<float> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event swap(
-    cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
-    std::complex<double> *y, std::int64_t incy,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
+                                   std::int64_t incx, std::complex<double> *y, std::int64_t incy,
+                                   const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
-    std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *transa,
+                                         oneapi::mkl::transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, float *alpha,
+                                         const float **a, std::int64_t *lda, const float **b,
+                                         std::int64_t *ldb, float *beta, float **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
-    std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
-    std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *transa,
+                                         oneapi::mkl::transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, double *alpha,
+                                         const double **a, std::int64_t *lda, const double **b,
+                                         std::int64_t *ldb, double *beta, double **c,
+                                         std::int64_t *ldc, std::int64_t group_count,
+                                         std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<float> *alpha,
-    const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
-    std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *transa,
+                                         oneapi::mkl::transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k,
+                                         std::complex<float> *alpha, const std::complex<float> **a,
+                                         std::int64_t *lda, const std::complex<float> **b,
+                                         std::int64_t *ldb, std::complex<float> *beta,
+                                         std::complex<float> **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
@@ -2257,26 +2388,31 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     std::int64_t group_count, std::int64_t *group_size,
     const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
-    std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
-    std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-    std::int64_t group_count, std::int64_t *group_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *transa,
+                                         oneapi::mkl::transpose *transb, std::int64_t *m,
+                                         std::int64_t *n, std::int64_t *k, half *alpha,
+                                         const half **a, std::int64_t *lda, const half **b,
+                                         std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t group_count, std::int64_t *group_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-    std::int64_t stride_a, const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
-    float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                         oneapi::mkl::transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, float alpha,
+                                         const float *a, std::int64_t lda, std::int64_t stride_a,
+                                         const float *b, std::int64_t ldb, std::int64_t stride_b,
+                                         float beta, float *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-    std::int64_t stride_a, const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
-    double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                         oneapi::mkl::transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, double alpha,
+                                         const double *a, std::int64_t lda, std::int64_t stride_a,
+                                         const double *b, std::int64_t ldb, std::int64_t stride_b,
+                                         double beta, double *c, std::int64_t ldc,
+                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -2294,35 +2430,43 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(
-    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-    std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-    std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-    half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
+                                         oneapi::mkl::transpose transb, std::int64_t m,
+                                         std::int64_t n, std::int64_t k, half alpha, const half *a,
+                                         std::int64_t lda, std::int64_t stride_a, const half *b,
+                                         std::int64_t ldb, std::int64_t stride_b, half beta,
+                                         half *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
+                                         const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
-    oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a,
-    std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                                    std::int64_t n, std::int64_t k, float alpha, const float *a,
+                                    std::int64_t lda, const float *b, std::int64_t ldb, float beta,
+                                    float *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
-    oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha, const double *a,
-    std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                                    std::int64_t n, std::int64_t k, double alpha, const double *a,
+                                    std::int64_t lda, const double *b, std::int64_t ldb,
+                                    double beta, double *c, std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
-    oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
-    const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
-    std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                                    std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                                    const std::complex<float> *a, std::int64_t lda,
+                                    const std::complex<float> *b, std::int64_t ldb,
+                                    std::complex<float> beta, std::complex<float> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemmt(
-    cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
-    oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
-    const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
-    std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemmt(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                                    oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                                    std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                                    const std::complex<double> *a, std::int64_t lda,
+                                    const std::complex<double> *b, std::int64_t ldb,
+                                    std::complex<double> beta, std::complex<double> *c,
+                                    std::int64_t ldc,
+                                    const std::vector<cl::sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
@@ -1069,1177 +1069,1177 @@ ONEMKL_EXPORT cl::sycl::event gemm(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
     std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
     const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
     const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
     std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
     const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::uint8_t *b, std::int64_t ldb,
     std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
     const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::int8_t *b, std::int64_t ldb,
     std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
     const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::int8_t *b,
     std::int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-    const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_bias(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
     const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::uint8_t *b,
     std::int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-    const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b,
     std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
     const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hemm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hemm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
-    float *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta,
-    double *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
     std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda, float *beta,
     float **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
     std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
     double *beta, double **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
     std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
     std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
     std::int64_t *n, std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
     std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     std::int64_t stride_a, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     std::int64_t stride_a, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
     std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk_batch(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
     std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event herk(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
     float beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event herk(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda,
     double beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2k(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
     std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2k(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2k(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2k(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her2k(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
     std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her2k(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, double beta,
     std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *b, std::int64_t ldb,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, std::int64_t stride_a, float *b,
     std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, std::int64_t stride_a, double *b,
     std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
     oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
     oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
     float *alpha, const float **a, std::int64_t *lda, float **b, std::int64_t *ldb,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
     oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
     double *alpha, const double **a, std::int64_t *lda, double **b, std::int64_t *ldb,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
     oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
     std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
     std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
     oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
     std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
     std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
     double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     float alpha, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
     std::int64_t incx, std::int64_t stridex, float beta, float *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     double alpha, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
     std::int64_t incx, std::int64_t stridex, double beta, double *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stridea, const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
     float *alpha, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
     float *beta, float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
     double *alpha, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
     double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
     std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
     std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemv_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
     std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> *beta,
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
     const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
     std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
     const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
     std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
     const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
     const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
     const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
     const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
     const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
     std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dgmm_batch(
     cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
     const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
     std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gbmv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda, const float *x,
     std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gbmv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
     const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gbmv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
     std::int64_t lda, const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gbmv(
     cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
     std::int64_t kl, std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
     std::int64_t lda, const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                                   float alpha, const float *x, std::int64_t incx, const float *y,
                                   std::int64_t incy, float *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                                   double alpha, const double *x, std::int64_t incx, const double *y,
                                   std::int64_t incy, double *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gerc(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gerc(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event geru(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
     const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
     std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event geru(
     cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
     std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hemv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hemv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const std::complex<float> *x,
                                   std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, double alpha, const std::complex<double> *x,
                                   std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event her2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
     std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
     std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const std::complex<float> *x,
                                   std::int64_t incx, std::complex<float> *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, double alpha, const std::complex<double> *x,
                                   std::int64_t incx, std::complex<double> *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpr2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event hpr2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
     std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event sbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
     float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event sbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
     double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
     double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
     const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event symv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
     const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
                                   float *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
                                   double *a, std::int64_t lda,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
     const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syr2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
     const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
     const float *a, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
     const double *a, const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, float alpha, const float *x, std::int64_t incx,
                                   float *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                   std::int64_t n, double alpha, const double *x, std::int64_t incx,
                                   double *a,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
     const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event spr2(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
     const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
-    float *x, std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda,
-    double *x, std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
     std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
     std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
-    float *x, std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda,
-    double *x, std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *x, std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
     std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tbsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
     std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event tpsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trmv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
     std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event trsv(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
     oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
     std::complex<double> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dotc(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dotc(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dotu(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dotu(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamax(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event iamin(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event asum(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-    float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-    double *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
     std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x, std::int64_t *incx,
     float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, double *alpha, const double **x, std::int64_t *incx,
     double **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
     const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
     const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
     std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
     std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
     std::int64_t incx, std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
     std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpy_batch(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
     std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
     const float beta, float *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
     const double beta, double *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
     std::int64_t incx, const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event axpby(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
     const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx, float **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx, double **y,
     std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const std::complex<float> **x, std::int64_t *incx,
     std::complex<float> **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t *n, const std::complex<double> **x, std::int64_t *incx,
     std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-    std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, std::int64_t stridex,
     float *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
     std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
     std::int64_t stridex, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event copy_batch(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
     std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                   std::int64_t incx, const float *y, std::int64_t incy,
                                   float *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                   std::int64_t incx, const double *y, std::int64_t incy,
                                   double *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event sdsdot(
     cl::sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
     const float *y, std::int64_t incy, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                   std::int64_t incx, const float *y, std::int64_t incy,
                                   double *result,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    float *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    double *result, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event nrm2(
     cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                                   std::int64_t incx, std::complex<float> *y, std::int64_t incy,
                                   float c, float s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                                   std::int64_t incx, std::complex<double> *y, std::int64_t incy,
                                   double c, double s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, float *x,
                                   std::int64_t incx, float *y, std::int64_t incy, float c, float s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, double *x,
                                   std::int64_t incx, double *y, std::int64_t incy, double c,
                                   double s,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+                                  const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotg(
     cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotg(
     cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotg(
     cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
-    std::complex<float> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::complex<float> *s, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotg(
     cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
-    std::complex<double> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotm(
     cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
     std::int64_t incy, float *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotm(
     cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
     std::int64_t incy, double *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotmg(
     cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event rotmg(
     cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, std::complex<float> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x, std::int64_t incx,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event scal(
     cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-    std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-    std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
     std::complex<float> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event swap(
     cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
     std::complex<double> *y, std::int64_t incy,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
     std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
     std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
     std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
@@ -2247,7 +2247,7 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
     std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
@@ -2255,28 +2255,28 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **b,
     std::int64_t *ldb, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
     std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
     std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
     std::int64_t group_count, std::int64_t *group_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
     std::int64_t stride_a, const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
     float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
     std::int64_t stride_a, const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
     double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -2284,7 +2284,7 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
     const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
     std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -2292,37 +2292,37 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
     const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(
     cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
     std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
     half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemmt(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
     oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a,
     std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemmt(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
     oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha, const double *a,
     std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemmt(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
     oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
     const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemmt(
     cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
     oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
     const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
     std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies = {});
+    const std::vector<cl::sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/blas/predicates.hxx
+++ b/include/oneapi/mkl/blas/predicates.hxx
@@ -3739,8 +3739,7 @@ inline void herk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 }
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
-                              std::int64_t incx,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3755,8 +3754,7 @@ inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, float alp
 }
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
-                              std::int64_t incx,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3908,8 +3906,7 @@ inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 
 inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const float *a, float *x,
-                              std::int64_t incx,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3926,8 +3923,7 @@ inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 
 inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const double *a, double *x,
-                              std::int64_t incx,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4601,8 +4597,7 @@ inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, std::comple
 
 inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                               std::int64_t incx, std::complex<float> *y, std::int64_t incy, float c,
-                              float s,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              float s, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4610,8 +4605,7 @@ inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 
 inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                              std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                             double c, double s,
-                             const std::vector<cl::sycl::event> &dependencies) {
+                             double c, double s, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5095,8 +5089,7 @@ inline void syr2k_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
 inline void gemv_precondition(cl::sycl::queue &queue, transpose trans, std::int64_t m,
                               std::int64_t n, float alpha, const float *a, std::int64_t lda,
                               const float *x, std::int64_t incx, float beta, float *y,
-                              std::int64_t incy,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5115,8 +5108,7 @@ inline void gemv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
 inline void gemv_precondition(cl::sycl::queue &queue, transpose trans, std::int64_t m,
                               std::int64_t n, double alpha, const double *a, std::int64_t lda,
                               const double *x, std::int64_t incx, double beta, double *y,
-                              std::int64_t incy,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5760,16 +5752,14 @@ inline void spmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 }
 
 inline void rotmg_precondition(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                               float *param,
-                               const std::vector<cl::sycl::event> &dependencies) {
+                               float *param, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
 }
 
 inline void rotmg_postcondition(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                                float *param,
-                                const std::vector<cl::sycl::event> &dependencies) {
+                                float *param, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6359,8 +6349,7 @@ inline void ger_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int64
 inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               float alpha, const float *a, std::int64_t lda, float *b,
-                              std::int64_t ldb,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6369,8 +6358,7 @@ inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
 inline void trsm_postcondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                float alpha, const float *a, std::int64_t lda, float *b,
-                               std::int64_t ldb,
-                               const std::vector<cl::sycl::event> &dependencies) {
+                               std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6379,8 +6367,7 @@ inline void trsm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
 inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               double alpha, const double *a, std::int64_t lda, double *b,
-                              std::int64_t ldb,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6389,8 +6376,7 @@ inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
 inline void trsm_postcondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                double alpha, const double *a, std::int64_t lda, double *b,
-                               std::int64_t ldb,
-                               const std::vector<cl::sycl::event> &dependencies) {
+                               std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7052,8 +7038,7 @@ inline void syr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 
 inline void syr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const double *x, std::int64_t incx, double *a,
-                              std::int64_t lda,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7062,8 +7047,7 @@ inline void syr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               float alpha, const float *a, std::int64_t lda, float *b,
-                              std::int64_t ldb,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7072,8 +7056,7 @@ inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
 inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                float alpha, const float *a, std::int64_t lda, float *b,
-                               std::int64_t ldb,
-                               const std::vector<cl::sycl::event> &dependencies) {
+                               std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7082,8 +7065,7 @@ inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
 inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               double alpha, const double *a, std::int64_t lda, double *b,
-                              std::int64_t ldb,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7092,8 +7074,7 @@ inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
 inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upper_lower,
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                double alpha, const double *a, std::int64_t lda, double *b,
-                               std::int64_t ldb,
-                               const std::vector<cl::sycl::event> &dependencies) {
+                               std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7177,8 +7158,7 @@ inline void symv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 
 inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const float *a, float *x,
-                              std::int64_t incx,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7195,8 +7175,7 @@ inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 
 inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const double *a, double *x,
-                              std::int64_t incx,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7654,8 +7633,7 @@ inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n,
 inline void sbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               std::int64_t k, float alpha, const float *a, std::int64_t lda,
                               const float *x, std::int64_t incx, float beta, float *y,
-                              std::int64_t incy,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7674,8 +7652,7 @@ inline void sbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void sbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               std::int64_t k, double alpha, const double *a, std::int64_t lda,
                               const double *x, std::int64_t incx, double beta, double *y,
-                              std::int64_t incy,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7833,8 +7810,7 @@ inline void tbsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 
 inline void spr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                              float *a,
-                              const std::vector<cl::sycl::event> &dependencies) {
+                              float *a, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7957,8 +7933,7 @@ inline void sdsdot_precondition(cl::sycl::queue &queue, std::int64_t n, float sb
 
 inline void sdsdot_postcondition(cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
                                  std::int64_t incx, const float *y, std::int64_t incy,
-                                 float *result,
-                                 const std::vector<cl::sycl::event> &dependencies) {
+                                 float *result, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif

--- a/include/oneapi/mkl/blas/predicates.hxx
+++ b/include/oneapi/mkl/blas/predicates.hxx
@@ -3702,7 +3702,7 @@ inline void herk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               std::int64_t n, std::int64_t k, float alpha,
                               const std::complex<float> *a, std::int64_t lda, float beta,
                               std::complex<float> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3712,7 +3712,7 @@ inline void herk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::int64_t n, std::int64_t k, float alpha,
                                const std::complex<float> *a, std::int64_t lda, float beta,
                                std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3722,7 +3722,7 @@ inline void herk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               std::int64_t n, std::int64_t k, double alpha,
                               const std::complex<double> *a, std::int64_t lda, double beta,
                               std::complex<double> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3732,7 +3732,7 @@ inline void herk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::int64_t n, std::int64_t k, double alpha,
                                const std::complex<double> *a, std::int64_t lda, double beta,
                                std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3740,7 +3740,7 @@ inline void herk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
                               std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3748,7 +3748,7 @@ inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, float alph
 
 inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
                                std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3756,7 +3756,7 @@ inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, float alp
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
                               std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3764,7 +3764,7 @@ inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, double alp
 
 inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
                                std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3772,7 +3772,7 @@ inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, double al
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                               std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3780,7 +3780,7 @@ inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 
 inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                                std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3788,7 +3788,7 @@ inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, std::comp
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                               std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3796,7 +3796,7 @@ inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 
 inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                                std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3804,7 +3804,7 @@ inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, std::comp
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, float alpha,
                               std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3812,7 +3812,7 @@ inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, float alph
 
 inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, float alpha,
                                std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3820,7 +3820,7 @@ inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, float alp
 
 inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, double alpha,
                               std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3828,7 +3828,7 @@ inline void scal_precondition(cl::sycl::queue &queue, std::int64_t n, double alp
 
 inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, double alpha,
                                std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3837,7 +3837,7 @@ inline void scal_postcondition(cl::sycl::queue &queue, std::int64_t n, double al
 inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
                               float *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3846,7 +3846,7 @@ inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
                                float *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3855,7 +3855,7 @@ inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
                               double *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3864,7 +3864,7 @@ inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
                                double *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3873,7 +3873,7 @@ inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<float> *a,
                               std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3882,7 +3882,7 @@ inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<float> *a,
                                std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3891,7 +3891,7 @@ inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<double> *a,
                               std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3900,7 +3900,7 @@ inline void trmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<double> *a,
                                std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3909,7 +3909,7 @@ inline void trmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const float *a, float *x,
                               std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3918,7 +3918,7 @@ inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const float *a, float *x,
                                std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3927,7 +3927,7 @@ inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const double *a, double *x,
                               std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3936,7 +3936,7 @@ inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const double *a, double *x,
                                std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3945,7 +3945,7 @@ inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<float> *a,
                               std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3954,7 +3954,7 @@ inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<float> *a,
                                std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3963,7 +3963,7 @@ inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<double> *a,
                               std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3972,7 +3972,7 @@ inline void tpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<double> *a,
                                std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3980,7 +3980,7 @@ inline void tpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 
 inline void spr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                              const float *x, std::int64_t incx, float *a,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -3988,7 +3988,7 @@ inline void spr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 
 inline void spr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const float *x, std::int64_t incx, float *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -3996,7 +3996,7 @@ inline void spr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 
 inline void spr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                              const double *x, std::int64_t incx, double *a,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4004,7 +4004,7 @@ inline void spr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 
 inline void spr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const double *x, std::int64_t incx, double *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4015,7 +4015,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose *transa, t
                                     const float **a, std::int64_t *lda, const float **b,
                                     std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4027,7 +4027,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose *transa, 
                                      const float **b, std::int64_t *ldb, float *beta, float **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4039,7 +4039,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose *transa, t
                                     const double **b, std::int64_t *ldb, double *beta, double **c,
                                     std::int64_t *ldc, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4051,7 +4051,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose *transa, 
                                      const double **b, std::int64_t *ldb, double *beta, double **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4064,7 +4064,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose *transa, t
                                     std::int64_t *ldb, std::complex<float> *beta,
                                     std::complex<float> **c, std::int64_t *ldc,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4077,7 +4077,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose *transa, 
                                      std::int64_t *ldb, std::complex<float> *beta,
                                      std::complex<float> **c, std::int64_t *ldc,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4090,7 +4090,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose *transa, t
                                     std::int64_t *ldb, std::complex<double> *beta,
                                     std::complex<double> **c, std::int64_t *ldc,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4103,7 +4103,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose *transa, 
                                      std::int64_t *ldb, std::complex<double> *beta,
                                      std::complex<double> **c, std::int64_t *ldc,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4114,7 +4114,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose *transa, t
                                     const half **a, std::int64_t *lda, const half **b,
                                     std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4125,7 +4125,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose *transa, 
                                      const half **a, std::int64_t *lda, const half **b,
                                      std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4137,7 +4137,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose transa, tr
                                     const float *b, std::int64_t ldb, std::int64_t stride_b,
                                     float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4149,7 +4149,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose transa, t
                                      const float *b, std::int64_t ldb, std::int64_t stride_b,
                                      float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4161,7 +4161,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose transa, tr
                                     const double *b, std::int64_t ldb, std::int64_t stride_b,
                                     double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4173,7 +4173,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose transa, t
                                      const double *b, std::int64_t ldb, std::int64_t stride_b,
                                      double beta, double *c, std::int64_t ldc,
                                      std::int64_t stride_c, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4184,7 +4184,7 @@ inline void gemm_batch_precondition(
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::int64_t stride_a, const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4195,7 +4195,7 @@ inline void gemm_batch_postcondition(
     std::int64_t k, std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
     std::int64_t stride_a, const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<float> beta, std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4206,7 +4206,7 @@ inline void gemm_batch_precondition(
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stride_a, const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4217,7 +4217,7 @@ inline void gemm_batch_postcondition(
     std::int64_t k, std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stride_a, const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4229,7 +4229,7 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose transa, tr
                                     const half *b, std::int64_t ldb, std::int64_t stride_b,
                                     half beta, half *c, std::int64_t ldc, std::int64_t stride_c,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4241,7 +4241,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose transa, t
                                      const half *b, std::int64_t ldb, std::int64_t stride_b,
                                      half beta, half *c, std::int64_t ldc, std::int64_t stride_c,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4250,7 +4250,7 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose transa, t
 inline void syrk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               std::int64_t n, std::int64_t k, float alpha, const float *a,
                               std::int64_t lda, float beta, float *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4259,7 +4259,7 @@ inline void syrk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void syrk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                std::int64_t n, std::int64_t k, float alpha, const float *a,
                                std::int64_t lda, float beta, float *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4268,7 +4268,7 @@ inline void syrk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void syrk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               std::int64_t n, std::int64_t k, double alpha, const double *a,
                               std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4277,7 +4277,7 @@ inline void syrk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void syrk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                std::int64_t n, std::int64_t k, double alpha, const double *a,
                                std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4287,7 +4287,7 @@ inline void syrk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               std::int64_t n, std::int64_t k, std::complex<float> alpha,
                               const std::complex<float> *a, std::int64_t lda,
                               std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4297,7 +4297,7 @@ inline void syrk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::int64_t n, std::int64_t k, std::complex<float> alpha,
                                const std::complex<float> *a, std::int64_t lda,
                                std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4307,7 +4307,7 @@ inline void syrk_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               std::int64_t n, std::int64_t k, std::complex<double> alpha,
                               const std::complex<double> *a, std::int64_t lda,
                               std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4317,7 +4317,7 @@ inline void syrk_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::int64_t n, std::int64_t k, std::complex<double> alpha,
                                const std::complex<double> *a, std::int64_t lda,
                                std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4327,7 +4327,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo *upper_lower, t
                                     std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
                                     std::int64_t *lda, float *beta, float **c, std::int64_t *ldc,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4338,7 +4338,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo *upper_lower, 
                                      const float **a, std::int64_t *lda, float *beta, float **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4349,7 +4349,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo *upper_lower, t
                                     const double **a, std::int64_t *lda, double *beta, double **c,
                                     std::int64_t *ldc, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4360,7 +4360,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo *upper_lower, 
                                      const double **a, std::int64_t *lda, double *beta, double **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4372,7 +4372,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo *upper_lower, t
                                     std::complex<float> *beta, std::complex<float> **c,
                                     std::int64_t *ldc, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4384,7 +4384,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo *upper_lower, 
                                      std::complex<float> *beta, std::complex<float> **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4396,7 +4396,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo *upper_lower, t
                                     std::complex<double> *beta, std::complex<double> **c,
                                     std::int64_t *ldc, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4408,7 +4408,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo *upper_lower, 
                                      std::complex<double> *beta, std::complex<double> **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4419,7 +4419,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo upper_lower, tr
                                     std::int64_t lda, std::int64_t stride_a, float beta, float *c,
                                     std::int64_t ldc, std::int64_t stride_c,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4430,7 +4430,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo upper_lower, t
                                      std::int64_t lda, std::int64_t stride_a, float beta, float *c,
                                      std::int64_t ldc, std::int64_t stride_c,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4441,7 +4441,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo upper_lower, tr
                                     std::int64_t lda, std::int64_t stride_a, double beta, double *c,
                                     std::int64_t ldc, std::int64_t stride_c,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4452,7 +4452,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo upper_lower, t
                                      std::int64_t lda, std::int64_t stride_a, double beta,
                                      double *c, std::int64_t ldc, std::int64_t stride_c,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4464,7 +4464,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo upper_lower, tr
                                     std::int64_t stride_a, std::complex<float> beta,
                                     std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4476,7 +4476,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo upper_lower, t
                                      std::int64_t stride_a, std::complex<float> beta,
                                      std::complex<float> *c, std::int64_t ldc,
                                      std::int64_t stride_c, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4488,7 +4488,7 @@ inline void syrk_batch_precondition(cl::sycl::queue &queue, uplo upper_lower, tr
                                     std::int64_t stride_a, std::complex<double> beta,
                                     std::complex<double> *c, std::int64_t ldc,
                                     std::int64_t stride_c, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4500,7 +4500,7 @@ inline void syrk_batch_postcondition(cl::sycl::queue &queue, uplo upper_lower, t
                                      std::int64_t stride_a, std::complex<double> beta,
                                      std::complex<double> *c, std::int64_t ldc,
                                      std::int64_t stride_c, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4510,7 +4510,7 @@ inline void her2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<float> alpha, const std::complex<float> *x,
                               std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                               std::complex<float> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4520,7 +4520,7 @@ inline void her2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::complex<float> alpha, const std::complex<float> *x,
                                std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                                std::complex<float> *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4530,7 +4530,7 @@ inline void her2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<double> alpha, const std::complex<double> *x,
                               std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                               std::complex<double> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4540,7 +4540,7 @@ inline void her2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::complex<double> alpha, const std::complex<double> *x,
                                std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                                std::complex<double> *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4551,7 +4551,7 @@ inline void hbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               const std::complex<float> *a, std::int64_t lda,
                               const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4562,7 +4562,7 @@ inline void hbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                const std::complex<float> *a, std::int64_t lda,
                                const std::complex<float> *x, std::int64_t incx,
                                std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4573,7 +4573,7 @@ inline void hbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               const std::complex<double> *a, std::int64_t lda,
                               const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4585,7 +4585,7 @@ inline void hbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                const std::complex<double> *x, std::int64_t incx,
                                std::complex<double> beta, std::complex<double> *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4593,7 +4593,7 @@ inline void hbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 
 inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                              std::int64_t incx, std::complex<float> *y, std::int64_t incy, float c,
-                             float s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             float s, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4602,7 +4602,7 @@ inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, std::comple
 inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                               std::int64_t incx, std::complex<float> *y, std::int64_t incy, float c,
                               float s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4611,7 +4611,7 @@ inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                              std::int64_t incx, std::complex<double> *y, std::int64_t incy,
                              double c, double s,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4620,7 +4620,7 @@ inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, std::comple
 inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                               std::int64_t incx, std::complex<double> *y, std::int64_t incy,
                               double c, double s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4628,7 +4628,7 @@ inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 
 inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
                              float *y, std::int64_t incy, float c, float s,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4636,7 +4636,7 @@ inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, float *x, s
 
 inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
                               float *y, std::int64_t incy, float c, float s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4644,7 +4644,7 @@ inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, float *x, 
 
 inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                              double *y, std::int64_t incy, double c, double s,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4652,7 +4652,7 @@ inline void rot_precondition(cl::sycl::queue &queue, std::int64_t n, double *x, 
 
 inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                               double *y, std::int64_t incy, double c, double s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4660,7 +4660,7 @@ inline void rot_postcondition(cl::sycl::queue &queue, std::int64_t n, double *x,
 
 inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                               std::int64_t incx, float *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4668,7 +4668,7 @@ inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, float alph
 
 inline void axpy_postcondition(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                                std::int64_t incx, float *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4676,7 +4676,7 @@ inline void axpy_postcondition(cl::sycl::queue &queue, std::int64_t n, float alp
 
 inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                               std::int64_t incx, double *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4684,7 +4684,7 @@ inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, double alp
 
 inline void axpy_postcondition(cl::sycl::queue &queue, std::int64_t n, double alpha,
                                const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4693,7 +4693,7 @@ inline void axpy_postcondition(cl::sycl::queue &queue, std::int64_t n, double al
 inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                               const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4702,7 +4702,7 @@ inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 inline void axpy_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                                const std::complex<float> *x, std::int64_t incx,
                                std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4711,7 +4711,7 @@ inline void axpy_postcondition(cl::sycl::queue &queue, std::int64_t n, std::comp
 inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                               const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4720,7 +4720,7 @@ inline void axpy_precondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 inline void axpy_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                                const std::complex<double> *x, std::int64_t incx,
                                std::complex<double> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4730,7 +4730,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n, flo
                                     const float **x, std::int64_t *incx, float **y,
                                     std::int64_t *incy, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4740,7 +4740,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n, fl
                                      const float **x, std::int64_t *incx, float **y,
                                      std::int64_t *incy, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4750,7 +4750,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n, dou
                                     const double **x, std::int64_t *incx, double **y,
                                     std::int64_t *incy, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4760,7 +4760,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n, do
                                      const double **x, std::int64_t *incx, double **y,
                                      std::int64_t *incy, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4770,7 +4770,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n,
                                     std::complex<float> *alpha, const std::complex<float> **x,
                                     std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4781,7 +4781,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n,
                                      std::int64_t *incx, std::complex<float> **y,
                                      std::int64_t *incy, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4792,7 +4792,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n,
                                     std::int64_t *incx, std::complex<double> **y,
                                     std::int64_t *incy, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4803,7 +4803,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n,
                                      std::int64_t *incx, std::complex<double> **y,
                                      std::int64_t *incy, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4813,7 +4813,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t n, floa
                                     const float *x, std::int64_t incx, std::int64_t stridex,
                                     float *y, std::int64_t incy, std::int64_t stridey,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4823,7 +4823,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n, flo
                                      const float *x, std::int64_t incx, std::int64_t stridex,
                                      float *y, std::int64_t incy, std::int64_t stridey,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4833,7 +4833,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t n, doub
                                     const double *x, std::int64_t incx, std::int64_t stridex,
                                     double *y, std::int64_t incy, std::int64_t stridey,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4843,7 +4843,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n, dou
                                      const double *x, std::int64_t incx, std::int64_t stridex,
                                      double *y, std::int64_t incy, std::int64_t stridey,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4854,7 +4854,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t n,
                                     std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                                     std::int64_t incy, std::int64_t stridey,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4865,7 +4865,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                      std::int64_t incx, std::int64_t stridex,
                                      std::complex<float> *y, std::int64_t incy,
                                      std::int64_t stridey, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4876,7 +4876,7 @@ inline void axpy_batch_precondition(cl::sycl::queue &queue, std::int64_t n,
                                     std::int64_t incx, std::int64_t stridex,
                                     std::complex<double> *y, std::int64_t incy,
                                     std::int64_t stridey, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4887,7 +4887,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                      std::int64_t incx, std::int64_t stridex,
                                      std::complex<double> *y, std::int64_t incy,
                                      std::int64_t stridey, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4895,7 +4895,7 @@ inline void axpy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n,
 
 inline void axpby_precondition(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                                std::int64_t incx, const float beta, float *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4903,7 +4903,7 @@ inline void axpby_precondition(cl::sycl::queue &queue, std::int64_t n, float alp
 
 inline void axpby_postcondition(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                                 std::int64_t incx, const float beta, float *y, std::int64_t incy,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4912,7 +4912,7 @@ inline void axpby_postcondition(cl::sycl::queue &queue, std::int64_t n, float al
 inline void axpby_precondition(cl::sycl::queue &queue, std::int64_t n, double alpha,
                                const double *x, std::int64_t incx, const double beta, double *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4921,7 +4921,7 @@ inline void axpby_precondition(cl::sycl::queue &queue, std::int64_t n, double al
 inline void axpby_postcondition(cl::sycl::queue &queue, std::int64_t n, double alpha,
                                 const double *x, std::int64_t incx, const double beta, double *y,
                                 std::int64_t incy,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4931,7 +4931,7 @@ inline void axpby_precondition(cl::sycl::queue &queue, std::int64_t n, std::comp
                                const std::complex<float> *x, std::int64_t incx,
                                const std::complex<float> beta, std::complex<float> *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4941,7 +4941,7 @@ inline void axpby_postcondition(cl::sycl::queue &queue, std::int64_t n, std::com
                                 const std::complex<float> *x, std::int64_t incx,
                                 const std::complex<float> beta, std::complex<float> *y,
                                 std::int64_t incy,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4951,7 +4951,7 @@ inline void axpby_precondition(cl::sycl::queue &queue, std::int64_t n, std::comp
                                const std::complex<double> *x, std::int64_t incx,
                                const std::complex<double> beta, std::complex<double> *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4961,7 +4961,7 @@ inline void axpby_postcondition(cl::sycl::queue &queue, std::int64_t n, std::com
                                 const std::complex<double> *x, std::int64_t incx,
                                 const std::complex<double> beta, std::complex<double> *y,
                                 std::int64_t incy,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4971,7 +4971,7 @@ inline void gerc_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64
                               std::complex<float> alpha, const std::complex<float> *x,
                               std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                               std::complex<float> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -4981,7 +4981,7 @@ inline void gerc_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int6
                                std::complex<float> alpha, const std::complex<float> *x,
                                std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                                std::complex<float> *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -4991,7 +4991,7 @@ inline void gerc_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64
                               std::complex<double> alpha, const std::complex<double> *x,
                               std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                               std::complex<double> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5001,7 +5001,7 @@ inline void gerc_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int6
                                std::complex<double> alpha, const std::complex<double> *x,
                                std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                                std::complex<double> *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5011,7 +5011,7 @@ inline void syr2k_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::int64_t n, std::int64_t k, float alpha, const float *a,
                                std::int64_t lda, const float *b, std::int64_t ldb, float beta,
                                float *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5021,7 +5021,7 @@ inline void syr2k_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 std::int64_t n, std::int64_t k, float alpha, const float *a,
                                 std::int64_t lda, const float *b, std::int64_t ldb, float beta,
                                 float *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5031,7 +5031,7 @@ inline void syr2k_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::int64_t n, std::int64_t k, double alpha, const double *a,
                                std::int64_t lda, const double *b, std::int64_t ldb, double beta,
                                double *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5041,7 +5041,7 @@ inline void syr2k_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 std::int64_t n, std::int64_t k, double alpha, const double *a,
                                 std::int64_t lda, const double *b, std::int64_t ldb, double beta,
                                 double *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5052,7 +5052,7 @@ inline void syr2k_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                const std::complex<float> *a, std::int64_t lda,
                                const std::complex<float> *b, std::int64_t ldb,
                                std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5063,7 +5063,7 @@ inline void syr2k_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 const std::complex<float> *a, std::int64_t lda,
                                 const std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5074,7 +5074,7 @@ inline void syr2k_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                const std::complex<double> *a, std::int64_t lda,
                                const std::complex<double> *b, std::int64_t ldb,
                                std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5086,7 +5086,7 @@ inline void syr2k_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 const std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> beta, std::complex<double> *c,
                                 std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5096,7 +5096,7 @@ inline void gemv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               std::int64_t n, float alpha, const float *a, std::int64_t lda,
                               const float *x, std::int64_t incx, float beta, float *y,
                               std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5106,7 +5106,7 @@ inline void gemv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                std::int64_t n, float alpha, const float *a, std::int64_t lda,
                                const float *x, std::int64_t incx, float beta, float *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5116,7 +5116,7 @@ inline void gemv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               std::int64_t n, double alpha, const double *a, std::int64_t lda,
                               const double *x, std::int64_t incx, double beta, double *y,
                               std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5126,7 +5126,7 @@ inline void gemv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                std::int64_t n, double alpha, const double *a, std::int64_t lda,
                                const double *x, std::int64_t incx, double beta, double *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5137,7 +5137,7 @@ inline void gemv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               const std::complex<float> *a, std::int64_t lda,
                               const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5148,7 +5148,7 @@ inline void gemv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                const std::complex<float> *a, std::int64_t lda,
                                const std::complex<float> *x, std::int64_t incx,
                                std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5159,7 +5159,7 @@ inline void gemv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               const std::complex<double> *a, std::int64_t lda,
                               const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5171,7 +5171,7 @@ inline void gemv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                const std::complex<double> *x, std::int64_t incx,
                                std::complex<double> beta, std::complex<double> *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5182,7 +5182,7 @@ inline void gemv_batch_precondition(cl::sycl::queue &queue, transpose trans, std
                                     std::int64_t stridea, const float *x, std::int64_t incx,
                                     std::int64_t stridex, float beta, float *y, std::int64_t incy,
                                     std::int64_t stridey, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5193,7 +5193,7 @@ inline void gemv_batch_postcondition(cl::sycl::queue &queue, transpose trans, st
                                      std::int64_t stridea, const float *x, std::int64_t incx,
                                      std::int64_t stridex, float beta, float *y, std::int64_t incy,
                                      std::int64_t stridey, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5204,7 +5204,7 @@ inline void gemv_batch_precondition(cl::sycl::queue &queue, transpose trans, std
                                     std::int64_t stridea, const double *x, std::int64_t incx,
                                     std::int64_t stridex, double beta, double *y, std::int64_t incy,
                                     std::int64_t stridey, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5216,7 +5216,7 @@ inline void gemv_batch_postcondition(cl::sycl::queue &queue, transpose trans, st
                                      std::int64_t incx, std::int64_t stridex, double beta,
                                      double *y, std::int64_t incy, std::int64_t stridey,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5227,7 +5227,7 @@ inline void gemv_batch_precondition(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5238,7 +5238,7 @@ inline void gemv_batch_postcondition(
     std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
     const std::complex<float> *x, std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
     std::complex<float> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5249,7 +5249,7 @@ inline void gemv_batch_precondition(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stridea, const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5260,7 +5260,7 @@ inline void gemv_batch_postcondition(
     std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
     std::int64_t stridea, const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
     std::complex<double> beta, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-    std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5271,7 +5271,7 @@ inline void gemv_batch_precondition(cl::sycl::queue &queue, transpose *trans, st
                                     std::int64_t *lda, const float **x, std::int64_t *incx,
                                     float *beta, float **y, std::int64_t *incy,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5282,7 +5282,7 @@ inline void gemv_batch_postcondition(cl::sycl::queue &queue, transpose *trans, s
                                      std::int64_t *lda, const float **x, std::int64_t *incx,
                                      float *beta, float **y, std::int64_t *incy,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5293,7 +5293,7 @@ inline void gemv_batch_precondition(cl::sycl::queue &queue, transpose *trans, st
                                     std::int64_t *lda, const double **x, std::int64_t *incx,
                                     double *beta, double **y, std::int64_t *incy,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5304,7 +5304,7 @@ inline void gemv_batch_postcondition(cl::sycl::queue &queue, transpose *trans, s
                                      std::int64_t *lda, const double **x, std::int64_t *incx,
                                      double *beta, double **y, std::int64_t *incy,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5317,7 +5317,7 @@ inline void gemv_batch_precondition(cl::sycl::queue &queue, transpose *trans, st
                                     std::complex<float> *beta, std::complex<float> **y,
                                     std::int64_t *incy, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5330,7 +5330,7 @@ inline void gemv_batch_postcondition(cl::sycl::queue &queue, transpose *trans, s
                                      std::complex<float> *beta, std::complex<float> **y,
                                      std::int64_t *incy, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5343,7 +5343,7 @@ inline void gemv_batch_precondition(cl::sycl::queue &queue, transpose *trans, st
                                     std::complex<double> *beta, std::complex<double> **y,
                                     std::int64_t *incy, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5356,7 +5356,7 @@ inline void gemv_batch_postcondition(cl::sycl::queue &queue, transpose *trans, s
                                      std::complex<double> *beta, std::complex<double> **y,
                                      std::int64_t *incy, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5367,7 +5367,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side left_right, std
                                     std::int64_t stridea, const float *x, std::int64_t incx,
                                     std::int64_t stridex, float *c, std::int64_t ldc,
                                     std::int64_t stridec, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5378,7 +5378,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side left_right, st
                                      std::int64_t stridea, const float *x, std::int64_t incx,
                                      std::int64_t stridex, float *c, std::int64_t ldc,
                                      std::int64_t stridec, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5389,7 +5389,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side left_right, std
                                     std::int64_t stridea, const double *x, std::int64_t incx,
                                     std::int64_t stridex, double *c, std::int64_t ldc,
                                     std::int64_t stridec, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5400,7 +5400,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side left_right, st
                                      std::int64_t stridea, const double *x, std::int64_t incx,
                                      std::int64_t stridex, double *c, std::int64_t ldc,
                                      std::int64_t stridec, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5411,7 +5411,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side left_right, std
                                     std::int64_t stridea, const std::complex<float> *x,
                                     std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
                                     std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5423,7 +5423,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side left_right, st
                                      std::int64_t incx, std::int64_t stridex,
                                      std::complex<float> *c, std::int64_t ldc, std::int64_t stridec,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5435,7 +5435,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side left_right, std
                                     std::int64_t incx, std::int64_t stridex,
                                     std::complex<double> *c, std::int64_t ldc, std::int64_t stridec,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5448,7 +5448,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side left_right, st
                                      std::int64_t stridex, std::complex<double> *c,
                                      std::int64_t ldc, std::int64_t stridec,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5459,7 +5459,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side *left_right, st
                                     const float **x, std::int64_t *incx, float **c,
                                     std::int64_t *ldc, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5470,7 +5470,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side *left_right, s
                                      const float **x, std::int64_t *incx, float **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5481,7 +5481,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side *left_right, st
                                     const double **x, std::int64_t *incx, double **c,
                                     std::int64_t *ldc, std::int64_t group_count,
                                     std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5492,7 +5492,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side *left_right, s
                                      const double **x, std::int64_t *incx, double **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5503,7 +5503,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side *left_right, st
                                     std::int64_t *lda, const std::complex<float> **x,
                                     std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5514,7 +5514,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side *left_right, s
                                      std::int64_t *lda, const std::complex<float> **x,
                                      std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5525,7 +5525,7 @@ inline void dgmm_batch_precondition(cl::sycl::queue &queue, side *left_right, st
                                     std::int64_t *lda, const std::complex<double> **x,
                                     std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5537,7 +5537,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side *left_right, s
                                      std::int64_t *incx, std::complex<double> **c,
                                      std::int64_t *ldc, std::int64_t group_count,
                                      std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5546,7 +5546,7 @@ inline void dgmm_batch_postcondition(cl::sycl::queue &queue, side *left_right, s
 inline void her_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                              const std::complex<float> *x, std::int64_t incx,
                              std::complex<float> *a, std::int64_t lda,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5555,7 +5555,7 @@ inline void her_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 inline void her_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5564,7 +5564,7 @@ inline void her_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void her_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                              const std::complex<double> *x, std::int64_t incx,
                              std::complex<double> *a, std::int64_t lda,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5573,7 +5573,7 @@ inline void her_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 inline void her_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5582,7 +5582,7 @@ inline void her_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void hpr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                              const std::complex<float> *x, std::int64_t incx,
                              std::complex<float> *a,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5591,7 +5591,7 @@ inline void hpr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 inline void hpr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5600,7 +5600,7 @@ inline void hpr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void hpr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                              const std::complex<double> *x, std::int64_t incx,
                              std::complex<double> *a,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5609,7 +5609,7 @@ inline void hpr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 inline void hpr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5617,7 +5617,7 @@ inline void hpr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 
 inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                std::int64_t incx, std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5625,7 +5625,7 @@ inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n, const flo
 
 inline void iamin_postcondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                 std::int64_t incx, std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5633,7 +5633,7 @@ inline void iamin_postcondition(cl::sycl::queue &queue, std::int64_t n, const fl
 
 inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                std::int64_t incx, std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5641,7 +5641,7 @@ inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n, const dou
 
 inline void iamin_postcondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                 std::int64_t incx, std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5649,7 +5649,7 @@ inline void iamin_postcondition(cl::sycl::queue &queue, std::int64_t n, const do
 
 inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                                std::int64_t incx, std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5658,7 +5658,7 @@ inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n, const std
 inline void iamin_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                 const std::complex<float> *x, std::int64_t incx,
                                 std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5667,7 +5667,7 @@ inline void iamin_postcondition(cl::sycl::queue &queue, std::int64_t n,
 inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n,
                                const std::complex<double> *x, std::int64_t incx,
                                std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5676,7 +5676,7 @@ inline void iamin_precondition(cl::sycl::queue &queue, std::int64_t n,
 inline void iamin_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                 const std::complex<double> *x, std::int64_t incx,
                                 std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5686,7 +5686,7 @@ inline void hpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<float> alpha, const std::complex<float> *a,
                               const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5696,7 +5696,7 @@ inline void hpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::complex<float> alpha, const std::complex<float> *a,
                                const std::complex<float> *x, std::int64_t incx,
                                std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5706,7 +5706,7 @@ inline void hpmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<double> alpha, const std::complex<double> *a,
                               const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5717,7 +5717,7 @@ inline void hpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                const std::complex<double> *x, std::int64_t incx,
                                std::complex<double> beta, std::complex<double> *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5726,7 +5726,7 @@ inline void hpmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void spmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const float *a, const float *x, std::int64_t incx, float beta,
                               float *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5735,7 +5735,7 @@ inline void spmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void spmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                float alpha, const float *a, const float *x, std::int64_t incx,
                                float beta, float *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5744,7 +5744,7 @@ inline void spmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void spmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const double *a, const double *x, std::int64_t incx,
                               double beta, double *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5753,7 +5753,7 @@ inline void spmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void spmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                double alpha, const double *a, const double *x, std::int64_t incx,
                                double beta, double *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5761,7 +5761,7 @@ inline void spmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 
 inline void rotmg_precondition(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
                                float *param,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5769,7 +5769,7 @@ inline void rotmg_precondition(cl::sycl::queue &queue, float *d1, float *d2, flo
 
 inline void rotmg_postcondition(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
                                 float *param,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5777,7 +5777,7 @@ inline void rotmg_postcondition(cl::sycl::queue &queue, float *d1, float *d2, fl
 
 inline void rotmg_precondition(cl::sycl::queue &queue, double *d1, double *d2, double *x1,
                                double y1, double *param,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5785,7 +5785,7 @@ inline void rotmg_precondition(cl::sycl::queue &queue, double *d1, double *d2, d
 
 inline void rotmg_postcondition(cl::sycl::queue &queue, double *d1, double *d2, double *x1,
                                 double y1, double *param,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5793,7 +5793,7 @@ inline void rotmg_postcondition(cl::sycl::queue &queue, double *d1, double *d2, 
 
 inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
                               float *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5801,7 +5801,7 @@ inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, float *x, 
 
 inline void swap_postcondition(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
                                float *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5809,7 +5809,7 @@ inline void swap_postcondition(cl::sycl::queue &queue, std::int64_t n, float *x,
 
 inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                               double *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5817,7 +5817,7 @@ inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, double *x,
 
 inline void swap_postcondition(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                                double *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5825,7 +5825,7 @@ inline void swap_postcondition(cl::sycl::queue &queue, std::int64_t n, double *x
 
 inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                               std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5833,7 +5833,7 @@ inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 
 inline void swap_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                                std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5841,7 +5841,7 @@ inline void swap_postcondition(cl::sycl::queue &queue, std::int64_t n, std::comp
 
 inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                               std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5849,7 +5849,7 @@ inline void swap_precondition(cl::sycl::queue &queue, std::int64_t n, std::compl
 
 inline void swap_postcondition(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                                std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5859,7 +5859,7 @@ inline void geru_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64
                               std::complex<float> alpha, const std::complex<float> *x,
                               std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                               std::complex<float> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5869,7 +5869,7 @@ inline void geru_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int6
                                std::complex<float> alpha, const std::complex<float> *x,
                                std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                                std::complex<float> *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5879,7 +5879,7 @@ inline void geru_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64
                               std::complex<double> alpha, const std::complex<double> *x,
                               std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                               std::complex<double> *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5889,7 +5889,7 @@ inline void geru_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int6
                                std::complex<double> alpha, const std::complex<double> *x,
                                std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                                std::complex<double> *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5897,7 +5897,7 @@ inline void geru_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int6
 
 inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                               std::int64_t incx, float *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5905,7 +5905,7 @@ inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 
 inline void nrm2_postcondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                                std::int64_t incx, float *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5913,7 +5913,7 @@ inline void nrm2_postcondition(cl::sycl::queue &queue, std::int64_t n, const std
 
 inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                               std::int64_t incx, double *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5921,7 +5921,7 @@ inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 
 inline void nrm2_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                const std::complex<double> *x, std::int64_t incx, double *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5929,7 +5929,7 @@ inline void nrm2_postcondition(cl::sycl::queue &queue, std::int64_t n,
 
 inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                               std::int64_t incx, float *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5937,7 +5937,7 @@ inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const floa
 
 inline void nrm2_postcondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                std::int64_t incx, float *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5945,7 +5945,7 @@ inline void nrm2_postcondition(cl::sycl::queue &queue, std::int64_t n, const flo
 
 inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                               std::int64_t incx, double *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5953,7 +5953,7 @@ inline void nrm2_precondition(cl::sycl::queue &queue, std::int64_t n, const doub
 
 inline void nrm2_postcondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                std::int64_t incx, double *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5963,7 +5963,7 @@ inline void gemmt_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                transpose transb, std::int64_t n, std::int64_t k, float alpha,
                                const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
                                float beta, float *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5973,7 +5973,7 @@ inline void gemmt_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 transpose transb, std::int64_t n, std::int64_t k, float alpha,
                                 const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
                                 float beta, float *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -5983,7 +5983,7 @@ inline void gemmt_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                transpose transb, std::int64_t n, std::int64_t k, double alpha,
                                const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                                double beta, double *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -5993,7 +5993,7 @@ inline void gemmt_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 transpose transb, std::int64_t n, std::int64_t k, double alpha,
                                 const double *a, std::int64_t lda, const double *b,
                                 std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6004,7 +6004,7 @@ inline void gemmt_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::complex<float> alpha, const std::complex<float> *a,
                                std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                                std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6015,7 +6015,7 @@ inline void gemmt_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 std::complex<float> alpha, const std::complex<float> *a,
                                 std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6026,7 +6026,7 @@ inline void gemmt_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                std::complex<double> alpha, const std::complex<double> *a,
                                std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                                std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6038,7 +6038,7 @@ inline void gemmt_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> beta, std::complex<double> *c,
                                 std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6048,7 +6048,7 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
                               std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                               const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
                               float beta, float *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6058,7 +6058,7 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
                                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                                const float *a, std::int64_t lda, const float *b, std::int64_t ldb,
                                float beta, float *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6068,7 +6068,7 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
                               std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
                               const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                               double beta, double *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6078,7 +6078,7 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
                                std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
                                const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                                double beta, double *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6089,7 +6089,7 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
                               std::complex<float> alpha, const std::complex<float> *a,
                               std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                               std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6100,7 +6100,7 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
                                std::complex<float> alpha, const std::complex<float> *a,
                                std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                                std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6111,7 +6111,7 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
                               std::complex<double> alpha, const std::complex<double> *a,
                               std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                               std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6122,7 +6122,7 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
                                std::complex<double> alpha, const std::complex<double> *a,
                                std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                                std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6132,7 +6132,7 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
                               std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
                               const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
                               half beta, half *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6142,7 +6142,7 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
                                std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
                                const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
                                half beta, half *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6152,7 +6152,7 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
                               std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                               const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
                               float beta, float *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6162,7 +6162,7 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
                                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                                const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
                                float beta, float *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6172,7 +6172,7 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
                               std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                               const bfloat16 *a, std::int64_t lda, const bfloat16 *b,
                               std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6182,7 +6182,7 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
                                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                                const bfloat16 *a, std::int64_t lda, const bfloat16 *b,
                                std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6194,7 +6194,7 @@ inline void gemm_bias_precondition(cl::sycl::queue &queue, transpose transa, tra
                                    std::int8_t ao, const std::uint8_t *b, std::int64_t ldb,
                                    std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                    const std::int32_t *co,
-                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                   const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6206,7 +6206,7 @@ inline void gemm_bias_postcondition(cl::sycl::queue &queue, transpose transa, tr
                                     std::int8_t ao, const std::uint8_t *b, std::int64_t ldb,
                                     std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                     const std::int32_t *co,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6218,7 +6218,7 @@ inline void gemm_bias_precondition(cl::sycl::queue &queue, transpose transa, tra
                                    std::int8_t ao, const std::int8_t *b, std::int64_t ldb,
                                    std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                    const std::int32_t *co,
-                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                   const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6230,7 +6230,7 @@ inline void gemm_bias_postcondition(cl::sycl::queue &queue, transpose transa, tr
                                     std::int8_t ao, const std::int8_t *b, std::int64_t ldb,
                                     std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                     const std::int32_t *co,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6242,7 +6242,7 @@ inline void gemm_bias_precondition(cl::sycl::queue &queue, transpose transa, tra
                                    std::uint8_t ao, const std::int8_t *b, std::int64_t ldb,
                                    std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                    const std::int32_t *co,
-                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                   const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6254,7 +6254,7 @@ inline void gemm_bias_postcondition(cl::sycl::queue &queue, transpose transa, tr
                                     std::uint8_t ao, const std::int8_t *b, std::int64_t ldb,
                                     std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                     const std::int32_t *co,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6266,7 +6266,7 @@ inline void gemm_bias_precondition(cl::sycl::queue &queue, transpose transa, tra
                                    std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb,
                                    std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                    const std::int32_t *co,
-                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                   const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6278,7 +6278,7 @@ inline void gemm_bias_postcondition(cl::sycl::queue &queue, transpose transa, tr
                                     std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb,
                                     std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                                     const std::int32_t *co,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6287,7 +6287,7 @@ inline void gemm_bias_postcondition(cl::sycl::queue &queue, transpose transa, tr
 inline void syr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const float *x, std::int64_t incx, const float *y, std::int64_t incy,
                               float *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6296,7 +6296,7 @@ inline void syr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void syr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                float alpha, const float *x, std::int64_t incx, const float *y,
                                std::int64_t incy, float *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6305,7 +6305,7 @@ inline void syr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void syr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const double *x, std::int64_t incx, const double *y,
                               std::int64_t incy, double *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6314,7 +6314,7 @@ inline void syr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void syr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                double alpha, const double *x, std::int64_t incx, const double *y,
                                std::int64_t incy, double *a, std::int64_t lda,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6323,7 +6323,7 @@ inline void syr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void ger_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha,
                              const float *x, std::int64_t incx, const float *y, std::int64_t incy,
                              float *a, std::int64_t lda,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6332,7 +6332,7 @@ inline void ger_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64_
 inline void ger_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha,
                               const float *x, std::int64_t incx, const float *y, std::int64_t incy,
                               float *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6341,7 +6341,7 @@ inline void ger_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int64
 inline void ger_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha,
                              const double *x, std::int64_t incx, const double *y, std::int64_t incy,
                              double *a, std::int64_t lda,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6350,7 +6350,7 @@ inline void ger_precondition(cl::sycl::queue &queue, std::int64_t m, std::int64_
 inline void ger_postcondition(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha,
                               const double *x, std::int64_t incx, const double *y,
                               std::int64_t incy, double *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6360,7 +6360,7 @@ inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               float alpha, const float *a, std::int64_t lda, float *b,
                               std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6370,7 +6370,7 @@ inline void trsm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                float alpha, const float *a, std::int64_t lda, float *b,
                                std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6380,7 +6380,7 @@ inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               double alpha, const double *a, std::int64_t lda, double *b,
                               std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6390,7 +6390,7 @@ inline void trsm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                double alpha, const double *a, std::int64_t lda, double *b,
                                std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6400,7 +6400,7 @@ inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               std::complex<float> alpha, const std::complex<float> *a,
                               std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6410,7 +6410,7 @@ inline void trsm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                std::complex<float> alpha, const std::complex<float> *a,
                                std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6420,7 +6420,7 @@ inline void trsm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               std::complex<double> alpha, const std::complex<double> *a,
                               std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6430,7 +6430,7 @@ inline void trsm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                std::complex<double> alpha, const std::complex<double> *a,
                                std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6441,7 +6441,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side left_right, upl
                                     float alpha, const float *a, std::int64_t lda,
                                     std::int64_t stride_a, float *b, std::int64_t ldb,
                                     std::int64_t stride_b, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6452,7 +6452,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side left_right, up
                                      std::int64_t n, float alpha, const float *a, std::int64_t lda,
                                      std::int64_t stride_a, float *b, std::int64_t ldb,
                                      std::int64_t stride_b, std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6463,7 +6463,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side left_right, upl
                                     double alpha, const double *a, std::int64_t lda,
                                     std::int64_t stride_a, double *b, std::int64_t ldb,
                                     std::int64_t stride_b, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6475,7 +6475,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side left_right, up
                                      std::int64_t lda, std::int64_t stride_a, double *b,
                                      std::int64_t ldb, std::int64_t stride_b,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6487,7 +6487,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side left_right, upl
                                     std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                                     std::int64_t ldb, std::int64_t stride_b,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6500,7 +6500,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side left_right, up
                                      std::int64_t stride_a, std::complex<float> *b,
                                      std::int64_t ldb, std::int64_t stride_b,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6512,7 +6512,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side left_right, upl
                                     std::int64_t lda, std::int64_t stride_a,
                                     std::complex<double> *b, std::int64_t ldb,
                                     std::int64_t stride_b, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6525,7 +6525,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side left_right, up
                                      std::int64_t stride_a, std::complex<double> *b,
                                      std::int64_t ldb, std::int64_t stride_b,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6536,7 +6536,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side *left_right, up
                                     std::int64_t *n, float *alpha, const float **a,
                                     std::int64_t *lda, float **b, std::int64_t *ldb,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6547,7 +6547,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side *left_right, u
                                      std::int64_t *n, float *alpha, const float **a,
                                      std::int64_t *lda, float **b, std::int64_t *ldb,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6558,7 +6558,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side *left_right, up
                                     std::int64_t *n, double *alpha, const double **a,
                                     std::int64_t *lda, double **b, std::int64_t *ldb,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6569,7 +6569,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side *left_right, u
                                      std::int64_t *n, double *alpha, const double **a,
                                      std::int64_t *lda, double **b, std::int64_t *ldb,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6581,7 +6581,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side *left_right, up
                                     const std::complex<float> **a, std::int64_t *lda,
                                     std::complex<float> **b, std::int64_t *ldb,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6593,7 +6593,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side *left_right, u
                                      const std::complex<float> **a, std::int64_t *lda,
                                      std::complex<float> **b, std::int64_t *ldb,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6605,7 +6605,7 @@ inline void trsm_batch_precondition(cl::sycl::queue &queue, side *left_right, up
                                     const std::complex<double> **a, std::int64_t *lda,
                                     std::complex<double> **b, std::int64_t *ldb,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6617,7 +6617,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side *left_right, u
                                      const std::complex<double> **a, std::int64_t *lda,
                                      std::complex<double> **b, std::int64_t *ldb,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6626,7 +6626,7 @@ inline void trsm_batch_postcondition(cl::sycl::queue &queue, side *left_right, u
 inline void dotu_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                               std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                               std::complex<float> *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6635,7 +6635,7 @@ inline void dotu_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 inline void dotu_postcondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                                std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                                std::complex<float> *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6644,7 +6644,7 @@ inline void dotu_postcondition(cl::sycl::queue &queue, std::int64_t n, const std
 inline void dotu_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                               std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                               std::complex<double> *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6654,7 +6654,7 @@ inline void dotu_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                const std::complex<double> *x, std::int64_t incx,
                                const std::complex<double> *y, std::int64_t incy,
                                std::complex<double> *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6665,7 +6665,7 @@ inline void hemm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               const std::complex<float> *a, std::int64_t lda,
                               const std::complex<float> *b, std::int64_t ldb,
                               std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6676,7 +6676,7 @@ inline void hemm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                const std::complex<float> *a, std::int64_t lda,
                                const std::complex<float> *b, std::int64_t ldb,
                                std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6687,7 +6687,7 @@ inline void hemm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               const std::complex<double> *a, std::int64_t lda,
                               const std::complex<double> *b, std::int64_t ldb,
                               std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6698,7 +6698,7 @@ inline void hemm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                const std::complex<double> *a, std::int64_t lda,
                                const std::complex<double> *b, std::int64_t ldb,
                                std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6708,7 +6708,7 @@ inline void hpr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<float> alpha, const std::complex<float> *x,
                               std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                               std::complex<float> *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6718,7 +6718,7 @@ inline void hpr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::complex<float> alpha, const std::complex<float> *x,
                                std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                                std::complex<float> *a,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6728,7 +6728,7 @@ inline void hpr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<double> alpha, const std::complex<double> *x,
                               std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                               std::complex<double> *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6738,7 +6738,7 @@ inline void hpr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::complex<double> alpha, const std::complex<double> *x,
                                std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                                std::complex<double> *a,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6748,7 +6748,7 @@ inline void gbmv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha,
                               const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                               float beta, float *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6758,7 +6758,7 @@ inline void gbmv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha,
                                const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                                float beta, float *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6768,7 +6768,7 @@ inline void gbmv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                               const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                               double beta, double *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6778,7 +6778,7 @@ inline void gbmv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                                const double *a, std::int64_t lda, const double *x,
                                std::int64_t incx, double beta, double *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6789,7 +6789,7 @@ inline void gbmv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               std::complex<float> alpha, const std::complex<float> *a,
                               std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6800,7 +6800,7 @@ inline void gbmv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                std::complex<float> alpha, const std::complex<float> *a,
                                std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                                std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6811,7 +6811,7 @@ inline void gbmv_precondition(cl::sycl::queue &queue, transpose trans, std::int6
                               std::complex<double> alpha, const std::complex<double> *a,
                               std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6823,7 +6823,7 @@ inline void gbmv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
                                std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                                std::complex<double> beta, std::complex<double> *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6832,7 +6832,7 @@ inline void gbmv_postcondition(cl::sycl::queue &queue, transpose trans, std::int
 inline void tbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                               std::int64_t lda, float *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6841,7 +6841,7 @@ inline void tbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                                std::int64_t lda, float *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6850,7 +6850,7 @@ inline void tbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                               std::int64_t lda, double *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6859,7 +6859,7 @@ inline void tbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                                std::int64_t lda, double *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6869,7 +6869,7 @@ inline void tbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               diag unit_diag, std::int64_t n, std::int64_t k,
                               const std::complex<float> *a, std::int64_t lda,
                               std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6879,7 +6879,7 @@ inline void tbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                diag unit_diag, std::int64_t n, std::int64_t k,
                                const std::complex<float> *a, std::int64_t lda,
                                std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6889,7 +6889,7 @@ inline void tbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               diag unit_diag, std::int64_t n, std::int64_t k,
                               const std::complex<double> *a, std::int64_t lda,
                               std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6899,7 +6899,7 @@ inline void tbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                diag unit_diag, std::int64_t n, std::int64_t k,
                                const std::complex<double> *a, std::int64_t lda,
                                std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6909,7 +6909,7 @@ inline void symm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               std::int64_t m, std::int64_t n, float alpha, const float *a,
                               std::int64_t lda, const float *b, std::int64_t ldb, float beta,
                               float *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6919,7 +6919,7 @@ inline void symm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                std::int64_t m, std::int64_t n, float alpha, const float *a,
                                std::int64_t lda, const float *b, std::int64_t ldb, float beta,
                                float *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6929,7 +6929,7 @@ inline void symm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               std::int64_t m, std::int64_t n, double alpha, const double *a,
                               std::int64_t lda, const double *b, std::int64_t ldb, double beta,
                               double *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6939,7 +6939,7 @@ inline void symm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                std::int64_t m, std::int64_t n, double alpha, const double *a,
                                std::int64_t lda, const double *b, std::int64_t ldb, double beta,
                                double *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6950,7 +6950,7 @@ inline void symm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               const std::complex<float> *a, std::int64_t lda,
                               const std::complex<float> *b, std::int64_t ldb,
                               std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6961,7 +6961,7 @@ inline void symm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                const std::complex<float> *a, std::int64_t lda,
                                const std::complex<float> *b, std::int64_t ldb,
                                std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6972,7 +6972,7 @@ inline void symm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               const std::complex<double> *a, std::int64_t lda,
                               const std::complex<double> *b, std::int64_t ldb,
                               std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -6983,7 +6983,7 @@ inline void symm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                const std::complex<double> *a, std::int64_t lda,
                                const std::complex<double> *b, std::int64_t ldb,
                                std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -6992,7 +6992,7 @@ inline void symm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
 inline void dotc_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                               std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                               std::complex<float> *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7001,7 +7001,7 @@ inline void dotc_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 inline void dotc_postcondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                                std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                                std::complex<float> *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7010,7 +7010,7 @@ inline void dotc_postcondition(cl::sycl::queue &queue, std::int64_t n, const std
 inline void dotc_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                               std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                               std::complex<double> *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7020,7 +7020,7 @@ inline void dotc_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                const std::complex<double> *x, std::int64_t incx,
                                const std::complex<double> *y, std::int64_t incy,
                                std::complex<double> *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7028,7 +7028,7 @@ inline void dotc_postcondition(cl::sycl::queue &queue, std::int64_t n,
 
 inline void syr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                              const float *x, std::int64_t incx, float *a, std::int64_t lda,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7036,7 +7036,7 @@ inline void syr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 
 inline void syr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const float *x, std::int64_t incx, float *a, std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7044,7 +7044,7 @@ inline void syr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 
 inline void syr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, double alpha,
                              const double *x, std::int64_t incx, double *a, std::int64_t lda,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7053,7 +7053,7 @@ inline void syr_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int6
 inline void syr_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const double *x, std::int64_t incx, double *a,
                               std::int64_t lda,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7063,7 +7063,7 @@ inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               float alpha, const float *a, std::int64_t lda, float *b,
                               std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7073,7 +7073,7 @@ inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                float alpha, const float *a, std::int64_t lda, float *b,
                                std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7083,7 +7083,7 @@ inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               double alpha, const double *a, std::int64_t lda, double *b,
                               std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7093,7 +7093,7 @@ inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                double alpha, const double *a, std::int64_t lda, double *b,
                                std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7103,7 +7103,7 @@ inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               std::complex<float> alpha, const std::complex<float> *a,
                               std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7113,7 +7113,7 @@ inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                std::complex<float> alpha, const std::complex<float> *a,
                                std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7123,7 +7123,7 @@ inline void trmm_precondition(cl::sycl::queue &queue, side left_right, uplo uppe
                               transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                               std::complex<double> alpha, const std::complex<double> *a,
                               std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7133,7 +7133,7 @@ inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
                                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
                                std::complex<double> alpha, const std::complex<double> *a,
                                std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7142,7 +7142,7 @@ inline void trmm_postcondition(cl::sycl::queue &queue, side left_right, uplo upp
 inline void symv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                               float beta, float *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7151,7 +7151,7 @@ inline void symv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void symv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                float alpha, const float *a, std::int64_t lda, const float *x,
                                std::int64_t incx, float beta, float *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7160,7 +7160,7 @@ inline void symv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void symv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const double *a, std::int64_t lda, const double *x,
                               std::int64_t incx, double beta, double *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7169,7 +7169,7 @@ inline void symv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void symv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                double alpha, const double *a, std::int64_t lda, const double *x,
                                std::int64_t incx, double beta, double *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7178,7 +7178,7 @@ inline void symv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const float *a, float *x,
                               std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7187,7 +7187,7 @@ inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const float *a, float *x,
                                std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7196,7 +7196,7 @@ inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const double *a, double *x,
                               std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7205,7 +7205,7 @@ inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const double *a, double *x,
                                std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7214,7 +7214,7 @@ inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<float> *a,
                               std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7223,7 +7223,7 @@ inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<float> *a,
                                std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7232,7 +7232,7 @@ inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<double> *a,
                               std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7241,7 +7241,7 @@ inline void tpsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<double> *a,
                                std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7250,7 +7250,7 @@ inline void tpsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
                               float *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7259,7 +7259,7 @@ inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
                                float *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7268,7 +7268,7 @@ inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
                               double *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7277,7 +7277,7 @@ inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
                                double *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7286,7 +7286,7 @@ inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<float> *a,
                               std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7295,7 +7295,7 @@ inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<float> *a,
                                std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7304,7 +7304,7 @@ inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, const std::complex<double> *a,
                               std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7313,7 +7313,7 @@ inline void trsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, const std::complex<double> *a,
                                std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7321,7 +7321,7 @@ inline void trsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 
 inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                               std::int64_t incx, float *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7329,7 +7329,7 @@ inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const floa
 
 inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                std::int64_t incx, float *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7337,7 +7337,7 @@ inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n, const flo
 
 inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                               std::int64_t incx, double *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7345,7 +7345,7 @@ inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const doub
 
 inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                std::int64_t incx, double *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7353,7 +7353,7 @@ inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n, const dou
 
 inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                               std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7361,7 +7361,7 @@ inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 
 inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                                std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7369,7 +7369,7 @@ inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n, const std
 
 inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                               std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7378,7 +7378,7 @@ inline void copy_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                const std::complex<double> *x, std::int64_t incx,
                                std::complex<double> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7387,7 +7387,7 @@ inline void copy_postcondition(cl::sycl::queue &queue, std::int64_t n,
 inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n, const float **x,
                                     std::int64_t *incx, float **y, std::int64_t *incy,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7396,7 +7396,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n, con
 inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n, const float **x,
                                      std::int64_t *incx, float **y, std::int64_t *incy,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7405,7 +7405,7 @@ inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n, co
 inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n, const double **x,
                                     std::int64_t *incx, double **y, std::int64_t *incy,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7414,7 +7414,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n, con
 inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n, const double **x,
                                      std::int64_t *incx, double **y, std::int64_t *incy,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7424,7 +7424,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n,
                                     const std::complex<float> **x, std::int64_t *incx,
                                     std::complex<float> **y, std::int64_t *incy,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7434,7 +7434,7 @@ inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n,
                                      const std::complex<float> **x, std::int64_t *incx,
                                      std::complex<float> **y, std::int64_t *incy,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7444,7 +7444,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t *n,
                                     const std::complex<double> **x, std::int64_t *incx,
                                     std::complex<double> **y, std::int64_t *incy,
                                     std::int64_t group_count, std::int64_t *group_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7454,7 +7454,7 @@ inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t *n,
                                      const std::complex<double> **x, std::int64_t *incx,
                                      std::complex<double> **y, std::int64_t *incy,
                                      std::int64_t group_count, std::int64_t *group_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7464,7 +7464,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t n, cons
                                     std::int64_t incx, std::int64_t stridex, float *y,
                                     std::int64_t incy, std::int64_t stridey,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7474,7 +7474,7 @@ inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n, con
                                      std::int64_t incx, std::int64_t stridex, float *y,
                                      std::int64_t incy, std::int64_t stridey,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7484,7 +7484,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t n, cons
                                     std::int64_t incx, std::int64_t stridex, double *y,
                                     std::int64_t incy, std::int64_t stridey,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7494,7 +7494,7 @@ inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n, con
                                      std::int64_t incx, std::int64_t stridex, double *y,
                                      std::int64_t incy, std::int64_t stridey,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7504,7 +7504,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t n,
                                     const std::complex<float> *x, std::int64_t incx,
                                     std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
                                     std::int64_t stridey, std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7515,7 +7515,7 @@ inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                      std::int64_t stridex, std::complex<float> *y,
                                      std::int64_t incy, std::int64_t stridey,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7526,7 +7526,7 @@ inline void copy_batch_precondition(cl::sycl::queue &queue, std::int64_t n,
                                     std::int64_t stridex, std::complex<double> *y,
                                     std::int64_t incy, std::int64_t stridey,
                                     std::int64_t batch_size,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                    const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7537,7 +7537,7 @@ inline void copy_batch_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                      std::int64_t stridex, std::complex<double> *y,
                                      std::int64_t incy, std::int64_t stridey,
                                      std::int64_t batch_size,
-                                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7547,7 +7547,7 @@ inline void hemv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<float> alpha, const std::complex<float> *a,
                               std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                               std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7557,7 +7557,7 @@ inline void hemv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::complex<float> alpha, const std::complex<float> *a,
                                std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                                std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7567,7 +7567,7 @@ inline void hemv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::complex<double> alpha, const std::complex<double> *a,
                               std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                               std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7578,7 +7578,7 @@ inline void hemv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                                std::complex<double> beta, std::complex<double> *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7586,7 +7586,7 @@ inline void hemv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 
 inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                std::int64_t incx, std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7594,7 +7594,7 @@ inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n, const flo
 
 inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                 std::int64_t incx, std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7602,7 +7602,7 @@ inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n, const fl
 
 inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                std::int64_t incx, std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7610,7 +7610,7 @@ inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n, const dou
 
 inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                 std::int64_t incx, std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7618,7 +7618,7 @@ inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n, const do
 
 inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                                std::int64_t incx, std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7627,7 +7627,7 @@ inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n, const std
 inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                 const std::complex<float> *x, std::int64_t incx,
                                 std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7636,7 +7636,7 @@ inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n,
 inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n,
                                const std::complex<double> *x, std::int64_t incx,
                                std::int64_t *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7645,7 +7645,7 @@ inline void iamax_precondition(cl::sycl::queue &queue, std::int64_t n,
 inline void iamax_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                 const std::complex<double> *x, std::int64_t incx,
                                 std::int64_t *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7655,7 +7655,7 @@ inline void sbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::int64_t k, float alpha, const float *a, std::int64_t lda,
                               const float *x, std::int64_t incx, float beta, float *y,
                               std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7665,7 +7665,7 @@ inline void sbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::int64_t k, float alpha, const float *a, std::int64_t lda,
                                const float *x, std::int64_t incx, float beta, float *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7675,7 +7675,7 @@ inline void sbmv_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
                               std::int64_t k, double alpha, const double *a, std::int64_t lda,
                               const double *x, std::int64_t incx, double beta, double *y,
                               std::int64_t incy,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7685,7 +7685,7 @@ inline void sbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
                                std::int64_t k, double alpha, const double *a, std::int64_t lda,
                                const double *x, std::int64_t incx, double beta, double *y,
                                std::int64_t incy,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7693,7 +7693,7 @@ inline void sbmv_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 
 inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                               std::int64_t incx, float *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7701,7 +7701,7 @@ inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 
 inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                                std::int64_t incx, float *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7709,7 +7709,7 @@ inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n, const std
 
 inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                               std::int64_t incx, double *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7717,7 +7717,7 @@ inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const std:
 
 inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n,
                                const std::complex<double> *x, std::int64_t incx, double *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7725,7 +7725,7 @@ inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n,
 
 inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                               std::int64_t incx, float *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7733,7 +7733,7 @@ inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const floa
 
 inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                                std::int64_t incx, float *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7741,7 +7741,7 @@ inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n, const flo
 
 inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                               std::int64_t incx, double *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7749,7 +7749,7 @@ inline void asum_precondition(cl::sycl::queue &queue, std::int64_t n, const doub
 
 inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                                std::int64_t incx, double *result,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7758,7 +7758,7 @@ inline void asum_postcondition(cl::sycl::queue &queue, std::int64_t n, const dou
 inline void tbsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                               std::int64_t lda, float *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7767,7 +7767,7 @@ inline void tbsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tbsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                                std::int64_t lda, float *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7776,7 +7776,7 @@ inline void tbsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void tbsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                               diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                               std::int64_t lda, double *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7785,7 +7785,7 @@ inline void tbsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
 inline void tbsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                                diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                                std::int64_t lda, double *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7795,7 +7795,7 @@ inline void tbsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               diag unit_diag, std::int64_t n, std::int64_t k,
                               const std::complex<float> *a, std::int64_t lda,
                               std::complex<float> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7805,7 +7805,7 @@ inline void tbsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                diag unit_diag, std::int64_t n, std::int64_t k,
                                const std::complex<float> *a, std::int64_t lda,
                                std::complex<float> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7815,7 +7815,7 @@ inline void tbsv_precondition(cl::sycl::queue &queue, uplo upper_lower, transpos
                               diag unit_diag, std::int64_t n, std::int64_t k,
                               const std::complex<double> *a, std::int64_t lda,
                               std::complex<double> *x, std::int64_t incx,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7825,7 +7825,7 @@ inline void tbsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                diag unit_diag, std::int64_t n, std::int64_t k,
                                const std::complex<double> *a, std::int64_t lda,
                                std::complex<double> *x, std::int64_t incx,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7834,7 +7834,7 @@ inline void tbsv_postcondition(cl::sycl::queue &queue, uplo upper_lower, transpo
 inline void spr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n, float alpha,
                               const float *x, std::int64_t incx, const float *y, std::int64_t incy,
                               float *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7843,7 +7843,7 @@ inline void spr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void spr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                float alpha, const float *x, std::int64_t incx, const float *y,
                                std::int64_t incy, float *a,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7852,7 +7852,7 @@ inline void spr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 inline void spr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                               double alpha, const double *x, std::int64_t incx, const double *y,
                               std::int64_t incy, double *a,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7861,7 +7861,7 @@ inline void spr2_precondition(cl::sycl::queue &queue, uplo upper_lower, std::int
 inline void spr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::int64_t n,
                                double alpha, const double *x, std::int64_t incx, const double *y,
                                std::int64_t incy, double *a,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7869,7 +7869,7 @@ inline void spr2_postcondition(cl::sycl::queue &queue, uplo upper_lower, std::in
 
 inline void rotm_precondition(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
                               float *y, std::int64_t incy, float *param,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7877,7 +7877,7 @@ inline void rotm_precondition(cl::sycl::queue &queue, std::int64_t n, float *x, 
 
 inline void rotm_postcondition(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx,
                                float *y, std::int64_t incy, float *param,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7885,7 +7885,7 @@ inline void rotm_postcondition(cl::sycl::queue &queue, std::int64_t n, float *x,
 
 inline void rotm_precondition(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                               double *y, std::int64_t incy, double *param,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7893,7 +7893,7 @@ inline void rotm_precondition(cl::sycl::queue &queue, std::int64_t n, double *x,
 
 inline void rotm_postcondition(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                                double *y, std::int64_t incy, double *param,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7901,7 +7901,7 @@ inline void rotm_postcondition(cl::sycl::queue &queue, std::int64_t n, double *x
 
 inline void dot_precondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                              std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7909,7 +7909,7 @@ inline void dot_precondition(cl::sycl::queue &queue, std::int64_t n, const float
 
 inline void dot_postcondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                               std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7917,7 +7917,7 @@ inline void dot_postcondition(cl::sycl::queue &queue, std::int64_t n, const floa
 
 inline void dot_precondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                              std::int64_t incx, const double *y, std::int64_t incy, double *result,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7925,7 +7925,7 @@ inline void dot_precondition(cl::sycl::queue &queue, std::int64_t n, const doubl
 
 inline void dot_postcondition(cl::sycl::queue &queue, std::int64_t n, const double *x,
                               std::int64_t incx, const double *y, std::int64_t incy, double *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7933,7 +7933,7 @@ inline void dot_postcondition(cl::sycl::queue &queue, std::int64_t n, const doub
 
 inline void dot_precondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                              std::int64_t incx, const float *y, std::int64_t incy, double *result,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7941,7 +7941,7 @@ inline void dot_precondition(cl::sycl::queue &queue, std::int64_t n, const float
 
 inline void dot_postcondition(cl::sycl::queue &queue, std::int64_t n, const float *x,
                               std::int64_t incx, const float *y, std::int64_t incy, double *result,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7949,7 +7949,7 @@ inline void dot_postcondition(cl::sycl::queue &queue, std::int64_t n, const floa
 
 inline void sdsdot_precondition(cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
                                 std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7958,7 +7958,7 @@ inline void sdsdot_precondition(cl::sycl::queue &queue, std::int64_t n, float sb
 inline void sdsdot_postcondition(cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
                                  std::int64_t incx, const float *y, std::int64_t incy,
                                  float *result,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                 const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7969,7 +7969,7 @@ inline void her2k_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                const std::complex<float> *a, std::int64_t lda,
                                const std::complex<float> *b, std::int64_t ldb, float beta,
                                std::complex<float> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -7980,7 +7980,7 @@ inline void her2k_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 const std::complex<float> *a, std::int64_t lda,
                                 const std::complex<float> *b, std::int64_t ldb, float beta,
                                 std::complex<float> *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -7991,7 +7991,7 @@ inline void her2k_precondition(cl::sycl::queue &queue, uplo upper_lower, transpo
                                const std::complex<double> *a, std::int64_t lda,
                                const std::complex<double> *b, std::int64_t ldb, double beta,
                                std::complex<double> *c, std::int64_t ldc,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -8002,35 +8002,35 @@ inline void her2k_postcondition(cl::sycl::queue &queue, uplo upper_lower, transp
                                 const std::complex<double> *a, std::int64_t lda,
                                 const std::complex<double> *b, std::int64_t ldb, double beta,
                                 std::complex<double> *c, std::int64_t ldc,
-                                const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
 }
 
 inline void rotg_precondition(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
 }
 
 inline void rotg_postcondition(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
 }
 
 inline void rotg_precondition(cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
 }
 
 inline void rotg_postcondition(cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -8038,7 +8038,7 @@ inline void rotg_postcondition(cl::sycl::queue &queue, double *a, double *b, dou
 
 inline void rotg_precondition(cl::sycl::queue &queue, std::complex<float> *a,
                               std::complex<float> *b, float *c, std::complex<float> *s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -8046,7 +8046,7 @@ inline void rotg_precondition(cl::sycl::queue &queue, std::complex<float> *a,
 
 inline void rotg_postcondition(cl::sycl::queue &queue, std::complex<float> *a,
                                std::complex<float> *b, float *c, std::complex<float> *s,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -8054,7 +8054,7 @@ inline void rotg_postcondition(cl::sycl::queue &queue, std::complex<float> *a,
 
 inline void rotg_precondition(cl::sycl::queue &queue, std::complex<double> *a,
                               std::complex<double> *b, double *c, std::complex<double> *s,
-                              const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                              const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
@@ -8062,7 +8062,7 @@ inline void rotg_precondition(cl::sycl::queue &queue, std::complex<double> *a,
 
 inline void rotg_postcondition(cl::sycl::queue &queue, std::complex<double> *a,
                                std::complex<double> *b, double *c, std::complex<double> *s,
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif

--- a/include/oneapi/mkl/lapack/detail/lapack_loader.hpp
+++ b/include/oneapi/mkl/lapack/detail/lapack_loader.hpp
@@ -637,417 +637,417 @@ ONEMKL_EXPORT sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, 
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda, float *d,
                                 float *e, std::complex<float> *tauq, std::complex<float> *taup,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, double *d, double *e,
                                 double *tauq, double *taup, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, float *d, float *e,
                                 float *tauq, float *taup, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 double *d, double *e, std::complex<double> *tauq,
                                 std::complex<double> *taup, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, std::int64_t *ipiv,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, std::int64_t *ipiv,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n,
                                 double *a, std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n,
                                 float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
                                 double *a, std::int64_t lda, std::int64_t *ipiv, double *b,
                                 std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
                                 float *a, std::int64_t lda, std::int64_t *ipiv, float *b,
                                 std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, double *s, double *u,
                                 std::int64_t ldu, double *vt, std::int64_t ldvt, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, float *s, float *u,
                                 std::int64_t ldu, float *vt, std::int64_t ldvt, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt, std::int64_t m,
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda, float *s,
                                 std::complex<float> *u, std::int64_t ldu, std::complex<float> *vt,
                                 std::int64_t ldvt, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt, std::int64_t m,
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 double *s, std::complex<double> *u, std::int64_t ldu,
                                 std::complex<double> *vt, std::int64_t ldvt,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event heevd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, float *w,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event heevd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, double *w,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hegvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                                 std::int64_t ldb, float *w, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hegvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                                 std::int64_t ldb, double *w, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, float *d, float *e, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, double *d, double *e, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgbr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                                 std::int64_t k, float *a, std::int64_t lda, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgbr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                                 std::int64_t k, double *a, std::int64_t lda, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                                 double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                                 float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 float *a, std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormrq(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k, float *a,
                                 std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormrq(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                                 std::int64_t lda, double *tau, double *c, std::int64_t ldc,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormqr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                                 std::int64_t lda, double *tau, double *c, std::int64_t ldc,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormqr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k, float *a,
                                 std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs, float *a,
                                 std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                 double *a, std::int64_t lda, double *b, std::int64_t ldb,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                                 std::int64_t ldb, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                 std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                                 std::int64_t ldb, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event syevd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *w, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event syevd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *w, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sygvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *b, std::int64_t ldb, double *w,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sygvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype,
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *b, std::int64_t ldb, float *w,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *d, double *e, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrd(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *d, float *e, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                 oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                                 std::int64_t ldb, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                 oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
                                 double *a, std::int64_t lda, double *b, std::int64_t ldb,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                 oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, float *a,
                                 std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                 oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
                                 std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                                 std::int64_t ldb, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungbr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                                 std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungbr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                                 std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::int64_t k, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,
                                 std::int64_t n, std::int64_t k, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmrq(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmrq(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k,
@@ -1055,14 +1055,14 @@ ONEMKL_EXPORT sycl::event unmrq(oneapi::mkl::device libkey, sycl::queue &queue,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmqr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmqr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::transpose trans,
                                 std::int64_t m, std::int64_t n, std::int64_t k,
@@ -1070,14 +1070,14 @@ ONEMKL_EXPORT sycl::event unmqr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -1085,157 +1085,157 @@ ONEMKL_EXPORT sycl::event unmtr(oneapi::mkl::device libkey, sycl::queue &queue,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                                       std::int64_t stride_a, float *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                                       std::int64_t stride_a, double *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, std::complex<float> *a,
                                       std::int64_t lda, std::int64_t stride_a,
                                       std::complex<float> *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, std::complex<double> *a,
                                       std::int64_t lda, std::int64_t stride_a,
                                       std::complex<double> *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, float **a,
                                       std::int64_t *lda, float **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, double **a,
                                       std::int64_t *lda, double **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::complex<float> **a,
                                       std::int64_t *lda, std::complex<float> **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::complex<double> **a,
                                       std::int64_t *lda, std::complex<double> **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, std::complex<float> *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, std::complex<double> *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, float **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, double **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::complex<float> **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::complex<double> **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t n, float *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t n, double *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *n, float **a, std::int64_t *lda,
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *n, double **a, std::int64_t *lda,
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *n, std::complex<float> **a, std::int64_t *lda,
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *n, std::complex<double> **a, std::int64_t *lda,
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::transpose trans, std::int64_t n,
                                       std::int64_t nrhs, float *a, std::int64_t lda,
@@ -1243,7 +1243,7 @@ ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &q
                                       std::int64_t stride_ipiv, float *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::transpose trans, std::int64_t n,
                                       std::int64_t nrhs, double *a, std::int64_t lda,
@@ -1251,33 +1251,33 @@ ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &q
                                       std::int64_t stride_ipiv, double *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(
     oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
     std::int64_t nrhs, std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
     std::int64_t *ipiv, std::int64_t stride_ipiv, std::complex<float> *b, std::int64_t ldb,
     std::int64_t stride_b, std::int64_t batch_size, std::complex<float> *scratchpad,
-    std::int64_t scratchpad_size, const sycl::vector_class<sycl::event> &dependencies = {});
+    std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(
     oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
     std::int64_t nrhs, std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
     std::int64_t *ipiv, std::int64_t stride_ipiv, std::complex<double> *b, std::int64_t ldb,
     std::int64_t stride_b, std::int64_t batch_size, std::complex<double> *scratchpad,
-    std::int64_t scratchpad_size, const sycl::vector_class<sycl::event> &dependencies = {});
+    std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::transpose *trans, std::int64_t *n,
                                       std::int64_t *nrhs, float **a, std::int64_t *lda,
                                       std::int64_t **ipiv, float **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::transpose *trans, std::int64_t *n,
                                       std::int64_t *nrhs, double **a, std::int64_t *lda,
                                       std::int64_t **ipiv, double **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::transpose *trans, std::int64_t *n,
                                       std::int64_t *nrhs, std::complex<float> **a,
@@ -1285,101 +1285,101 @@ ONEMKL_EXPORT sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &q
                                       std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(
     oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n,
     std::int64_t *nrhs, std::complex<double> **a, std::int64_t *lda, std::int64_t **ipiv,
     std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
     std::int64_t *group_sizes, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-    const sycl::vector_class<sycl::event> &dependencies = {});
+    const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, std::int64_t k, float *a,
                                       std::int64_t lda, std::int64_t stride_a, float *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                                       std::int64_t lda, std::int64_t stride_a, double *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::int64_t *k, float **a,
                                       std::int64_t *lda, float **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::int64_t *k, double **a,
                                       std::int64_t *lda, double **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                                       std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                                       std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::complex<double> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n, float **a,
                                       std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n, double **a,
                                       std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::complex<double> **a, std::int64_t *lda,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                       float *a, std::int64_t lda, std::int64_t stride_a, float *b,
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                       double *a, std::int64_t lda, std::int64_t stride_a, double *b,
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                       std::complex<float> *a, std::int64_t lda,
@@ -1387,7 +1387,7 @@ ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &q
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                       std::complex<double> *a, std::int64_t lda,
@@ -1395,26 +1395,26 @@ ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &q
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n, std::int64_t *nrhs,
                                       float **a, std::int64_t *lda, float **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n, std::int64_t *nrhs,
                                       double **a, std::int64_t *lda, double **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n, std::int64_t *nrhs,
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       oneapi::mkl::uplo *uplo, std::int64_t *n, std::int64_t *nrhs,
                                       std::complex<double> **a, std::int64_t *lda,
@@ -1422,33 +1422,33 @@ ONEMKL_EXPORT sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &q
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t m, std::int64_t n, std::int64_t k,
                                       std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::complex<float> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(
     oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
     std::complex<double> *a, std::int64_t lda, std::int64_t stride_a, std::complex<double> *tau,
     std::int64_t stride_tau, std::int64_t batch_size, std::complex<double> *scratchpad,
-    std::int64_t scratchpad_size, const sycl::vector_class<sycl::event> &dependencies = {});
+    std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::int64_t *k,
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::complex<float> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                                       std::int64_t *m, std::int64_t *n, std::int64_t *k,
                                       std::complex<double> **a, std::int64_t *lda,
                                       std::complex<double> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 
 template <typename fp_type, oneapi::mkl::lapack::internal::is_floating_point<fp_type> = nullptr>
 std::int64_t gebrd_scratchpad_size(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m,

--- a/include/oneapi/mkl/lapack/detail/lapack_rt.hpp
+++ b/include/oneapi/mkl/lapack/detail/lapack_rt.hpp
@@ -904,21 +904,21 @@ static inline sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t
                                 std::complex<float> *a, std::int64_t lda, float *d, float *e,
                                 std::complex<float> *tauq, std::complex<float> *taup,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gebrd(get_device_id(queue), queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, double *d, double *e, double *tauq, double *taup,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gebrd(get_device_id(queue), queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *d, float *e, float *tauq, float *taup,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gebrd(get_device_id(queue), queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -926,28 +926,28 @@ static inline sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t
                                 std::complex<double> *a, std::int64_t lda, double *d, double *e,
                                 std::complex<double> *tauq, std::complex<double> *taup,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gebrd(get_device_id(queue), queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gerqf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gerqf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gerqf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -955,28 +955,28 @@ static inline sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gerqf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -984,62 +984,62 @@ static inline sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf(get_device_id(queue), queue, m, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf(get_device_id(queue), queue, m, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf(get_device_id(queue), queue, m, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf(get_device_id(queue), queue, m, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf(get_device_id(queue), queue, m, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri(get_device_id(queue), queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event getri(sycl::queue &queue, std::int64_t n, double *a, std::int64_t lda,
                                 std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri(get_device_id(queue), queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event getri(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda,
                                 std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri(get_device_id(queue), queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri(get_device_id(queue), queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                          dependencies);
 }
@@ -1047,7 +1047,7 @@ static inline sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans
                                 std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1055,7 +1055,7 @@ static inline sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans
                                 std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t *ipiv,
                                 double *b, std::int64_t ldb, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1063,7 +1063,7 @@ static inline sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans
                                 std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t *ipiv,
                                 float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1071,7 +1071,7 @@ static inline sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans
                                 std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1080,7 +1080,7 @@ static inline sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 double *a, std::int64_t lda, double *s, double *u, std::int64_t ldu,
                                 double *vt, std::int64_t ldvt, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gesvd(get_device_id(queue), queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                          ldvt, scratchpad, scratchpad_size, dependencies);
 }
@@ -1088,7 +1088,7 @@ static inline sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *s, float *u, std::int64_t ldu, float *vt,
                                 std::int64_t ldvt, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gesvd(get_device_id(queue), queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                          ldvt, scratchpad, scratchpad_size, dependencies);
 }
@@ -1098,7 +1098,7 @@ static inline sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 std::complex<float> *u, std::int64_t ldu, std::complex<float> *vt,
                                 std::int64_t ldvt, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gesvd(get_device_id(queue), queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                          ldvt, scratchpad, scratchpad_size, dependencies);
 }
@@ -1108,14 +1108,14 @@ static inline sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 std::complex<double> *u, std::int64_t ldu, std::complex<double> *vt,
                                 std::int64_t ldvt, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::gesvd(get_device_id(queue), queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                          ldvt, scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda, float *w,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::heevd(get_device_id(queue), queue, jobz, uplo, n, a, lda, w, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1123,7 +1123,7 @@ static inline sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneap
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 double *w, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::heevd(get_device_id(queue), queue, jobz, uplo, n, a, lda, w, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1132,7 +1132,7 @@ static inline sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::
                                 std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                                 float *w, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::hegvd(get_device_id(queue), queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1141,7 +1141,7 @@ static inline sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::
                                 std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                                 double *w, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::hegvd(get_device_id(queue), queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1149,7 +1149,7 @@ static inline sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std:
                                 std::complex<float> *a, std::int64_t lda, float *d, float *e,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::hetrd(get_device_id(queue), queue, uplo, n, a, lda, d, e, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1157,63 +1157,63 @@ static inline sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std:
                                 std::complex<double> *a, std::int64_t lda, double *d, double *e,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::hetrd(get_device_id(queue), queue, uplo, n, a, lda, d, e, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::hetrf(get_device_id(queue), queue, uplo, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::hetrf(get_device_id(queue), queue, uplo, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                 std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                                 float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgbr(get_device_id(queue), queue, vec, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                 std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                                 double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgbr(get_device_id(queue), queue, vec, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                                 double *a, std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgqr(get_device_id(queue), queue, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                                 float *a, std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgqr(get_device_id(queue), queue, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgtr(get_device_id(queue), queue, uplo, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgtr(get_device_id(queue), queue, uplo, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1221,7 +1221,7 @@ static inline sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, onea
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 float *a, std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ormtr(get_device_id(queue), queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1229,7 +1229,7 @@ static inline sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, onea
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ormtr(get_device_id(queue), queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1237,7 +1237,7 @@ static inline sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, float *a, std::int64_t lda, float *tau, float *c,
                                 std::int64_t ldc, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ormrq(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1245,7 +1245,7 @@ static inline sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ormrq(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1253,7 +1253,7 @@ static inline sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ormqr(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1261,77 +1261,77 @@ static inline sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, float *a, std::int64_t lda, float *tau, float *c,
                                 std::int64_t ldc, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ormqr(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potri(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potri(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potri(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potri(get_device_id(queue), queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                          dependencies);
 }
 static inline sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::int64_t nrhs, float *a, std::int64_t lda, float *b,
                                 std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::int64_t nrhs, double *a, std::int64_t lda, double *b,
                                 std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1339,7 +1339,7 @@ static inline sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std:
                                 std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1347,21 +1347,21 @@ static inline sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std:
                                 std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
                                 std::int64_t n, double *a, std::int64_t lda, double *w,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::syevd(get_device_id(queue), queue, jobz, uplo, n, a, lda, w, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
                                 std::int64_t n, float *a, std::int64_t lda, float *w,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::syevd(get_device_id(queue), queue, jobz, uplo, n, a, lda, w, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1369,7 +1369,7 @@ static inline sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *b, std::int64_t ldb, double *w, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sygvd(get_device_id(queue), queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1377,49 +1377,49 @@ static inline sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *b, std::int64_t ldb, float *w, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sygvd(get_device_id(queue), queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                          scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *d, double *e, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sytrd(get_device_id(queue), queue, uplo, n, a, lda, d, e, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *d, float *e, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sytrd(get_device_id(queue), queue, uplo, n, a, lda, d, e, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sytrf(get_device_id(queue), queue, uplo, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sytrf(get_device_id(queue), queue, uplo, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sytrf(get_device_id(queue), queue, uplo, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::sytrf(get_device_id(queue), queue, uplo, n, a, lda, ipiv, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1428,7 +1428,7 @@ static inline sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 std::int64_t n, std::int64_t nrhs, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::trtrs(get_device_id(queue), queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1437,7 +1437,7 @@ static inline sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 std::int64_t n, std::int64_t nrhs, double *a, std::int64_t lda,
                                 double *b, std::int64_t ldb, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::trtrs(get_device_id(queue), queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1446,7 +1446,7 @@ static inline sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 std::int64_t n, std::int64_t nrhs, float *a, std::int64_t lda,
                                 float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::trtrs(get_device_id(queue), queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1455,7 +1455,7 @@ static inline sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 std::int64_t n, std::int64_t nrhs, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::trtrs(get_device_id(queue), queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1463,7 +1463,7 @@ static inline sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, s
                                 std::int64_t n, std::int64_t k, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungbr(get_device_id(queue), queue, vec, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1471,14 +1471,14 @@ static inline sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, s
                                 std::int64_t n, std::int64_t k, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungbr(get_device_id(queue), queue, vec, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungqr(get_device_id(queue), queue, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1486,14 +1486,14 @@ static inline sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungqr(get_device_id(queue), queue, m, n, k, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
 static inline sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungtr(get_device_id(queue), queue, uplo, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1501,7 +1501,7 @@ static inline sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std:
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungtr(get_device_id(queue), queue, uplo, n, a, lda, tau, scratchpad,
                          scratchpad_size, dependencies);
 }
@@ -1510,7 +1510,7 @@ static inline sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side,
                                 std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::unmrq(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1520,7 +1520,7 @@ static inline sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::unmrq(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1529,7 +1529,7 @@ static inline sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side,
                                 std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::unmqr(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1539,7 +1539,7 @@ static inline sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::unmqr(get_device_id(queue), queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1548,7 +1548,7 @@ static inline sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, onea
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::unmtr(get_device_id(queue), queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1558,7 +1558,7 @@ static inline sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, onea
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return detail::unmtr(get_device_id(queue), queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                          scratchpad, scratchpad_size, dependencies);
 }
@@ -1566,7 +1566,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t lda, std::int64_t stride_a, float *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, tau, stride_tau,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1574,7 +1574,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t lda, std::int64_t stride_a, double *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, tau, stride_tau,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1583,7 +1583,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_a, std::complex<float> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, tau, stride_tau,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1593,7 +1593,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, tau, stride_tau,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1601,7 +1601,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       float **a, std::int64_t *lda, float **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1609,7 +1609,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       double **a, std::int64_t *lda, double **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1618,7 +1618,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::complex<float> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1627,7 +1627,7 @@ static inline sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::complex<double> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::geqrf_batch(get_device_id(queue), queue, m, n, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1635,7 +1635,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, ipiv,
                                stride_ipiv, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1643,7 +1643,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, ipiv,
                                stride_ipiv, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1652,7 +1652,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, ipiv,
                                stride_ipiv, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1662,7 +1662,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, stride_a, ipiv,
                                stride_ipiv, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1670,7 +1670,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       float **a, std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1678,7 +1678,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       double **a, std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1687,7 +1687,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1696,7 +1696,7 @@ static inline sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrf_batch(get_device_id(queue), queue, m, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1704,7 +1704,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t n, float 
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1712,7 +1712,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t n, double
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1720,7 +1720,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::c
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1729,7 +1729,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::c
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1737,7 +1737,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, float
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1745,7 +1745,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, doubl
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1753,7 +1753,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1762,7 +1762,7 @@ static inline sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getri_batch(get_device_id(queue), queue, n, a, lda, ipiv, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1772,7 +1772,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t stride_ipiv, float *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                scratchpad_size, dependencies);
@@ -1783,7 +1783,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t stride_ipiv, double *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                scratchpad_size, dependencies);
@@ -1795,7 +1795,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                scratchpad_size, dependencies);
@@ -1807,7 +1807,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                scratchpad_size, dependencies);
@@ -1818,7 +1818,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1828,7 +1828,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1838,7 +1838,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1849,7 +1849,7 @@ static inline sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::getrs_batch(get_device_id(queue), queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1858,7 +1858,7 @@ static inline sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_a, float *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgqr_batch(get_device_id(queue), queue, m, n, k, a, lda, stride_a, tau,
                                stride_tau, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1867,7 +1867,7 @@ static inline sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_a, double *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgqr_batch(get_device_id(queue), queue, m, n, k, a, lda, stride_a, tau,
                                stride_tau, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1875,7 +1875,7 @@ static inline sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::int64_t *k, float **a, std::int64_t *lda, float **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgqr_batch(get_device_id(queue), queue, m, n, k, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1883,7 +1883,7 @@ static inline sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::int64_t *k, double **a, std::int64_t *lda, double **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::orgqr_batch(get_device_id(queue), queue, m, n, k, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1891,7 +1891,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       float *a, std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, stride_a, batch_size,
                                scratchpad, scratchpad_size, dependencies);
 }
@@ -1899,7 +1899,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       double *a, std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, stride_a, batch_size,
                                scratchpad, scratchpad_size, dependencies);
 }
@@ -1907,7 +1907,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, stride_a, batch_size,
                                scratchpad, scratchpad_size, dependencies);
 }
@@ -1916,7 +1916,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, stride_a, batch_size,
                                scratchpad, scratchpad_size, dependencies);
 }
@@ -1924,7 +1924,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       float **a, std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1932,7 +1932,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       double **a, std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1940,7 +1940,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1949,7 +1949,7 @@ static inline sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrf_batch(get_device_id(queue), queue, uplo, n, a, lda, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -1958,7 +1958,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       std::int64_t stride_a, float *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                stride_b, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1967,7 +1967,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       std::int64_t stride_a, double *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                stride_b, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1977,7 +1977,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                stride_b, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1987,7 +1987,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                stride_b, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1996,7 +1996,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -2005,7 +2005,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -2014,7 +2014,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -2024,7 +2024,7 @@ static inline sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *upl
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::potrs_batch(get_device_id(queue), queue, uplo, n, nrhs, a, lda, b, ldb,
                                group_count, group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -2033,7 +2033,7 @@ static inline sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_a, std::complex<float> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungqr_batch(get_device_id(queue), queue, m, n, k, a, lda, stride_a, tau,
                                stride_tau, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -2043,7 +2043,7 @@ static inline sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::i
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungqr_batch(get_device_id(queue), queue, m, n, k, a, lda, stride_a, tau,
                                stride_tau, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -2052,7 +2052,7 @@ static inline sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::complex<float> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungqr_batch(get_device_id(queue), queue, m, n, k, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }
@@ -2061,7 +2061,7 @@ static inline sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::
                                       std::complex<double> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return detail::ungqr_batch(get_device_id(queue), queue, m, n, k, a, lda, tau, group_count,
                                group_sizes, scratchpad, scratchpad_size, dependencies);
 }

--- a/include/oneapi/mkl/lapack/detail/mkl_common/lapack_ct.hxx
+++ b/include/oneapi/mkl/lapack/detail/mkl_common/lapack_ct.hxx
@@ -986,7 +986,7 @@ static inline sycl::event gebrd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda, float *d,
                                 float *e, std::complex<float> *tauq, std::complex<float> *taup,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gebrd(selector.get_queue(), m, n, a, lda, d, e,
                                                       tauq, taup, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -995,7 +995,7 @@ static inline sycl::event gebrd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, double *a, std::int64_t lda, double *d, double *e,
                                 double *tauq, double *taup, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gebrd(selector.get_queue(), m, n, a, lda, d, e,
                                                       tauq, taup, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1004,7 +1004,7 @@ static inline sycl::event gebrd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, float *a, std::int64_t lda, float *d, float *e,
                                 float *tauq, float *taup, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gebrd(selector.get_queue(), m, n, a, lda, d, e,
                                                       tauq, taup, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1014,7 +1014,7 @@ static inline sycl::event gebrd(backend_selector<backend::LAPACK_BACKEND> select
                                 double *d, double *e, std::complex<double> *tauq,
                                 std::complex<double> *taup, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gebrd(selector.get_queue(), m, n, a, lda, d, e,
                                                       tauq, taup, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1022,14 +1022,14 @@ static inline sycl::event gebrd(backend_selector<backend::LAPACK_BACKEND> select
 static inline sycl::event gerqf(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gerqf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event gerqf(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gerqf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1037,7 +1037,7 @@ static inline sycl::event gerqf(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gerqf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1045,7 +1045,7 @@ static inline sycl::event gerqf(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gerqf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1053,21 +1053,21 @@ static inline sycl::event geqrf(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event geqrf(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event geqrf(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1075,7 +1075,7 @@ static inline sycl::event geqrf(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf(selector.get_queue(), m, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1083,21 +1083,21 @@ static inline sycl::event getrf(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf(selector.get_queue(), m, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event getrf(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, double *a, std::int64_t lda, std::int64_t *ipiv,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf(selector.get_queue(), m, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event getrf(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, float *a, std::int64_t lda, std::int64_t *ipiv,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf(selector.get_queue(), m, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1105,35 +1105,35 @@ static inline sycl::event getrf(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf(selector.get_queue(), m, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event getri(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri(selector.get_queue(), n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event getri(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t n,
                                 double *a, std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri(selector.get_queue(), n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event getri(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t n,
                                 float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri(selector.get_queue(), n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event getri(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri(selector.get_queue(), n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1142,7 +1142,7 @@ static inline sycl::event getrs(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs(selector.get_queue(), trans, n, nrhs, a, lda,
                                                       ipiv, b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1151,7 +1151,7 @@ static inline sycl::event getrs(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
                                 double *a, std::int64_t lda, std::int64_t *ipiv, double *b,
                                 std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs(selector.get_queue(), trans, n, nrhs, a, lda,
                                                       ipiv, b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1160,7 +1160,7 @@ static inline sycl::event getrs(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
                                 float *a, std::int64_t lda, std::int64_t *ipiv, float *b,
                                 std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs(selector.get_queue(), trans, n, nrhs, a, lda,
                                                       ipiv, b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1170,7 +1170,7 @@ static inline sycl::event getrs(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs(selector.get_queue(), trans, n, nrhs, a, lda,
                                                       ipiv, b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1180,7 +1180,7 @@ static inline sycl::event gesvd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, double *a, std::int64_t lda, double *s, double *u,
                                 std::int64_t ldu, double *vt, std::int64_t ldvt, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gesvd(selector.get_queue(), jobu, jobvt, m, n, a,
                                                       lda, s, u, ldu, vt, ldvt, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1190,7 +1190,7 @@ static inline sycl::event gesvd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, float *a, std::int64_t lda, float *s, float *u,
                                 std::int64_t ldu, float *vt, std::int64_t ldvt, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gesvd(selector.get_queue(), jobu, jobvt, m, n, a,
                                                       lda, s, u, ldu, vt, ldvt, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1201,7 +1201,7 @@ static inline sycl::event gesvd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<float> *u, std::int64_t ldu, std::complex<float> *vt,
                                 std::int64_t ldvt, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gesvd(selector.get_queue(), jobu, jobvt, m, n, a,
                                                       lda, s, u, ldu, vt, ldvt, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1212,7 +1212,7 @@ static inline sycl::event gesvd(backend_selector<backend::LAPACK_BACKEND> select
                                 double *s, std::complex<double> *u, std::int64_t ldu,
                                 std::complex<double> *vt, std::int64_t ldvt,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::gesvd(selector.get_queue(), jobu, jobvt, m, n, a,
                                                       lda, s, u, ldu, vt, ldvt, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1221,7 +1221,7 @@ static inline sycl::event heevd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, float *w,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::heevd(selector.get_queue(), jobz, uplo, n, a, lda,
                                                       w, scratchpad, scratchpad_size, dependencies);
 }
@@ -1229,7 +1229,7 @@ static inline sycl::event heevd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, double *w,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::heevd(selector.get_queue(), jobz, uplo, n, a, lda,
                                                       w, scratchpad, scratchpad_size, dependencies);
 }
@@ -1238,7 +1238,7 @@ static inline sycl::event hegvd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *b, std::int64_t ldb, float *w,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::hegvd(selector.get_queue(), itype, jobz, uplo, n, a,
                                                       lda, b, ldb, w, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1248,7 +1248,7 @@ static inline sycl::event hegvd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *b, std::int64_t ldb, double *w,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::hegvd(selector.get_queue(), itype, jobz, uplo, n, a,
                                                       lda, b, ldb, w, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1257,7 +1257,7 @@ static inline sycl::event hetrd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, float *d, float *e, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::hetrd(selector.get_queue(), uplo, n, a, lda, d, e,
                                                       tau, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1266,7 +1266,7 @@ static inline sycl::event hetrd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, double *d, double *e, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::hetrd(selector.get_queue(), uplo, n, a, lda, d, e,
                                                       tau, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1275,7 +1275,7 @@ static inline sycl::event hetrf(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::hetrf(selector.get_queue(), uplo, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1283,7 +1283,7 @@ static inline sycl::event hetrf(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::hetrf(selector.get_queue(), uplo, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1291,7 +1291,7 @@ static inline sycl::event orgbr(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                                 std::int64_t k, float *a, std::int64_t lda, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgbr(
         selector.get_queue(), vec, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies);
 }
@@ -1299,35 +1299,35 @@ static inline sycl::event orgbr(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                                 std::int64_t k, double *a, std::int64_t lda, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgbr(
         selector.get_queue(), vec, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event orgqr(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                                 double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgqr(selector.get_queue(), m, n, k, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event orgqr(backend_selector<backend::LAPACK_BACKEND> selector, std::int64_t m,
                                 std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                                 float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgqr(selector.get_queue(), m, n, k, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event orgtr(backend_selector<backend::LAPACK_BACKEND> selector,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgtr(selector.get_queue(), uplo, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event orgtr(backend_selector<backend::LAPACK_BACKEND> selector,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgtr(selector.get_queue(), uplo, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1336,7 +1336,7 @@ static inline sycl::event ormtr(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 float *a, std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ormtr(selector.get_queue(), side, uplo, trans, m, n,
                                                       a, lda, tau, c, ldc, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1346,7 +1346,7 @@ static inline sycl::event ormtr(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ormtr(selector.get_queue(), side, uplo, trans, m, n,
                                                       a, lda, tau, c, ldc, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1356,7 +1356,7 @@ static inline sycl::event ormrq(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t m, std::int64_t n, std::int64_t k, float *a,
                                 std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ormrq(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1366,7 +1366,7 @@ static inline sycl::event ormrq(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                                 std::int64_t lda, double *tau, double *c, std::int64_t ldc,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ormrq(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1376,7 +1376,7 @@ static inline sycl::event ormqr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                                 std::int64_t lda, double *tau, double *c, std::int64_t ldc,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ormqr(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1386,7 +1386,7 @@ static inline sycl::event ormqr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t m, std::int64_t n, std::int64_t k, float *a,
                                 std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ormqr(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1394,14 +1394,14 @@ static inline sycl::event ormqr(backend_selector<backend::LAPACK_BACKEND> select
 static inline sycl::event potrf(backend_selector<backend::LAPACK_BACKEND> selector,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event potrf(backend_selector<backend::LAPACK_BACKEND> selector,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1409,7 +1409,7 @@ static inline sycl::event potrf(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1417,21 +1417,21 @@ static inline sycl::event potrf(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event potri(backend_selector<backend::LAPACK_BACKEND> selector,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potri(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
 static inline sycl::event potri(backend_selector<backend::LAPACK_BACKEND> selector,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potri(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1439,7 +1439,7 @@ static inline sycl::event potri(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potri(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1447,7 +1447,7 @@ static inline sycl::event potri(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potri(selector.get_queue(), uplo, n, a, lda,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1455,7 +1455,7 @@ static inline sycl::event potrs(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs, float *a,
                                 std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs(selector.get_queue(), uplo, n, nrhs, a, lda,
                                                       b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1464,7 +1464,7 @@ static inline sycl::event potrs(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                                 double *a, std::int64_t lda, double *b, std::int64_t ldb,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs(selector.get_queue(), uplo, n, nrhs, a, lda,
                                                       b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1474,7 +1474,7 @@ static inline sycl::event potrs(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                                 std::int64_t ldb, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs(selector.get_queue(), uplo, n, nrhs, a, lda,
                                                       b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1484,7 +1484,7 @@ static inline sycl::event potrs(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                                 std::int64_t ldb, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs(selector.get_queue(), uplo, n, nrhs, a, lda,
                                                       b, ldb, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1493,7 +1493,7 @@ static inline sycl::event syevd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *w, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::syevd(selector.get_queue(), jobz, uplo, n, a, lda,
                                                       w, scratchpad, scratchpad_size, dependencies);
 }
@@ -1501,7 +1501,7 @@ static inline sycl::event syevd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *w, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::syevd(selector.get_queue(), jobz, uplo, n, a, lda,
                                                       w, scratchpad, scratchpad_size, dependencies);
 }
@@ -1510,7 +1510,7 @@ static inline sycl::event sygvd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, double *a, std::int64_t lda, double *b,
                                 std::int64_t ldb, double *w, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sygvd(selector.get_queue(), itype, jobz, uplo, n, a,
                                                       lda, b, ldb, w, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1520,7 +1520,7 @@ static inline sycl::event sygvd(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, float *a, std::int64_t lda, float *b,
                                 std::int64_t ldb, float *w, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sygvd(selector.get_queue(), itype, jobz, uplo, n, a,
                                                       lda, b, ldb, w, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1529,7 +1529,7 @@ static inline sycl::event sytrd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *d, double *e, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sytrd(selector.get_queue(), uplo, n, a, lda, d, e,
                                                       tau, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1538,7 +1538,7 @@ static inline sycl::event sytrd(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *d, float *e, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sytrd(selector.get_queue(), uplo, n, a, lda, d, e,
                                                       tau, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1546,7 +1546,7 @@ static inline sycl::event sytrd(backend_selector<backend::LAPACK_BACKEND> select
 static inline sycl::event sytrf(backend_selector<backend::LAPACK_BACKEND> selector,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sytrf(selector.get_queue(), uplo, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1554,7 +1554,7 @@ static inline sycl::event sytrf(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sytrf(selector.get_queue(), uplo, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1562,7 +1562,7 @@ static inline sycl::event sytrf(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sytrf(selector.get_queue(), uplo, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1570,7 +1570,7 @@ static inline sycl::event sytrf(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::sytrf(selector.get_queue(), uplo, n, a, lda, ipiv,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1580,7 +1580,7 @@ static inline sycl::event trtrs(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                                 std::int64_t ldb, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::trtrs(selector.get_queue(), uplo, trans, diag, n,
                                                       nrhs, a, lda, b, ldb, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1590,7 +1590,7 @@ static inline sycl::event trtrs(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
                                 double *a, std::int64_t lda, double *b, std::int64_t ldb,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::trtrs(selector.get_queue(), uplo, trans, diag, n,
                                                       nrhs, a, lda, b, ldb, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1600,7 +1600,7 @@ static inline sycl::event trtrs(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, float *a,
                                 std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::trtrs(selector.get_queue(), uplo, trans, diag, n,
                                                       nrhs, a, lda, b, ldb, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1611,7 +1611,7 @@ static inline sycl::event trtrs(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                                 std::int64_t ldb, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::trtrs(selector.get_queue(), uplo, trans, diag, n,
                                                       nrhs, a, lda, b, ldb, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1621,7 +1621,7 @@ static inline sycl::event ungbr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungbr(
         selector.get_queue(), vec, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies);
 }
@@ -1630,7 +1630,7 @@ static inline sycl::event ungbr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungbr(
         selector.get_queue(), vec, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies);
 }
@@ -1638,7 +1638,7 @@ static inline sycl::event ungqr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::int64_t k, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungqr(selector.get_queue(), m, n, k, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1646,7 +1646,7 @@ static inline sycl::event ungqr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::int64_t n, std::int64_t k, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungqr(selector.get_queue(), m, n, k, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1654,7 +1654,7 @@ static inline sycl::event ungtr(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungtr(selector.get_queue(), uplo, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1662,7 +1662,7 @@ static inline sycl::event ungtr(backend_selector<backend::LAPACK_BACKEND> select
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungtr(selector.get_queue(), uplo, n, a, lda, tau,
                                                       scratchpad, scratchpad_size, dependencies);
 }
@@ -1672,7 +1672,7 @@ static inline sycl::event unmrq(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::unmrq(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1684,7 +1684,7 @@ static inline sycl::event unmrq(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::unmrq(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1695,7 +1695,7 @@ static inline sycl::event unmqr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::unmqr(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1707,7 +1707,7 @@ static inline sycl::event unmqr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::unmqr(selector.get_queue(), side, trans, m, n, k, a,
                                                       lda, tau, c, ldc, scratchpad, scratchpad_size,
                                                       dependencies);
@@ -1718,7 +1718,7 @@ static inline sycl::event unmtr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::unmtr(selector.get_queue(), side, uplo, trans, m, n,
                                                       a, lda, tau, c, ldc, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1730,7 +1730,7 @@ static inline sycl::event unmtr(backend_selector<backend::LAPACK_BACKEND> select
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::unmtr(selector.get_queue(), side, uplo, trans, m, n,
                                                       a, lda, tau, c, ldc, scratchpad,
                                                       scratchpad_size, dependencies);
@@ -1740,7 +1740,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, float *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1750,7 +1750,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, double *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1761,7 +1761,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<float> *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1772,7 +1772,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<double> *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1782,7 +1782,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, float **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(selector.get_queue(), m, n, a, lda, tau,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1792,7 +1792,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, double **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(selector.get_queue(), m, n, a, lda, tau,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1802,7 +1802,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, std::complex<float> **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(selector.get_queue(), m, n, a, lda, tau,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1813,7 +1813,7 @@ static inline sycl::event geqrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::geqrf_batch(selector.get_queue(), m, n, a, lda, tau,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1823,7 +1823,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1833,7 +1833,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1843,7 +1843,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1854,7 +1854,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1864,7 +1864,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, ipiv, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -1874,7 +1874,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, ipiv, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -1884,7 +1884,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, ipiv, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -1895,7 +1895,7 @@ static inline sycl::event getrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrf_batch(
         selector.get_queue(), m, n, a, lda, ipiv, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -1905,7 +1905,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(
         selector.get_queue(), n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1915,7 +1915,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(
         selector.get_queue(), n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1925,7 +1925,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(
         selector.get_queue(), n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1936,7 +1936,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(
         selector.get_queue(), n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -1946,7 +1946,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(selector.get_queue(), n, a, lda, ipiv,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1956,7 +1956,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(selector.get_queue(), n, a, lda, ipiv,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1966,7 +1966,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(selector.get_queue(), n, a, lda, ipiv,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1976,7 +1976,7 @@ static inline sycl::event getri_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getri_batch(selector.get_queue(), n, a, lda, ipiv,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -1988,7 +1988,7 @@ static inline sycl::event getrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_ipiv, float *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies);
@@ -2000,7 +2000,7 @@ static inline sycl::event getrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_ipiv, double *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies);
@@ -2013,7 +2013,7 @@ static inline sycl::event getrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies);
@@ -2026,7 +2026,7 @@ static inline sycl::event getrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies);
@@ -2037,7 +2037,7 @@ static inline sycl::event getrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t **ipiv, float **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, ipiv, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies);
@@ -2048,7 +2048,7 @@ static inline sycl::event getrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t **ipiv, double **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, ipiv, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies);
@@ -2060,7 +2060,7 @@ static inline sycl::event getrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, ipiv, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies);
@@ -2070,7 +2070,7 @@ static inline sycl::event getrs_batch(
     std::int64_t *n, std::int64_t *nrhs, std::complex<double> **a, std::int64_t *lda,
     std::int64_t **ipiv, std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
     std::int64_t *group_sizes, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-    const sycl::vector_class<sycl::event> &dependencies = {}) {
+    const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::getrs_batch(
         selector.get_queue(), trans, n, nrhs, a, lda, ipiv, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies);
@@ -2080,7 +2080,7 @@ static inline sycl::event orgqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t lda, std::int64_t stride_a, float *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgqr_batch(
         selector.get_queue(), m, n, k, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -2090,7 +2090,7 @@ static inline sycl::event orgqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t lda, std::int64_t stride_a, double *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgqr_batch(
         selector.get_queue(), m, n, k, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -2100,7 +2100,7 @@ static inline sycl::event orgqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, float **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgqr_batch(
         selector.get_queue(), m, n, k, a, lda, tau, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -2110,7 +2110,7 @@ static inline sycl::event orgqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, double **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::orgqr_batch(
         selector.get_queue(), m, n, k, a, lda, tau, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -2120,7 +2120,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             stride_a, batch_size, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2130,7 +2130,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             stride_a, batch_size, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2140,7 +2140,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             stride_a, batch_size, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2151,7 +2151,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             stride_a, batch_size, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2161,7 +2161,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2171,7 +2171,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2181,7 +2181,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2192,7 +2192,7 @@ static inline sycl::event potrf_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrf_batch(selector.get_queue(), uplo, n, a, lda,
                                                             group_count, group_sizes, scratchpad,
                                                             scratchpad_size, dependencies);
@@ -2203,7 +2203,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, stride_a, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -2214,7 +2214,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, stride_a, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -2226,7 +2226,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, stride_a, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -2238,7 +2238,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, stride_a, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -2248,7 +2248,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       float **a, std::int64_t *lda, float **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -2258,7 +2258,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       double **a, std::int64_t *lda, double **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -2269,7 +2269,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -2281,7 +2281,7 @@ static inline sycl::event potrs_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::potrs_batch(
         selector.get_queue(), uplo, n, nrhs, a, lda, b, ldb, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -2292,7 +2292,7 @@ static inline sycl::event ungqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_a, std::complex<float> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungqr_batch(
         selector.get_queue(), m, n, k, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -2304,7 +2304,7 @@ static inline sycl::event ungqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungqr_batch(
         selector.get_queue(), m, n, k, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad,
         scratchpad_size, dependencies);
@@ -2315,7 +2315,7 @@ static inline sycl::event ungqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<float> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungqr_batch(
         selector.get_queue(), m, n, k, a, lda, tau, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);
@@ -2326,7 +2326,7 @@ static inline sycl::event ungqr_batch(backend_selector<backend::LAPACK_BACKEND> 
                                       std::complex<double> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {}) {
+                                      const std::vector<sycl::event> &dependencies = {}) {
     return oneapi::mkl::lapack::LAPACK_BACKEND::ungqr_batch(
         selector.get_queue(), m, n, k, a, lda, tau, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies);

--- a/include/oneapi/mkl/lapack/detail/mkl_common/onemkl_lapack_backends.hxx
+++ b/include/oneapi/mkl/lapack/detail/mkl_common/onemkl_lapack_backends.hxx
@@ -583,552 +583,552 @@ ONEMKL_EXPORT sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t
                                 std::complex<float> *a, std::int64_t lda, float *d, float *e,
                                 std::complex<float> *tauq, std::complex<float> *taup,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, double *d, double *e, double *tauq, double *taup,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *d, float *e, float *tauq, float *taup,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, double *d, double *e,
                                 std::complex<double> *tauq, std::complex<double> *taup,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                 std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(sycl::queue &queue, std::int64_t n, double *a, std::int64_t lda,
                                 std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda,
                                 std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                 std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                 std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t *ipiv,
                                 double *b, std::int64_t ldb, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                 std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t *ipiv,
                                 float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                 std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                                 std::int64_t *ipiv, std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n,
                                 double *a, std::int64_t lda, double *s, double *u, std::int64_t ldu,
                                 double *vt, std::int64_t ldvt, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n, float *a,
                                 std::int64_t lda, float *s, float *u, std::int64_t ldu, float *vt,
                                 std::int64_t ldvt, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, float *s,
                                 std::complex<float> *u, std::int64_t ldu, std::complex<float> *vt,
                                 std::int64_t ldvt, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                 oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, double *s,
                                 std::complex<double> *u, std::int64_t ldu, std::complex<double> *vt,
                                 std::int64_t ldvt, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
                                 std::int64_t n, std::complex<float> *a, std::int64_t lda, float *w,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
                                 std::int64_t n, std::complex<double> *a, std::int64_t lda,
                                 double *w, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                                 float *w, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                 oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                                 double *w, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, float *d, float *e,
                                 std::complex<float> *tau, std::complex<float> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, double *d, double *e,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                 std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                                 float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                 std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                                 double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                                 double *a, std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                                 float *a, std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *tau, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *tau, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 float *a, std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, float *a, std::int64_t lda, float *tau, float *c,
                                 std::int64_t ldc, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, double *a, std::int64_t lda, double *tau, double *c,
                                 std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, float *a, std::int64_t lda, float *tau, float *c,
                                 std::int64_t ldc, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::int64_t nrhs, float *a, std::int64_t lda, float *b,
                                 std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::int64_t nrhs, double *a, std::int64_t lda, double *b,
                                 std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
                                 std::int64_t n, double *a, std::int64_t lda, double *w,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo,
                                 std::int64_t n, float *a, std::int64_t lda, float *w,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                 oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda,
                                 double *b, std::int64_t ldb, double *w, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                 oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda,
                                 float *b, std::int64_t ldb, float *w, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, double *d, double *e, double *tau,
                                 double *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, float *d, float *e, float *tau,
                                 float *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 double *a, std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                 std::int64_t n, std::int64_t nrhs, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                 std::int64_t n, std::int64_t nrhs, double *a, std::int64_t lda,
                                 double *b, std::int64_t ldb, double *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                 std::int64_t n, std::int64_t nrhs, float *a, std::int64_t lda,
                                 float *b, std::int64_t ldb, float *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                 std::int64_t n, std::int64_t nrhs, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                 std::int64_t n, std::int64_t k, std::complex<float> *a,
                                 std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                 std::int64_t n, std::int64_t k, std::complex<double> *a,
                                 std::int64_t lda, std::complex<double> *tau,
                                 std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                 std::complex<float> *tau, std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                                 std::complex<float> *c, std::int64_t ldc,
                                 std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                                 oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                 std::complex<double> *a, std::int64_t lda,
                                 std::complex<double> *tau, std::complex<double> *c,
                                 std::int64_t ldc, std::complex<double> *scratchpad,
                                 std::int64_t scratchpad_size,
-                                const sycl::vector_class<sycl::event> &dependencies = {});
+                                const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                       std::int64_t lda, std::int64_t stride_a, float *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                       std::int64_t lda, std::int64_t stride_a, double *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::complex<float> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::complex<double> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::complex<double> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       float **a, std::int64_t *lda, float **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       double **a, std::int64_t *lda, double **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::complex<float> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::complex<double> **a, std::int64_t *lda,
                                       std::complex<double> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::complex<double> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       float **a, std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       double **a, std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::complex<double> **a, std::int64_t *lda,
                                       std::int64_t **ipiv, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t n, float *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t n, double *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::complex<float> *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::complex<double> *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, float **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, double **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::complex<float> **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::complex<double> **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans,
                                       std::int64_t n, std::int64_t nrhs, float *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, float *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans,
                                       std::int64_t n, std::int64_t nrhs, double *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                                       std::int64_t stride_ipiv, double *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans,
                                       std::int64_t n, std::int64_t nrhs, std::complex<float> *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
@@ -1136,7 +1136,7 @@ ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans,
                                       std::int64_t n, std::int64_t nrhs, std::complex<double> *a,
                                       std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
@@ -1144,28 +1144,28 @@ ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans,
                                       std::int64_t *n, std::int64_t *nrhs, float **a,
                                       std::int64_t *lda, std::int64_t **ipiv, float **b,
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans,
                                       std::int64_t *n, std::int64_t *nrhs, double **a,
                                       std::int64_t *lda, std::int64_t **ipiv, double **b,
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans,
                                       std::int64_t *n, std::int64_t *nrhs, std::complex<float> **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
                                       std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans,
                                       std::int64_t *n, std::int64_t *nrhs, std::complex<double> **a,
                                       std::int64_t *lda, std::int64_t **ipiv,
@@ -1173,147 +1173,147 @@ ONEMKL_EXPORT sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::int64_t k, float *a, std::int64_t lda,
                                       std::int64_t stride_a, float *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::int64_t k, double *a, std::int64_t lda,
                                       std::int64_t stride_a, double *tau, std::int64_t stride_tau,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::int64_t *k, float **a, std::int64_t *lda, float **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::int64_t *k, double **a, std::int64_t *lda, double **tau,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       float *a, std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       double *a, std::int64_t lda, std::int64_t stride_a,
                                       std::int64_t batch_size, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::complex<double> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       float **a, std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       double **a, std::int64_t *lda, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::complex<float> **a, std::int64_t *lda,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::complex<double> **a, std::int64_t *lda,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::int64_t nrhs, float *a, std::int64_t lda,
                                       std::int64_t stride_a, float *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       float *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::int64_t nrhs, double *a, std::int64_t lda,
                                       std::int64_t stride_a, double *b, std::int64_t ldb,
                                       std::int64_t stride_b, std::int64_t batch_size,
                                       double *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::complex<float> *b,
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                       std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::complex<double> *b,
                                       std::int64_t ldb, std::int64_t stride_b,
                                       std::int64_t batch_size, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::int64_t *nrhs, float **a, std::int64_t *lda, float **b,
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, float *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::int64_t *nrhs, double **a, std::int64_t *lda, double **b,
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, double *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::int64_t *nrhs, std::complex<float> **a,
                                       std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb,
                                       std::int64_t group_count, std::int64_t *group_sizes,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                                       std::int64_t *nrhs, std::complex<double> **a,
                                       std::int64_t *lda, std::complex<double> **b,
                                       std::int64_t *ldb, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::complex<float> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                       std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                       std::int64_t stride_a, std::complex<double> *tau,
                                       std::int64_t stride_tau, std::int64_t batch_size,
                                       std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::int64_t *k, std::complex<float> **a, std::int64_t *lda,
                                       std::complex<float> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 ONEMKL_EXPORT sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                       std::int64_t *k, std::complex<double> **a, std::int64_t *lda,
                                       std::complex<double> **tau, std::int64_t group_count,
                                       std::int64_t *group_sizes, std::complex<double> *scratchpad,
                                       std::int64_t scratchpad_size,
-                                      const sycl::vector_class<sycl::event> &dependencies = {});
+                                      const std::vector<sycl::event> &dependencies = {});
 
 template <typename fp_type, internal::is_floating_point<fp_type> = nullptr>
 std::int64_t gebrd_scratchpad_size(sycl::queue &queue, std::int64_t m, std::int64_t n,

--- a/include/oneapi/mkl/lapack/exceptions.hpp
+++ b/include/oneapi/mkl/lapack/exceptions.hpp
@@ -57,23 +57,23 @@ public:
 class batch_error : public oneapi::mkl::batch_error, public oneapi::mkl::lapack::exception {
 public:
     batch_error(const std::string &function, const std::string &info, std::int64_t num_errors,
-                sycl::vector_class<std::int64_t> ids = {},
-                sycl::vector_class<std::exception_ptr> exceptions = {})
+                std::vector<std::int64_t> ids = {},
+                std::vector<std::exception_ptr> exceptions = {})
             : oneapi::mkl::batch_error("LAPACK", function, info),
               oneapi::mkl::lapack::exception(this, num_errors),
               _ids(ids),
               _exceptions(exceptions) {}
     using oneapi::mkl::batch_error::what;
-    const sycl::vector_class<std::int64_t> &ids() const {
+    const std::vector<std::int64_t> &ids() const {
         return _ids;
     }
-    const sycl::vector_class<std::exception_ptr> &exceptions() const {
+    const std::vector<std::exception_ptr> &exceptions() const {
         return _exceptions;
     }
 
 private:
-    sycl::vector_class<std::int64_t> _ids;
-    sycl::vector_class<std::exception_ptr> _exceptions;
+    std::vector<std::int64_t> _ids;
+    std::vector<std::exception_ptr> _exceptions;
 };
 
 class invalid_argument : public oneapi::mkl::invalid_argument,

--- a/include/oneapi/mkl/lapack/exceptions.hpp
+++ b/include/oneapi/mkl/lapack/exceptions.hpp
@@ -57,8 +57,7 @@ public:
 class batch_error : public oneapi::mkl::batch_error, public oneapi::mkl::lapack::exception {
 public:
     batch_error(const std::string &function, const std::string &info, std::int64_t num_errors,
-                std::vector<std::int64_t> ids = {},
-                std::vector<std::exception_ptr> exceptions = {})
+                std::vector<std::int64_t> ids = {}, std::vector<std::exception_ptr> exceptions = {})
             : oneapi::mkl::batch_error("LAPACK", function, info),
               oneapi::mkl::lapack::exception(this, num_errors),
               _ids(ids),

--- a/include/oneapi/mkl/rng/detail/engine_impl.hpp
+++ b/include/oneapi/mkl/rng/detail/engine_impl.hpp
@@ -95,65 +95,65 @@ public:
                           cl::sycl::buffer<std::uint32_t, 1>& r) = 0;
 
     // USM APIs
-    virtual cl::sycl::event generate(
-        const uniform<float, uniform_method::standard>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const uniform<float, uniform_method::standard>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const uniform<double, uniform_method::standard>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const uniform<double, uniform_method::standard>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const uniform<std::int32_t, uniform_method::standard>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const uniform<std::int32_t, uniform_method::standard>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const uniform<float, uniform_method::accurate>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const uniform<float, uniform_method::accurate>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const uniform<double, uniform_method::accurate>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const uniform<double, uniform_method::accurate>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const gaussian<float, gaussian_method::box_muller2>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const gaussian<float, gaussian_method::box_muller2>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const gaussian<double, gaussian_method::box_muller2>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const gaussian<double, gaussian_method::box_muller2>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const gaussian<float, gaussian_method::icdf>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const gaussian<float, gaussian_method::icdf>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const gaussian<double, gaussian_method::icdf>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const lognormal<float, lognormal_method::box_muller2>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const lognormal<float, lognormal_method::box_muller2>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const lognormal<double, lognormal_method::box_muller2>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const lognormal<double, lognormal_method::box_muller2>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const lognormal<float, lognormal_method::icdf>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const lognormal<double, lognormal_method::icdf>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
@@ -163,9 +163,9 @@ public:
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
         std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) = 0;
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual engine_impl* copy_state() = 0;
 

--- a/include/oneapi/mkl/rng/detail/engine_impl.hpp
+++ b/include/oneapi/mkl/rng/detail/engine_impl.hpp
@@ -97,75 +97,75 @@ public:
     // USM APIs
     virtual cl::sycl::event generate(
         const uniform<float, uniform_method::standard>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const uniform<double, uniform_method::standard>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const uniform<std::int32_t, uniform_method::standard>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const uniform<float, uniform_method::accurate>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const uniform<double, uniform_method::accurate>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const gaussian<float, gaussian_method::box_muller2>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const gaussian<double, gaussian_method::box_muller2>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const gaussian<float, gaussian_method::icdf>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const lognormal<float, lognormal_method::box_muller2>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const lognormal<double, lognormal_method::box_muller2>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) = 0;
+        const std::vector<cl::sycl::event>& dependencies) = 0;
 
     virtual engine_impl* copy_state() = 0;
 

--- a/include/oneapi/mkl/rng/engines.hpp
+++ b/include/oneapi/mkl/rng/engines.hpp
@@ -126,7 +126,7 @@ private:
     template <typename Distr, typename Engine>
     friend sycl::event generate(const Distr& distr, Engine& engine, std::int64_t n,
                                 typename Distr::result_type* r,
-                                const sycl::vector_class<sycl::event>& dependencies);
+                                const std::vector<sycl::event>& dependencies);
 };
 
 // Class oneapi::mkl::rng::mrg32k3a
@@ -207,7 +207,7 @@ private:
     template <typename Distr, typename Engine>
     friend sycl::event generate(const Distr& distr, Engine& engine, std::int64_t n,
                                 typename Distr::result_type* r,
-                                const sycl::vector_class<sycl::event>& dependencies);
+                                const std::vector<sycl::event>& dependencies);
 };
 
 // Default engine to be used for common cases

--- a/include/oneapi/mkl/rng/functions.hpp
+++ b/include/oneapi/mkl/rng/functions.hpp
@@ -63,9 +63,9 @@ static inline void generate(const Distr& distr, Engine& engine, std::int64_t n,
 // Returns:
 //      cl::sycl::event - event for the submitted to the engine's queue task
 template <typename Distr, typename Engine>
-static inline cl::sycl::event generate(
-    const Distr& distr, Engine& engine, std::int64_t n, typename Distr::result_type* r,
-    const std::vector<cl::sycl::event>& dependencies = {}) {
+static inline cl::sycl::event generate(const Distr& distr, Engine& engine, std::int64_t n,
+                                       typename Distr::result_type* r,
+                                       const std::vector<cl::sycl::event>& dependencies = {}) {
     generate_precondition(distr, engine, n, r, dependencies);
     return engine.pimpl_->generate(distr, n, r, dependencies);
 }

--- a/include/oneapi/mkl/rng/functions.hpp
+++ b/include/oneapi/mkl/rng/functions.hpp
@@ -54,7 +54,7 @@ static inline void generate(const Distr& distr, Engine& engine, std::int64_t n,
 //      const Distr& distr               - distribution object
 //      Engine& engine                   - engine object
 //      std::int64_t n                   - number of random values to be generated
-//      const cl::sycl::vector_class<cl::sycl::event>& dependencies - list of events to wait for
+//      const std::vector<cl::sycl::event>& dependencies - list of events to wait for
 //                  before starting computation, if any. If omitted, defaults to no dependencies
 //
 // Output parameters:
@@ -65,7 +65,7 @@ static inline void generate(const Distr& distr, Engine& engine, std::int64_t n,
 template <typename Distr, typename Engine>
 static inline cl::sycl::event generate(
     const Distr& distr, Engine& engine, std::int64_t n, typename Distr::result_type* r,
-    const cl::sycl::vector_class<cl::sycl::event>& dependencies = {}) {
+    const std::vector<cl::sycl::event>& dependencies = {}) {
     generate_precondition(distr, engine, n, r, dependencies);
     return engine.pimpl_->generate(distr, n, r, dependencies);
 }

--- a/include/oneapi/mkl/rng/predicates.hpp
+++ b/include/oneapi/mkl/rng/predicates.hpp
@@ -47,7 +47,7 @@ inline void generate_precondition(const Distr& distr, Engine& engine, std::int64
 template <typename Distr, typename Engine>
 inline void generate_precondition(const Distr& distr, Engine& engine, std::int64_t n,
                                   typename Distr::result_type* r,
-                                  const cl::sycl::vector_class<cl::sycl::event>& dependencies) {
+                                  const std::vector<cl::sycl::event>& dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     if (n < 0) {
         throw oneapi::mkl::invalid_argument("rng", "generate", "n");

--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -309,15 +309,13 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
@@ -337,31 +335,27 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<doub
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
@@ -419,8 +413,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -436,16 +429,14 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -453,8 +444,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *a, int64_t lda, int64_t stride_a,
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -462,8 +452,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *a, int64_t lda, int64_t stride_a,
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -536,7 +525,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
         cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,          \
         int64_t k, TYPE alpha, const TYPE *a, int64_t lda, int64_t stride_a, const TYPE *b,        \
         int64_t ldb, int64_t stride_b, TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c,          \
-        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {         \
+        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {                    \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, \
                           b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);     \
     }
@@ -594,7 +583,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                                int64_t *m, int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a,  \
                                int64_t *lda, const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c, \
                                int64_t *ldc, int64_t group_count, int64_t *group_size,           \
-                               const std::vector<cl::sycl::event> &dependencies) {    \
+                               const std::vector<cl::sycl::event> &dependencies) {               \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, \
                           beta, c, ldc, group_count, group_size, dependencies);                  \
     }
@@ -627,8 +616,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
@@ -636,8 +624,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
@@ -681,7 +668,7 @@ inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_
                                transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,         \
                                TYPE *alpha, const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb, \
                                int64_t group_count, int64_t *group_size,                          \
-                               const std::vector<cl::sycl::event> &dependencies) {     \
+                               const std::vector<cl::sycl::event> &dependencies) {                \
         return trsm_batch(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, \
                           alpha, a, lda, b, ldb, group_count, group_size, dependencies);          \
     }
@@ -733,8 +720,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -742,8 +728,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -751,8 +736,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -1019,15 +1003,13 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
@@ -1047,31 +1029,27 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<doub
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
@@ -1129,8 +1107,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1146,16 +1123,14 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1163,8 +1138,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *a, int64_t lda, int64_t stride_a,
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1172,8 +1146,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *a, int64_t lda, int64_t stride_a,
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1222,7 +1195,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
         cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,          \
         int64_t k, TYPE alpha, const TYPE *a, int64_t lda, int64_t stride_a, const TYPE *b,        \
         int64_t ldb, int64_t stride_b, TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c,          \
-        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {         \
+        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {                    \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, \
                           b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);     \
     }
@@ -1249,7 +1222,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                                int64_t *m, int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a,  \
                                int64_t *lda, const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c, \
                                int64_t *ldc, int64_t group_count, int64_t *group_size,           \
-                               const std::vector<cl::sycl::event> &dependencies) {    \
+                               const std::vector<cl::sycl::event> &dependencies) {               \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, \
                           beta, c, ldc, group_count, group_size, dependencies);                  \
     }
@@ -1282,8 +1255,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
@@ -1291,8 +1263,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
@@ -1310,7 +1281,7 @@ inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_
                                transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,         \
                                TYPE *alpha, const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb, \
                                int64_t group_count, int64_t *group_size,                          \
-                               const std::vector<cl::sycl::event> &dependencies) {     \
+                               const std::vector<cl::sycl::event> &dependencies) {                \
         return trsm_batch(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, \
                           alpha, a, lda, b, ldb, group_count, group_size, dependencies);          \
     }
@@ -1362,8 +1333,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
@@ -1371,8 +1341,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
@@ -1380,8 +1349,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 

--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -255,97 +255,97 @@ void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
                            float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
                            double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
                            int64_t *incx, std::complex<float> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
                            int64_t *incx, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                            std::int64_t stridex, float *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                            std::int64_t stridex, double *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, std::int64_t stridex, std::complex<float> *y, int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
@@ -353,7 +353,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
@@ -361,7 +361,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<doubl
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
@@ -369,7 +369,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            float alpha, const float *a, int64_t lda, int64_t stride_a,
                            const float *x, int64_t incx, int64_t stride_x, float beta, float *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -377,7 +377,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            double alpha, const double *a, int64_t lda, int64_t stride_a,
                            const double *x, int64_t incx, int64_t stride_x, double beta, double *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -386,7 +386,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<float> *x, int64_t incx,
                            int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -395,7 +395,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<double> *x, int64_t incx,
                            int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -403,7 +403,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            float *alpha, const float **a, int64_t *lda, const float **x,
                            int64_t *incx, float *beta, float **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -411,7 +411,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            double *alpha, const double **a, int64_t *lda, const double **x,
                            int64_t *incx, double *beta, double **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -420,7 +420,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -429,7 +429,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            int64_t *lda, const std::complex<double> **x, int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
@@ -437,7 +437,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -445,7 +445,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -454,7 +454,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -463,21 +463,21 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const double **a, int64_t *lda, const double **x, int64_t *incx,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -485,7 +485,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -493,7 +493,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
@@ -503,7 +503,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
                                   const T *a, int64_t lda, int64_t stride_a, const T *b,
                                   int64_t ldb, int64_t stride_b, T beta, T *c, int64_t ldc,
                                   int64_t stride_c, int64_t batch_size,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                  const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, k, lda, ldb, ldc, stride_a, stride_b, stride_c, batch_size);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -536,7 +536,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
         cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,          \
         int64_t k, TYPE alpha, const TYPE *a, int64_t lda, int64_t stride_a, const TYPE *b,        \
         int64_t ldb, int64_t stride_b, TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c,          \
-        int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {         \
+        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {         \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, \
                           b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);     \
     }
@@ -554,7 +554,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                                   transpose *transb, int64_t *m, int64_t *n, int64_t *k, T *alpha,
                                   const T **a, int64_t *lda, const T **b, int64_t *ldb, T *beta,
                                   T **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                  const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     for (int64_t i = 0; i < group_count; i++) {
         overflow_check(m[i], n[i], k[i], lda[i], ldb[i], ldc[i], group_size[i]);
@@ -594,7 +594,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                                int64_t *m, int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a,  \
                                int64_t *lda, const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c, \
                                int64_t *ldc, int64_t group_count, int64_t *group_size,           \
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {    \
+                               const std::vector<cl::sycl::event> &dependencies) {    \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, \
                           beta, c, ldc, group_count, group_size, dependencies);                  \
     }
@@ -611,7 +611,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
                            const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
@@ -619,7 +619,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
                            const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
@@ -628,7 +628,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
@@ -637,7 +637,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
@@ -646,7 +646,7 @@ inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_
                                   uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
                                   int64_t *n, T *alpha, const T **a, int64_t *lda, T **b,
                                   int64_t *ldb, int64_t group_count, int64_t *group_size,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                  const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     for (int64_t i = 0; i < group_count; i++) {
         overflow_check(m[i], n[i], lda[i], ldb[i], group_size[i]);
@@ -681,7 +681,7 @@ inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_
                                transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,         \
                                TYPE *alpha, const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb, \
                                int64_t group_count, int64_t *group_size,                          \
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                               const std::vector<cl::sycl::event> &dependencies) {     \
         return trsm_batch(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, \
                           alpha, a, lda, b, ldb, group_count, group_size, dependencies);          \
     }
@@ -696,14 +696,14 @@ TRSM_BATCH_LAUNCHER_USM(std::complex<double>, cublasZtrsmBatched)
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
                            float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -711,7 +711,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
                            int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -719,14 +719,14 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -734,7 +734,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -743,7 +743,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -752,7 +752,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -965,97 +965,97 @@ void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
                            float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
                            double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
                            int64_t *incx, std::complex<float> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
                            int64_t *incx, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                            std::int64_t stridex, float *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                            std::int64_t stridex, double *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, std::int64_t stridex, std::complex<float> *y, int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
@@ -1063,7 +1063,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
@@ -1071,7 +1071,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<doubl
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
@@ -1079,7 +1079,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            float alpha, const float *a, int64_t lda, int64_t stride_a,
                            const float *x, int64_t incx, int64_t stride_x, float beta, float *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1087,7 +1087,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            double alpha, const double *a, int64_t lda, int64_t stride_a,
                            const double *x, int64_t incx, int64_t stride_x, double beta, double *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1096,7 +1096,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<float> *x, int64_t incx,
                            int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1105,7 +1105,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<double> *x, int64_t incx,
                            int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1113,7 +1113,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            float *alpha, const float **a, int64_t *lda, const float **x,
                            int64_t *incx, float *beta, float **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1121,7 +1121,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            double *alpha, const double **a, int64_t *lda, const double **x,
                            int64_t *incx, double *beta, double **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1130,7 +1130,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1139,7 +1139,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            int64_t *lda, const std::complex<double> **x, int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
@@ -1147,7 +1147,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1155,7 +1155,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1164,7 +1164,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1173,21 +1173,21 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const double **a, int64_t *lda, const double **x, int64_t *incx,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1195,7 +1195,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1203,7 +1203,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
@@ -1213,7 +1213,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
                                   const T *a, int64_t lda, int64_t stride_a, const T *b,
                                   int64_t ldb, int64_t stride_b, T beta, T *c, int64_t ldc,
                                   int64_t stride_c, int64_t batch_size,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                  const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_batch", "for row_major layout");
 }
 
@@ -1222,7 +1222,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
         cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,          \
         int64_t k, TYPE alpha, const TYPE *a, int64_t lda, int64_t stride_a, const TYPE *b,        \
         int64_t ldb, int64_t stride_b, TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c,          \
-        int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {         \
+        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {         \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, \
                           b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);     \
     }
@@ -1240,7 +1240,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                                   transpose *transb, int64_t *m, int64_t *n, int64_t *k, T *alpha,
                                   const T **a, int64_t *lda, const T **b, int64_t *ldb, T *beta,
                                   T **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                  const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_batch", "for row_major layout");
 }
 
@@ -1249,7 +1249,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                                int64_t *m, int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a,  \
                                int64_t *lda, const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c, \
                                int64_t *ldc, int64_t group_count, int64_t *group_size,           \
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {    \
+                               const std::vector<cl::sycl::event> &dependencies) {    \
         return gemm_batch(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, \
                           beta, c, ldc, group_count, group_size, dependencies);                  \
     }
@@ -1266,7 +1266,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
                            const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
@@ -1274,7 +1274,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
                            const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
@@ -1283,7 +1283,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
@@ -1292,7 +1292,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
@@ -1301,7 +1301,7 @@ inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_
                                   uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
                                   int64_t *n, T *alpha, const T **a, int64_t *lda, T **b,
                                   int64_t *ldb, int64_t group_count, int64_t *group_size,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                  const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
@@ -1310,7 +1310,7 @@ inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_
                                transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,         \
                                TYPE *alpha, const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb, \
                                int64_t group_count, int64_t *group_size,                          \
-                               const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                               const std::vector<cl::sycl::event> &dependencies) {     \
         return trsm_batch(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, \
                           alpha, a, lda, b, ldb, group_count, group_size, dependencies);          \
     }
@@ -1325,14 +1325,14 @@ TRSM_BATCH_LAUNCHER_USM(std::complex<double>, cublasZtrsmBatched)
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
                            float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
@@ -1340,7 +1340,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
                            int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
@@ -1348,14 +1348,14 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
@@ -1363,7 +1363,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
@@ -1372,7 +1372,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
@@ -1381,7 +1381,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 

--- a/src/blas/backends/cublas/cublas_extensions.cpp
+++ b/src/blas/backends/cublas/cublas_extensions.cpp
@@ -95,7 +95,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
@@ -103,7 +103,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
@@ -111,7 +111,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
@@ -119,21 +119,21 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                       const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                       const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
@@ -141,7 +141,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
@@ -149,7 +149,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<double> alpha,
                       const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
                       int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
@@ -224,7 +224,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
@@ -232,7 +232,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
@@ -240,7 +240,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
@@ -248,21 +248,21 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                       const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                       const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
@@ -270,7 +270,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
@@ -278,7 +278,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<double> alpha,
                       const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
                       int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -649,8 +649,7 @@ inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const 
 
 #define ASUM_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result,                                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {         \
+                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
         return asum(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 ASUM_LAUNCHER_USM(float, float, cublasSasum)
@@ -683,7 +682,7 @@ inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, 
 
 #define SCAL_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                      \
     cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {                 \
         return scal(CUBLAS_ROUTINE, queue, n, a, x, incx, dependencies);                     \
     }
 SCAL_LAUNCHER_USM(float, float, cublasSscal)
@@ -716,11 +715,11 @@ inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alph
     return done;
 }
 
-#define AXPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
-    cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x,  \
-                         int64_t incx, TYPE *y, int64_t incy,                           \
-                         const std::vector<cl::sycl::event> &dependencies) { \
-        return axpy(CUBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);   \
+#define AXPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                        \
+    cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x, \
+                         int64_t incx, TYPE *y, int64_t incy,                          \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
+        return axpy(CUBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);  \
     }
 
 AXPY_LAUNCHER_USM(float, cublasSaxpy)
@@ -777,7 +776,7 @@ inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 
 
 #define ROTG_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                  \
     cl::sycl::event rotg(cl::sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
-                         const std::vector<cl::sycl::event> &dependencies) {  \
+                         const std::vector<cl::sycl::event> &dependencies) {             \
         return rotg(CUBLAS_ROUTINE, queue, a, b, c, s, dependencies);                    \
     }
 
@@ -813,7 +812,7 @@ inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, 
 #define ROTM_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy, TYPE *param,                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {                \
         return rotm(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);       \
     }
 
@@ -823,8 +822,7 @@ ROTM_LAUNCHER_USM(double, cublasDrotm)
 
 template <typename Func, typename T>
 inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const T *x, int64_t incx,
-                            T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            T *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -845,8 +843,7 @@ inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const 
 
 #define COPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy,                                                            \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {        \
         return copy(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                    \
     }
 
@@ -882,7 +879,7 @@ inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T
 #define DOT_LAUNCHER_USM(EXT, TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event dot##EXT(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                              const TYPE *y, const int64_t incy, TYPE *result,                      \
-                             const std::vector<cl::sycl::event> &dependencies) {        \
+                             const std::vector<cl::sycl::event> &dependencies) {                   \
         return dot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);              \
     }
 DOT_LAUNCHER_USM(, float, cublasSdot)
@@ -921,7 +918,7 @@ inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, 
 #define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, CUBLAS_ROUTINE)                                      \
     cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
                         int64_t incy, TYPE2 c, TYPE3 s,                                            \
-                        const std::vector<cl::sycl::event> &dependencies) {             \
+                        const std::vector<cl::sycl::event> &dependencies) {                        \
         return rot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);                \
     }
 
@@ -984,11 +981,10 @@ inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T 
     return done;
 }
 
-#define ROTMG_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
-    cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1, \
-                          TYPE *param,                                                   \
-                          const std::vector<cl::sycl::event> &dependencies) { \
-        return rotmg(CUBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);        \
+#define ROTMG_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
+    cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1,   \
+                          TYPE *param, const std::vector<cl::sycl::event> &dependencies) { \
+        return rotmg(CUBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);          \
     }
 
 ROTMG_LAUNCHER_USM(float, cublasSrotmg)
@@ -1030,8 +1026,7 @@ inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const
 
 #define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result,                                                      \
-                          const std::vector<cl::sycl::event> &dependencies) {        \
+                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
         return iamax(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMAX_LAUNCHER_USM(float, cublasIsamax)
@@ -1042,8 +1037,7 @@ IAMAX_LAUNCHER_USM(std::complex<double>, cublasIzamax)
 
 template <typename Func, typename T>
 inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
-                            int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1064,8 +1058,7 @@ inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, 
 
 #define SWAP_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy,                                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {  \
         return swap(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);              \
     }
 
@@ -1110,8 +1103,7 @@ inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const
 
 #define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result,                                                      \
-                          const std::vector<cl::sycl::event> &dependencies) {        \
+                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
         return iamin(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMIN_LAUNCHER_USM(float, cublasIsamin)
@@ -1147,8 +1139,7 @@ inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const 
 
 #define NRM2_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result,                                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {         \
+                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
         return nrm2(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 NRM2_LAUNCHER_USM(float, float, cublasSnrm2)
@@ -1443,8 +1434,7 @@ inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const 
 
 #define ASUM_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result,                                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {         \
+                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
         return asum(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 ASUM_LAUNCHER_USM(float, float, cublasSasum)
@@ -1461,7 +1451,7 @@ inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, 
 
 #define SCAL_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                      \
     cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {                 \
         return scal(CUBLAS_ROUTINE, queue, n, a, x, incx, dependencies);                     \
     }
 SCAL_LAUNCHER_USM(float, float, cublasSscal)
@@ -1479,11 +1469,11 @@ inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alph
     throw unimplemented("blas", "axpy", "for row_major layout");
 }
 
-#define AXPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
-    cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x,  \
-                         int64_t incx, TYPE *y, int64_t incy,                           \
-                         const std::vector<cl::sycl::event> &dependencies) { \
-        return axpy(CUBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);   \
+#define AXPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                        \
+    cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x, \
+                         int64_t incx, TYPE *y, int64_t incy,                          \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
+        return axpy(CUBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);  \
     }
 
 AXPY_LAUNCHER_USM(float, cublasSaxpy)
@@ -1523,7 +1513,7 @@ inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 
 
 #define ROTG_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                  \
     cl::sycl::event rotg(cl::sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
-                         const std::vector<cl::sycl::event> &dependencies) {  \
+                         const std::vector<cl::sycl::event> &dependencies) {             \
         return rotg(CUBLAS_ROUTINE, queue, a, b, c, s, dependencies);                    \
     }
 
@@ -1543,7 +1533,7 @@ inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, 
 #define ROTM_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy, TYPE *param,                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {                \
         return rotm(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);       \
     }
 
@@ -1553,15 +1543,13 @@ ROTM_LAUNCHER_USM(double, cublasDrotm)
 
 template <typename Func, typename T>
 inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const T *x, int64_t incx,
-                            T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            T *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy", "for row_major layout");
 }
 
 #define COPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy,                                                            \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {        \
         return copy(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                    \
     }
 
@@ -1581,7 +1569,7 @@ inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T
 #define DOT_LAUNCHER_USM(EXT, TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event dot##EXT(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                              const TYPE *y, const int64_t incy, TYPE *result,                      \
-                             const std::vector<cl::sycl::event> &dependencies) {        \
+                             const std::vector<cl::sycl::event> &dependencies) {                   \
         return dot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);              \
     }
 DOT_LAUNCHER_USM(, float, cublasSdot)
@@ -1602,7 +1590,7 @@ inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, 
 #define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, CUBLAS_ROUTINE)                                      \
     cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
                         int64_t incy, TYPE2 c, TYPE3 s,                                            \
-                        const std::vector<cl::sycl::event> &dependencies) {             \
+                        const std::vector<cl::sycl::event> &dependencies) {                        \
         return rot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);                \
     }
 
@@ -1630,11 +1618,10 @@ inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T 
     throw unimplemented("blas", "rotmg", "for row_major layout");
 }
 
-#define ROTMG_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
-    cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1, \
-                          TYPE *param,                                                   \
-                          const std::vector<cl::sycl::event> &dependencies) { \
-        return rotmg(CUBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);        \
+#define ROTMG_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
+    cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1,   \
+                          TYPE *param, const std::vector<cl::sycl::event> &dependencies) { \
+        return rotmg(CUBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);          \
     }
 
 ROTMG_LAUNCHER_USM(float, cublasSrotmg)
@@ -1650,8 +1637,7 @@ inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const
 
 #define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result,                                                      \
-                          const std::vector<cl::sycl::event> &dependencies) {        \
+                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
         return iamax(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMAX_LAUNCHER_USM(float, cublasIsamax)
@@ -1662,15 +1648,13 @@ IAMAX_LAUNCHER_USM(std::complex<double>, cublasIzamax)
 
 template <typename Func, typename T>
 inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
-                            int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "swap", "for row_major layout");
 }
 
 #define SWAP_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy,                                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {  \
         return swap(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);              \
     }
 
@@ -1689,8 +1673,7 @@ inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const
 
 #define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result,                                                      \
-                          const std::vector<cl::sycl::event> &dependencies) {        \
+                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
         return iamin(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMIN_LAUNCHER_USM(float, cublasIsamin)
@@ -1708,8 +1691,7 @@ inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const 
 
 #define NRM2_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result,                                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {         \
+                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
         return nrm2(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 NRM2_LAUNCHER_USM(float, float, cublasSnrm2)

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -625,7 +625,7 @@ NRM2_LAUNCHER(std::complex<double>, double, cublasDznrm2)
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
                             const int64_t incx, T2 *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType1 = typename CudaEquivalentType<T1>::Type;
     using cuDataType2 = typename CudaEquivalentType<T2>::Type;
     overflow_check(n, incx);
@@ -650,7 +650,7 @@ inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const 
 #define ASUM_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
                          TYPE2 *result,                                                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {         \
+                         const std::vector<cl::sycl::event> &dependencies) {         \
         return asum(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 ASUM_LAUNCHER_USM(float, float, cublasSasum)
@@ -661,7 +661,7 @@ ASUM_LAUNCHER_USM(std::complex<double>, double, cublasDzasum)
 
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, T2 *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType1 = typename CudaEquivalentType<T1>::Type;
     using cuDataType2 = typename CudaEquivalentType<T2>::Type;
     overflow_check(n, incx);
@@ -683,7 +683,7 @@ inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, 
 
 #define SCAL_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                      \
     cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {      \
         return scal(CUBLAS_ROUTINE, queue, n, a, x, incx, dependencies);                     \
     }
 SCAL_LAUNCHER_USM(float, float, cublasSscal)
@@ -697,7 +697,7 @@ SCAL_LAUNCHER_USM(double, std::complex<double>, cublasZdscal)
 template <typename Func, typename T>
 inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alpha, const T *x,
                             int64_t incx, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -719,7 +719,7 @@ inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alph
 #define AXPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
     cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x,  \
                          int64_t incx, TYPE *y, int64_t incy,                           \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) { \
+                         const std::vector<cl::sycl::event> &dependencies) { \
         return axpy(CUBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);   \
     }
 
@@ -731,30 +731,30 @@ AXPY_LAUNCHER_USM(std::complex<double>, cublasZaxpy)
 
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
                       float beta, float *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                       int64_t incx, double beta, double *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                       const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                       std::complex<float> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                       const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                       std::complex<double> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 *c, T1 *s,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType1 = typename CudaEquivalentType<T1>::Type;
     using cuDataType2 = typename CudaEquivalentType<T2>::Type;
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -777,7 +777,7 @@ inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 
 
 #define ROTG_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                  \
     cl::sycl::event rotg(cl::sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {  \
+                         const std::vector<cl::sycl::event> &dependencies) {  \
         return rotg(CUBLAS_ROUTINE, queue, a, b, c, s, dependencies);                    \
     }
 
@@ -790,7 +790,7 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, cublasZrotg)
 template <typename Func, typename T>
 inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
                             int64_t incy, T *param,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -813,7 +813,7 @@ inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, 
 #define ROTM_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy, TYPE *param,                                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return rotm(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);       \
     }
 
@@ -824,7 +824,7 @@ ROTM_LAUNCHER_USM(double, cublasDrotm)
 template <typename Func, typename T>
 inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const T *x, int64_t incx,
                             T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -846,7 +846,7 @@ inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const 
 #define COPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy,                                                            \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return copy(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                    \
     }
 
@@ -859,7 +859,7 @@ COPY_LAUNCHER_USM(std::complex<double>, cublasZcopy)
 template <typename Func, typename T>
 inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
                            const int64_t incx, const T *y, int64_t incy, T *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -882,7 +882,7 @@ inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T
 #define DOT_LAUNCHER_USM(EXT, TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event dot##EXT(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                              const TYPE *y, const int64_t incy, TYPE *result,                      \
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                             const std::vector<cl::sycl::event> &dependencies) {        \
         return dot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);              \
     }
 DOT_LAUNCHER_USM(, float, cublasSdot)
@@ -896,7 +896,7 @@ DOT_LAUNCHER_USM(u, std::complex<double>, cublasZdotu)
 template <typename Func, typename T1, typename T2, typename T3>
 inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, const int64_t incx,
                            T1 *y, int64_t incy, T2 c, T3 s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType1 = typename CudaEquivalentType<T1>::Type;
     using cuDataType2 = typename CudaEquivalentType<T2>::Type;
     using cuDataType3 = typename CudaEquivalentType<T3>::Type;
@@ -921,7 +921,7 @@ inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, 
 #define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, CUBLAS_ROUTINE)                                      \
     cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
                         int64_t incy, TYPE2 c, TYPE3 s,                                            \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {             \
+                        const std::vector<cl::sycl::event> &dependencies) {             \
         return rot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);                \
     }
 
@@ -933,7 +933,7 @@ ROT_LAUNCHER_USM(std::complex<double>, double, double, cublasZdrot)
 
 cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
                        const float *y, int64_t incy, float *result,
-                       const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       const std::vector<cl::sycl::event> &dependencies) {
     overflow_check(n, incx, incy);
     // cuBLAS does not support sdot so we need to mimic sdot.
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -957,13 +957,13 @@ cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float 
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
                     int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dot", "for column_major layout");
 }
 
 template <typename Func, typename T>
 inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T *x1, T y1, T *param,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
@@ -987,7 +987,7 @@ inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T 
 #define ROTMG_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
     cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1, \
                           TYPE *param,                                                   \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) { \
+                          const std::vector<cl::sycl::event> &dependencies) { \
         return rotmg(CUBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);        \
     }
 
@@ -998,7 +998,7 @@ ROTMG_LAUNCHER_USM(double, cublasDrotmg)
 template <typename Func, typename T>
 inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
                              const int64_t incx, int64_t *result,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
     // cuBLAS does not support int64_t as return type for the data. So we need to
@@ -1031,7 +1031,7 @@ inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const
 #define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                           int64_t *result,                                                      \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                          const std::vector<cl::sycl::event> &dependencies) {        \
         return iamax(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMAX_LAUNCHER_USM(float, cublasIsamax)
@@ -1043,7 +1043,7 @@ IAMAX_LAUNCHER_USM(std::complex<double>, cublasIzamax)
 template <typename Func, typename T>
 inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
                             int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1065,7 +1065,7 @@ inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, 
 #define SWAP_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy,                                                      \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return swap(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);              \
     }
 
@@ -1078,7 +1078,7 @@ SWAP_LAUNCHER_USM(std::complex<double>, cublasZswap)
 template <typename Func, typename T>
 inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
                              const int64_t incx, int64_t *result,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
     // cuBLAS does not support int64_t as return type for the data. So we need to
@@ -1111,7 +1111,7 @@ inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const
 #define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                           int64_t *result,                                                      \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                          const std::vector<cl::sycl::event> &dependencies) {        \
         return iamin(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMIN_LAUNCHER_USM(float, cublasIsamin)
@@ -1123,7 +1123,7 @@ IAMIN_LAUNCHER_USM(std::complex<double>, cublasIzamin)
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
                             const int64_t incx, T2 *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType1 = typename CudaEquivalentType<T1>::Type;
     using cuDataType2 = typename CudaEquivalentType<T2>::Type;
     overflow_check(n, incx);
@@ -1148,7 +1148,7 @@ inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const 
 #define NRM2_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
                          TYPE2 *result,                                                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {         \
+                         const std::vector<cl::sycl::event> &dependencies) {         \
         return nrm2(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 NRM2_LAUNCHER_USM(float, float, cublasSnrm2)
@@ -1437,14 +1437,14 @@ NRM2_LAUNCHER(std::complex<double>, double, cublasDznrm2)
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
                             const int64_t incx, T2 *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "asum", "for row_major layout");
 }
 
 #define ASUM_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
                          TYPE2 *result,                                                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {         \
+                         const std::vector<cl::sycl::event> &dependencies) {         \
         return asum(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 ASUM_LAUNCHER_USM(float, float, cublasSasum)
@@ -1455,13 +1455,13 @@ ASUM_LAUNCHER_USM(std::complex<double>, double, cublasDzasum)
 
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, T2 *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "scal", "for row_major layout");
 }
 
 #define SCAL_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                      \
     cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {      \
         return scal(CUBLAS_ROUTINE, queue, n, a, x, incx, dependencies);                     \
     }
 SCAL_LAUNCHER_USM(float, float, cublasSscal)
@@ -1475,14 +1475,14 @@ SCAL_LAUNCHER_USM(double, std::complex<double>, cublasZdscal)
 template <typename Func, typename T>
 inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alpha, const T *x,
                             int64_t incx, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy", "for row_major layout");
 }
 
 #define AXPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
     cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x,  \
                          int64_t incx, TYPE *y, int64_t incy,                           \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) { \
+                         const std::vector<cl::sycl::event> &dependencies) { \
         return axpy(CUBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);   \
     }
 
@@ -1494,36 +1494,36 @@ AXPY_LAUNCHER_USM(std::complex<double>, cublasZaxpy)
 
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
                       float beta, float *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                       int64_t incx, double beta, double *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                       const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                       std::complex<float> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                       const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                       std::complex<double> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 *c, T1 *s,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "rotg", "for row_major layout");
 }
 
 #define ROTG_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                  \
     cl::sycl::event rotg(cl::sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {  \
+                         const std::vector<cl::sycl::event> &dependencies) {  \
         return rotg(CUBLAS_ROUTINE, queue, a, b, c, s, dependencies);                    \
     }
 
@@ -1536,14 +1536,14 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, cublasZrotg)
 template <typename Func, typename T>
 inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
                             int64_t incy, T *param,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "rotm", "for row_major layout");
 }
 
 #define ROTM_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy, TYPE *param,                                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return rotm(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);       \
     }
 
@@ -1554,14 +1554,14 @@ ROTM_LAUNCHER_USM(double, cublasDrotm)
 template <typename Func, typename T>
 inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const T *x, int64_t incx,
                             T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "copy", "for row_major layout");
 }
 
 #define COPY_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy,                                                            \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return copy(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                    \
     }
 
@@ -1574,14 +1574,14 @@ COPY_LAUNCHER_USM(std::complex<double>, cublasZcopy)
 template <typename Func, typename T>
 inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
                            const int64_t incx, const T *y, int64_t incy, T *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dot", "for row_major layout");
 }
 
 #define DOT_LAUNCHER_USM(EXT, TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event dot##EXT(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                              const TYPE *y, const int64_t incy, TYPE *result,                      \
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                             const std::vector<cl::sycl::event> &dependencies) {        \
         return dot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);              \
     }
 DOT_LAUNCHER_USM(, float, cublasSdot)
@@ -1595,14 +1595,14 @@ DOT_LAUNCHER_USM(u, std::complex<double>, cublasZdotu)
 template <typename Func, typename T1, typename T2, typename T3>
 inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, const int64_t incx,
                            T1 *y, int64_t incy, T2 c, T3 s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "rot", "for row_major layout");
 }
 
 #define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, CUBLAS_ROUTINE)                                      \
     cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
                         int64_t incy, TYPE2 c, TYPE3 s,                                            \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {             \
+                        const std::vector<cl::sycl::event> &dependencies) {             \
         return rot(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);                \
     }
 
@@ -1614,26 +1614,26 @@ ROT_LAUNCHER_USM(std::complex<double>, double, double, cublasZdrot)
 
 cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
                        const float *y, int64_t incy, float *result,
-                       const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "sdsdot", "for row_major layout");
 }
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
                     int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "dot", "for row_major layout");
 }
 
 template <typename Func, typename T>
 inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T *x1, T y1, T *param,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "rotmg", "for row_major layout");
 }
 
 #define ROTMG_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                         \
     cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1, \
                           TYPE *param,                                                   \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) { \
+                          const std::vector<cl::sycl::event> &dependencies) { \
         return rotmg(CUBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);        \
     }
 
@@ -1644,14 +1644,14 @@ ROTMG_LAUNCHER_USM(double, cublasDrotmg)
 template <typename Func, typename T>
 inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
                              const int64_t incx, int64_t *result,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "iamax", "for row_major layout");
 }
 
 #define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                           int64_t *result,                                                      \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                          const std::vector<cl::sycl::event> &dependencies) {        \
         return iamax(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMAX_LAUNCHER_USM(float, cublasIsamax)
@@ -1663,14 +1663,14 @@ IAMAX_LAUNCHER_USM(std::complex<double>, cublasIzamax)
 template <typename Func, typename T>
 inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
                             int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "swap", "for row_major layout");
 }
 
 #define SWAP_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
                          int64_t incy,                                                      \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return swap(CUBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);              \
     }
 
@@ -1683,14 +1683,14 @@ SWAP_LAUNCHER_USM(std::complex<double>, cublasZswap)
 template <typename Func, typename T>
 inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
                              const int64_t incx, int64_t *result,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "iamin", "for row_major layout");
 }
 
 #define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
     cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
                           int64_t *result,                                                      \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                          const std::vector<cl::sycl::event> &dependencies) {        \
         return iamin(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
     }
 IAMIN_LAUNCHER_USM(float, cublasIsamin)
@@ -1702,14 +1702,14 @@ IAMIN_LAUNCHER_USM(std::complex<double>, cublasIzamin)
 template <typename Func, typename T1, typename T2>
 inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
                             const int64_t incx, T2 *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "nrm2", "for row_major layout");
 }
 
 #define NRM2_LAUNCHER_USM(TYPE1, TYPE2, CUBLAS_ROUTINE)                                         \
     cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
                          TYPE2 *result,                                                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {         \
+                         const std::vector<cl::sycl::event> &dependencies) {         \
         return nrm2(CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                   \
     }
 NRM2_LAUNCHER_USM(float, float, cublasSnrm2)

--- a/src/blas/backends/cublas/cublas_level2.cpp
+++ b/src/blas/backends/cublas/cublas_level2.cpp
@@ -856,7 +856,7 @@ inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,        \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const std::vector<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {                   \
         return gemv(CUBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                             \
     }
@@ -897,7 +897,7 @@ inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,          \
                          int64_t kl, int64_t ku, TYPE alpha, const TYPE *a, int64_t lda,         \
                          const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,          \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return gbmv(CUBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                         \
     }
@@ -935,8 +935,7 @@ inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t
 #define GER_LAUNCHER_USM(EXT, TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,          \
                              const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                             int64_t lda,                                                       \
-                             const std::vector<cl::sycl::event> &dependencies) {     \
+                             int64_t lda, const std::vector<cl::sycl::event> &dependencies) {   \
         return ger(CUBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies); \
     }
 
@@ -978,7 +977,7 @@ inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const std::vector<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {                   \
         return hbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -990,8 +989,7 @@ HBMV_LAUNCHER_USM(std::complex<double>, cublasZhbmv)
 template <typename Func, typename T>
 inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1017,7 +1015,7 @@ inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return hemv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -1029,8 +1027,7 @@ HEMV_LAUNCHER_USM(std::complex<double>, cublasZhemv)
 template <typename Func, typename ScalarType, typename DataType>
 inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                            const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     using cuScalarType = typename CudaEquivalentType<ScalarType>::Type;
     using cuDataType = typename CudaEquivalentType<DataType>::Type;
     overflow_check(n, lda, incx);
@@ -1055,8 +1052,7 @@ inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define HER_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, CUBLAS_ROUTINE)                                 \
     cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        int64_t lda,                                                             \
-                        const std::vector<cl::sycl::event> &dependencies) {           \
+                        int64_t lda, const std::vector<cl::sycl::event> &dependencies) {         \
         return her(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -1092,8 +1088,7 @@ inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define HER2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         int64_t lda,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {   \
         return her2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -1130,8 +1125,7 @@ inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define HPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
-                         int64_t incy,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {      \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {   \
         return hpmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -1168,7 +1162,7 @@ inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, CUBLAS_ROUTINE)                                 \
     cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        const std::vector<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {                      \
         return hpr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);      \
     }
 
@@ -1204,7 +1198,7 @@ inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define HPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {                \
         return hpr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -1244,7 +1238,7 @@ inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const std::vector<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {                   \
         return sbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -1257,8 +1251,7 @@ SBMV_LAUNCHER_USM(double, cublasDsbmv)
 template <typename Func, typename T>
 inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1284,7 +1277,7 @@ inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return symv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -1320,7 +1313,7 @@ inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define SYR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                         const TYPE *x, int64_t incx, TYPE *a, int64_t lda,                       \
-                        const std::vector<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {                      \
         return syr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -1358,8 +1351,7 @@ inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SYR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         int64_t lda,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {   \
         return syr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -1399,8 +1391,7 @@ inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
-                         int64_t incy,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {      \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {   \
         return spmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -1436,7 +1427,7 @@ inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define SPR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                         const TYPE *x, int64_t incx, TYPE *a,                               \
-                        const std::vector<cl::sycl::event> &dependencies) {      \
+                        const std::vector<cl::sycl::event> &dependencies) {                 \
         return spr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies); \
     }
 
@@ -1472,7 +1463,7 @@ inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {                \
         return spr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -1485,8 +1476,7 @@ SPR2_LAUNCHER_USM(double, cublasDspr2)
 template <typename Func, typename T>
 inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1511,7 +1501,7 @@ inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return tbmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -1526,8 +1516,7 @@ TBMV_LAUNCHER_USM(std::complex<double>, cublasZtbmv)
 template <typename Func, typename T>
 inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1552,7 +1541,7 @@ inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return tbsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -1591,7 +1580,7 @@ inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {              \
         return tpmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -1630,7 +1619,7 @@ inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TPSV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {              \
         return tpsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -1669,8 +1658,7 @@ inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TRMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                               \
     cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
-                         int64_t incx,                                                        \
-                         const std::vector<cl::sycl::event> &dependencies) {       \
+                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {    \
         return trmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }
@@ -1709,8 +1697,7 @@ inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TRSV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                               \
     cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
-                         int64_t incx,                                                        \
-                         const std::vector<cl::sycl::event> &dependencies) {       \
+                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {    \
         return trsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }
@@ -2195,7 +2182,7 @@ inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,        \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const std::vector<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {                   \
         return gemv(CUBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                             \
     }
@@ -2218,7 +2205,7 @@ inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,          \
                          int64_t kl, int64_t ku, TYPE alpha, const TYPE *a, int64_t lda,         \
                          const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,          \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return gbmv(CUBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                         \
     }
@@ -2239,8 +2226,7 @@ inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t
 #define GER_LAUNCHER_USM(EXT, TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,          \
                              const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                             int64_t lda,                                                       \
-                             const std::vector<cl::sycl::event> &dependencies) {     \
+                             int64_t lda, const std::vector<cl::sycl::event> &dependencies) {   \
         return ger(CUBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies); \
     }
 
@@ -2264,7 +2250,7 @@ inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const std::vector<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {                   \
         return hbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -2276,8 +2262,7 @@ HBMV_LAUNCHER_USM(std::complex<double>, cublasZhbmv)
 template <typename Func, typename T>
 inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "hemv", "for row_major layout");
 }
 
@@ -2285,7 +2270,7 @@ inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return hemv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -2297,16 +2282,14 @@ HEMV_LAUNCHER_USM(std::complex<double>, cublasZhemv)
 template <typename Func, typename ScalarType, typename DataType>
 inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                            const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "her", "for row_major layout");
 }
 
 #define HER_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, CUBLAS_ROUTINE)                                 \
     cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        int64_t lda,                                                             \
-                        const std::vector<cl::sycl::event> &dependencies) {           \
+                        int64_t lda, const std::vector<cl::sycl::event> &dependencies) {         \
         return her(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -2325,8 +2308,7 @@ inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define HER2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         int64_t lda,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {   \
         return her2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -2346,8 +2328,7 @@ inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define HPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
-                         int64_t incy,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {      \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {   \
         return hpmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -2367,7 +2348,7 @@ inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, CUBLAS_ROUTINE)                                 \
     cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        const std::vector<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {                      \
         return hpr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);      \
     }
 
@@ -2386,7 +2367,7 @@ inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define HPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {                \
         return hpr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -2408,7 +2389,7 @@ inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const std::vector<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {                   \
         return sbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -2421,8 +2402,7 @@ SBMV_LAUNCHER_USM(double, cublasDsbmv)
 template <typename Func, typename T>
 inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "symv", "for row_major layout");
 }
 
@@ -2430,7 +2410,7 @@ inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return symv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -2450,7 +2430,7 @@ inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define SYR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                         const TYPE *x, int64_t incx, TYPE *a, int64_t lda,                       \
-                        const std::vector<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {                      \
         return syr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -2471,8 +2451,7 @@ inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SYR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         int64_t lda,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {   \
         return syr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -2495,8 +2474,7 @@ inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
-                         int64_t incy,                                                       \
-                         const std::vector<cl::sycl::event> &dependencies) {      \
+                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {   \
         return spmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -2516,7 +2494,7 @@ inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define SPR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                         const TYPE *x, int64_t incx, TYPE *a,                               \
-                        const std::vector<cl::sycl::event> &dependencies) {      \
+                        const std::vector<cl::sycl::event> &dependencies) {                 \
         return spr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies); \
     }
 
@@ -2535,7 +2513,7 @@ inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {                \
         return spr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -2548,8 +2526,7 @@ SPR2_LAUNCHER_USM(double, cublasDspr2)
 template <typename Func, typename T>
 inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "tbmv", "for row_major layout");
 }
 
@@ -2557,7 +2534,7 @@ inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return tbmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -2572,8 +2549,7 @@ TBMV_LAUNCHER_USM(std::complex<double>, cublasZtbmv)
 template <typename Func, typename T>
 inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "tbsv", "for row_major layout");
 }
 
@@ -2581,7 +2557,7 @@ inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return tbsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -2603,7 +2579,7 @@ inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {              \
         return tpmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -2625,7 +2601,7 @@ inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TPSV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {              \
         return tpsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -2647,8 +2623,7 @@ inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TRMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                               \
     cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
-                         int64_t incx,                                                        \
-                         const std::vector<cl::sycl::event> &dependencies) {       \
+                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {    \
         return trmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }
@@ -2670,8 +2645,7 @@ inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TRSV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                               \
     cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
-                         int64_t incx,                                                        \
-                         const std::vector<cl::sycl::event> &dependencies) {       \
+                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {    \
         return trsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }

--- a/src/blas/backends/cublas/cublas_level2.cpp
+++ b/src/blas/backends/cublas/cublas_level2.cpp
@@ -830,7 +830,7 @@ template <typename Func, typename T>
 inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
                             int64_t n, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
                             T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, m, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -856,7 +856,7 @@ inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,        \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {        \
         return gemv(CUBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                             \
     }
@@ -871,7 +871,7 @@ template <typename Func, typename T>
 inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
                             int64_t n, int64_t kl, int64_t ku, T alpha, const T *a, int64_t lda,
                             const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, m, lda, kl, ku, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -897,7 +897,7 @@ inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,          \
                          int64_t kl, int64_t ku, TYPE alpha, const TYPE *a, int64_t lda,         \
                          const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,          \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return gbmv(CUBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                         \
     }
@@ -911,7 +911,7 @@ GBMV_LAUNCHER_USM(std::complex<double>, cublasZgbmv)
 template <typename Func, typename T>
 inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t n, T alpha,
                            const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, m, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -936,7 +936,7 @@ inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t
     cl::sycl::event ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,          \
                              const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
                              int64_t lda,                                                       \
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                             const std::vector<cl::sycl::event> &dependencies) {     \
         return ger(CUBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies); \
     }
 
@@ -952,7 +952,7 @@ template <typename Func, typename T>
 inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                             int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
                             T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -978,7 +978,7 @@ inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {        \
         return hbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -991,7 +991,7 @@ template <typename Func, typename T>
 inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
                             int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1017,7 +1017,7 @@ inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return hemv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -1030,7 +1030,7 @@ template <typename Func, typename ScalarType, typename DataType>
 inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                            const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     using cuScalarType = typename CudaEquivalentType<ScalarType>::Type;
     using cuDataType = typename CudaEquivalentType<DataType>::Type;
     overflow_check(n, lda, incx);
@@ -1056,7 +1056,7 @@ inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, 
     cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
                         int64_t lda,                                                             \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {           \
         return her(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -1068,7 +1068,7 @@ HER_LAUNCHER_USM(double, std::complex<double>, cublasZher)
 template <typename Func, typename T>
 inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1093,7 +1093,7 @@ inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
                          int64_t lda,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return her2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -1106,7 +1106,7 @@ HER2_LAUNCHER_USM(std::complex<double>, cublasZher2)
 template <typename Func, typename T>
 inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1131,7 +1131,7 @@ inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
                          int64_t incy,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {      \
         return hpmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -1144,7 +1144,7 @@ HPMV_LAUNCHER_USM(std::complex<double>, cublasZhpmv)
 template <typename Func, typename ScalarType, typename DataType>
 inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                            const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     using cuScalarType = typename CudaEquivalentType<ScalarType>::Type;
     using cuDataType = typename CudaEquivalentType<DataType>::Type;
     overflow_check(n, incx);
@@ -1168,7 +1168,7 @@ inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, CUBLAS_ROUTINE)                                 \
     cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {           \
         return hpr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);      \
     }
 
@@ -1180,7 +1180,7 @@ HPR_LAUNCHER_USM(double, std::complex<double>, cublasZhpr)
 template <typename Func, typename T>
 inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1204,7 +1204,7 @@ inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define HPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return hpr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -1218,7 +1218,7 @@ template <typename Func, typename T>
 inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                             int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
                             T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1244,7 +1244,7 @@ inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {        \
         return sbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -1258,7 +1258,7 @@ template <typename Func, typename T>
 inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
                             int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1284,7 +1284,7 @@ inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return symv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -1297,7 +1297,7 @@ SYMV_LAUNCHER_USM(double, cublasDsymv)
 template <typename Func, typename T>
 inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                            const T *x, int64_t incx, T *a, int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1320,7 +1320,7 @@ inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define SYR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                         const TYPE *x, int64_t incx, TYPE *a, int64_t lda,                       \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {           \
         return syr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -1334,7 +1334,7 @@ SYR_LAUNCHER_USM(std::complex<double>, cublasZsyr)
 template <typename Func, typename T>
 inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1359,7 +1359,7 @@ inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
                          int64_t lda,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return syr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -1375,7 +1375,7 @@ SYR2_LAUNCHER_USM(std::complex<double>, cublasZsyr2)
 template <typename Func, typename T>
 inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1400,7 +1400,7 @@ inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
                          int64_t incy,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {      \
         return spmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -1413,7 +1413,7 @@ SPMV_LAUNCHER_USM(double, cublasDspmv)
 template <typename Func, typename T>
 inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                            const T *x, int64_t incx, T *a,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1436,7 +1436,7 @@ inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 #define SPR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                         const TYPE *x, int64_t incx, TYPE *a,                               \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                        const std::vector<cl::sycl::event> &dependencies) {      \
         return spr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies); \
     }
 
@@ -1448,7 +1448,7 @@ SPR_LAUNCHER_USM(double, cublasDspr)
 template <typename Func, typename T>
 inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1472,7 +1472,7 @@ inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return spr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -1486,7 +1486,7 @@ template <typename Func, typename T>
 inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
                             int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1511,7 +1511,7 @@ inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return tbmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -1527,7 +1527,7 @@ template <typename Func, typename T>
 inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
                             int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1552,7 +1552,7 @@ inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return tbsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -1567,7 +1567,7 @@ TBSV_LAUNCHER_USM(std::complex<double>, cublasZtbsv)
 template <typename Func, typename T>
 inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1591,7 +1591,7 @@ inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {   \
         return tpmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -1606,7 +1606,7 @@ TPMV_LAUNCHER_USM(std::complex<double>, cublasZtpmv)
 template <typename Func, typename T>
 inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1630,7 +1630,7 @@ inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define TPSV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {   \
         return tpsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -1645,7 +1645,7 @@ TPSV_LAUNCHER_USM(std::complex<double>, cublasZtpsv)
 template <typename Func, typename T>
 inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1670,7 +1670,7 @@ inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
                          int64_t incx,                                                        \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {       \
+                         const std::vector<cl::sycl::event> &dependencies) {       \
         return trmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }
@@ -1685,7 +1685,7 @@ TRMV_LAUNCHER_USM(std::complex<double>, cublasZtrmv)
 template <typename Func, typename T>
 inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -1710,7 +1710,7 @@ inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
                          int64_t incx,                                                        \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {       \
+                         const std::vector<cl::sycl::event> &dependencies) {       \
         return trsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }
@@ -2187,7 +2187,7 @@ template <typename Func, typename T>
 inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
                             int64_t n, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
                             T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv", "for row_major layout");
 }
 
@@ -2195,7 +2195,7 @@ inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,        \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {        \
         return gemv(CUBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                             \
     }
@@ -2210,7 +2210,7 @@ template <typename Func, typename T>
 inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
                             int64_t n, int64_t kl, int64_t ku, T alpha, const T *a, int64_t lda,
                             const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gbmv", "for row_major layout");
 }
 
@@ -2218,7 +2218,7 @@ inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, 
     cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,          \
                          int64_t kl, int64_t ku, TYPE alpha, const TYPE *a, int64_t lda,         \
                          const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,          \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return gbmv(CUBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                         \
     }
@@ -2232,7 +2232,7 @@ GBMV_LAUNCHER_USM(std::complex<double>, cublasZgbmv)
 template <typename Func, typename T>
 inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t n, T alpha,
                            const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "ger", "for row_major layout");
 }
 
@@ -2240,7 +2240,7 @@ inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t
     cl::sycl::event ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,          \
                              const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
                              int64_t lda,                                                       \
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                             const std::vector<cl::sycl::event> &dependencies) {     \
         return ger(CUBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies); \
     }
 
@@ -2256,7 +2256,7 @@ template <typename Func, typename T>
 inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                             int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
                             T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "hbmv", "for row_major layout");
 }
 
@@ -2264,7 +2264,7 @@ inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {        \
         return hbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -2277,7 +2277,7 @@ template <typename Func, typename T>
 inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
                             int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "hemv", "for row_major layout");
 }
 
@@ -2285,7 +2285,7 @@ inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return hemv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -2298,7 +2298,7 @@ template <typename Func, typename ScalarType, typename DataType>
 inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                            const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "her", "for row_major layout");
 }
 
@@ -2306,7 +2306,7 @@ inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, 
     cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
                         int64_t lda,                                                             \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {           \
         return her(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -2318,7 +2318,7 @@ HER_LAUNCHER_USM(double, std::complex<double>, cublasZher)
 template <typename Func, typename T>
 inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "her2", "for row_major layout");
 }
 
@@ -2326,7 +2326,7 @@ inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
                          int64_t lda,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return her2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -2339,7 +2339,7 @@ HER2_LAUNCHER_USM(std::complex<double>, cublasZher2)
 template <typename Func, typename T>
 inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "hpmv", "for row_major layout");
 }
 
@@ -2347,7 +2347,7 @@ inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
                          int64_t incy,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {      \
         return hpmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -2360,14 +2360,14 @@ HPMV_LAUNCHER_USM(std::complex<double>, cublasZhpmv)
 template <typename Func, typename ScalarType, typename DataType>
 inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                            const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "hpr", "for row_major layout");
 }
 
 #define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, CUBLAS_ROUTINE)                                 \
     cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
                         const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {           \
         return hpr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);      \
     }
 
@@ -2379,14 +2379,14 @@ HPR_LAUNCHER_USM(double, std::complex<double>, cublasZhpr)
 template <typename Func, typename T>
 inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "hpr2", "for row_major layout");
 }
 
 #define HPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return hpr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -2400,7 +2400,7 @@ template <typename Func, typename T>
 inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                             int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
                             T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "sbmv", "for row_major layout");
 }
 
@@ -2408,7 +2408,7 @@ inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,       \
                          TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,  \
                          TYPE beta, TYPE *y, int64_t incy,                                     \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {        \
+                         const std::vector<cl::sycl::event> &dependencies) {        \
         return sbmv(CUBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                       \
     }
@@ -2422,7 +2422,7 @@ template <typename Func, typename T>
 inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
                             int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "symv", "for row_major layout");
 }
 
@@ -2430,7 +2430,7 @@ inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                          const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,      \
                          TYPE *y, int64_t incy,                                                   \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return symv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                \
     }
@@ -2443,14 +2443,14 @@ SYMV_LAUNCHER_USM(double, cublasDsymv)
 template <typename Func, typename T>
 inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                            const T *x, int64_t incx, T *a, int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syr", "for row_major layout");
 }
 
 #define SYR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,         \
                         const TYPE *x, int64_t incx, TYPE *a, int64_t lda,                       \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                        const std::vector<cl::sycl::event> &dependencies) {           \
         return syr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -2464,7 +2464,7 @@ SYR_LAUNCHER_USM(std::complex<double>, cublasZsyr)
 template <typename Func, typename T>
 inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syr2", "for row_major layout");
 }
 
@@ -2472,7 +2472,7 @@ inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
                          int64_t lda,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return syr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
                     dependencies);                                                          \
     }
@@ -2488,7 +2488,7 @@ SYR2_LAUNCHER_USM(std::complex<double>, cublasZsyr2)
 template <typename Func, typename T>
 inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "spmv", "for row_major layout");
 }
 
@@ -2496,7 +2496,7 @@ inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                          const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,     \
                          int64_t incy,                                                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                         const std::vector<cl::sycl::event> &dependencies) {      \
         return spmv(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
                     dependencies);                                                           \
     }
@@ -2509,14 +2509,14 @@ SPMV_LAUNCHER_USM(double, cublasDspmv)
 template <typename Func, typename T>
 inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                            const T *x, int64_t incx, T *a,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "spr", "for row_major layout");
 }
 
 #define SPR_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                              \
     cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
                         const TYPE *x, int64_t incx, TYPE *a,                               \
-                        const cl::sycl::vector_class<cl::sycl::event> &dependencies) {      \
+                        const std::vector<cl::sycl::event> &dependencies) {      \
         return spr(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies); \
     }
 
@@ -2528,14 +2528,14 @@ SPR_LAUNCHER_USM(double, cublasDspr)
 template <typename Func, typename T>
 inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
                             const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "spr2", "for row_major layout");
 }
 
 #define SPR2_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                             \
     cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
                          const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {     \
+                         const std::vector<cl::sycl::event> &dependencies) {     \
         return spr2(CUBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,      \
                     dependencies);                                                          \
     }
@@ -2549,7 +2549,7 @@ template <typename Func, typename T>
 inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
                             int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "tbmv", "for row_major layout");
 }
 
@@ -2557,7 +2557,7 @@ inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return tbmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -2573,7 +2573,7 @@ template <typename Func, typename T>
 inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
                             int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "tbsv", "for row_major layout");
 }
 
@@ -2581,7 +2581,7 @@ inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,              \
                          diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,       \
                          TYPE *x, int64_t incx,                                                  \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return tbsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                               \
     }
@@ -2596,14 +2596,14 @@ TBSV_LAUNCHER_USM(std::complex<double>, cublasZtbsv)
 template <typename Func, typename T>
 inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "tpmv", "for row_major layout");
 }
 
 #define TPMV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {   \
         return tpmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -2618,14 +2618,14 @@ TPMV_LAUNCHER_USM(std::complex<double>, cublasZtpmv)
 template <typename Func, typename T>
 inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "tpsv", "for row_major layout");
 }
 
 #define TPSV_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                           \
     cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
                          diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {   \
+                         const std::vector<cl::sycl::event> &dependencies) {   \
         return tpsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,  \
                     dependencies);                                                        \
     }
@@ -2640,7 +2640,7 @@ TPSV_LAUNCHER_USM(std::complex<double>, cublasZtpsv)
 template <typename Func, typename T>
 inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trmv", "for row_major layout");
 }
 
@@ -2648,7 +2648,7 @@ inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
                          int64_t incx,                                                        \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {       \
+                         const std::vector<cl::sycl::event> &dependencies) {       \
         return trmv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }
@@ -2663,7 +2663,7 @@ TRMV_LAUNCHER_USM(std::complex<double>, cublasZtrmv)
 template <typename Func, typename T>
 inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsv", "for row_major layout");
 }
 
@@ -2671,7 +2671,7 @@ inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,           \
                          diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,      \
                          int64_t incx,                                                        \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {       \
+                         const std::vector<cl::sycl::event> &dependencies) {       \
         return trsv(CUBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                            \
     }

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -453,7 +453,7 @@ inline cl::sycl::event gemm(Func func, cl::sycl::queue &queue, transpose transa,
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,  \
                          int64_t n, int64_t k, TYPE alpha, const TYPE *a, int64_t lda,           \
                          const TYPE *b, int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,            \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return gemm(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, \
                     c, ldc, dependencies);                                                       \
     }
@@ -471,8 +471,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
                                    cl::sycl::queue &queue, transpose transa, transpose transb,
                                    int64_t m, int64_t n, int64_t k, T_C alpha, const T_A *a,
                                    int64_t lda, const T_B *b, int64_t ldb, T_C beta, T_C *c,
-                                   int64_t ldc,
-                                   const std::vector<cl::sycl::event> &dependencies) {
+                                   int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType_A = typename CudaEquivalentType<T_A>::Type;
     using cuDataType_B = typename CudaEquivalentType<T_B>::Type;
     using cuDataType_C = typename CudaEquivalentType<T_C>::Type;
@@ -502,7 +501,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,   \
                          int64_t n, int64_t k, TYPE_C alpha, const TYPE_A *a, int64_t lda,        \
                          const TYPE_B *b, int64_t ldb, TYPE_C beta, TYPE_C *c, int64_t ldc,       \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return gemm_ex_usm(CUDADATATYPE_A, CUDADATATYPE_B, CUDADATATYPE_C, queue, transa, transb, \
                            m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);           \
     }
@@ -549,7 +548,7 @@ inline cl::sycl::event symm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return symm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -591,7 +590,7 @@ inline cl::sycl::event hemm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return hemm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -603,8 +602,7 @@ HEMM_LAUNCHER_USM(std::complex<double>, cublasZhemm)
 template <typename Func, typename T>
 inline cl::sycl::event syrk(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             int64_t n, int64_t k, T alpha, const T *a, int64_t lda, T beta, T *c,
-                            int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, ldc);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -628,8 +626,7 @@ inline cl::sycl::event syrk(Func func, cl::sycl::queue &queue, uplo upper_lower,
 #define SYRK_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, TYPE alpha, const TYPE *a, int64_t lda, TYPE beta, TYPE *c,   \
-                         int64_t ldc,                                                             \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {         \
         return syrk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -671,7 +668,7 @@ inline cl::sycl::event herk(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, const SCALAR_TYPE alpha, const DATA_TYPE *a, int64_t lda,     \
                          const SCALAR_TYPE beta, DATA_TYPE *c, int64_t ldc,                       \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return herk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -711,7 +708,7 @@ inline cl::sycl::event syr2k(Func func, cl::sycl::queue &queue, uplo upper_lower
     cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                           int64_t k, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,        \
                           int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                            \
-                          const std::vector<cl::sycl::event> &dependencies) {           \
+                          const std::vector<cl::sycl::event> &dependencies) {                      \
         return syr2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -754,8 +751,7 @@ inline cl::sycl::event her2k(Func func, cl::sycl::queue &queue, uplo upper_lower
     cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                           int64_t k, const DATA_TYPE alpha, const DATA_TYPE *a, int64_t lda,       \
                           const DATA_TYPE *b, int64_t ldb, const SCALAR_TYPE beta, DATA_TYPE *c,   \
-                          int64_t ldc,                                                             \
-                          const std::vector<cl::sycl::event> &dependencies) {           \
+                          int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {         \
         return her2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -799,7 +795,7 @@ inline cl::sycl::event trmm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const std::vector<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {                       \
         return trmm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }
@@ -840,7 +836,7 @@ inline cl::sycl::event trsm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const std::vector<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {                       \
         return trsm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }
@@ -1097,7 +1093,7 @@ inline cl::sycl::event gemm(Func func, cl::sycl::queue &queue, transpose transa,
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,  \
                          int64_t n, int64_t k, TYPE alpha, const TYPE *a, int64_t lda,           \
                          const TYPE *b, int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,            \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return gemm(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, \
                     c, ldc, dependencies);                                                       \
     }
@@ -1115,8 +1111,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
                                    cl::sycl::queue &queue, transpose transa, transpose transb,
                                    int64_t m, int64_t n, int64_t k, T_C alpha, const T_A *a,
                                    int64_t lda, const T_B *b, int64_t ldb, T_C beta, T_C *c,
-                                   int64_t ldc,
-                                   const std::vector<cl::sycl::event> &dependencies) {
+                                   int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for row_major layout");
 }
 
@@ -1125,7 +1120,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,   \
                          int64_t n, int64_t k, TYPE_C alpha, const TYPE_A *a, int64_t lda,        \
                          const TYPE_B *b, int64_t ldb, TYPE_C beta, TYPE_C *c, int64_t ldc,       \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return gemm_ex_usm(CUDADATATYPE_A, CUDADATATYPE_B, CUDADATATYPE_C, queue, transa, transb, \
                            m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);           \
     }
@@ -1154,7 +1149,7 @@ inline cl::sycl::event symm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return symm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -1178,7 +1173,7 @@ inline cl::sycl::event hemm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const std::vector<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {                     \
         return hemm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -1190,16 +1185,14 @@ HEMM_LAUNCHER_USM(std::complex<double>, cublasZhemm)
 template <typename Func, typename T>
 inline cl::sycl::event syrk(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             int64_t n, int64_t k, T alpha, const T *a, int64_t lda, T beta, T *c,
-                            int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies) {
+                            int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk", "for row_major layout");
 }
 
 #define SYRK_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                   \
     cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, TYPE alpha, const TYPE *a, int64_t lda, TYPE beta, TYPE *c,   \
-                         int64_t ldc,                                                             \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {         \
         return syrk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -1223,7 +1216,7 @@ inline cl::sycl::event herk(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, const SCALAR_TYPE alpha, const DATA_TYPE *a, int64_t lda,     \
                          const SCALAR_TYPE beta, DATA_TYPE *c, int64_t ldc,                       \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {                      \
         return herk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -1245,7 +1238,7 @@ inline cl::sycl::event syr2k(Func func, cl::sycl::queue &queue, uplo upper_lower
     cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                           int64_t k, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,        \
                           int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                            \
-                          const std::vector<cl::sycl::event> &dependencies) {           \
+                          const std::vector<cl::sycl::event> &dependencies) {                      \
         return syr2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -1269,8 +1262,7 @@ inline cl::sycl::event her2k(Func func, cl::sycl::queue &queue, uplo upper_lower
     cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                           int64_t k, const DATA_TYPE alpha, const DATA_TYPE *a, int64_t lda,       \
                           const DATA_TYPE *b, int64_t ldb, const SCALAR_TYPE beta, DATA_TYPE *c,   \
-                          int64_t ldc,                                                             \
-                          const std::vector<cl::sycl::event> &dependencies) {           \
+                          int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {         \
         return her2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -1296,7 +1288,7 @@ inline cl::sycl::event trmm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const std::vector<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {                       \
         return trmm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }
@@ -1319,7 +1311,7 @@ inline cl::sycl::event trsm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const std::vector<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {                       \
         return trsm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -427,7 +427,7 @@ template <typename Func, typename T>
 inline cl::sycl::event gemm(Func func, cl::sycl::queue &queue, transpose transa, transpose transb,
                             int64_t m, int64_t n, int64_t k, T alpha, const T *a, int64_t lda,
                             const T *b, int64_t ldb, T beta, T *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, k, lda, ldb, ldc);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -453,7 +453,7 @@ inline cl::sycl::event gemm(Func func, cl::sycl::queue &queue, transpose transa,
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,  \
                          int64_t n, int64_t k, TYPE alpha, const TYPE *a, int64_t lda,           \
                          const TYPE *b, int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,            \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return gemm(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, \
                     c, ldc, dependencies);                                                       \
     }
@@ -472,7 +472,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
                                    int64_t m, int64_t n, int64_t k, T_C alpha, const T_A *a,
                                    int64_t lda, const T_B *b, int64_t ldb, T_C beta, T_C *c,
                                    int64_t ldc,
-                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                   const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType_A = typename CudaEquivalentType<T_A>::Type;
     using cuDataType_B = typename CudaEquivalentType<T_B>::Type;
     using cuDataType_C = typename CudaEquivalentType<T_C>::Type;
@@ -502,7 +502,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,   \
                          int64_t n, int64_t k, TYPE_C alpha, const TYPE_A *a, int64_t lda,        \
                          const TYPE_B *b, int64_t ldb, TYPE_C beta, TYPE_C *c, int64_t ldc,       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return gemm_ex_usm(CUDADATATYPE_A, CUDADATATYPE_B, CUDADATATYPE_C, queue, transa, transb, \
                            m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);           \
     }
@@ -515,7 +515,7 @@ GEMM_EX_LAUNCHER_USM(half, half, half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const bfloat16 *a, int64_t lda,
                      const bfloat16 *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for column_major layout");
 }
 
@@ -523,7 +523,7 @@ template <typename Func, typename T>
 inline cl::sycl::event symm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             int64_t m, int64_t n, T alpha, const T *a, int64_t lda, const T *b,
                             int64_t ldb, T beta, T *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, lda, ldb, ldc);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -549,7 +549,7 @@ inline cl::sycl::event symm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return symm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -565,7 +565,7 @@ template <typename Func, typename T>
 inline cl::sycl::event hemm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             int64_t m, int64_t n, T alpha, const T *a, int64_t lda, const T *b,
                             int64_t ldb, T beta, T *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, lda, ldb, ldc);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -591,7 +591,7 @@ inline cl::sycl::event hemm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return hemm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -604,7 +604,7 @@ template <typename Func, typename T>
 inline cl::sycl::event syrk(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             int64_t n, int64_t k, T alpha, const T *a, int64_t lda, T beta, T *c,
                             int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, ldc);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -629,7 +629,7 @@ inline cl::sycl::event syrk(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, TYPE alpha, const TYPE *a, int64_t lda, TYPE beta, TYPE *c,   \
                          int64_t ldc,                                                             \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return syrk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -645,7 +645,7 @@ template <typename Func, typename DataType, typename ScalarType>
 inline cl::sycl::event herk(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             int64_t n, int64_t k, const ScalarType alpha, const DataType *a,
                             int64_t lda, const ScalarType beta, DataType *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<DataType>::Type;
     using cuScalarType = typename CudaEquivalentType<ScalarType>::Type;
     overflow_check(n, k, lda, ldc);
@@ -671,7 +671,7 @@ inline cl::sycl::event herk(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, const SCALAR_TYPE alpha, const DATA_TYPE *a, int64_t lda,     \
                          const SCALAR_TYPE beta, DATA_TYPE *c, int64_t ldc,                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return herk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -685,7 +685,7 @@ template <typename Func, typename T>
 inline cl::sycl::event syr2k(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                              int64_t n, int64_t k, T alpha, const T *a, int64_t lda, const T *b,
                              int64_t ldb, T beta, T *c, int64_t ldc,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, k, lda, ldb, ldc);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -711,7 +711,7 @@ inline cl::sycl::event syr2k(Func func, cl::sycl::queue &queue, uplo upper_lower
     cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                           int64_t k, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,        \
                           int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                            \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                          const std::vector<cl::sycl::event> &dependencies) {           \
         return syr2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -727,7 +727,7 @@ inline cl::sycl::event her2k(Func func, cl::sycl::queue &queue, uplo upper_lower
                              int64_t n, int64_t k, const DataType alpha, const DataType *a,
                              int64_t lda, const DataType *b, int64_t ldb, const ScalarType beta,
                              DataType *c, int64_t ldc,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<DataType>::Type;
     using cuScalarType = typename CudaEquivalentType<ScalarType>::Type;
     overflow_check(n, k, lda, ldb, ldc);
@@ -755,7 +755,7 @@ inline cl::sycl::event her2k(Func func, cl::sycl::queue &queue, uplo upper_lower
                           int64_t k, const DATA_TYPE alpha, const DATA_TYPE *a, int64_t lda,       \
                           const DATA_TYPE *b, int64_t ldb, const SCALAR_TYPE beta, DATA_TYPE *c,   \
                           int64_t ldc,                                                             \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                          const std::vector<cl::sycl::event> &dependencies) {           \
         return her2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -773,7 +773,7 @@ template <typename Func, typename T>
 inline cl::sycl::event trmm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             transpose trans, diag unit_diag, int64_t m, int64_t n, T alpha,
                             const T *a, int64_t lda, T *b, int64_t ldb,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, lda, ldb);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -799,7 +799,7 @@ inline cl::sycl::event trmm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {            \
         return trmm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }
@@ -814,7 +814,7 @@ template <typename Func, typename T>
 inline cl::sycl::event trsm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             transpose trans, diag unit_diag, int64_t m, int64_t n, T alpha,
                             const T *a, int64_t lda, T *b, int64_t ldb,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(m, n, lda, ldb);
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -840,7 +840,7 @@ inline cl::sycl::event trsm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {            \
         return trsm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }
@@ -1089,7 +1089,7 @@ template <typename Func, typename T>
 inline cl::sycl::event gemm(Func func, cl::sycl::queue &queue, transpose transa, transpose transb,
                             int64_t m, int64_t n, int64_t k, T alpha, const T *a, int64_t lda,
                             const T *b, int64_t ldb, T beta, T *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for row_major layout");
 }
 
@@ -1097,7 +1097,7 @@ inline cl::sycl::event gemm(Func func, cl::sycl::queue &queue, transpose transa,
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,  \
                          int64_t n, int64_t k, TYPE alpha, const TYPE *a, int64_t lda,           \
                          const TYPE *b, int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,            \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return gemm(CUBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, \
                     c, ldc, dependencies);                                                       \
     }
@@ -1116,7 +1116,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
                                    int64_t m, int64_t n, int64_t k, T_C alpha, const T_A *a,
                                    int64_t lda, const T_B *b, int64_t ldb, T_C beta, T_C *c,
                                    int64_t ldc,
-                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                   const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for row_major layout");
 }
 
@@ -1125,7 +1125,7 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
     cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,   \
                          int64_t n, int64_t k, TYPE_C alpha, const TYPE_A *a, int64_t lda,        \
                          const TYPE_B *b, int64_t ldb, TYPE_C beta, TYPE_C *c, int64_t ldc,       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return gemm_ex_usm(CUDADATATYPE_A, CUDADATATYPE_B, CUDADATATYPE_C, queue, transa, transb, \
                            m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);           \
     }
@@ -1138,7 +1138,7 @@ GEMM_EX_LAUNCHER_USM(half, half, half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const bfloat16 *a, int64_t lda,
                      const bfloat16 *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm", "for row_major layout");
 }
 
@@ -1146,7 +1146,7 @@ template <typename Func, typename T>
 inline cl::sycl::event symm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             int64_t m, int64_t n, T alpha, const T *a, int64_t lda, const T *b,
                             int64_t ldb, T beta, T *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "symm", "for row_major layout");
 }
 
@@ -1154,7 +1154,7 @@ inline cl::sycl::event symm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return symm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -1170,7 +1170,7 @@ template <typename Func, typename T>
 inline cl::sycl::event hemm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             int64_t m, int64_t n, T alpha, const T *a, int64_t lda, const T *b,
                             int64_t ldb, T beta, T *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "hemm", "for row_major layout");
 }
 
@@ -1178,7 +1178,7 @@ inline cl::sycl::event hemm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,   \
                          int64_t n, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,       \
                          int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                           \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {          \
+                         const std::vector<cl::sycl::event> &dependencies) {          \
         return hemm(CUBLAS_ROUTINE, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, \
                     beta, c, ldc, dependencies);                                                 \
     }
@@ -1191,7 +1191,7 @@ template <typename Func, typename T>
 inline cl::sycl::event syrk(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             int64_t n, int64_t k, T alpha, const T *a, int64_t lda, T beta, T *c,
                             int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk", "for row_major layout");
 }
 
@@ -1199,7 +1199,7 @@ inline cl::sycl::event syrk(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, TYPE alpha, const TYPE *a, int64_t lda, TYPE beta, TYPE *c,   \
                          int64_t ldc,                                                             \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return syrk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -1215,7 +1215,7 @@ template <typename Func, typename DataType, typename ScalarType>
 inline cl::sycl::event herk(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                             int64_t n, int64_t k, const ScalarType alpha, const DataType *a,
                             int64_t lda, const ScalarType beta, DataType *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "herk", "for row_major layout");
 }
 
@@ -1223,7 +1223,7 @@ inline cl::sycl::event herk(Func func, cl::sycl::queue &queue, uplo upper_lower,
     cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                          int64_t k, const SCALAR_TYPE alpha, const DATA_TYPE *a, int64_t lda,     \
                          const SCALAR_TYPE beta, DATA_TYPE *c, int64_t ldc,                       \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                         const std::vector<cl::sycl::event> &dependencies) {           \
         return herk(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, \
                     dependencies);                                                                \
     }
@@ -1237,7 +1237,7 @@ template <typename Func, typename T>
 inline cl::sycl::event syr2k(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                              int64_t n, int64_t k, T alpha, const T *a, int64_t lda, const T *b,
                              int64_t ldb, T beta, T *c, int64_t ldc,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "syr2k", "for row_major layout");
 }
 
@@ -1245,7 +1245,7 @@ inline cl::sycl::event syr2k(Func func, cl::sycl::queue &queue, uplo upper_lower
     cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,    \
                           int64_t k, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *b,        \
                           int64_t ldb, TYPE beta, TYPE *c, int64_t ldc,                            \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                          const std::vector<cl::sycl::event> &dependencies) {           \
         return syr2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -1261,7 +1261,7 @@ inline cl::sycl::event her2k(Func func, cl::sycl::queue &queue, uplo upper_lower
                              int64_t n, int64_t k, const DataType alpha, const DataType *a,
                              int64_t lda, const DataType *b, int64_t ldb, const ScalarType beta,
                              DataType *c, int64_t ldc,
-                             const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                             const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "her2k", "for row_major layout");
 }
 
@@ -1270,7 +1270,7 @@ inline cl::sycl::event her2k(Func func, cl::sycl::queue &queue, uplo upper_lower
                           int64_t k, const DATA_TYPE alpha, const DATA_TYPE *a, int64_t lda,       \
                           const DATA_TYPE *b, int64_t ldb, const SCALAR_TYPE beta, DATA_TYPE *c,   \
                           int64_t ldc,                                                             \
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {           \
+                          const std::vector<cl::sycl::event> &dependencies) {           \
         return her2k(CUBLAS_ROUTINE, queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, \
                      c, ldc, dependencies);                                                        \
     }
@@ -1288,7 +1288,7 @@ template <typename Func, typename T>
 inline cl::sycl::event trmm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             transpose trans, diag unit_diag, int64_t m, int64_t n, T alpha,
                             const T *a, int64_t lda, T *b, int64_t ldb,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trmm", "for row_major layout");
 }
 
@@ -1296,7 +1296,7 @@ inline cl::sycl::event trmm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {            \
         return trmm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }
@@ -1311,7 +1311,7 @@ template <typename Func, typename T>
 inline cl::sycl::event trsm(Func func, cl::sycl::queue &queue, side left_right, uplo upper_lower,
                             transpose trans, diag unit_diag, int64_t m, int64_t n, T alpha,
                             const T *a, int64_t lda, T *b, int64_t ldb,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                            const std::vector<cl::sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm", "for row_major layout");
 }
 
@@ -1319,7 +1319,7 @@ inline cl::sycl::event trsm(Func func, cl::sycl::queue &queue, side left_right, 
     cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower,                \
                          transpose trans, diag unit_diag, int64_t m, int64_t n, TYPE alpha,        \
                          const TYPE *a, int64_t lda, TYPE *b, int64_t ldb,                         \
-                         const cl::sycl::vector_class<cl::sycl::event> &dependencies) {            \
+                         const std::vector<cl::sycl::event> &dependencies) {            \
         return trsm(CUBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, \
                     a, lda, b, ldb, dependencies);                                                 \
     }

--- a/src/blas/backends/mklcpu/mklcpu_batch.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_batch.cxx
@@ -931,7 +931,7 @@ void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
                            float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -952,7 +952,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, 
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
                            double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -974,7 +974,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x,
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
                            int64_t *incx, std::complex<float> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -996,7 +996,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::comple
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
                            int64_t *incx, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1018,7 +1018,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::comple
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                            std::int64_t stridex, float *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1037,7 +1037,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, in
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                            std::int64_t stridex, double *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1056,7 +1056,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, i
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, std::int64_t stridex, std::complex<float> *y, int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1075,7 +1075,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1094,7 +1094,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1111,7 +1111,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, con
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1128,7 +1128,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, co
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1146,7 +1146,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<floa
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1164,7 +1164,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<doub
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1180,7 +1180,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1197,7 +1197,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1215,7 +1215,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<doubl
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1233,7 +1233,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            float alpha, const float *a, int64_t lda, int64_t stride_a,
                            const float *x, int64_t incx, int64_t stride_x, float beta, float *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1275,7 +1275,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            double alpha, const double *a, int64_t lda, int64_t stride_a,
                            const double *x, int64_t incx, int64_t stride_x, double beta, double *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1318,7 +1318,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<float> *x, int64_t incx,
                            int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1364,7 +1364,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<double> *x, int64_t incx,
                            int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1409,7 +1409,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            float *alpha, const float **a, int64_t *lda, const float **x,
                            int64_t *incx, float *beta, float **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1440,7 +1440,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            double *alpha, const double **a, int64_t *lda, const double **x,
                            int64_t *incx, double *beta, double **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1472,7 +1472,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1504,7 +1504,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            int64_t *lda, const std::complex<double> **x, int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1535,7 +1535,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1576,7 +1576,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1619,7 +1619,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1664,7 +1664,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1707,7 +1707,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1736,7 +1736,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const double **a, int64_t *lda, const double **x, int64_t *incx,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1766,7 +1766,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1796,7 +1796,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1826,7 +1826,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, float *alpha, const float **a, int64_t *lda,
                            const float **b, int64_t *ldb, float *beta, float **c, int64_t *ldc,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1862,7 +1862,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, double *alpha, const double **a, int64_t *lda,
                            const double **b, int64_t *ldb, double *beta, double **c, int64_t *ldc,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1901,7 +1901,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
                            std::complex<float> **c, int64_t *ldc, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1940,7 +1940,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
                            std::complex<double> **c, int64_t *ldc, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1977,7 +1977,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, half *alpha, const half **a, int64_t *lda,
                            const half **b, int64_t *ldb, half *beta, half **c, int64_t *ldc,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
             throw oneapi::mkl::unimplemented(
@@ -2074,7 +2074,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                            int64_t stride_a, const float *b, int64_t ldb, int64_t stride_b,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2118,7 +2118,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t stride_a, const double *b, int64_t ldb, int64_t stride_b,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2163,7 +2163,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            std::complex<float> beta, std::complex<float> *c, int64_t ldc,
                            int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2211,7 +2211,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            std::complex<double> beta, std::complex<double> *c, int64_t ldc,
                            int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2257,7 +2257,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, half alpha, const half *a, int64_t lda,
                            int64_t stride_a, const half *b, int64_t ldb, int64_t stride_b,
                            half beta, half *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
             throw oneapi::mkl::unimplemented(
@@ -2342,7 +2342,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
                            const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2381,7 +2381,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
                            const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2421,7 +2421,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2463,7 +2463,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2504,7 +2504,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha,
                            const float **a, int64_t *lda, float **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2548,7 +2548,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha,
                            const double **a, int64_t *lda, double **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2593,7 +2593,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            std::complex<float> **b, int64_t *ldb, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2638,7 +2638,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2681,7 +2681,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
                            float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2708,7 +2708,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2736,7 +2736,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
                            int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2765,7 +2765,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2793,7 +2793,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2813,7 +2813,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2834,7 +2834,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2860,7 +2860,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_batch.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_batch.cxx
@@ -1093,8 +1093,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1110,8 +1109,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, con
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1163,8 +1161,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<doub
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1179,8 +1176,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1196,8 +1192,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, cons
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1214,8 +1209,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1471,8 +1465,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1534,8 +1527,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1575,8 +1567,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1618,8 +1609,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *a, int64_t lda, int64_t stride_a,
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1663,8 +1653,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *a, int64_t lda, int64_t stride_a,
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1900,8 +1889,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
                            std::complex<float> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1939,8 +1927,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
                            std::complex<double> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2117,8 +2104,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                            int64_t stride_a, const double *b, int64_t ldb, int64_t stride_b,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2420,8 +2406,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2462,8 +2447,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2592,8 +2576,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            std::complex<float> **b, int64_t *ldb, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2812,8 +2795,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2833,8 +2815,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2859,8 +2840,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_extensions.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_extensions.cxx
@@ -259,7 +259,7 @@ cl::sycl::event gemm_bias_fallback(cl::sycl::queue &queue, MKL_LAYOUT layout, tr
                                    int64_t k, float alpha, const Ta *a, int64_t lda, Ta ao,
                                    const Tb *b, int64_t ldb, Tb bo, float beta, int32_t *c,
                                    int64_t ldc, const int32_t *co,
-                                   const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                                   const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -303,7 +303,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao,
                               b, ldb, bo, beta, c, ldc, co, dependencies);
 }
@@ -312,7 +312,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     if (is_int8(-int(ao)) && is_int8(-int(bo))) {
         auto done = queue.submit([&](cl::sycl::handler &cgh) {
@@ -348,7 +348,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
         return gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda,
                                   ao, b, ldb, bo, beta, c, ldc, co, dependencies);
@@ -384,7 +384,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao,
                               b, ldb, bo, beta, c, ldc, co, dependencies);
 }
@@ -392,7 +392,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                       const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -412,7 +412,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                       const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -433,7 +433,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -458,7 +458,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<double> alpha,
                       const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
                       int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_extensions.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_extensions.cxx
@@ -111,9 +111,8 @@ void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offse
                            ldb, bo, beta, c, ldc, co);
 #endif
 #ifdef ROW_MAJOR
-    gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b,
-                       ldb, bo, beta, c, ldc, co);
-
+    gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb,
+                       bo, beta, c, ldc, co);
 
 #endif
 }
@@ -124,8 +123,8 @@ void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offse
                float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
                cl::sycl::buffer<int32_t, 1> &co) {
 #ifdef COLUMN_MAJOR
-    gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b,
-                       ldb, bo, beta, c, ldc, co);
+    gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb,
+                       bo, beta, c, ldc, co);
 
 #endif
 #ifdef ROW_MAJOR
@@ -339,8 +338,8 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                                   ao, b, ldb, bo, beta, c, ldc, co, dependencies);
 #endif
 #ifdef ROW_MAJOR
-    return gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda,
-                              ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    return gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao,
+                              b, ldb, bo, beta, c, ldc, co, dependencies);
 #endif
 }
 
@@ -350,8 +349,8 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
-        return gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda,
-                                  ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    return gemm_bias_fallback(queue, MKLMAJOR, transa, transb, offsetc, m, n, k, alpha, a, lda, ao,
+                              b, ldb, bo, beta, c, ldc, co, dependencies);
 #endif
 #ifdef ROW_MAJOR
     if (is_int8(-int(ao)) && is_int8(-int(bo))) {

--- a/src/blas/backends/mklcpu/mklcpu_level1.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level1.cxx
@@ -749,7 +749,7 @@ void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<doubl
 // USM APIs
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -762,7 +762,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const float *x, int64_t 
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -775,7 +775,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const double *x, int64_t
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -788,7 +788,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<float
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -802,7 +802,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -816,7 +816,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -830,7 +830,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, double alpha, const doub
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, std::complex<float> *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -847,7 +847,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<float> alph
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, int64_t incx, std::complex<double> *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -864,7 +864,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<double> alp
 
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
                       float beta, float *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -877,7 +877,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const floa
 }
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                       int64_t incx, double beta, double *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -891,7 +891,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const dou
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                       const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                       std::complex<float> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -910,7 +910,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alp
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                       const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                       std::complex<double> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -928,7 +928,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> al
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -940,7 +940,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const float *x, int64_t 
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -953,7 +953,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const double *x, int64_t
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -966,7 +966,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<float
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -979,7 +979,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
                     int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -993,7 +993,7 @@ cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t i
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                     const double *y, int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1007,7 +1007,7 @@ cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const double *x, int64_t 
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
                     int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1021,7 +1021,7 @@ cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t i
 
 cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                      const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1035,7 +1035,7 @@ cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<float
 
 cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1049,7 +1049,7 @@ cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                      const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1063,7 +1063,7 @@ cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<float
 
 cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1077,7 +1077,7 @@ cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1091,7 +1091,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1105,7 +1105,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1119,7 +1119,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<floa
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                       int64_t incx, int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1133,7 +1133,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<doub
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1147,7 +1147,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1161,7 +1161,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1175,7 +1175,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<floa
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                       int64_t incx, int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1188,7 +1188,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<doub
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1201,7 +1201,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const float *x, int64_t 
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1214,7 +1214,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const double *x, int64_t
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1227,7 +1227,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<float
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1241,7 +1241,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
                     int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1255,7 +1255,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, f
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
                     int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1269,7 +1269,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, 
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
                     std::complex<float> *y, int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1283,7 +1283,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, i
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
                     std::complex<double> *y, int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1296,7 +1296,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, 
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1308,7 +1308,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1321,7 +1321,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c, do
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b,
                      float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1334,7 +1334,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a, std::comple
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b,
                      double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1347,7 +1347,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::compl
 
 cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
                      int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1361,7 +1361,7 @@ cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, 
 
 cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
                      int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1374,7 +1374,7 @@ cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx,
 }
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                      float *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      float *param, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1387,7 +1387,7 @@ cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, f
 }
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1,
-                      double *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      double *param, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1400,7 +1400,7 @@ cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1414,7 +1414,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, float *x, i
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1429,7 +1429,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, double *x,
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                      std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1445,7 +1445,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<float> alph
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, std::complex<float> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1460,7 +1460,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, std::comple
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                      std::complex<double> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1476,7 +1476,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<double> alp
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1491,7 +1491,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, std::compl
 
 cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
                        const float *y, int64_t incy, float *result,
-                       const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1504,7 +1504,7 @@ cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float 
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1516,7 +1516,7 @@ cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, 
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1529,7 +1529,7 @@ cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx,
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1542,7 +1542,7 @@ cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, 
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_level1.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level1.cxx
@@ -801,8 +801,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -815,8 +814,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -978,8 +976,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 }
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, float *result,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    int64_t incy, float *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1076,8 +1073,7 @@ cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1090,8 +1086,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1104,8 +1099,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1132,8 +1126,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<doub
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1146,8 +1139,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1160,8 +1152,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1346,8 +1337,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::compl
 }
 
 cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, float *param,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     int64_t incy, float *param, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_level2.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level2.cxx
@@ -1182,8 +1182,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1199,8 +1198,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1636,8 +1634,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1653,8 +1650,7 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1764,8 +1760,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1781,8 +1776,7 @@ cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_level2.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level2.cxx
@@ -1103,7 +1103,7 @@ void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_d
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
                      int64_t ku, float alpha, const float *a, int64_t lda, const float *x,
                      int64_t incx, float beta, float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1120,7 +1120,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
                      int64_t ku, double alpha, const double *a, int64_t lda, const double *x,
                      int64_t incx, double beta, double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1138,7 +1138,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *x, int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1161,7 +1161,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, const std::complex<double> *x, int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1183,7 +1183,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1200,7 +1200,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1218,7 +1218,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                      const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1241,7 +1241,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1262,7 +1262,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 
 cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, float alpha, const float *x,
                     int64_t incx, const float *y, int64_t incy, float *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1276,7 +1276,7 @@ cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, float alpha, c
 
 cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, double alpha, const double *x,
                     int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1291,7 +1291,7 @@ cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, double alpha, 
 cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1309,7 +1309,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<
 cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
                      int64_t incy, std::complex<double> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1327,7 +1327,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<
 cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1345,7 +1345,7 @@ cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<
 cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
                      int64_t incy, std::complex<double> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1364,7 +1364,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
                      std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                      const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1387,7 +1387,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
                      std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1409,7 +1409,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
                      int64_t incx, std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1432,7 +1432,7 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1453,7 +1453,7 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const std::complex<float> *x, int64_t incx, std::complex<float> *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1468,7 +1468,7 @@ cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const std::complex<double> *x, int64_t incx, std::complex<double> *a,
-                    int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1484,7 +1484,7 @@ cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1504,7 +1504,7 @@ cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::c
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1524,7 +1524,7 @@ cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *ap, const std::complex<float> *x, int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1547,7 +1547,7 @@ cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *ap,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1568,7 +1568,7 @@ cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const std::complex<float> *x, int64_t incx, std::complex<float> *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1583,7 +1583,7 @@ cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const std::complex<double> *x, int64_t incx, std::complex<double> *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1599,7 +1599,7 @@ cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1618,7 +1618,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::c
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1637,7 +1637,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1654,7 +1654,7 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1670,7 +1670,7 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *ap, const float *x, int64_t incx, float beta, float *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1686,7 +1686,7 @@ cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *ap, const double *x, int64_t incx, double beta, double *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1702,7 +1702,7 @@ cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const float *x, int64_t incx, float *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1717,7 +1717,7 @@ cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const double *x, int64_t incx, double *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1732,7 +1732,7 @@ cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *x, int64_t incx, const float *y, int64_t incy, float *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1748,7 +1748,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *x, int64_t incx, const double *y, int64_t incy, double *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1765,7 +1765,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1782,7 +1782,7 @@ cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1798,7 +1798,7 @@ cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const float *x, int64_t incx, float *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1813,7 +1813,7 @@ cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const double *x, int64_t incx, double *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1828,7 +1828,7 @@ cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *x, int64_t incx, const float *y, int64_t incy, float *a,
-                     int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1844,7 +1844,7 @@ cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *x, int64_t incx, const double *y, int64_t incy, double *a,
-                     int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1860,7 +1860,7 @@ cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1878,7 +1878,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1897,7 +1897,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
                      std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1916,7 +1916,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
                      std::complex<double> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1934,7 +1934,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1952,7 +1952,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1971,7 +1971,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
                      std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1990,7 +1990,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
                      std::complex<double> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2008,7 +2008,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const float *ap, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2026,7 +2026,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const double *ap, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2044,7 +2044,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2062,7 +2062,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<double> *ap, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2080,7 +2080,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const float *ap, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2098,7 +2098,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const double *ap, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2116,7 +2116,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2134,7 +2134,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<double> *ap, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2152,7 +2152,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const float *a, int64_t lda, float *b, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2170,7 +2170,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const double *a, int64_t lda, double *b, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2188,7 +2188,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *b,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2206,7 +2206,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2224,7 +2224,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2242,7 +2242,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const double *a, int64_t lda, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2260,7 +2260,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2278,7 +2278,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_level3.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cxx
@@ -1273,8 +1273,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1361,8 +1360,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklcpu/mklcpu_level3.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cxx
@@ -697,7 +697,7 @@ void trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose t
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
                      int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -716,7 +716,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                      const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -736,7 +736,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *b, int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -760,7 +760,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      int64_t n, int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
                      int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -783,7 +783,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, half alpha, const half *a, int64_t lda, const half *b,
                      int64_t ldb, half beta, half *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
             throw oneapi::mkl::unimplemented(
@@ -833,7 +833,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const half *a, int64_t lda, const half *b,
                      int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
             throw oneapi::mkl::unimplemented(
@@ -875,7 +875,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const bfloat16 *a, int64_t lda,
                      const bfloat16 *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -895,7 +895,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *b, int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -919,7 +919,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, const std::complex<double> *b, int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -942,7 +942,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, float alpha, const std::complex<float> *a, int64_t lda, float beta,
                      std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -960,7 +960,7 @@ cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, double alpha, const std::complex<double> *a, int64_t lda,
                      double beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -979,7 +979,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb, float beta,
                       std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1001,7 +1001,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       int64_t lda, const std::complex<double> *b, int64_t ldb, double beta,
                       std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1022,7 +1022,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
                      int64_t n, float alpha, const float *a, int64_t lda, const float *b,
                      int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1041,7 +1041,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
                      int64_t n, double alpha, const double *a, int64_t lda, const double *b,
                      int64_t ldb, double beta, double *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1061,7 +1061,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *b, int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1085,7 +1085,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, const std::complex<double> *b, int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1107,7 +1107,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, float alpha, const float *a, int64_t lda, float beta, float *c,
-                     int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1124,7 +1124,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, double alpha, const double *a, int64_t lda, double beta, double *c,
-                     int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1142,7 +1142,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1165,7 +1165,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1188,7 +1188,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                       int64_t k, float alpha, const float *a, int64_t lda, const float *b,
                       int64_t ldb, float beta, float *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1207,7 +1207,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                       int64_t k, double alpha, const double *a, int64_t lda, const double *b,
                       int64_t ldb, double beta, double *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1227,7 +1227,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1251,7 +1251,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       int64_t lda, const std::complex<double> *b, int64_t ldb,
                       std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1274,7 +1274,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
                      float *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1295,7 +1295,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
                      int64_t lda, double *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1316,7 +1316,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1339,7 +1339,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1362,7 +1362,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
                      float *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1383,7 +1383,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
                      int64_t lda, double *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1404,7 +1404,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1427,7 +1427,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/mklgpu/mklgpu_batch.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_batch.cxx
@@ -306,7 +306,7 @@ cl::sycl::event *coalesce_events(cl::sycl::queue &queue, std::vector<cl::sycl::e
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                            std::int64_t stridex, float *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::scopy_batch_sycl(&queue, n, x, incx, stridex, y, incy, stridey,
                                                 batch_size, dependencies);
 }
@@ -314,7 +314,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, in
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                            std::int64_t stridex, double *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dcopy_batch_sycl(&queue, n, x, incx, stridex, y, incy, stridey,
                                                 batch_size, dependencies);
 }
@@ -322,7 +322,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, i
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, std::int64_t stridex, std::complex<float> *y, int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ccopy_batch_sycl(&queue, n, x, incx, stridex, y, incy, stridey,
                                                 batch_size, dependencies);
 }
@@ -330,14 +330,14 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zcopy_batch_sycl(&queue, n, x, incx, stridex, y, incy, stridey,
                                                 batch_size, dependencies);
 }
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
                            float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -353,7 +353,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, 
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
                            double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -370,7 +370,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x,
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
                            int64_t *incx, std::complex<float> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -387,7 +387,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::comple
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
                            int64_t *incx, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -404,7 +404,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::comple
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::saxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
@@ -412,7 +412,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::daxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
@@ -421,7 +421,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::caxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
@@ -430,7 +430,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<doubl
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zaxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
@@ -438,7 +438,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<doubl
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -455,7 +455,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, con
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -472,7 +472,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, co
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -489,7 +489,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<floa
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -507,7 +507,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            float alpha, const float *a, int64_t lda, int64_t stride_a,
                            const float *x, int64_t incx, int64_t stride_x, float beta, float *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sgemv_batch_sycl(&queue, MAJOR, mkl_convert(transa), m, n, alpha, a,
                                                 lda, stride_a, x, incx, stride_x, beta, y, incy,
                                                 stride_y, batch_size, dependencies);
@@ -517,7 +517,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            double alpha, const double *a, int64_t lda, int64_t stride_a,
                            const double *x, int64_t incx, int64_t stride_x, double beta, double *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgemv_batch_sycl(&queue, MAJOR, mkl_convert(transa), m, n, alpha, a,
                                                 lda, stride_a, x, incx, stride_x, beta, y, incy,
                                                 stride_y, batch_size, dependencies);
@@ -528,7 +528,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<float> *x, int64_t incx,
                            int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgemv_batch_sycl(&queue, MAJOR, mkl_convert(transa), m, n, alpha, a,
                                                 lda, stride_a, x, incx, stride_x, beta, y, incy,
                                                 stride_y, batch_size, dependencies);
@@ -539,7 +539,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<double> *x, int64_t incx,
                            int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgemv_batch_sycl(&queue, MAJOR, mkl_convert(transa), m, n, alpha, a,
                                                 lda, stride_a, x, incx, stride_x, beta, y, incy,
                                                 stride_y, batch_size, dependencies);
@@ -549,7 +549,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            float *alpha, const float **a, int64_t *lda, const float **x,
                            int64_t *incx, float *beta, float **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -568,7 +568,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            double *alpha, const double **a, int64_t *lda, const double **x,
                            int64_t *incx, double *beta, double **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -588,7 +588,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -608,7 +608,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            int64_t *lda, const std::complex<double> **x, int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -627,7 +627,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sdgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -637,7 +637,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ddgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -648,7 +648,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cdgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -659,7 +659,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zdgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -668,7 +668,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -686,7 +686,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const double **a, int64_t *lda, const double **x, int64_t *incx,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -705,7 +705,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -724,7 +724,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -743,7 +743,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                            int64_t stride_a, const float *b, int64_t ldb, int64_t stride_b,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sgemm_batch_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k, alpha, a, lda, stride_a,
         b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -754,7 +754,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t stride_a, const double *b, int64_t ldb, int64_t stride_b,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgemm_batch_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k, alpha, a, lda, stride_a,
         b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -766,7 +766,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            std::complex<float> beta, std::complex<float> *c, int64_t ldc,
                            int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgemm_batch_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k, alpha, a, lda, stride_a,
         b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -778,7 +778,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            std::complex<double> beta, std::complex<double> *c, int64_t ldc,
                            int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgemm_batch_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k, alpha, a, lda, stride_a,
         b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -788,7 +788,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, half alpha, const half *a, int64_t lda,
                            int64_t stride_a, const half *b, int64_t ldb, int64_t stride_b,
                            half beta, half *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::hgemm_batch_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k, alpha, a, lda, stride_a,
         b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -798,7 +798,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, float *alpha, const float **a, int64_t *lda,
                            const float **b, int64_t *ldb, float *beta, float **c, int64_t *ldc,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -818,7 +818,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, double *alpha, const double **a, int64_t *lda,
                            const double **b, int64_t *ldb, double *beta, double **c, int64_t *ldc,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -840,7 +840,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
                            std::complex<float> **c, int64_t *ldc, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -862,7 +862,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
                            std::complex<double> **c, int64_t *ldc, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -882,7 +882,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, half *alpha, const half **a, int64_t *lda,
                            const half **b, int64_t *ldb, half *beta, half **c, int64_t *ldc,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -902,7 +902,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
                            const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::strsm_batch_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(trans),
         mkl_convert(unit_diag), m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
@@ -913,7 +913,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
                            const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtrsm_batch_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(trans),
         mkl_convert(unit_diag), m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
@@ -925,7 +925,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrsm_batch_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(trans),
         mkl_convert(unit_diag), m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
@@ -937,7 +937,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrsm_batch_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(trans),
         mkl_convert(unit_diag), m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
@@ -948,7 +948,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha,
                            const float **a, int64_t *lda, float **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -968,7 +968,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha,
                            const double **a, int64_t *lda, double **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -989,7 +989,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            std::complex<float> **b, int64_t *ldb, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -1010,7 +1010,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -1029,7 +1029,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssyrk_batch_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                                 mkl_convert(trans), n, k, alpha, a, lda, stride_a,
                                                 beta, c, ldc, stride_c, batch_size, dependencies);
@@ -1039,7 +1039,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsyrk_batch_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                                 mkl_convert(trans), n, k, alpha, a, lda, stride_a,
                                                 beta, c, ldc, stride_c, batch_size, dependencies);
@@ -1050,7 +1050,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csyrk_batch_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                                 mkl_convert(trans), n, k, alpha, a, lda, stride_a,
                                                 beta, c, ldc, stride_c, batch_size, dependencies);
@@ -1061,7 +1061,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zsyrk_batch_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                                 mkl_convert(trans), n, k, alpha, a, lda, stride_a,
                                                 beta, c, ldc, stride_c, batch_size, dependencies);
@@ -1070,7 +1070,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
                            float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -1089,7 +1089,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -1109,7 +1109,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
                            int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -1129,7 +1129,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;

--- a/src/blas/backends/mklgpu/mklgpu_batch.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_batch.cxx
@@ -403,16 +403,14 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::comple
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::saxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::daxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
@@ -420,8 +418,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, cons
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::caxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
@@ -429,16 +426,14 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zaxpy_batch_sycl(&queue, n, alpha, x, incx, stridex, y, incy,
                                                 stridey, batch_size, dependencies);
 }
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -454,8 +449,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, con
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -587,8 +581,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -626,8 +619,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sdgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -636,8 +628,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ddgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -647,8 +638,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *a, int64_t lda, int64_t stride_a,
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cdgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -658,8 +648,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *a, int64_t lda, int64_t stride_a,
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zdgmm_batch_sycl(&queue, MAJOR, mkl_convert(left_right), m, n, a,
                                                 lda, stride_a, x, incx, stride_x, c, ldc, stride_c,
                                                 batch_size, dependencies);
@@ -753,8 +742,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                            int64_t stride_a, const double *b, int64_t ldb, int64_t stride_b,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgemm_batch_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k, alpha, a, lda, stride_a,
         b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -839,8 +827,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
                            std::complex<float> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -861,8 +848,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
                            std::complex<double> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_group_size = 0;
@@ -924,8 +910,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrsm_batch_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(trans),
         mkl_convert(unit_diag), m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
@@ -936,8 +921,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrsm_batch_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(trans),
         mkl_convert(unit_diag), m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
@@ -988,8 +972,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            std::complex<float> **b, int64_t *ldb, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);
     int64_t total_groupsize = 0;
@@ -1038,8 +1021,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsyrk_batch_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                                 mkl_convert(trans), n, k, alpha, a, lda, stride_a,
                                                 beta, c, ldc, stride_c, batch_size, dependencies);
@@ -1049,8 +1031,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csyrk_batch_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                                 mkl_convert(trans), n, k, alpha, a, lda, stride_a,
                                                 beta, c, ldc, stride_c, batch_size, dependencies);
@@ -1060,8 +1041,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zsyrk_batch_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                                 mkl_convert(trans), n, k, alpha, a, lda, stride_a,
                                                 beta, c, ldc, stride_c, batch_size, dependencies);

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -1001,14 +1001,14 @@ cl::sycl::event sgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
                            const float *a, int64_t lda, const float *b, int64_t ldb, float beta,
                            float *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, double alpha,
                            const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
                            double *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1016,7 +1016,7 @@ cl::sycl::event cgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1024,21 +1024,21 @@ cl::sycl::event zgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, half alpha,
                            const half *a, int64_t lda, const half *b, int64_t ldb, half beta,
                            half *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event gemm_f16f16f32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                     MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k,
                                     float alpha, const half *a, int64_t lda, const half *b,
                                     int64_t ldb, float beta, float *c, int64_t ldc,
-                                    const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                    const std::vector<cl::sycl::event> &dependencies,
                                     int64_t offset_a = 0, int64_t offset_b = 0,
                                     int64_t offset_c = 0);
 
@@ -1047,28 +1047,28 @@ cl::sycl::event gemm_bf16bf16f32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout,
                                       int64_t n, int64_t k, float alpha, const bfloat16 *a,
                                       int64_t lda, const bfloat16 *b, int64_t ldb, float beta,
                                       float *c, int64_t ldc,
-                                      const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                      const std::vector<cl::sycl::event> &dependencies,
                                       int64_t offset_a = 0, int64_t offset_b = 0,
                                       int64_t offset_c = 0);
 
 cl::sycl::event ssymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, int64_t m, int64_t n, float alpha, const float *a,
                            int64_t lda, const float *b, int64_t ldb, float beta, float *c,
-                           int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dsymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, int64_t m, int64_t n, double alpha,
                            const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
                            double *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event csymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, int64_t m, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
                            int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                           int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zsymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1076,14 +1076,14 @@ cl::sycl::event zsymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE l
                            const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event chemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, int64_t m, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
                            int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                           int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zhemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1091,47 +1091,47 @@ cl::sycl::event zhemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE l
                            const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event ssyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha, const float *a,
                            int64_t lda, float beta, float *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event dsyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha, const double *a,
                            int64_t lda, double beta, double *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event csyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event zsyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<double> alpha,
                            const std::complex<double> *a, int64_t lda, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event ssyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                                  MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha,
                                  const float *a, int64_t lda, int64_t stride_a, float beta,
                                  float *c, int64_t ldc, int64_t stride_c, int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event dsyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                                  MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha,
                                  const double *a, int64_t lda, int64_t stride_a, double beta,
                                  double *c, int64_t ldc, int64_t stride_c, int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event csyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1140,7 +1140,7 @@ cl::sycl::event csyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t lda, int64_t stride_a, std::complex<float> beta,
                                  std::complex<float> *c, int64_t ldc, int64_t stride_c,
                                  int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event zsyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1149,21 +1149,21 @@ cl::sycl::event zsyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t lda, int64_t stride_a, std::complex<double> beta,
                                  std::complex<double> *c, int64_t ldc, int64_t stride_c,
                                  int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event ssyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                                  MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha,
                                  const float **a, int64_t lda, float beta, float **c, int64_t ldc,
                                  int64_t offset_batch, int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event dsyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                                  MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha,
                                  const double **a, int64_t lda, double beta, double **c,
                                  int64_t ldc, int64_t offset_batch, int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event csyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1171,7 +1171,7 @@ cl::sycl::event csyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  std::complex<float> alpha, const std::complex<float> **a,
                                  int64_t lda, std::complex<float> beta, std::complex<float> **c,
                                  int64_t ldc, int64_t offset_batch, int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event zsyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1179,35 +1179,35 @@ cl::sycl::event zsyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  std::complex<double> alpha, const std::complex<double> **a,
                                  int64_t lda, std::complex<double> beta, std::complex<double> **c,
                                  int64_t ldc, int64_t offset_batch, int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event cherk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha,
                            const std::complex<float> *a, int64_t lda, float beta,
                            std::complex<float> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event zherk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha,
                            const std::complex<double> *a, int64_t lda, double beta,
                            std::complex<double> *c, int64_t ldc,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_c = 0);
 
 cl::sycl::event ssyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha, const float *a,
                             int64_t lda, const float *b, int64_t ldb, float beta, float *c,
                             int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dsyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha,
                             const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
                             double *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event csyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1215,7 +1215,7 @@ cl::sycl::event csyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO 
                             const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
                             int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                             int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zsyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1223,14 +1223,14 @@ cl::sycl::event zsyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO 
                             const std::complex<double> *a, int64_t lda,
                             const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                             std::complex<double> *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cher2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<float> alpha,
                             const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
                             int64_t ldb, float beta, std::complex<float> *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zher2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1238,75 +1238,75 @@ cl::sycl::event zher2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO 
                             const std::complex<double> *a, int64_t lda,
                             const std::complex<double> *b, int64_t ldb, double beta,
                             std::complex<double> *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event strmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, float alpha, const float *a, int64_t lda, float *b,
-                           int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event dtrmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
                            double *b, int64_t ldb,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ctrmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *b,
-                           int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ztrmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                           int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event strsm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, float alpha, const float *a, int64_t lda, float *b,
-                           int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event dtrsm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
                            double *b, int64_t ldb,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ctrsm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *b,
-                           int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ztrsm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                           int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                           int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event strsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                                  MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                                  int64_t m, int64_t n, float alpha, const float **a, int64_t lda,
                                  float **b, int64_t ldb, int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event dtrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                                  MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                                  int64_t m, int64_t n, double alpha, const double **a, int64_t lda,
                                  double **b, int64_t ldb, int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ctrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1315,7 +1315,7 @@ cl::sycl::event ctrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<float> **a, int64_t lda,
                                  std::complex<float> **b, int64_t ldb, int64_t offset_batch,
                                  int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ztrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1324,7 +1324,7 @@ cl::sycl::event ztrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<double> **a, int64_t lda,
                                  std::complex<double> **b, int64_t ldb, int64_t offset_batch,
                                  int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event strsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1332,7 +1332,7 @@ cl::sycl::event strsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
                                  int64_t stridea, float *b, int64_t ldb, int64_t strideb,
                                  int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event dtrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1340,7 +1340,7 @@ cl::sycl::event dtrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
                                  int64_t stridea, double *b, int64_t ldb, int64_t strideb,
                                  int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ctrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1349,7 +1349,7 @@ cl::sycl::event ctrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<float> *a, int64_t lda, int64_t stridea,
                                  std::complex<float> *b, int64_t ldb, int64_t strideb,
                                  int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ztrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1358,39 +1358,39 @@ cl::sycl::event ztrsm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<double> *a, int64_t lda, int64_t stridea,
                                  std::complex<double> *b, int64_t ldb, int64_t strideb,
                                  int64_t batchsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event sgemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
                            const float *x, int64_t incx, float beta, float *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dgemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
                            const double *x, int64_t incx, double beta, double *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cgemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
                            int64_t incx, std::complex<float> beta, std::complex<float> *y,
                            int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                            std::complex<double> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                  int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
                                  int64_t strideA, const float *x, int64_t incx, int64_t stride_x,
                                  float beta, float *y, int64_t incy, int64_t stride_y,
                                  int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event dgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1398,7 +1398,7 @@ cl::sycl::event dgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t strideA, const double *x, int64_t incx, int64_t stride_x,
                                  double beta, double *y, int64_t incy, int64_t stride_y,
                                  int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event cgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1407,7 +1407,7 @@ cl::sycl::event cgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<float> *x, int64_t incx, int64_t stride_x,
                                  std::complex<float> beta, std::complex<float> *y, int64_t incy,
                                  int64_t stride_y, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event zgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1416,21 +1416,21 @@ cl::sycl::event zgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<double> *x, int64_t incx, int64_t stride_x,
                                  std::complex<double> beta, std::complex<double> *y, int64_t incy,
                                  int64_t stride_y, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event sgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                  int64_t m, int64_t n, float alpha, const float **a, int64_t lda,
                                  const float **x, int64_t incx, float beta, float **y, int64_t incy,
                                  int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event dgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                  int64_t m, int64_t n, double alpha, const double **a, int64_t lda,
                                  const double **x, int64_t incx, double beta, double **y,
                                  int64_t incy, int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event cgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1439,7 +1439,7 @@ cl::sycl::event cgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<float> **x, int64_t incx,
                                  std::complex<float> beta, std::complex<float> **y, int64_t incy,
                                  int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event zgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1448,21 +1448,21 @@ cl::sycl::event zgemv_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<double> **x, int64_t incx,
                                  std::complex<double> beta, std::complex<double> **y, int64_t incy,
                                  int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_y = 0);
 
 cl::sycl::event sdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                                  int64_t m, int64_t n, const float *a, int64_t lda, int64_t strideA,
                                  const float *x, int64_t incx, int64_t stride_x, float *c,
                                  int64_t ldc, int64_t stride_c, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event ddgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                                  int64_t m, int64_t n, const double *a, int64_t lda,
                                  int64_t strideA, const double *x, int64_t incx, int64_t stride_x,
                                  double *c, int64_t ldc, int64_t stride_c, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event cdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1470,7 +1470,7 @@ cl::sycl::event cdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t strideA, const std::complex<float> *x, int64_t incx,
                                  int64_t stride_x, std::complex<float> *c, int64_t ldc,
                                  int64_t stride_c, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event zdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1478,21 +1478,21 @@ cl::sycl::event zdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t strideA, const std::complex<double> *x, int64_t incx,
                                  int64_t stride_x, std::complex<double> *c, int64_t ldc,
                                  int64_t stride_c, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event sdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                                  int64_t m, int64_t n, const float **a, int64_t lda,
                                  const float **x, int64_t incx, float **c, int64_t ldc,
                                  int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event ddgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                                  int64_t m, int64_t n, const double **a, int64_t lda,
                                  const double **x, int64_t incx, double **c, int64_t ldc,
                                  int64_t offset_batch, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event cdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1500,7 +1500,7 @@ cl::sycl::event cdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<float> **x, int64_t incx,
                                  std::complex<float> **c, int64_t ldc, int64_t offset_batch,
                                  int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event zdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1508,613 +1508,613 @@ cl::sycl::event zdgmm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const std::complex<double> **x, int64_t incx,
                                  std::complex<double> **c, int64_t ldc, int64_t offset_batch,
                                  int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_x = 0, int64_t offset_c = 0);
 
 cl::sycl::event sgbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, int64_t kl, int64_t ku, float alpha,
                            const float *a, int64_t lda, const float *x, int64_t incx, float beta,
                            float *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dgbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, int64_t kl, int64_t ku, double alpha,
                            const double *a, int64_t lda, const double *x, int64_t incx, double beta,
                            double *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cgbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, int64_t kl, int64_t ku, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
                            int64_t incx, std::complex<float> beta, std::complex<float> *y,
                            int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, int64_t kl, int64_t ku, std::complex<double> alpha,
                            const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                            std::complex<double> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sger_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                           float alpha, const float *x, int64_t incx, const float *y, int64_t incy,
                           float *a, int64_t lda,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dger_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                           double alpha, const double *x, int64_t incx, const double *y,
                           int64_t incy, double *a, int64_t lda,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cgerc_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
                            const std::complex<float> *y, int64_t incy, std::complex<float> *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgerc_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                            const std::complex<double> *y, int64_t incy, std::complex<double> *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cgeru_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
                            const std::complex<float> *y, int64_t incy, std::complex<float> *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgeru_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                            const std::complex<double> *y, int64_t incy, std::complex<double> *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event chbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                            int64_t lda, const std::complex<float> *x, int64_t incx,
                            std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zhbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                            int64_t lda, const std::complex<double> *x, int64_t incx,
                            std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event chemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                            std::complex<float> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zhemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                            std::complex<double> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cher_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           float alpha, const std::complex<float> *x, int64_t incx,
                           std::complex<float> *a, int64_t lda,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zher_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           double alpha, const std::complex<double> *x, int64_t incx,
                           std::complex<double> *a, int64_t lda,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cher2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
                            const std::complex<float> *y, int64_t incy, std::complex<float> *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zher2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                            const std::complex<double> *y, int64_t incy, std::complex<double> *a,
                            int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event chpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a,
                            const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                            std::complex<float> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zhpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a,
                            const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                            std::complex<double> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event chpr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           float alpha, const std::complex<float> *x, int64_t incx,
                           std::complex<float> *a,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zhpr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           double alpha, const std::complex<double> *x, int64_t incx,
                           std::complex<double> *a,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event chpr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
                            const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zhpr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                            const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ssbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            int64_t k, float alpha, const float *a, int64_t lda, const float *x,
                            int64_t incx, float beta, float *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dsbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            int64_t k, double alpha, const double *a, int64_t lda, const double *x,
                            int64_t incx, double beta, double *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sspmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            float alpha, const float *a, const float *x, int64_t incx, float beta,
                            float *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dspmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            double alpha, const double *a, const double *x, int64_t incx,
                            double beta, double *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sspr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           float alpha, const float *x, int64_t incx, float *a,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dspr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           double alpha, const double *x, int64_t incx, double *a,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sspr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            float alpha, const float *x, int64_t incx, const float *y, int64_t incy,
-                           float *a, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           float *a, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dspr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            double alpha, const double *x, int64_t incx, const double *y,
                            int64_t incy, double *a,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ssymv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            float alpha, const float *a, int64_t lda, const float *x, int64_t incx,
                            float beta, float *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dsymv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            double alpha, const double *a, int64_t lda, const double *x,
                            int64_t incx, double beta, double *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ssyr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           float alpha, const float *x, int64_t incx, float *a, int64_t lda,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dsyr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           double alpha, const double *x, int64_t incx, double *a, int64_t lda,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ssyr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            float alpha, const float *x, int64_t incx, const float *y, int64_t incy,
                            float *a, int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dsyr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            double alpha, const double *x, int64_t incx, const double *y,
                            int64_t incy, double *a, int64_t lda,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event stbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k, const float *a,
                            int64_t lda, float *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const double *a, int64_t lda, double *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ctbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event stbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k, const float *a,
                            int64_t lda, float *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const double *a, int64_t lda, double *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ctbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event stpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const float *a, float *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const double *a,
                            double *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ctpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<float> *a, std::complex<float> *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<double> *a, std::complex<double> *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event stpsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const float *a, float *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtpsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const double *a,
                            double *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ctpsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<float> *a, std::complex<float> *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztpsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<double> *a, std::complex<double> *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event strmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const float *a,
                            int64_t lda, float *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtrmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const double *a,
                            int64_t lda, double *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ctrmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztrmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event strsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const float *a,
                            int64_t lda, float *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtrsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const double *a,
                            int64_t lda, double *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ctrsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztrsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
                            int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event scasum_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                             int64_t incx, float *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dzasum_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                             int64_t incx, double *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sasum_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                            float *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dasum_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
                            double *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event saxpy_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float *x,
                            int64_t incx, float *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event daxpy_sycl(cl::sycl::queue *queue, int64_t n, double alpha, const double *x,
                            int64_t incx, double *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event caxpy_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, int64_t incx, std::complex<float> *y,
                            int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zaxpy_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, int64_t incx, std::complex<double> *y,
                            int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event saxpby_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float *x,
                             int64_t incx, float beta, float *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event daxpby_sycl(cl::sycl::queue *queue, int64_t n, double alpha, const double *x,
                             int64_t incx, double beta, double *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event caxpby_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> alpha,
                             const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                             std::complex<float> *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zaxpby_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> alpha,
                             const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                             std::complex<double> *y, int64_t incy,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event scopy_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                            float *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dcopy_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
                            double *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ccopy_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, std::complex<float> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zcopy_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, std::complex<double> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event scopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const float **x, int64_t incx,
                                  float **y, int64_t incy, int64_t offset_batch, int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 cl::sycl::event ccopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> **x,
                                  int64_t incx, std::complex<float> **y, int64_t incy,
                                  int64_t offset_batch, int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 cl::sycl::event zcopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> **x,
                                  int64_t incx, std::complex<double> **y, int64_t incy,
                                  int64_t offset_batch, int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 cl::sycl::event dcopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const double **x, int64_t incx,
                                  double **y, int64_t incy, int64_t offset_batch, int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 cl::sycl::event scopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                                  std::int64_t stridex, float *y, int64_t incy, std::int64_t stridey,
                                  std::int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 cl::sycl::event ccopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                                  int64_t incx, std::int64_t stridex, std::complex<float> *y,
                                  int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 cl::sycl::event zcopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                                  int64_t incx, std::int64_t stridex, std::complex<double> *y,
                                  int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 cl::sycl::event dcopy_batch_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
                                  std::int64_t stridex, double *y, int64_t incy,
                                  std::int64_t stridey, std::int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sdot_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                           const float *y, int64_t incy, float *result,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ddot_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
                           const double *y, int64_t incy, double *result,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sdsdot_sycl(cl::sycl::queue *queue, int64_t n, float sb, const float *x,
                             int64_t incx, const float *y, int64_t incy, float *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dsdot_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                            const float *y, int64_t incy, double *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cdotc_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, const std::complex<float> *y, int64_t incy,
                            std::complex<float> *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zdotc_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, const std::complex<double> *y, int64_t incy,
                            std::complex<double> *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cdotu_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, const std::complex<float> *y, int64_t incy,
                            std::complex<float> *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zdotu_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, const std::complex<double> *y, int64_t incy,
                            std::complex<double> *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event scnrm2_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                             int64_t incx, float *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dznrm2_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                             int64_t incx, double *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event snrm2_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                            float *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dnrm2_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
                            double *result,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event csrot_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> *x, int64_t incx,
                            std::complex<float> *y, int64_t incy, float c, float s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zdrot_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> *x, int64_t incx,
                            std::complex<double> *y, int64_t incy, double c, double s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event srot_sycl(cl::sycl::queue *queue, int64_t n, float *x, int64_t incx, float *y,
                           int64_t incy, float c, float s,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event drot_sycl(cl::sycl::queue *queue, int64_t n, double *x, int64_t incx, double *y,
                           int64_t incy, double c, double s,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                          const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event srotg_sycl(cl::sycl::queue *queue, float *a, float *b, float *c, float *s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event drotg_sycl(cl::sycl::queue *queue, double *a, double *b, double *c, double *s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event crotg_sycl(cl::sycl::queue *queue, std::complex<float> *a, std::complex<float> *b,
                            float *c, std::complex<float> *s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zrotg_sycl(cl::sycl::queue *queue, std::complex<double> *a, std::complex<double> *b,
                            double *c, std::complex<double> *s,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event srotm_sycl(cl::sycl::queue *queue, int64_t n, float *x, int64_t incx, float *y,
                            int64_t incy, float *param,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event drotm_sycl(cl::sycl::queue *queue, int64_t n, double *x, int64_t incx, double *y,
                            int64_t incy, double *param,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event srotmg_sycl(cl::sycl::queue *queue, float *d1, float *d2, float *x1, float y1,
                             float *param,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event drotmg_sycl(cl::sycl::queue *queue, double *d1, double *d2, double *x1, double y1,
                             double *param,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sscal_sycl(cl::sycl::queue *queue, int64_t n, float alpha, float *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dscal_sycl(cl::sycl::queue *queue, int64_t n, double alpha, double *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cscal_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> alpha,
                            std::complex<float> *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zscal_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> alpha,
                            std::complex<double> *x, int64_t incx,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event csscal_sycl(cl::sycl::queue *queue, int64_t n, float alpha, std::complex<float> *x,
                             int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zdscal_sycl(cl::sycl::queue *queue, int64_t n, double alpha,
                             std::complex<double> *x, int64_t incx,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sswap_sycl(cl::sycl::queue *queue, int64_t n, float *x, int64_t incx, float *y,
                            int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dswap_sycl(cl::sycl::queue *queue, int64_t n, double *x, int64_t incx, double *y,
                            int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cswap_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> *x, int64_t incx,
                            std::complex<float> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zswap_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> *x, int64_t incx,
                            std::complex<double> *y, int64_t incy,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                           const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event isamax_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                             int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event idamax_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
                             int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event icamax_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                             int64_t incx, int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event izamax_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                             int64_t incx, int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event isamin_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
                             int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event idamin_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
                             int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event icamin_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                             int64_t incx, int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event izamin_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<double> *x,
                             int64_t incx, int64_t *result,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                  MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
                                  const float *a, int64_t lda, int64_t strideA, const float *b,
                                  int64_t ldb, int64_t strideB, float beta, float *c, int64_t ldc,
                                  int64_t strideC, int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2122,7 +2122,7 @@ cl::sycl::event dgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  double alpha, const double *a, int64_t lda, int64_t strideA,
                                  const double *b, int64_t ldb, int64_t strideB, double beta,
                                  double *c, int64_t ldc, int64_t strideC, int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2132,7 +2132,7 @@ cl::sycl::event cgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t ldb, int64_t strideB, std::complex<float> beta,
                                  std::complex<float> *c, int64_t ldc, int64_t strideC,
                                  int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2142,7 +2142,7 @@ cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t ldb, int64_t strideB, std::complex<double> beta,
                                  std::complex<double> *c, int64_t ldc, int64_t strideC,
                                  int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2150,7 +2150,7 @@ cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const half *a, int64_t lda, int64_t strideA, const half *b,
                                  int64_t ldb, int64_t strideB, half beta, half *c, int64_t ldc,
                                  int64_t strideC, int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event sgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2158,7 +2158,7 @@ cl::sycl::event sgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const float **a, int64_t lda, const float **b, int64_t ldb,
                                  float beta, float **c, int64_t ldc, int64_t offset_batch,
                                  int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2166,7 +2166,7 @@ cl::sycl::event dgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  double alpha, const double **a, int64_t lda, const double **b,
                                  int64_t ldb, double beta, double **c, int64_t ldc,
                                  int64_t offset_batch, int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2175,7 +2175,7 @@ cl::sycl::event cgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t lda, const std::complex<float> **b, int64_t ldb,
                                  std::complex<float> beta, std::complex<float> **c, int64_t ldc,
                                  int64_t offset_batch, int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2184,7 +2184,7 @@ cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t lda, const std::complex<double> **b, int64_t ldb,
                                  std::complex<double> beta, std::complex<double> **c, int64_t ldc,
                                  int64_t offset_batch, int64_t group_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2192,65 +2192,65 @@ cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  const half **a, int64_t lda, const half **b, int64_t ldb,
                                  half beta, half **c, int64_t ldc, int64_t offset_batch,
                                  int64_t groupsize,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                 const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event saxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float **x,
                                  int64_t incx, float **y, int64_t incy, int64_t batch_size,
                                  int64_t offset,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event daxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, double alpha, const double **x,
                                  int64_t incx, double **y, int64_t incy, int64_t batch_size,
                                  int64_t offset,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zaxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> alpha,
                                  const std::complex<double> **x, int64_t incx,
                                  std::complex<double> **y, int64_t incy, int64_t batch_size,
                                  int64_t offset,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event caxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> alpha,
                                  const std::complex<float> **x, int64_t incx,
                                  std::complex<float> **y, int64_t incy, int64_t batch_size,
                                  int64_t offset,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event saxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float *x,
                                  int64_t incx, int64_t stridex, float *y, int64_t incy,
                                  int64_t stridey, int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event daxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, double alpha, const double *x,
                                  int64_t incx, int64_t stridex, double *y, int64_t incy,
                                  int64_t stridey, int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event caxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> alpha,
                                  const std::complex<float> *x, int64_t incx, int64_t stridex,
                                  std::complex<float> *y, int64_t incy, int64_t stridey,
                                  int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zaxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> alpha,
                                  const std::complex<double> *x, int64_t incx, int64_t stridex,
                                  std::complex<double> *y, int64_t incy, int64_t stridey,
                                  int64_t batch_size,
-                                 const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+                                 const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t n, int64_t k,
                             float alpha, const float *a, int64_t lda, const float *b, int64_t ldb,
                             float beta, float *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t n, int64_t k,
                             double alpha, const double *a, int64_t lda, const double *b,
                             int64_t ldb, double beta, double *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -2258,7 +2258,7 @@ cl::sycl::event zgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO 
                             std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                             const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                             std::complex<double> *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -2266,7 +2266,7 @@ cl::sycl::event cgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO 
                             std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                             const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
                             std::complex<float> *c, int64_t ldc,
-                            const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                            const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event gemm_s8s8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -2274,7 +2274,7 @@ cl::sycl::event gemm_s8s8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL
                                   int64_t k, float alpha, const int8_t *a, int64_t lda, int8_t ao,
                                   const int8_t *b, int64_t ldb, int8_t bo, float beta, int32_t *c,
                                   int64_t ldc, const int32_t *co,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                  const std::vector<cl::sycl::event> &dependencies,
                                   int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0,
                                   int64_t offset_co = 0);
 
@@ -2283,7 +2283,7 @@ cl::sycl::event gemm_s8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL
                                   int64_t k, float alpha, const int8_t *a, int64_t lda, int8_t ao,
                                   const uint8_t *b, int64_t ldb, uint8_t bo, float beta, int32_t *c,
                                   int64_t ldc, const int32_t *co,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                  const std::vector<cl::sycl::event> &dependencies,
                                   int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0,
                                   int64_t offset_co = 0);
 
@@ -2292,7 +2292,7 @@ cl::sycl::event gemm_u8s8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL
                                   int64_t k, float alpha, const uint8_t *a, int64_t lda, uint8_t ao,
                                   const int8_t *b, int64_t ldb, int8_t bo, float beta, int32_t *c,
                                   int64_t ldc, const int32_t *co,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                  const std::vector<cl::sycl::event> &dependencies,
                                   int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0,
                                   int64_t offset_co = 0);
 
@@ -2301,7 +2301,7 @@ cl::sycl::event gemm_u8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL
                                   int64_t k, float alpha, const uint8_t *a, int64_t lda, uint8_t ao,
                                   const uint8_t *b, int64_t ldb, uint8_t bo, float beta, int32_t *c,
                                   int64_t ldc, const int32_t *co,
-                                  const cl::sycl::vector_class<cl::sycl::event> &dependencies,
+                                  const std::vector<cl::sycl::event> &dependencies,
                                   int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0,
                                   int64_t offset_co = 0);
 

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -1000,15 +1000,13 @@ cl::sycl::event gemm_u8u8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL
 cl::sycl::event sgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
                            const float *a, int64_t lda, const float *b, int64_t ldb, float beta,
-                           float *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
+                           float *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, double alpha,
                            const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
-                           double *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
+                           double *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1016,22 +1014,21 @@ cl::sycl::event cgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k,
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, half alpha,
                            const half *a, int64_t lda, const half *b, int64_t ldb, half beta,
-                           half *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
+                           half *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event gemm_f16f16f32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1060,8 +1057,7 @@ cl::sycl::event ssymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE l
 cl::sycl::event dsymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, int64_t m, int64_t n, double alpha,
                            const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
-                           double *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
+                           double *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event csymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1076,8 +1072,8 @@ cl::sycl::event zsymm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE l
                            const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event chemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, int64_t m, int64_t n, std::complex<float> alpha,
@@ -1091,34 +1087,34 @@ cl::sycl::event zhemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE l
                            const std::complex<double> *a, int64_t lda,
                            const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event ssyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha, const float *a,
                            int64_t lda, float beta, float *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_c = 0);
 
 cl::sycl::event dsyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha, const double *a,
                            int64_t lda, double beta, double *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_c = 0);
 
 cl::sycl::event csyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_c = 0);
 
 cl::sycl::event zsyrk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<double> alpha,
                            const std::complex<double> *a, int64_t lda, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_c = 0);
 
 cl::sycl::event ssyrk_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                                  MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha,
@@ -1186,36 +1182,34 @@ cl::sycl::event cherk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO u
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha,
                            const std::complex<float> *a, int64_t lda, float beta,
                            std::complex<float> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_c = 0);
 
 cl::sycl::event zherk_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                            MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha,
                            const std::complex<double> *a, int64_t lda, double beta,
                            std::complex<double> *c, int64_t ldc,
-                           const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_c = 0);
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_c = 0);
 
 cl::sycl::event ssyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha, const float *a,
                             int64_t lda, const float *b, int64_t ldb, float beta, float *c,
-                            int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
+                            int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dsyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha,
                             const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
                             double *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event csyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<float> alpha,
                             const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
                             int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                            int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
+                            int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                             int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zsyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
@@ -1223,23 +1217,23 @@ cl::sycl::event zsyr2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO 
                             const std::complex<double> *a, int64_t lda,
                             const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                             std::complex<double> *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cher2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<float> alpha,
                             const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
                             int64_t ldb, float beta, std::complex<float> *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zher2k_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE trans, int64_t n, int64_t k, std::complex<double> alpha,
                             const std::complex<double> *a, int64_t lda,
                             const std::complex<double> *b, int64_t ldb, double beta,
                             std::complex<double> *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event strmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
@@ -1250,8 +1244,7 @@ cl::sycl::event strmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE l
 cl::sycl::event dtrmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
-                           double *b, int64_t ldb,
-                           const std::vector<cl::sycl::event> &dependencies,
+                           double *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ctrmm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1277,8 +1270,7 @@ cl::sycl::event strsm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE l
 cl::sycl::event dtrsm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                            MKL_UPLO upper_lower, MKL_TRANSPOSE transa, MKL_DIAG unit_diag,
                            int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
-                           double *b, int64_t ldb,
-                           const std::vector<cl::sycl::event> &dependencies,
+                           double *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0);
 
 cl::sycl::event ctrsm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -1375,8 +1367,7 @@ cl::sycl::event cgemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
                            int64_t m, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
                            int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                           int64_t incy,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incy, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgemv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, std::complex<double> alpha,
@@ -1527,8 +1518,7 @@ cl::sycl::event cgbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
                            int64_t m, int64_t n, int64_t kl, int64_t ku, std::complex<float> alpha,
                            const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
                            int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                           int64_t incy,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incy, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE trans,
                            int64_t m, int64_t n, int64_t kl, int64_t ku, std::complex<double> alpha,
@@ -1539,8 +1529,7 @@ cl::sycl::event zgbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
 
 cl::sycl::event sger_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                           float alpha, const float *x, int64_t incx, const float *y, int64_t incy,
-                          float *a, int64_t lda,
-                          const std::vector<cl::sycl::event> &dependencies);
+                          float *a, int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dger_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                           double alpha, const double *x, int64_t incx, const double *y,
@@ -1550,26 +1539,22 @@ cl::sycl::event dger_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, 
 cl::sycl::event cgerc_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
                            const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgerc_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                            const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cgeru_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
                            const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zgeru_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                            const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event chbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            int64_t k, std::complex<float> alpha, const std::complex<float> *a,
@@ -1608,14 +1593,12 @@ cl::sycl::event zher_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO up
 cl::sycl::event cher2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
                            const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zher2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                            const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                           int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event chpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO uplo, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a,
@@ -1631,8 +1614,7 @@ cl::sycl::event zhpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO u
 
 cl::sycl::event chpr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           float alpha, const std::complex<float> *x, int64_t incx,
-                          std::complex<float> *a,
-                          const std::vector<cl::sycl::event> &dependencies);
+                          std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zhpr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                           double alpha, const std::complex<double> *x, int64_t incx,
@@ -1706,8 +1688,7 @@ cl::sycl::event dsyr_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO up
 
 cl::sycl::event ssyr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            float alpha, const float *x, int64_t incx, const float *y, int64_t incy,
-                           float *a, int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           float *a, int64_t lda, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dsyr2_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo, int64_t n,
                            double alpha, const double *x, int64_t incx, const double *y,
@@ -1727,14 +1708,12 @@ cl::sycl::event dtbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO u
 cl::sycl::event ctbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztbmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event stbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k, const float *a,
@@ -1749,19 +1728,16 @@ cl::sycl::event dtbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO u
 cl::sycl::event ctbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztbsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, int64_t k,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event stpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const float *a, float *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const double *a,
@@ -1780,8 +1756,7 @@ cl::sycl::event ztpmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO u
 
 cl::sycl::event stpsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const float *a, float *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dtpsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const double *a,
@@ -1811,14 +1786,12 @@ cl::sycl::event dtrmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO u
 cl::sycl::event ctrmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztrmv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event strsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n, const float *a,
@@ -1833,14 +1806,12 @@ cl::sycl::event dtrsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO u
 cl::sycl::event ctrsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event ztrsv_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upplo,
                            MKL_TRANSPOSE trans, MKL_DIAG diag, int64_t n,
                            const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                           int64_t incx,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event scasum_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                             int64_t incx, float *result,
@@ -1851,12 +1822,10 @@ cl::sycl::event dzasum_sycl(cl::sycl::queue *queue, int64_t n, const std::comple
                             const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sasum_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
-                           float *result,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           float *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dasum_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
-                           double *result,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           double *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event saxpy_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float *x,
                            int64_t incx, float *y, int64_t incy,
@@ -1868,13 +1837,11 @@ cl::sycl::event daxpy_sycl(cl::sycl::queue *queue, int64_t n, double alpha, cons
 
 cl::sycl::event caxpy_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, int64_t incx, std::complex<float> *y,
-                           int64_t incy,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incy, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zaxpy_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, int64_t incx, std::complex<double> *y,
-                           int64_t incy,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incy, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event saxpby_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float *x,
                             int64_t incx, float beta, float *y, int64_t incy,
@@ -1986,12 +1953,10 @@ cl::sycl::event dznrm2_sycl(cl::sycl::queue *queue, int64_t n, const std::comple
                             const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event snrm2_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
-                           float *result,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           float *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dnrm2_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
-                           double *result,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           double *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event csrot_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> *x, int64_t incx,
                            std::complex<float> *y, int64_t incy, float c, float s,
@@ -2032,12 +1997,10 @@ cl::sycl::event drotm_sycl(cl::sycl::queue *queue, int64_t n, double *x, int64_t
                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event srotmg_sycl(cl::sycl::queue *queue, float *d1, float *d2, float *x1, float y1,
-                            float *param,
-                            const std::vector<cl::sycl::event> &dependencies);
+                            float *param, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event drotmg_sycl(cl::sycl::queue *queue, double *d1, double *d2, double *x1, double y1,
-                            double *param,
-                            const std::vector<cl::sycl::event> &dependencies);
+                            double *param, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sscal_sycl(cl::sycl::queue *queue, int64_t n, float alpha, float *x, int64_t incx,
                            const std::vector<cl::sycl::event> &dependencies);
@@ -2054,20 +2017,17 @@ cl::sycl::event zscal_sycl(cl::sycl::queue *queue, int64_t n, std::complex<doubl
                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event csscal_sycl(cl::sycl::queue *queue, int64_t n, float alpha, std::complex<float> *x,
-                            int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies);
+                            int64_t incx, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zdscal_sycl(cl::sycl::queue *queue, int64_t n, double alpha,
                             std::complex<double> *x, int64_t incx,
                             const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event sswap_sycl(cl::sycl::queue *queue, int64_t n, float *x, int64_t incx, float *y,
-                           int64_t incy,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incy, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event dswap_sycl(cl::sycl::queue *queue, int64_t n, double *x, int64_t incx, double *y,
-                           int64_t incy,
-                           const std::vector<cl::sycl::event> &dependencies);
+                           int64_t incy, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event cswap_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> *x, int64_t incx,
                            std::complex<float> *y, int64_t incy,
@@ -2078,12 +2038,10 @@ cl::sycl::event zswap_sycl(cl::sycl::queue *queue, int64_t n, std::complex<doubl
                            const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event isamax_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
-                            int64_t *result,
-                            const std::vector<cl::sycl::event> &dependencies);
+                            int64_t *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event idamax_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
-                            int64_t *result,
-                            const std::vector<cl::sycl::event> &dependencies);
+                            int64_t *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event icamax_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                             int64_t incx, int64_t *result,
@@ -2094,12 +2052,10 @@ cl::sycl::event izamax_sycl(cl::sycl::queue *queue, int64_t n, const std::comple
                             const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event isamin_sycl(cl::sycl::queue *queue, int64_t n, const float *x, int64_t incx,
-                            int64_t *result,
-                            const std::vector<cl::sycl::event> &dependencies);
+                            int64_t *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event idamin_sycl(cl::sycl::queue *queue, int64_t n, const double *x, int64_t incx,
-                            int64_t *result,
-                            const std::vector<cl::sycl::event> &dependencies);
+                            int64_t *result, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event icamin_sycl(cl::sycl::queue *queue, int64_t n, const std::complex<float> *x,
                             int64_t incx, int64_t *result,
@@ -2197,25 +2153,21 @@ cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
 
 cl::sycl::event saxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float **x,
                                  int64_t incx, float **y, int64_t incy, int64_t batch_size,
-                                 int64_t offset,
-                                 const std::vector<cl::sycl::event> &dependencies);
+                                 int64_t offset, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event daxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, double alpha, const double **x,
                                  int64_t incx, double **y, int64_t incy, int64_t batch_size,
-                                 int64_t offset,
-                                 const std::vector<cl::sycl::event> &dependencies);
+                                 int64_t offset, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event zaxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, std::complex<double> alpha,
                                  const std::complex<double> **x, int64_t incx,
                                  std::complex<double> **y, int64_t incy, int64_t batch_size,
-                                 int64_t offset,
-                                 const std::vector<cl::sycl::event> &dependencies);
+                                 int64_t offset, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event caxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, std::complex<float> alpha,
                                  const std::complex<float> **x, int64_t incx,
                                  std::complex<float> **y, int64_t incy, int64_t batch_size,
-                                 int64_t offset,
-                                 const std::vector<cl::sycl::event> &dependencies);
+                                 int64_t offset, const std::vector<cl::sycl::event> &dependencies);
 
 cl::sycl::event saxpy_batch_sycl(cl::sycl::queue *queue, int64_t n, float alpha, const float *x,
                                  int64_t incx, int64_t stridex, float *y, int64_t incy,
@@ -2243,31 +2195,31 @@ cl::sycl::event sgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO 
                             MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t n, int64_t k,
                             float alpha, const float *a, int64_t lda, const float *b, int64_t ldb,
                             float beta, float *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event dgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t n, int64_t k,
                             double alpha, const double *a, int64_t lda, const double *b,
                             int64_t ldb, double beta, double *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event zgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t n, int64_t k,
                             std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                             const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
                             std::complex<double> *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event cgemmt_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_UPLO upper_lower,
                             MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t n, int64_t k,
                             std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                             const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
                             std::complex<float> *c, int64_t ldc,
-                            const std::vector<cl::sycl::event> &dependencies,
-                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                            const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event gemm_s8s8s32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                   MKL_TRANSPOSE transb, CBLAS_OFFSET offsetc, int64_t m, int64_t n,

--- a/src/blas/backends/mklgpu/mklgpu_extensions.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_extensions.cxx
@@ -97,7 +97,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_s8s8s32_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), mkl_convert(offsetc), m, n, k,
         alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co, dependencies);
@@ -107,7 +107,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_s8u8s32_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), mkl_convert(offsetc), m, n, k,
         alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co, dependencies);
@@ -117,7 +117,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_u8s8s32_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), mkl_convert(offsetc), m, n, k,
         alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co, dependencies);
@@ -127,7 +127,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_u8u8s32_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), mkl_convert(offsetc), m, n, k,
         alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co, dependencies);
@@ -136,7 +136,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                       const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sgemmt_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(transa), mkl_convert(transb), n, k, alpha, a,
                                            lda, b, ldb, beta, c, ldc, dependencies);
@@ -145,7 +145,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                       const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgemmt_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(transa), mkl_convert(transb), n, k, alpha, a,
                                            lda, b, ldb, beta, c, ldc, dependencies);
@@ -155,7 +155,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgemmt_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(transa), mkl_convert(transb), n, k, alpha, a,
                                            lda, b, ldb, beta, c, ldc, dependencies);
@@ -165,7 +165,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<double> alpha,
                       const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
                       int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgemmt_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(transa), mkl_convert(transb), n, k, alpha, a,
                                            lda, b, ldb, beta, c, ldc, dependencies);

--- a/src/blas/backends/mklgpu/mklgpu_level1.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level1.cxx
@@ -327,348 +327,348 @@ void iamin(cl::sycl::queue &queue, std::int64_t n, cl::sycl::buffer<std::complex
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::scasum_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dzasum_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                     float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sasum_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dasum_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::saxpy_sycl(&queue, n, alpha, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::daxpy_sycl(&queue, n, alpha, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::caxpy_sycl(&queue, n, alpha, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zaxpy_sycl(&queue, n, alpha, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                       std::int64_t incx, float beta, float *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::saxpby_sycl(&queue, n, alpha, x, incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                       std::int64_t incx, double beta, double *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::daxpby_sycl(&queue, n, alpha, x, incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                       const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                       std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::caxpby_sycl(&queue, n, alpha, x, incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event axpby(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                       const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                       std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zaxpby_sycl(&queue, n, alpha, x, incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                      float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::scopy_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dcopy_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ccopy_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zcopy_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                     const float *y, std::int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sdot_sycl(&queue, n, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                     const double *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ddot_sycl(&queue, n, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event sdsdot(cl::sycl::queue &queue, std::int64_t n, float sb, const float *x,
                        std::int64_t incx, const float *y, std::int64_t incy, float *result,
-                       const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sdsdot_sycl(&queue, n, sb, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event dot(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                     const float *y, std::int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsdot_sycl(&queue, n, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cdotc_sycl(&queue, n, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event dotc(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zdotc_sycl(&queue, n, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cdotu_sycl(&queue, n, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event dotu(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zdotu_sycl(&queue, n, x, incx, y, incy, result, dependencies);
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                      std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::scnrm2_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                      std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dznrm2_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                     float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::snrm2_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dnrm2_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                     std::int64_t incx, std::complex<float> *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csrot_sycl(&queue, n, x, incx, y, incy, c, s, dependencies);
 }
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                     std::int64_t incx, std::complex<double> *y, std::int64_t incy, double c,
-                    double s, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    double s, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zdrot_sycl(&queue, n, x, incx, y, incy, c, s, dependencies);
 }
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::srot_sycl(&queue, n, x, incx, y, incy, c, s, dependencies);
 }
 
 cl::sycl::event rot(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::drot_sycl(&queue, n, x, incx, y, incy, c, s, dependencies);
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::srotg_sycl(&queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::drotg_sycl(&queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b,
                      float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::crotg_sycl(&queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b,
                      double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zrotg_sycl(&queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                      std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::srotm_sycl(&queue, n, x, incx, y, incy, param, dependencies);
 }
 
 cl::sycl::event rotm(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                      double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::drotm_sycl(&queue, n, x, incx, y, incy, param, dependencies);
 }
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                      float *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      float *param, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::srotmg_sycl(&queue, d1, d2, x1, y1, param, dependencies);
 }
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1,
-                      double *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      double *param, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::drotmg_sycl(&queue, d1, d2, x1, y1, param, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zdscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sswap_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx,
                      double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dswap_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x,
                      std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cswap_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x,
                      std::int64_t incx, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zswap_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::isamax_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::idamax_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::icamax_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::izamax_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::isamin_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                       std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::idamin_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::icamin_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                       std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::izamin_sycl(&queue, n, x, incx, result, dependencies);
 }

--- a/src/blas/backends/mklgpu/mklgpu_level1.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level1.cxx
@@ -361,15 +361,13 @@ cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, double alpha, const
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::caxpy_sycl(&queue, n, alpha, x, incx, y, incy, dependencies);
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zaxpy_sycl(&queue, n, alpha, x, incx, y, incy, dependencies);
 }
 
@@ -566,14 +564,12 @@ cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
@@ -590,20 +586,17 @@ cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, std::complex<double
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zdscal_sycl(&queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sswap_sycl(&queue, n, x, incx, y, incy, dependencies);
 }
 
@@ -626,14 +619,12 @@ cl::sycl::event swap(cl::sycl::queue &queue, std::int64_t n, std::complex<double
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::isamax_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::idamax_sycl(&queue, n, x, incx, result, dependencies);
 }
 
@@ -650,14 +641,12 @@ cl::sycl::event iamax(cl::sycl::queue &queue, std::int64_t n, const std::complex
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::isamin_sycl(&queue, n, x, incx, result, dependencies);
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-                      std::int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::idamin_sycl(&queue, n, x, incx, result, dependencies);
 }
 

--- a/src/blas/backends/mklgpu/mklgpu_level2.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level2.cxx
@@ -514,8 +514,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
@@ -523,8 +522,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      std::int64_t kl, std::int64_t ku, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
@@ -533,8 +531,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
@@ -543,8 +540,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
@@ -558,8 +554,7 @@ cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, floa
 
 cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, const double *y, std::int64_t incy,
-                    double *a, std::int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    double *a, std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dger_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                          dependencies);
 }
@@ -567,8 +562,7 @@ cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, doub
 cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgerc_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -576,8 +570,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
 cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgerc_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -585,8 +578,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
 cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgeru_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -594,8 +586,7 @@ cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
 cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgeru_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -621,8 +612,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::int
 cl::sycl::event hemv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::chemv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -630,8 +620,7 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
 cl::sycl::event hemv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhemv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -661,8 +650,7 @@ cl::sycl::event her2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
 cl::sycl::event her2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zher2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, lda, dependencies);
 }
@@ -678,8 +666,7 @@ cl::sycl::event hpmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
 cl::sycl::event hpmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhpmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, x, incx,
                                           beta, y, incy, dependencies);
 }
@@ -739,15 +726,13 @@ cl::sycl::event spmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float al
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                      const double *a, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dspmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, x, incx,
                                           beta, y, incy, dependencies);
 }
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *x,
-                    std::int64_t incx, float *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::int64_t incx, float *a, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sspr_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          dependencies);
 }
@@ -775,8 +760,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double a
 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssymv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -805,8 +789,7 @@ cl::sycl::event syr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double al
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *x,
                      std::int64_t incx, const float *y, std::int64_t incy, float *a,
-                     std::int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssyr2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, lda, dependencies);
 }
@@ -828,8 +811,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtbmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -859,8 +841,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const double *a, std::int64_t lda, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtbsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -953,16 +934,14 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
@@ -983,16 +962,14 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }

--- a/src/blas/backends/mklgpu/mklgpu_level2.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level2.cxx
@@ -480,7 +480,7 @@ void trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::in
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sgemv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -488,7 +488,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, std::int64_t n,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgemv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -497,7 +497,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgemv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -506,7 +506,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgemv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -515,7 +515,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      std::int64_t kl, std::int64_t ku, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
@@ -524,7 +524,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      std::int64_t kl, std::int64_t ku, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
@@ -534,7 +534,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
@@ -544,14 +544,14 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, std::int64_t m, st
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgbmv_sycl(&queue, MAJOR, mkl_convert(trans), m, n, kl, ku, alpha, a,
                                           lda, x, incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha,
                     const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-                    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sger_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                          dependencies);
 }
@@ -559,7 +559,7 @@ cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, floa
 cl::sycl::event ger(cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, const double *y, std::int64_t incy,
                     double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dger_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                          dependencies);
 }
@@ -568,7 +568,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgerc_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -577,7 +577,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgerc_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -586,7 +586,7 @@ cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgeru_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -595,7 +595,7 @@ cl::sycl::event geru(cl::sycl::queue &queue, std::int64_t m, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgeru_sycl(&queue, MAJOR, m, n, alpha, x, incx, y, incy, a, lda,
                                           dependencies);
 }
@@ -604,7 +604,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::int
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::chbmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, k, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -613,7 +613,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::int
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhbmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, k, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -622,7 +622,7 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::chemv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -631,21 +631,21 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhemv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha,
                     const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-                    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cher_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          lda, dependencies);
 }
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                     const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-                    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zher_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          lda, dependencies);
 }
@@ -653,7 +653,7 @@ cl::sycl::event her(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double al
 cl::sycl::event her2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cher2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, lda, dependencies);
 }
@@ -662,7 +662,7 @@ cl::sycl::event her2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zher2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, lda, dependencies);
 }
@@ -670,7 +670,7 @@ cl::sycl::event her2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
 cl::sycl::event hpmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::chpmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, x, incx,
                                           beta, y, incy, dependencies);
 }
@@ -679,21 +679,21 @@ cl::sycl::event hpmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
                      const std::complex<double> *a, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhpmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, x, incx,
                                           beta, y, incy, dependencies);
 }
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha,
                     const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::chpr_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          dependencies);
 }
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                     const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhpr_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          dependencies);
 }
@@ -701,7 +701,7 @@ cl::sycl::event hpr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double al
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::chpr2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, dependencies);
 }
@@ -709,7 +709,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhpr2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, dependencies);
 }
@@ -717,7 +717,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::com
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::int64_t k, float alpha,
                      const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                      float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssbmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, k, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -725,14 +725,14 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::int
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, std::int64_t k,
                      double alpha, const double *a, std::int64_t lda, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsbmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, k, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *a,
                      const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sspmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, x, incx,
                                           beta, y, incy, dependencies);
 }
@@ -740,35 +740,35 @@ cl::sycl::event spmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float al
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                      const double *a, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dspmv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, x, incx,
                                           beta, y, incy, dependencies);
 }
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *x,
                     std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sspr_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          dependencies);
 }
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dspr_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          dependencies);
 }
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *x,
                      std::int64_t incx, const float *y, std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sspr2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, dependencies);
 }
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, const double *y, std::int64_t incy,
-                     double *a, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *a, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dspr2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, dependencies);
 }
@@ -776,7 +776,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double a
 cl::sycl::event symv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssymv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
@@ -784,21 +784,21 @@ cl::sycl::event symv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float al
 cl::sycl::event symv(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsymv_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, a, lda, x,
                                           incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *x,
                     std::int64_t incx, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssyr_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          lda, dependencies);
 }
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                     const double *x, std::int64_t incx, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsyr_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, a,
                                          lda, dependencies);
 }
@@ -806,7 +806,7 @@ cl::sycl::event syr(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double al
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float alpha, const float *x,
                      std::int64_t incx, const float *y, std::int64_t incy, float *a,
                      std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssyr2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, lda, dependencies);
 }
@@ -814,14 +814,14 @@ cl::sycl::event syr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, float al
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo uplo, std::int64_t n, double alpha,
                      const double *x, std::int64_t incx, const double *y, std::int64_t incy,
                      double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsyr2_sycl(&queue, MAJOR, mkl_convert(uplo), n, alpha, x, incx, y,
                                           incy, a, lda, dependencies);
 }
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::stbmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -829,7 +829,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtbmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -837,7 +837,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctbmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -845,14 +845,14 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztbmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::stbsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -860,7 +860,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const double *a, std::int64_t lda, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtbsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -868,7 +868,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const std::complex<float> *a, std::int64_t lda,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctbsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
@@ -876,77 +876,77 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      std::int64_t k, const std::complex<double> *a, std::int64_t lda,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztbsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, k, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::stpmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtpmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctpmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztpmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const float *a, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::stpsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const double *a, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtpsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<float> *a, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctpsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<double> *a, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztpsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, x, incx, dependencies);
 }
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::strmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const double *a, std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtrmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
@@ -954,7 +954,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
@@ -962,21 +962,21 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrmv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::strsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const double *a, std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtrsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
@@ -984,7 +984,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }
@@ -992,7 +992,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag di
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo uplo, transpose trans, diag diag, std::int64_t n,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrsv_sycl(&queue, MAJOR, mkl_convert(uplo), mkl_convert(trans),
                                           mkl_convert(diag), n, a, lda, x, incx, dependencies);
 }

--- a/src/blas/backends/mklgpu/mklgpu_level3.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level3.cxx
@@ -297,7 +297,7 @@ void trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose t
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::sgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -307,7 +307,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -318,7 +318,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -329,7 +329,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -338,7 +338,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
                      const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::hgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -347,7 +347,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
                      const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_f16f16f32_sycl(&queue, MAJOR, mkl_convert(transa),
                                                    mkl_convert(transb), m, n, k, alpha, a, lda, b,
                                                    ldb, beta, c, ldc, dependencies);
@@ -357,7 +357,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_bf16bf16f32_sycl(&queue, MAJOR, mkl_convert(transa),
                                                      mkl_convert(transb), m, n, k, alpha, a, lda, b,
                                                      ldb, beta, c, ldc, dependencies);
@@ -366,7 +366,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *b,
                      std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssymm_sycl(&queue, MAJOR, mkl_convert(left_right),
                                           mkl_convert(upper_lower), m, n, alpha, a, lda, b, ldb,
                                           beta, c, ldc, dependencies);
@@ -375,7 +375,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsymm_sycl(&queue, MAJOR, mkl_convert(left_right),
                                           mkl_convert(upper_lower), m, n, alpha, a, lda, b, ldb,
                                           beta, c, ldc, dependencies);
@@ -385,7 +385,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csymm_sycl(&queue, MAJOR, mkl_convert(left_right),
                                           mkl_convert(upper_lower), m, n, alpha, a, lda, b, ldb,
                                           beta, c, ldc, dependencies);
@@ -395,7 +395,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zsymm_sycl(&queue, MAJOR, mkl_convert(left_right),
                                           mkl_convert(upper_lower), m, n, alpha, a, lda, b, ldb,
                                           beta, c, ldc, dependencies);
@@ -405,7 +405,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::chemm_sycl(&queue, MAJOR, mkl_convert(left_right),
                                           mkl_convert(upper_lower), m, n, alpha, a, lda, b, ldb,
                                           beta, c, ldc, dependencies);
@@ -415,7 +415,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zhemm_sycl(&queue, MAJOR, mkl_convert(left_right),
                                           mkl_convert(upper_lower), m, n, alpha, a, lda, b, ldb,
                                           beta, c, ldc, dependencies);
@@ -424,7 +424,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
                      float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssyrk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -433,7 +433,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, double alpha, const double *a, std::int64_t lda, double beta,
                      double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsyrk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -443,7 +443,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csyrk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -453,7 +453,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zsyrk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -462,7 +462,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
                      float beta, std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cherk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -471,7 +471,7 @@ cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, double alpha, const std::complex<double> *a, std::int64_t lda,
                      double beta, std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zherk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -480,7 +480,7 @@ cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssyr2k_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(trans), n, k, alpha, a, lda, b, ldb, beta, c,
                                            ldc, dependencies);
@@ -489,7 +489,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                       std::int64_t k, double alpha, const double *a, std::int64_t lda,
                       const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dsyr2k_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(trans), n, k, alpha, a, lda, b, ldb, beta, c,
                                            ldc, dependencies);
@@ -499,7 +499,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       std::int64_t lda, const std::complex<float> *b, std::int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csyr2k_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(trans), n, k, alpha, a, lda, b, ldb, beta, c,
                                            ldc, dependencies);
@@ -509,7 +509,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                       std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zsyr2k_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(trans), n, k, alpha, a, lda, b, ldb, beta, c,
                                            ldc, dependencies);
@@ -519,7 +519,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cher2k_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(trans), n, k, alpha, a, lda, b, ldb, beta, c,
                                            ldc, dependencies);
@@ -529,7 +529,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
                       double beta, std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zher2k_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                            mkl_convert(trans), n, k, alpha, a, lda, b, ldb, beta, c,
                                            ldc, dependencies);
@@ -538,7 +538,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::strmm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -547,7 +547,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtrmm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -557,7 +557,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrmm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -567,7 +567,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrmm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -576,7 +576,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, float *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::strsm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -585,7 +585,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, double *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dtrsm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -595,7 +595,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrsm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -605,7 +605,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrsm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);

--- a/src/blas/backends/mklgpu/mklgpu_level3.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level3.cxx
@@ -306,8 +306,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::dgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -317,8 +316,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::cgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -328,8 +326,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                                           dependencies);
@@ -356,8 +353,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
                      std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_bf16bf16f32_sycl(&queue, MAJOR, mkl_convert(transa),
                                                      mkl_convert(transb), m, n, k, alpha, a, lda, b,
                                                      ldb, beta, c, ldc, dependencies);
@@ -423,8 +419,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
-                     float *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ssyrk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -442,8 +437,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::csyrk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -452,8 +446,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, std::int64_t n,
                      std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::zsyrk_sycl(&queue, MAJOR, mkl_convert(upper_lower),
                                           mkl_convert(trans), n, k, alpha, a, lda, beta, c, ldc,
                                           dependencies);
@@ -556,8 +549,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrmm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -566,8 +558,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrmm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -594,8 +585,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ctrsm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);
@@ -604,8 +594,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::ztrsm_sycl(
         &queue, MAJOR, mkl_convert(left_right), mkl_convert(upper_lower), mkl_convert(transa),
         mkl_convert(unit_diag), m, n, alpha, a, lda, b, ldb, dependencies);

--- a/src/blas/backends/netlib/netlib_batch.cxx
+++ b/src/blas/backends/netlib/netlib_batch.cxx
@@ -382,7 +382,7 @@ void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
                            float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -393,7 +393,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, 
 
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
                            double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -405,7 +405,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x,
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
                            int64_t *incx, std::complex<float> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -417,7 +417,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::comple
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
                            int64_t *incx, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -429,7 +429,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::comple
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                            std::int64_t stridex, float *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -441,7 +441,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, in
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                            std::int64_t stridex, double *y, int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -453,7 +453,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, i
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
                            int64_t incx, std::int64_t stridex, std::complex<float> *y, int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -465,7 +465,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                            int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 #endif
@@ -477,7 +477,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -489,7 +489,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, con
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -501,7 +501,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, co
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -513,7 +513,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<floa
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
                            int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -525,7 +525,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<doub
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -537,7 +537,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -550,7 +550,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -563,7 +563,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<doubl
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -576,7 +576,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            float alpha, const float *a, int64_t lda, int64_t stride_a,
                            const float *x, int64_t incx, int64_t stride_x, float beta, float *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -589,7 +589,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            double alpha, const double *a, int64_t lda, int64_t stride_a,
                            const double *x, int64_t incx, int64_t stride_x, double beta, double *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -603,7 +603,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<float> *x, int64_t incx,
                            int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -617,7 +617,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, 
                            int64_t stride_a, const std::complex<double> *x, int64_t incx,
                            int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
                            int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -630,7 +630,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            float *alpha, const float **a, int64_t *lda, const float **x,
                            int64_t *incx, float *beta, float **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -643,7 +643,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            double *alpha, const double **a, int64_t *lda, const double **x,
                            int64_t *incx, double *beta, double **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -657,7 +657,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -671,7 +671,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            int64_t *lda, const std::complex<double> **x, int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -684,7 +684,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -697,7 +697,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -711,7 +711,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -725,7 +725,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -737,7 +737,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -749,7 +749,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
                            const double **a, int64_t *lda, const double **x, int64_t *incx,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -762,7 +762,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -775,7 +775,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m,
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -788,7 +788,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, float *alpha, const float **a, int64_t *lda,
                            const float **b, int64_t *ldb, float *beta, float **c, int64_t *ldc,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -801,7 +801,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, double *alpha, const double **a, int64_t *lda,
                            const double **b, int64_t *ldb, double *beta, double **c, int64_t *ldc,
                            int64_t group_count, int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -816,7 +816,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
                            std::complex<float> **c, int64_t *ldc, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -831,7 +831,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
                            std::complex<double> **c, int64_t *ldc, int64_t group_count,
                            int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -844,7 +844,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            int64_t *n, int64_t *k, half *alpha, const half **a, int64_t *lda,
                            const half **b, int64_t *ldb, half *beta, half **c, int64_t *ldc,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -857,7 +857,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                            int64_t stride_a, const float *b, int64_t ldb, int64_t stride_b,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -871,7 +871,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t stride_a, const double *b, int64_t ldb, int64_t stride_b,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -886,7 +886,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            std::complex<float> beta, std::complex<float> *c, int64_t ldc,
                            int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -901,7 +901,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            std::complex<double> beta, std::complex<double> *c, int64_t ldc,
                            int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -914,7 +914,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, half alpha, const half *a, int64_t lda,
                            int64_t stride_a, const half *b, int64_t ldb, int64_t stride_b,
                            half beta, half *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -927,7 +927,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
                            const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -940,7 +940,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
                            const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
                            int64_t stride_b, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -954,7 +954,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -968,7 +968,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -981,7 +981,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha,
                            const float **a, int64_t *lda, float **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -994,7 +994,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha,
                            const double **a, int64_t *lda, double **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -1008,7 +1008,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            std::complex<float> **b, int64_t *ldb, int64_t group_count,
                            int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -1022,7 +1022,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> **b, int64_t *ldb,
                            int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -1034,7 +1034,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
                            float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1046,7 +1046,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
                            int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
                            double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1059,7 +1059,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
                            int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1072,7 +1072,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
                            int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
                            int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1084,7 +1084,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose 
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
                            float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1097,7 +1097,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1111,7 +1111,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1125,7 +1125,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
                            int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif

--- a/src/blas/backends/netlib/netlib_batch.cxx
+++ b/src/blas/backends/netlib/netlib_batch.cxx
@@ -476,8 +476,7 @@ cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
                            int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -488,8 +487,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, con
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
                            int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -524,8 +522,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<doub
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
                            int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -536,8 +533,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const
 
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                            int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -549,8 +545,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, cons
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                            const std::complex<float> *x, int64_t incx, int64_t stridex,
                            std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -562,8 +557,7 @@ cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float
 cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                            const std::complex<double> *x, int64_t incx, int64_t stridex,
                            std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 #endif
@@ -656,8 +650,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
                            std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 #endif
@@ -683,8 +676,7 @@ cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const float *a, int64_t lda, int64_t stride_a, const float *x,
                            int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -696,8 +688,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
 cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
                            const double *a, int64_t lda, int64_t stride_a, const double *x,
                            int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -710,8 +701,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<float> *a, int64_t lda, int64_t stride_a,
                            const std::complex<float> *x, int64_t incx, int64_t stride_x,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -724,8 +714,7 @@ cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, i
                            const std::complex<double> *a, int64_t lda, int64_t stride_a,
                            const std::complex<double> *x, int64_t incx, int64_t stride_x,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 #endif
@@ -815,8 +804,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<float> **a, int64_t *lda,
                            const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
                            std::complex<float> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -830,8 +818,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::complex<double> **a, int64_t *lda,
                            const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
                            std::complex<double> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -870,8 +857,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                            int64_t stride_a, const double *b, int64_t ldb, int64_t stride_b,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -953,8 +939,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                            int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -967,8 +952,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_l
                            transpose trans, diag unit_diag, int64_t m, int64_t n,
                            std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                            int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -1007,8 +991,7 @@ cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper
                            transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
                            std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
                            std::complex<float> **b, int64_t *ldb, int64_t group_count,
-                           int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 #endif
@@ -1096,8 +1079,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
 cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                            int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
                            double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1110,8 +1092,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                            int64_t lda, int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif
@@ -1124,8 +1105,7 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
                            int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                            int64_t lda, int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 #endif

--- a/src/blas/backends/netlib/netlib_extensions.cxx
+++ b/src/blas/backends/netlib/netlib_extensions.cxx
@@ -125,7 +125,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 #endif
@@ -138,7 +138,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const int8_t *a, int64_t lda, int8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 #endif
@@ -151,7 +151,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const int8_t *b, int64_t ldb,
                           int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 #endif
@@ -164,7 +164,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
                           offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
                           const uint8_t *a, int64_t lda, uint8_t ao, const uint8_t *b, int64_t ldb,
                           uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 #endif
@@ -176,7 +176,7 @@ cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose tr
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
                       const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemmt", "for column_major layout");
 #endif
@@ -188,7 +188,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
                       int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                       const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemmt", "for column_major layout");
 #endif
@@ -201,7 +201,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemmt", "for column_major layout");
 #endif
@@ -214,7 +214,7 @@ cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa
                       int64_t n, int64_t k, std::complex<double> alpha,
                       const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
                       int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemmt", "for column_major layout");
 #endif

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -741,7 +741,7 @@ void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<doubl
 // USM APIs
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -754,7 +754,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const float *x, int64_t 
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -767,7 +767,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const double *x, int64_t
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -780,7 +780,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<float
 }
 
 cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -794,7 +794,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -809,7 +809,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -825,7 +825,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, double alpha, const doub
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, std::complex<float> *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -841,7 +841,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<float> alph
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, int64_t incx, std::complex<double> *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -857,7 +857,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<double> alp
 
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
                       float beta, float *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -868,7 +868,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const floa
 
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
                       int64_t incx, double beta, double *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -880,7 +880,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const dou
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                       const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                       std::complex<float> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -892,7 +892,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alp
 cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                       const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                       std::complex<double> *y, int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -902,7 +902,7 @@ cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> al
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -915,7 +915,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const float *x, int64_t 
 }
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -929,7 +929,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const double *x, int64_t
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -943,7 +943,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<float
 
 cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -957,7 +957,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
                     int64_t incy, float *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -972,7 +972,7 @@ cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t i
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                     const double *y, int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -987,7 +987,7 @@ cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const double *x, int64_t 
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
                     int64_t incy, double *result,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1002,7 +1002,7 @@ cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t i
 
 cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                      const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1017,7 +1017,7 @@ cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<float
 
 cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1032,7 +1032,7 @@ cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                      const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1047,7 +1047,7 @@ cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<float
 
 cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1062,7 +1062,7 @@ cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1076,7 +1076,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1090,7 +1090,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1104,7 +1104,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<floa
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                       int64_t incx, int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1118,7 +1118,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<doub
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1132,7 +1132,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1146,7 +1146,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
                       int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1160,7 +1160,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<floa
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
                       int64_t incx, int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1173,7 +1173,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<doub
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1186,7 +1186,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const float *x, int64_t 
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1199,7 +1199,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const double *x, int64_t
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     float *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1212,7 +1212,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<float
 }
 
 cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     double *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1226,7 +1226,7 @@ cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
                     int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1242,7 +1242,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, f
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
                     int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1258,7 +1258,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, 
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
                     std::complex<float> *y, int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1274,7 +1274,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, i
 
 cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
                     std::complex<double> *y, int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1289,7 +1289,7 @@ cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, 
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1301,7 +1301,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float
 }
 
 cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1314,7 +1314,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c, do
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b,
                      float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1327,7 +1327,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a, std::comple
 
 cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b,
                      double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1340,7 +1340,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::compl
 
 cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
                      int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1355,7 +1355,7 @@ cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, 
 
 cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
                      int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1369,7 +1369,7 @@ cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx,
 }
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                      float *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      float *param, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1382,7 +1382,7 @@ cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, f
 }
 
 cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1,
-                      double *param, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      double *param, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1395,7 +1395,7 @@ cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1409,7 +1409,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, float *x, i
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1424,7 +1424,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, double *x,
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
                      std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1438,7 +1438,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<float> alph
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, std::complex<float> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1453,7 +1453,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, std::comple
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
                      std::complex<double> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1467,7 +1467,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<double> alp
 }
 
 cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1482,7 +1482,7 @@ cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, std::compl
 
 cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
                        const float *y, int64_t incy, float *result,
-                       const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1497,7 +1497,7 @@ cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float 
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1510,7 +1510,7 @@ cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, 
 }
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1524,7 +1524,7 @@ cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx,
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1538,7 +1538,7 @@ cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, 
 
 cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -793,8 +793,7 @@ cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -808,8 +807,7 @@ cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float
 }
 
 cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -956,8 +954,7 @@ cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 }
 
 cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, float *result,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    int64_t incy, float *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1061,8 +1058,7 @@ cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<doubl
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1075,8 +1071,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1089,8 +1084,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 }
 
 cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1117,8 +1111,7 @@ cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<doub
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1131,8 +1124,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1145,8 +1137,7 @@ cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_
 }
 
 cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      int64_t *result, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1339,8 +1330,7 @@ cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::compl
 }
 
 cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, float *param,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     int64_t incy, float *param, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/netlib/netlib_level2.cxx
+++ b/src/blas/backends/netlib/netlib_level2.cxx
@@ -1100,8 +1100,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1118,8 +1117,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1520,8 +1518,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1538,8 +1535,7 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1654,8 +1650,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1672,8 +1667,7 @@ cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/netlib/netlib_level2.cxx
+++ b/src/blas/backends/netlib/netlib_level2.cxx
@@ -1027,7 +1027,7 @@ void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_d
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
                      int64_t ku, float alpha, const float *a, int64_t lda, const float *x,
                      int64_t incx, float beta, float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1045,7 +1045,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
                      int64_t ku, double alpha, const double *a, int64_t lda, const double *x,
                      int64_t incx, double beta, double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1064,7 +1064,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *x, int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1083,7 +1083,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, const std::complex<double> *x, int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1101,7 +1101,7 @@ cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1119,7 +1119,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1138,7 +1138,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                      const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1157,7 +1157,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
                      std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1174,7 +1174,7 @@ cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t
 
 cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, float alpha, const float *x,
                     int64_t incx, const float *y, int64_t incy, float *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1190,7 +1190,7 @@ cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, float alpha, c
 
 cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, double alpha, const double *x,
                     int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1207,7 +1207,7 @@ cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, double alpha, 
 cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1224,7 +1224,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<
 cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
                      int64_t incy, std::complex<double> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1241,7 +1241,7 @@ cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<
 cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1258,7 +1258,7 @@ cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<
 cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
                      int64_t incy, std::complex<double> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1276,7 +1276,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
                      std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
                      const std::complex<float> *x, int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1295,7 +1295,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
                      std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1313,7 +1313,7 @@ cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
                      int64_t incx, std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1332,7 +1332,7 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1349,7 +1349,7 @@ cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const std::complex<float> *x, int64_t incx, std::complex<float> *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1365,7 +1365,7 @@ cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const std::complex<double> *x, int64_t incx, std::complex<double> *a,
-                    int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1382,7 +1382,7 @@ cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *a, int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1400,7 +1400,7 @@ cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::c
 cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1418,7 +1418,7 @@ cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *ap, const std::complex<float> *x, int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1437,7 +1437,7 @@ cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *ap,
                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1454,7 +1454,7 @@ cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const std::complex<float> *x, int64_t incx, std::complex<float> *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1470,7 +1470,7 @@ cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const std::complex<double> *x, int64_t incx, std::complex<double> *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1487,7 +1487,7 @@ cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
                      int64_t incy, std::complex<float> *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1504,7 +1504,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::c
 cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
                      const std::complex<double> *y, int64_t incy, std::complex<double> *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1521,7 +1521,7 @@ cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1539,7 +1539,7 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1556,7 +1556,7 @@ cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *ap, const float *x, int64_t incx, float beta, float *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1573,7 +1573,7 @@ cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *ap, const double *x, int64_t incx, double beta, double *y,
-                     int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1590,7 +1590,7 @@ cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const float *x, int64_t incx, float *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1606,7 +1606,7 @@ cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const double *x, int64_t incx, double *ap,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1622,7 +1622,7 @@ cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *x, int64_t incx, const float *y, int64_t incy, float *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1638,7 +1638,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *x, int64_t incx, const double *y, int64_t incy, double *ap,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1655,7 +1655,7 @@ cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *a, int64_t lda, const float *x, int64_t incx, float beta,
                      float *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1673,7 +1673,7 @@ cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *a, int64_t lda, const double *x, int64_t incx, double beta,
                      double *y, int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1690,7 +1690,7 @@ cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                     const float *x, int64_t incx, float *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1706,7 +1706,7 @@ cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float a
 
 cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                     const double *x, int64_t incx, double *a, int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1722,7 +1722,7 @@ cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double 
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
                      const float *x, int64_t incx, const float *y, int64_t incy, float *a,
-                     int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1739,7 +1739,7 @@ cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float 
 
 cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
                      const double *x, int64_t incx, const double *y, int64_t incy, double *a,
-                     int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1756,7 +1756,7 @@ cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1773,7 +1773,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1791,7 +1791,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
                      std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1809,7 +1809,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
                      std::complex<double> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1826,7 +1826,7 @@ cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1843,7 +1843,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1861,7 +1861,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
                      std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1879,7 +1879,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
                      std::complex<double> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1896,7 +1896,7 @@ cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const float *ap, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1912,7 +1912,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const double *ap, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1928,7 +1928,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1944,7 +1944,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<double> *ap, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1960,7 +1960,7 @@ cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const float *ap, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1976,7 +1976,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const double *ap, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1992,7 +1992,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2008,7 +2008,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<double> *ap, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2024,7 +2024,7 @@ cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const float *a, int64_t lda, float *b, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2041,7 +2041,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const double *a, int64_t lda, double *b, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2058,7 +2058,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *b,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2075,7 +2075,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
                      int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2092,7 +2092,7 @@ cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose transa,
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2109,7 +2109,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const double *a, int64_t lda, double *x, int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2126,7 +2126,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2143,7 +2143,7 @@ cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
                      int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                     int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/netlib/netlib_level3.cxx
+++ b/src/blas/backends/netlib/netlib_level3.cxx
@@ -1013,8 +1013,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1089,8 +1088,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/netlib/netlib_level3.cxx
+++ b/src/blas/backends/netlib/netlib_level3.cxx
@@ -566,7 +566,7 @@ void trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose t
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
                      int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -584,7 +584,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
                      const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -603,7 +603,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *b, int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -623,7 +623,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      int64_t n, int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
                      int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -642,7 +642,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, half alpha, const half *a, int64_t lda, const half *b,
                      int64_t ldb, half beta, half *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -654,7 +654,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const half *a, int64_t lda, const half *b,
                      int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -666,7 +666,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
                      int64_t n, int64_t k, float alpha, const bfloat16 *a, int64_t lda,
                      const bfloat16 *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -679,7 +679,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *b, int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -699,7 +699,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, const std::complex<double> *b, int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -718,7 +718,7 @@ cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, float alpha, const std::complex<float> *a, int64_t lda, float beta,
                      std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -736,7 +736,7 @@ cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, double alpha, const std::complex<double> *a, int64_t lda,
                      double beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -755,7 +755,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb, float beta,
                       std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -774,7 +774,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       int64_t lda, const std::complex<double> *b, int64_t ldb, double beta,
                       std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -792,7 +792,7 @@ cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
                      int64_t n, float alpha, const float *a, int64_t lda, const float *b,
                      int64_t ldb, float beta, float *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -811,7 +811,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
                      int64_t n, double alpha, const double *a, int64_t lda, const double *b,
                      int64_t ldb, double beta, double *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -831,7 +831,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, const std::complex<float> *b, int64_t ldb,
                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -851,7 +851,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
                      int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, const std::complex<double> *b, int64_t ldb,
                      std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -869,7 +869,7 @@ cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, float alpha, const float *a, int64_t lda, float beta, float *c,
-                     int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -886,7 +886,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, double alpha, const double *a, int64_t lda, double beta, double *c,
-                     int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -904,7 +904,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                      int64_t lda, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -922,7 +922,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                      int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                      int64_t lda, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -940,7 +940,7 @@ cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, 
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                       int64_t k, float alpha, const float *a, int64_t lda, const float *b,
                       int64_t ldb, float beta, float *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -958,7 +958,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
                       int64_t k, double alpha, const double *a, int64_t lda, const double *b,
                       int64_t ldb, double beta, double *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -977,7 +977,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<float> alpha, const std::complex<float> *a,
                       int64_t lda, const std::complex<float> *b, int64_t ldb,
                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -996,7 +996,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
                       int64_t k, std::complex<double> alpha, const std::complex<double> *a,
                       int64_t lda, const std::complex<double> *b, int64_t ldb,
                       std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1014,7 +1014,7 @@ cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans,
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
                      float *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1033,7 +1033,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
                      int64_t lda, double *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1052,7 +1052,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1071,7 +1071,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1090,7 +1090,7 @@ cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
                      float *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1109,7 +1109,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
                      int64_t lda, double *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1128,7 +1128,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1147,7 +1147,7 @@ cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, 
 cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
                      diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -1513,42 +1513,42 @@ void gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose tra
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_scasum_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dzasum_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const float *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sasum_usm_sycl(queue, n, x, incx, result,
                                                                dependencies);
 }
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const double *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dasum_usm_sycl(queue, n, x, incx, result,
                                                                dependencies);
 }
 
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_saxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                                dependencies);
 }
 
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_daxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                                dependencies);
 }
@@ -1556,7 +1556,7 @@ cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_caxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                                dependencies);
 }
@@ -1564,7 +1564,7 @@ cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zaxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                                dependencies);
 }
@@ -1572,7 +1572,7 @@ cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            float *alpha, const float **x, std::int64_t *incx, float **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_saxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1580,7 +1580,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            double *alpha, const double **x, std::int64_t *incx, double **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_daxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1589,7 +1589,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<float> *alpha, const std::complex<float> **x,
                            std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_caxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1598,7 +1598,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<double> *alpha, const std::complex<double> **x,
                            std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zaxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1607,7 +1607,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            float alpha, const float *x, std::int64_t incx, std::int64_t stridex,
                            float *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_saxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -1616,7 +1616,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            double alpha, const double *x, std::int64_t incx, std::int64_t stridex,
                            double *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_daxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -1625,7 +1625,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<float> alpha, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_caxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -1634,7 +1634,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<double> alpha, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zaxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -1642,7 +1642,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       float alpha, const float *x, std::int64_t incx, const float beta, float *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_saxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                                 incy, dependencies);
 }
@@ -1650,7 +1650,7 @@ cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::i
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       double alpha, const double *x, std::int64_t incx, const double beta,
                       double *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_daxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                                 incy, dependencies);
 }
@@ -1658,7 +1658,7 @@ cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::i
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                       const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_caxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                                 incy, dependencies);
 }
@@ -1666,21 +1666,21 @@ cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::i
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                       const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zaxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                                 incy, dependencies);
 }
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_scopy_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dcopy_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -1688,7 +1688,7 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ccopy_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -1696,7 +1696,7 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zcopy_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -1704,7 +1704,7 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_scopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1712,7 +1712,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dcopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1721,7 +1721,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ccopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1730,7 +1730,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zcopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -1738,7 +1738,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_scopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -1746,7 +1746,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dcopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -1755,7 +1755,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ccopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -1764,28 +1764,28 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zcopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
 
 cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    float *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sdot_usm_sycl(queue, n, x, incx, y, incy, result,
                                                               dependencies);
 }
 
 cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     const double *x, std::int64_t incx, const double *y, std::int64_t incy,
-                    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    double *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ddot_usm_sycl(queue, n, x, incx, y, incy, result,
                                                               dependencies);
 }
 
 cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    double *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsdot_usm_sycl(queue, n, x, incx, y, incy, result,
                                                                dependencies);
 }
@@ -1793,7 +1793,7 @@ cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cdotc_usm_sycl(queue, n, x, incx, y, incy, result,
                                                                dependencies);
 }
@@ -1801,7 +1801,7 @@ cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zdotc_usm_sycl(queue, n, x, incx, y, incy, result,
                                                                dependencies);
 }
@@ -1809,7 +1809,7 @@ cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cdotu_usm_sycl(queue, n, x, incx, y, incy, result,
                                                                dependencies);
 }
@@ -1817,91 +1817,91 @@ cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zdotu_usm_sycl(queue, n, x, incx, y, incy, result,
                                                                dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const float *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_isamin_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const double *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_idamin_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_icamin_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_izamin_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const float *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_isamax_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const double *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_idamax_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_icamax_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_izamax_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_scnrm2_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dznrm2_usm_sycl(queue, n, x, incx, result,
                                                                 dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const float *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_snrm2_usm_sycl(queue, n, x, incx, result,
                                                                dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const double *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dnrm2_usm_sycl(queue, n, x, incx, result,
                                                                dependencies);
 }
@@ -1909,7 +1909,7 @@ cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_srot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                               dependencies);
 }
@@ -1917,136 +1917,136 @@ cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_drot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                               dependencies);
 }
 
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x,
                     std::int64_t incx, float *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csrot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                                dependencies);
 }
 
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
                     std::int64_t incx, double *y, std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zdrot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                                dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *a, float *b,
                      float *c, float *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_srotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *a, double *b,
                      double *c, double *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_drotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<float> *a,
                      std::complex<float> *b, float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_crotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<double> *a,
                      std::complex<double> *b, double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zrotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotm(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_srotm_usm_sycl(queue, n, x, incx, y, incy, param,
                                                                dependencies);
 }
 
 cl::sycl::event rotm(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_drotm_usm_sycl(queue, n, x, incx, y, incy, param,
                                                                dependencies);
 }
 
 cl::sycl::event rotmg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *d1, float *d2,
                       float *x1, float y1, float *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_srotmg_usm_sycl(queue, d1, d2, x1, y1, param,
                                                                 dependencies);
 }
 
 cl::sycl::event rotmg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *d1, double *d2,
                       double *x1, double y1, double *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_drotmg_usm_sycl(queue, d1, d2, x1, y1, param,
                                                                 dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      float alpha, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sscal_usm_sycl(queue, n, alpha, x, incx,
                                                                dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      double alpha, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dscal_usm_sycl(queue, n, alpha, x, incx,
                                                                dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cscal_usm_sycl(queue, n, alpha, x, incx,
                                                                dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csscal_usm_sycl(queue, n, alpha, x, incx,
                                                                 dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      float alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zscal_usm_sycl(queue, n, alpha, x, incx,
                                                                dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      double alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zdscal_usm_sycl(queue, n, alpha, x, incx,
                                                                 dependencies);
 }
 
 cl::sycl::event sdsdot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float sb,
                        const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                       float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       float *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sdsdot_usm_sycl(queue, n, sb, x, incx, y, incy,
                                                                 result, dependencies);
 }
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sswap_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dswap_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -2054,7 +2054,7 @@ cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cswap_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -2062,7 +2062,7 @@ cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zswap_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -2071,7 +2071,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha,
                      const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                      float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2080,7 +2080,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2090,7 +2090,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2100,7 +2100,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2108,7 +2108,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans,
                      std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
                      const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2117,7 +2117,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2127,7 +2127,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2137,7 +2137,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2147,7 +2147,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t lda, std::int64_t stridea, const float *x,
                            std::int64_t incx, std::int64_t stridex, float beta, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -2158,7 +2158,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t lda, std::int64_t stridea, const double *x,
                            std::int64_t incx, std::int64_t stridex, double beta, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -2170,7 +2170,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -2182,7 +2182,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -2193,7 +2193,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const float **x, std::int64_t *incx, float *beta,
                            float **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -2204,7 +2204,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
                            double **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -2216,7 +2216,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -2228,7 +2228,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -2239,7 +2239,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t stridea, const float *x, std::int64_t incx,
                            std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sdgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -2250,7 +2250,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t stridea, const double *x, std::int64_t incx,
                            std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ddgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -2261,7 +2261,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cdgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -2272,7 +2272,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zdgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -2282,7 +2282,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *m, std::int64_t *n, const float **a, std::int64_t *lda,
                            const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sdgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -2291,7 +2291,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *m, std::int64_t *n, const double **a, std::int64_t *lda,
                            const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ddgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -2301,7 +2301,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cdgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -2311,7 +2311,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zdgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -2319,7 +2319,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m,
                     std::int64_t n, float alpha, const float *x, std::int64_t incx, const float *y,
                     std::int64_t incy, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sger_usm_sycl(queue, m, n, alpha, x, incx, y, incy,
                                                               a, lda, dependencies);
 }
@@ -2327,7 +2327,7 @@ cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m,
                     std::int64_t n, double alpha, const double *x, std::int64_t incx,
                     const double *y, std::int64_t incy, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dger_usm_sycl(queue, m, n, alpha, x, incx, y, incy,
                                                               a, lda, dependencies);
 }
@@ -2336,7 +2336,7 @@ cl::sycl::event gerc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgerc_usm_sycl(queue, m, n, alpha, x, incx, y, incy,
                                                                a, lda, dependencies);
 }
@@ -2345,7 +2345,7 @@ cl::sycl::event gerc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgerc_usm_sycl(queue, m, n, alpha, x, incx, y, incy,
                                                                a, lda, dependencies);
 }
@@ -2354,7 +2354,7 @@ cl::sycl::event geru(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgeru_usm_sycl(queue, m, n, alpha, x, incx, y, incy,
                                                                a, lda, dependencies);
 }
@@ -2363,7 +2363,7 @@ cl::sycl::event geru(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgeru_usm_sycl(queue, m, n, alpha, x, incx, y, incy,
                                                                a, lda, dependencies);
 }
@@ -2373,7 +2373,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chbmv_usm_sycl(
         queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2383,7 +2383,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhbmv_usm_sycl(
         queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2392,7 +2392,7 @@ cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chemv_usm_sycl(
         queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2401,7 +2401,7 @@ cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhemv_usm_sycl(
         queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2409,7 +2409,7 @@ cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cher_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, lda, dependencies);
 }
@@ -2417,7 +2417,7 @@ cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zher_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, lda, dependencies);
 }
@@ -2426,7 +2426,7 @@ cl::sycl::event her2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cher2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, lda, dependencies);
 }
@@ -2435,7 +2435,7 @@ cl::sycl::event her2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zher2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, lda, dependencies);
 }
@@ -2444,7 +2444,7 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chpmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2453,7 +2453,7 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhpmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2461,7 +2461,7 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chpr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, dependencies);
 }
@@ -2469,7 +2469,7 @@ cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhpr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, dependencies);
 }
@@ -2478,7 +2478,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chpr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, dependencies);
 }
@@ -2487,7 +2487,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhpr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, dependencies);
 }
@@ -2495,7 +2495,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssbmv_usm_sycl(
         queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2504,7 +2504,7 @@ cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsbmv_usm_sycl(
         queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2512,7 +2512,7 @@ cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *a, const float *x, std::int64_t incx,
                      float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sspmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2520,21 +2520,21 @@ cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *a, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dspmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                                incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const float *x, std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sspr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, dependencies);
 }
 
 cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dspr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, dependencies);
 }
@@ -2542,7 +2542,7 @@ cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sspr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, dependencies);
 }
@@ -2550,7 +2550,7 @@ cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *x, std::int64_t incx,
                      const double *y, std::int64_t incy, double *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dspr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, dependencies);
 }
@@ -2558,7 +2558,7 @@ cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssymv_usm_sycl(
         queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2566,21 +2566,21 @@ cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsymv_usm_sycl(
         queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const float *x, std::int64_t incx, float *a,
-                    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssyr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, lda, dependencies);
 }
 
 cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const double *x, std::int64_t incx, double *a,
-                    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsyr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, lda, dependencies);
 }
@@ -2588,7 +2588,7 @@ cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssyr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, lda, dependencies);
 }
@@ -2596,7 +2596,7 @@ cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *x, std::int64_t incx,
                      const double *y, std::int64_t incy, double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsyr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, lda, dependencies);
 }
@@ -2604,7 +2604,7 @@ cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_stbmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2612,7 +2612,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const double *a, std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtbmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2621,7 +2621,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctbmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2630,7 +2630,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztbmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2638,7 +2638,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_stbsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2646,7 +2646,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const double *a, std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtbsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2655,7 +2655,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctbsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2664,7 +2664,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztbsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2672,7 +2672,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_stpmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2680,7 +2680,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtpmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2688,7 +2688,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctpmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2696,7 +2696,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztpmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2704,7 +2704,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_stpsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2712,7 +2712,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtpsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2720,7 +2720,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctpsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2728,7 +2728,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztpsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2736,7 +2736,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2744,7 +2744,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2752,7 +2752,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctrmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2760,7 +2760,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztrmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2768,7 +2768,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2776,7 +2776,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2784,7 +2784,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctrsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2792,7 +2792,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztrsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, lda, x, incx, dependencies);
 }
@@ -2801,7 +2801,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
                      float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2810,7 +2810,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
                      const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                      double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2820,7 +2820,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2830,7 +2830,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2839,7 +2839,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, half beta,
                      half *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2848,7 +2848,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, float beta,
                      float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2857,7 +2857,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const bfloat16 *a, std::int64_t lda, const bfloat16 *b, std::int64_t ldb,
                      float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_bf16bf16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2867,7 +2867,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2877,7 +2877,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2886,7 +2886,7 @@ cl::sycl::event herk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, float alpha,
                      const std::complex<float> *a, std::int64_t lda, float beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cherk_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
 }
@@ -2895,7 +2895,7 @@ cl::sycl::event herk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, double alpha,
                      const std::complex<double> *a, std::int64_t lda, double beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zherk_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
 }
@@ -2904,7 +2904,7 @@ cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cher2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2914,7 +2914,7 @@ cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, double beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zher2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2923,7 +2923,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2932,7 +2932,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                      double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2942,7 +2942,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2952,7 +2952,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zsymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2960,7 +2960,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssyrk_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
 }
@@ -2968,7 +2968,7 @@ cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsyrk_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
 }
@@ -2977,7 +2977,7 @@ cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csyrk_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
 }
@@ -2986,7 +2986,7 @@ cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zsyrk_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
 }
@@ -2995,7 +2995,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            transpose *trans, std::int64_t *n, std::int64_t *k, float *alpha,
                            const float **a, std::int64_t *lda, float *beta, float **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -3005,7 +3005,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            transpose *trans, std::int64_t *n, std::int64_t *k, double *alpha,
                            const double **a, std::int64_t *lda, double *beta, double **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -3016,7 +3016,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::complex<float> *alpha, const std::complex<float> **a,
                            std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -3027,7 +3027,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::complex<double> *alpha, const std::complex<double> **a,
                            std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zsyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -3038,7 +3038,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -3049,7 +3049,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -3061,7 +3061,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -3073,7 +3073,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zsyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -3083,7 +3083,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, float alpha, const float *a,
                       std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3092,7 +3092,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, double alpha,
                       const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                       double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3102,7 +3102,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3112,7 +3112,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zsyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3121,7 +3121,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strmm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3131,7 +3131,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrmm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3141,7 +3141,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctrmm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3151,7 +3151,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztrmm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3161,7 +3161,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strsm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3171,7 +3171,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrsm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3181,7 +3181,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctrsm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3191,7 +3191,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztrsm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3202,7 +3202,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -3213,7 +3213,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t n, double alpha, const double *a, std::int64_t lda,
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -3224,7 +3224,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctrsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -3236,7 +3236,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztrsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -3247,7 +3247,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
                            float **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -3258,7 +3258,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
                            double **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -3270,7 +3270,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<float> **a, std::int64_t *lda,
                            std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctrsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -3282,7 +3282,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> **a, std::int64_t *lda,
                            std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztrsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -3293,7 +3293,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            float *alpha, const float **a, std::int64_t *lda, const float **b,
                            std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -3304,7 +3304,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            double *alpha, const double **a, std::int64_t *lda, const double **b,
                            std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -3316,7 +3316,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -3328,7 +3328,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -3339,7 +3339,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            half *alpha, const half **a, std::int64_t *lda, const half **b,
                            std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -3351,7 +3351,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -3363,7 +3363,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -3376,7 +3376,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -3389,7 +3389,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -3401,7 +3401,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
                            half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -3411,7 +3411,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemmt_usm_sycl(queue, upper_lower, transa, transb,
                                                                 n, k, alpha, a, lda, b, ldb, beta,
                                                                 c, ldc, dependencies);
@@ -3421,7 +3421,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       double alpha, const double *a, std::int64_t lda, const double *b,
                       std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemmt_usm_sycl(queue, upper_lower, transa, transb,
                                                                 n, k, alpha, a, lda, b, ldb, beta,
                                                                 c, ldc, dependencies);
@@ -3432,7 +3432,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                       const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemmt_usm_sycl(queue, upper_lower, transa, transb,
                                                                 n, k, alpha, a, lda, b, ldb, beta,
                                                                 c, ldc, dependencies);
@@ -3443,7 +3443,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemmt_usm_sycl(queue, upper_lower, transa, transb,
                                                                 n, k, alpha, a, lda, b, ldb, beta,
                                                                 c, ldc, dependencies);
@@ -3454,7 +3454,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_s8u8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);
@@ -3465,7 +3465,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_s8s8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);
@@ -3476,7 +3476,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_u8s8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);
@@ -3487,7 +3487,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_u8u8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);
@@ -4979,42 +4979,42 @@ void gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose tra
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_scasum_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dzasum_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const float *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sasum_usm_sycl(queue, n, x, incx, result,
                                                             dependencies);
 }
 
 cl::sycl::event asum(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const double *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dasum_usm_sycl(queue, n, x, incx, result,
                                                             dependencies);
 }
 
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      float alpha, const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_saxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                             dependencies);
 }
 
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      double alpha, const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_daxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5022,7 +5022,7 @@ cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_caxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5030,7 +5030,7 @@ cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zaxpy_usm_sycl(queue, n, alpha, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5038,7 +5038,7 @@ cl::sycl::event axpy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            float *alpha, const float **x, std::int64_t *incx, float **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_saxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5046,7 +5046,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            double *alpha, const double **x, std::int64_t *incx, double **y,
                            std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_daxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5055,7 +5055,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<float> *alpha, const std::complex<float> **x,
                            std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_caxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5064,7 +5064,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<double> *alpha, const std::complex<double> **x,
                            std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zaxpy_batch_group_usm_sycl(
         queue, n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5073,7 +5073,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            float alpha, const float *x, std::int64_t incx, std::int64_t stridex,
                            float *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_saxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -5082,7 +5082,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            double alpha, const double *x, std::int64_t incx, std::int64_t stridex,
                            double *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_daxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -5091,7 +5091,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<float> alpha, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_caxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -5100,7 +5100,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::complex<double> alpha, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zaxpy_batch_strided_usm_sycl(
         queue, n, alpha, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -5108,7 +5108,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       float alpha, const float *x, std::int64_t incx, const float beta, float *y,
                       std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_saxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                              incy, dependencies);
 }
@@ -5116,7 +5116,7 @@ cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::i
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       double alpha, const double *x, std::int64_t incx, const double beta,
                       double *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_daxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                              incy, dependencies);
 }
@@ -5124,7 +5124,7 @@ cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::i
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                       const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_caxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                              incy, dependencies);
 }
@@ -5132,21 +5132,21 @@ cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::i
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                       const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zaxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                              incy, dependencies);
 }
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const float *x, std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_scopy_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const double *x, std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dcopy_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5154,7 +5154,7 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ccopy_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5162,7 +5162,7 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zcopy_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5170,7 +5170,7 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_scopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5178,7 +5178,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t *n,
                            const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dcopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5187,7 +5187,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ccopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5196,7 +5196,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zcopy_batch_group_usm_sycl(
         queue, n, x, incx, y, incy, group_count, group_size, dependencies);
 }
@@ -5204,7 +5204,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                            const float *x, std::int64_t incx, std::int64_t stridex, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_scopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -5212,7 +5212,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                            const double *x, std::int64_t incx, std::int64_t stridex, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dcopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -5221,7 +5221,7 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ccopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
@@ -5230,28 +5230,28 @@ cl::sycl::event copy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zcopy_batch_strided_usm_sycl(
         queue, n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
 }
 
 cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                    float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    float *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sdot_usm_sycl(queue, n, x, incx, y, incy, result,
                                                            dependencies);
 }
 
 cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     const double *x, std::int64_t incx, const double *y, std::int64_t incy,
-                    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    double *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ddot_usm_sycl(queue, n, x, incx, y, incy, result,
                                                            dependencies);
 }
 
 cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                    double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    double *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsdot_usm_sycl(queue, n, x, incx, y, incy, result,
                                                             dependencies);
 }
@@ -5259,7 +5259,7 @@ cl::sycl::event dot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cdotc_usm_sycl(queue, n, x, incx, y, incy, result,
                                                             dependencies);
 }
@@ -5267,7 +5267,7 @@ cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zdotc_usm_sycl(queue, n, x, incx, y, incy, result,
                                                             dependencies);
 }
@@ -5275,7 +5275,7 @@ cl::sycl::event dotc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                      std::int64_t incy, std::complex<float> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cdotu_usm_sycl(queue, n, x, incx, y, incy, result,
                                                             dependencies);
 }
@@ -5283,91 +5283,91 @@ cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event dotu(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx,
                      const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zdotu_usm_sycl(queue, n, x, incx, y, incy, result,
                                                             dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const float *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_isamin_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const double *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_idamin_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_icamin_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event iamin(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_izamin_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const float *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_isamax_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const double *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_idamax_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_icamax_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event iamax(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_izamax_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_scnrm2_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dznrm2_usm_sycl(queue, n, x, incx, result,
                                                              dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const float *x, std::int64_t incx, float *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_snrm2_usm_sycl(queue, n, x, incx, result,
                                                             dependencies);
 }
 
 cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const double *x, std::int64_t incx, double *result,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dnrm2_usm_sycl(queue, n, x, incx, result,
                                                             dependencies);
 }
@@ -5375,7 +5375,7 @@ cl::sycl::event nrm2(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                     std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_srot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                            dependencies);
 }
@@ -5383,132 +5383,132 @@ cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                     std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                     std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_drot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                            dependencies);
 }
 
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x,
                     std::int64_t incx, float *y, std::int64_t incy, float c, float s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csrot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                             dependencies);
 }
 
 cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
                     std::int64_t incx, double *y, std::int64_t incy, double c, double s,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zdrot_usm_sycl(queue, n, x, incx, y, incy, c, s,
                                                             dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *a, float *b,
                      float *c, float *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_srotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *a, double *b,
                      double *c, double *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_drotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<float> *a,
                      std::complex<float> *b, float *c, std::complex<float> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_crotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::complex<double> *a,
                      std::complex<double> *b, double *c, std::complex<double> *s,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zrotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotm(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy, float *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_srotm_usm_sycl(queue, n, x, incx, y, incy, param,
                                                             dependencies);
 }
 
 cl::sycl::event rotm(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy, double *param,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_drotm_usm_sycl(queue, n, x, incx, y, incy, param,
                                                             dependencies);
 }
 
 cl::sycl::event rotmg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *d1, float *d2,
                       float *x1, float y1, float *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_srotmg_usm_sycl(queue, d1, d2, x1, y1, param,
                                                              dependencies);
 }
 
 cl::sycl::event rotmg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *d1, double *d2,
                       double *x1, double y1, double *param,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_drotmg_usm_sycl(queue, d1, d2, x1, y1, param,
                                                              dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      float alpha, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sscal_usm_sycl(queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      double alpha, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dscal_usm_sycl(queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cscal_usm_sycl(queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csscal_usm_sycl(queue, n, alpha, x, incx,
                                                              dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      float alpha, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zscal_usm_sycl(queue, n, alpha, x, incx, dependencies);
 }
 
 cl::sycl::event scal(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      double alpha, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zdscal_usm_sycl(queue, n, alpha, x, incx,
                                                              dependencies);
 }
 
 cl::sycl::event sdsdot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float sb,
                        const float *x, std::int64_t incx, const float *y, std::int64_t incy,
-                       float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                       float *result, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sdsdot_usm_sycl(queue, n, sb, x, incx, y, incy, result,
                                                              dependencies);
 }
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, float *x,
                      std::int64_t incx, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sswap_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n, double *x,
                      std::int64_t incx, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dswap_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5516,7 +5516,7 @@ cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cswap_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5524,7 +5524,7 @@ cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zswap_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5533,7 +5533,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha,
                      const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                      float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -5542,7 +5542,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
                      const double *a, std::int64_t lda, const double *x, std::int64_t incx,
                      double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -5552,7 +5552,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -5562,7 +5562,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgbmv_usm_sycl(
         queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -5570,7 +5570,7 @@ cl::sycl::event gbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans,
                      std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
                      const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5579,7 +5579,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5589,7 +5589,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5599,7 +5599,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5609,7 +5609,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t lda, std::int64_t stridea, const float *x,
                            std::int64_t incx, std::int64_t stridex, float beta, float *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -5620,7 +5620,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t lda, std::int64_t stridea, const double *x,
                            std::int64_t incx, std::int64_t stridex, double beta, double *y,
                            std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -5632,7 +5632,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -5644,7 +5644,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                            std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
                            std::int64_t stridey, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemv_batch_strided_usm_sycl(
         queue, trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy, stridey,
         batch_size, dependencies);
@@ -5655,7 +5655,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const float **x, std::int64_t *incx, float *beta,
                            float **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -5666,7 +5666,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
                            double **y, std::int64_t *incy, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -5678,7 +5678,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -5690,7 +5690,7 @@ cl::sycl::event gemv_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemv_batch_group_usm_sycl(
         queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count, group_size,
         dependencies);
@@ -5701,7 +5701,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t stridea, const float *x, std::int64_t incx,
                            std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sdgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -5712,7 +5712,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t stridea, const double *x, std::int64_t incx,
                            std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ddgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -5723,7 +5723,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cdgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -5734,7 +5734,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
                            std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
                            std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zdgmm_batch_strided_usm_sycl(
         queue, left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec, batch_size,
         dependencies);
@@ -5744,7 +5744,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *m, std::int64_t *n, const float **a, std::int64_t *lda,
                            const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sdgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -5753,7 +5753,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *m, std::int64_t *n, const double **a, std::int64_t *lda,
                            const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ddgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -5763,7 +5763,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
                            std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cdgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -5773,7 +5773,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
                            std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zdgmm_batch_group_usm_sycl(
         queue, left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size, dependencies);
 }
@@ -5781,7 +5781,7 @@ cl::sycl::event dgmm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m,
                     std::int64_t n, float alpha, const float *x, std::int64_t incx, const float *y,
                     std::int64_t incy, float *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sger_usm_sycl(queue, m, n, alpha, x, incx, y, incy, a,
                                                            lda, dependencies);
 }
@@ -5789,7 +5789,7 @@ cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 cl::sycl::event ger(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t m,
                     std::int64_t n, double alpha, const double *x, std::int64_t incx,
                     const double *y, std::int64_t incy, double *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dger_usm_sycl(queue, m, n, alpha, x, incx, y, incy, a,
                                                            lda, dependencies);
 }
@@ -5798,7 +5798,7 @@ cl::sycl::event gerc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgerc_usm_sycl(queue, m, n, alpha, x, incx, y, incy, a,
                                                             lda, dependencies);
 }
@@ -5807,7 +5807,7 @@ cl::sycl::event gerc(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgerc_usm_sycl(queue, m, n, alpha, x, incx, y, incy, a,
                                                             lda, dependencies);
 }
@@ -5816,7 +5816,7 @@ cl::sycl::event geru(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgeru_usm_sycl(queue, m, n, alpha, x, incx, y, incy, a,
                                                             lda, dependencies);
 }
@@ -5825,7 +5825,7 @@ cl::sycl::event geru(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgeru_usm_sycl(queue, m, n, alpha, x, incx, y, incy, a,
                                                             lda, dependencies);
 }
@@ -5835,7 +5835,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chbmv_usm_sycl(queue, upper_lower, n, k, alpha, a, lda,
                                                             x, incx, beta, y, incy, dependencies);
 }
@@ -5845,7 +5845,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhbmv_usm_sycl(queue, upper_lower, n, k, alpha, a, lda,
                                                             x, incx, beta, y, incy, dependencies);
 }
@@ -5854,7 +5854,7 @@ cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
                      std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chemv_usm_sycl(queue, upper_lower, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5863,7 +5863,7 @@ cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
                      std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhemv_usm_sycl(queue, upper_lower, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5871,7 +5871,7 @@ cl::sycl::event hemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cher_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            lda, dependencies);
 }
@@ -5879,7 +5879,7 @@ cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event her(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a, std::int64_t lda,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zher_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            lda, dependencies);
 }
@@ -5888,7 +5888,7 @@ cl::sycl::event her2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cher2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, lda, dependencies);
 }
@@ -5897,7 +5897,7 @@ cl::sycl::event her2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zher2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, lda, dependencies);
 }
@@ -5906,7 +5906,7 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                      std::complex<float> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chpmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5915,7 +5915,7 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                      std::complex<double> *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhpmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5923,7 +5923,7 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const std::complex<float> *x, std::int64_t incx,
                     std::complex<float> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chpr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            dependencies);
 }
@@ -5931,7 +5931,7 @@ cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const std::complex<double> *x, std::int64_t incx,
                     std::complex<double> *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhpr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            dependencies);
 }
@@ -5940,7 +5940,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                      std::complex<float> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chpr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, dependencies);
 }
@@ -5949,7 +5949,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                      std::complex<double> *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhpr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, dependencies);
 }
@@ -5957,7 +5957,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                      const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssbmv_usm_sycl(queue, upper_lower, n, k, alpha, a, lda,
                                                             x, incx, beta, y, incy, dependencies);
 }
@@ -5966,7 +5966,7 @@ cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
                      std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsbmv_usm_sycl(queue, upper_lower, n, k, alpha, a, lda,
                                                             x, incx, beta, y, incy, dependencies);
 }
@@ -5974,7 +5974,7 @@ cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *a, const float *x, std::int64_t incx,
                      float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sspmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5982,21 +5982,21 @@ cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event spmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *a, const double *x,
                      std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dspmv_usm_sycl(queue, upper_lower, n, alpha, a, x,
                                                             incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const float *x, std::int64_t incx, float *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sspr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            dependencies);
 }
 
 cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const double *x, std::int64_t incx, double *a,
-                    const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dspr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            dependencies);
 }
@@ -6004,7 +6004,7 @@ cl::sycl::event spr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sspr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, dependencies);
 }
@@ -6012,7 +6012,7 @@ cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *x, std::int64_t incx,
                      const double *y, std::int64_t incy, double *a,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dspr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, dependencies);
 }
@@ -6020,7 +6020,7 @@ cl::sycl::event spr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
                      std::int64_t incx, float beta, float *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssymv_usm_sycl(queue, upper_lower, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -6028,21 +6028,21 @@ cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event symv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda,
                      const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsymv_usm_sycl(queue, upper_lower, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
 
 cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const float *x, std::int64_t incx, float *a,
-                    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssyr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            lda, dependencies);
 }
 
 cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const double *x, std::int64_t incx, double *a,
-                    std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                    std::int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsyr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            lda, dependencies);
 }
@@ -6050,7 +6050,7 @@ cl::sycl::event syr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, float alpha, const float *x, std::int64_t incx, const float *y,
                      std::int64_t incy, float *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssyr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, lda, dependencies);
 }
@@ -6058,7 +6058,7 @@ cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, double alpha, const double *x, std::int64_t incx,
                      const double *y, std::int64_t incy, double *a, std::int64_t lda,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsyr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, lda, dependencies);
 }
@@ -6066,7 +6066,7 @@ cl::sycl::event syr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_stbmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6074,7 +6074,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const double *a, std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtbmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6083,7 +6083,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctbmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6092,7 +6092,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztbmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6100,7 +6100,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const float *a, std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_stbsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6108,7 +6108,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const double *a, std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtbsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6117,7 +6117,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctbsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6126,7 +6126,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztbsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6134,7 +6134,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_stpmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6142,7 +6142,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtpmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6150,7 +6150,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctpmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6158,7 +6158,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztpmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6166,7 +6166,7 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_stpsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6174,7 +6174,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
                      std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtpsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6182,7 +6182,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctpsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6190,7 +6190,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztpsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6198,7 +6198,7 @@ cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6206,7 +6206,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6214,7 +6214,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctrmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6222,7 +6222,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztrmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6230,7 +6230,7 @@ cl::sycl::event trmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a,
                      std::int64_t lda, float *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6238,7 +6238,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a,
                      std::int64_t lda, double *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6246,7 +6246,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctrsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6254,7 +6254,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztrsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, lda, x, incx, dependencies);
 }
@@ -6263,7 +6263,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
                      float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6272,7 +6272,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
                      const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                      double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6282,7 +6282,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                      const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6292,7 +6292,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                      const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6301,7 +6301,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, half beta,
                      half *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6310,7 +6310,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, float beta,
                      float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6319,7 +6319,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const bfloat16 *a, std::int64_t lda, const bfloat16 *b, std::int64_t ldb,
                      float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_bf16bf16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6329,7 +6329,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6339,7 +6339,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6348,7 +6348,7 @@ cl::sycl::event herk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, float alpha,
                      const std::complex<float> *a, std::int64_t lda, float beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cherk_usm_sycl(queue, upper_lower, trans, n, k, alpha,
                                                             a, lda, beta, c, ldc, dependencies);
 }
@@ -6357,7 +6357,7 @@ cl::sycl::event herk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, double alpha,
                      const std::complex<double> *a, std::int64_t lda, double beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zherk_usm_sycl(queue, upper_lower, trans, n, k, alpha,
                                                             a, lda, beta, c, ldc, dependencies);
 }
@@ -6366,7 +6366,7 @@ cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cher2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6376,7 +6376,7 @@ cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, double beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zher2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6385,7 +6385,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6394,7 +6394,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, double alpha,
                      const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                      double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6404,7 +6404,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6414,7 +6414,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                      std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zsymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6422,7 +6422,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, std::int64_t n, std::int64_t k, float alpha, const float *a,
                      std::int64_t lda, float beta, float *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssyrk_usm_sycl(queue, upper_lower, trans, n, k, alpha,
                                                             a, lda, beta, c, ldc, dependencies);
 }
@@ -6430,7 +6430,7 @@ cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, double beta, double *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsyrk_usm_sycl(queue, upper_lower, trans, n, k, alpha,
                                                             a, lda, beta, c, ldc, dependencies);
 }
@@ -6439,7 +6439,7 @@ cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
                      std::complex<float> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csyrk_usm_sycl(queue, upper_lower, trans, n, k, alpha,
                                                             a, lda, beta, c, ldc, dependencies);
 }
@@ -6448,7 +6448,7 @@ cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      transpose trans, std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
                      std::complex<double> *c, std::int64_t ldc,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zsyrk_usm_sycl(queue, upper_lower, trans, n, k, alpha,
                                                             a, lda, beta, c, ldc, dependencies);
 }
@@ -6457,7 +6457,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            transpose *trans, std::int64_t *n, std::int64_t *k, float *alpha,
                            const float **a, std::int64_t *lda, float *beta, float **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -6467,7 +6467,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            transpose *trans, std::int64_t *n, std::int64_t *k, double *alpha,
                            const double **a, std::int64_t *lda, double *beta, double **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -6478,7 +6478,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::complex<float> *alpha, const std::complex<float> **a,
                            std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -6489,7 +6489,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::complex<double> *alpha, const std::complex<double> **a,
                            std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                            std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zsyrk_batch_group_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count, group_size,
         dependencies);
@@ -6500,7 +6500,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -6511,7 +6511,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -6523,7 +6523,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -6535,7 +6535,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
                            std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zsyrk_batch_strided_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc, stride_c,
         batch_size, dependencies);
@@ -6545,7 +6545,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, float alpha, const float *a,
                       std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6554,7 +6554,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, double alpha,
                       const double *a, std::int64_t lda, const double *b, std::int64_t ldb,
                       double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6564,7 +6564,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                       std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6574,7 +6574,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zsyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6583,7 +6583,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strmm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6593,7 +6593,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrmm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6603,7 +6603,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctrmm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6613,7 +6613,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztrmm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6623,7 +6623,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strsm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6633,7 +6633,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
                      std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrsm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6643,7 +6643,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                      std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctrsm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6653,7 +6653,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                      std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
-                     const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztrsm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6664,7 +6664,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -6675,7 +6675,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t n, double alpha, const double *a, std::int64_t lda,
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -6686,7 +6686,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctrsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -6698,7 +6698,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztrsm_batch_strided_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, stride_a, b, ldb,
         stride_b, batch_size, dependencies);
@@ -6709,7 +6709,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
                            float **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -6720,7 +6720,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
                            double **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -6732,7 +6732,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<float> **a, std::int64_t *lda,
                            std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctrsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -6744,7 +6744,7 @@ cl::sycl::event trsm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
                            const std::complex<double> **a, std::int64_t *lda,
                            std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                            std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztrsm_batch_group_usm_sycl(
         queue, left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b, ldb, group_count,
         group_size, dependencies);
@@ -6755,7 +6755,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            float *alpha, const float **a, std::int64_t *lda, const float **b,
                            std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -6766,7 +6766,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            double *alpha, const double **a, std::int64_t *lda, const double **b,
                            std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -6778,7 +6778,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
                            std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -6790,7 +6790,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
                            std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -6801,7 +6801,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            half *alpha, const half **a, std::int64_t *lda, const half **b,
                            std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
         group_size, dependencies);
@@ -6813,7 +6813,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
                            float *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -6825,7 +6825,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
                            double *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -6838,7 +6838,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                            std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -6851,7 +6851,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                            std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -6863,7 +6863,7 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
                            const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
                            half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
-                           const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                           const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size, dependencies);
@@ -6873,7 +6873,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       float alpha, const float *a, std::int64_t lda, const float *b,
                       std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemmt_usm_sycl(queue, upper_lower, transa, transb, n,
                                                              k, alpha, a, lda, b, ldb, beta, c, ldc,
                                                              dependencies);
@@ -6883,7 +6883,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose transa, transpose transb, std::int64_t n, std::int64_t k,
                       double alpha, const double *a, std::int64_t lda, const double *b,
                       std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemmt_usm_sycl(queue, upper_lower, transa, transb, n,
                                                              k, alpha, a, lda, b, ldb, beta, c, ldc,
                                                              dependencies);
@@ -6894,7 +6894,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
                       const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                       std::complex<float> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemmt_usm_sycl(queue, upper_lower, transa, transb, n,
                                                              k, alpha, a, lda, b, ldb, beta, c, ldc,
                                                              dependencies);
@@ -6905,7 +6905,7 @@ cl::sycl::event gemmt(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
                       const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                       std::complex<double> *c, std::int64_t ldc,
-                      const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                      const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemmt_usm_sycl(queue, upper_lower, transa, transb, n,
                                                              k, alpha, a, lda, b, ldb, beta, c, ldc,
                                                              dependencies);
@@ -6916,7 +6916,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_s8u8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);
@@ -6927,7 +6927,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
                           std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_s8s8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);
@@ -6938,7 +6938,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_u8s8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);
@@ -6949,7 +6949,7 @@ cl::sycl::event gemm_bias(oneapi::mkl::device libkey, cl::sycl::queue &queue, tr
                           std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
                           std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
                           float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
-                          const cl::sycl::vector_class<cl::sycl::event> &dependencies) {
+                          const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_u8u8s32_bias_usm_sycl(
         queue, transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc, co,
         dependencies);

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -1641,8 +1641,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       float alpha, const float *x, std::int64_t incx, const float beta, float *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_saxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                                 incy, dependencies);
 }
@@ -1687,16 +1686,14 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ccopy_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zcopy_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -1937,14 +1934,12 @@ cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *a, float *b,
-                     float *c, float *s,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *c, float *s, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_srotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *a, double *b,
-                     double *c, double *s,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *c, double *s, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_drotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
@@ -2053,16 +2048,14 @@ cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cswap_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zswap_usm_sycl(queue, n, x, incx, y, incy,
                                                                dependencies);
 }
@@ -2116,8 +2109,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans,
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2126,8 +2118,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_cgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2136,8 +2127,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                                incx, beta, y, incy, dependencies);
 }
@@ -2372,8 +2362,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chbmv_usm_sycl(
         queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2382,8 +2371,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhbmv_usm_sycl(
         queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2460,16 +2448,14 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const std::complex<float> *x, std::int64_t incx,
-                    std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chpr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, dependencies);
 }
 
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const std::complex<double> *x, std::int64_t incx,
-                    std::complex<double> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhpr_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                               a, dependencies);
 }
@@ -2477,8 +2463,7 @@ cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
-                     std::complex<float> *a,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chpr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, dependencies);
 }
@@ -2486,8 +2471,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
-                     std::complex<double> *a,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhpr2_usm_sycl(queue, upper_lower, n, alpha, x,
                                                                incx, y, incy, a, dependencies);
 }
@@ -2503,8 +2487,7 @@ cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dsbmv_usm_sycl(
         queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy, dependencies);
 }
@@ -2620,8 +2603,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctbmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2629,8 +2611,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztbmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2654,8 +2635,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ctbsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
@@ -2663,24 +2643,21 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ztbsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, k, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_stpmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtpmv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2703,16 +2680,14 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_stpsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
 
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtpsv_usm_sycl(queue, upper_lower, trans, unit_diag,
                                                                n, a, x, incx, dependencies);
 }
@@ -2800,8 +2775,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
-                     float *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_sgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2838,8 +2812,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, half beta,
-                     half *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2847,8 +2820,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, float beta,
-                     float *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2866,8 +2838,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_chemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2876,8 +2847,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zhemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2922,8 +2892,7 @@ cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
 cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2941,8 +2910,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -2951,8 +2919,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_zsymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3082,8 +3049,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
 cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                       transpose trans, std::int64_t n, std::int64_t k, float alpha, const float *a,
                       std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_ssyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3101,8 +3067,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_csyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3120,8 +3085,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
 cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strmm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3130,8 +3094,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrmm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3160,8 +3123,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_strsm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -3170,8 +3132,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_dtrsm_usm_sycl(queue, left_right, upper_lower,
                                                                trans, unit_diag, m, n, alpha, a,
                                                                lda, b, ldb, dependencies);
@@ -5107,8 +5068,7 @@ cl::sycl::event axpy_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, s
 
 cl::sycl::event axpby(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                       float alpha, const float *x, std::int64_t incx, const float beta, float *y,
-                      std::int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_saxpby_usm_sycl(queue, n, alpha, x, incx, beta, y,
                                                              incy, dependencies);
 }
@@ -5153,16 +5113,14 @@ cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ccopy_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
 
 cl::sycl::event copy(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zcopy_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5403,14 +5361,12 @@ cl::sycl::event rot(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, float *a, float *b,
-                     float *c, float *s,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *c, float *s, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_srotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
 cl::sycl::event rotg(oneapi::mkl::device libkey, cl::sycl::queue &queue, double *a, double *b,
-                     double *c, double *s,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     double *c, double *s, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_drotg_usm_sycl(queue, a, b, c, s, dependencies);
 }
 
@@ -5515,16 +5471,14 @@ cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::in
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cswap_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
 
 cl::sycl::event swap(oneapi::mkl::device libkey, cl::sycl::queue &queue, std::int64_t n,
                      std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zswap_usm_sycl(queue, n, x, incx, y, incy,
                                                             dependencies);
 }
@@ -5578,8 +5532,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose trans,
                      std::int64_t m, std::int64_t n, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5588,8 +5541,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_cgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5598,8 +5550,7 @@ cl::sycl::event gemv(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
                      std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zgemv_usm_sycl(queue, trans, m, n, alpha, a, lda, x,
                                                             incx, beta, y, incy, dependencies);
 }
@@ -5834,8 +5785,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::int64_t k, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                      std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chbmv_usm_sycl(queue, upper_lower, n, k, alpha, a, lda,
                                                             x, incx, beta, y, incy, dependencies);
 }
@@ -5844,8 +5794,7 @@ cl::sycl::event hbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
                      std::int64_t n, std::int64_t k, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                      std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhbmv_usm_sycl(queue, upper_lower, n, k, alpha, a, lda,
                                                             x, incx, beta, y, incy, dependencies);
 }
@@ -5922,16 +5871,14 @@ cl::sycl::event hpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, float alpha, const std::complex<float> *x, std::int64_t incx,
-                    std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chpr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            dependencies);
 }
 
 cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                     std::int64_t n, double alpha, const std::complex<double> *x, std::int64_t incx,
-                    std::complex<double> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+                    std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhpr_usm_sycl(queue, upper_lower, n, alpha, x, incx, a,
                                                            dependencies);
 }
@@ -5939,8 +5886,7 @@ cl::sycl::event hpr(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upp
 cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::complex<float> alpha, const std::complex<float> *x,
                      std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
-                     std::complex<float> *a,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::complex<float> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chpr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, dependencies);
 }
@@ -5948,8 +5894,7 @@ cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event hpr2(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::complex<double> alpha, const std::complex<double> *x,
                      std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
-                     std::complex<double> *a,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhpr2_usm_sycl(queue, upper_lower, n, alpha, x, incx,
                                                             y, incy, a, dependencies);
 }
@@ -5965,8 +5910,7 @@ cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event sbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      std::int64_t n, std::int64_t k, double alpha, const double *a,
                      std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
-                     std::int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dsbmv_usm_sycl(queue, upper_lower, n, k, alpha, a, lda,
                                                             x, incx, beta, y, incy, dependencies);
 }
@@ -6082,8 +6026,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctbmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6091,8 +6034,7 @@ cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztbmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6116,8 +6058,7 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ctbsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
@@ -6125,24 +6066,21 @@ cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event tbsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, std::int64_t k,
                      const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ztbsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             k, a, lda, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_stpmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
 
 cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtpmv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6165,16 +6103,14 @@ cl::sycl::event tpmv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const float *a, float *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_stpsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
 
 cl::sycl::event tpsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                      transpose trans, diag unit_diag, std::int64_t n, const double *a, double *x,
-                     std::int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtpsv_usm_sycl(queue, upper_lower, trans, unit_diag, n,
                                                             a, x, incx, dependencies);
 }
@@ -6262,8 +6198,7 @@ cl::sycl::event trsv(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo up
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
-                     float *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_sgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6300,8 +6235,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, half beta,
-                     half *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6309,8 +6243,7 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
                      const half *a, std::int64_t lda, const half *b, std::int64_t ldb, float beta,
-                     float *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6328,8 +6261,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_chemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6338,8 +6270,7 @@ cl::sycl::event hemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zhemm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6384,8 +6315,7 @@ cl::sycl::event her2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
 cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, std::int64_t m, std::int64_t n, float alpha, const float *a,
                      std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6403,8 +6333,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                      const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                      std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6413,8 +6342,7 @@ cl::sycl::event symm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
                      uplo upper_lower, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                      const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                      std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
-                     std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_zsymm_usm_sycl(
         queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6544,8 +6472,7 @@ cl::sycl::event syrk_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, u
 cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                       transpose trans, std::int64_t n, std::int64_t k, float alpha, const float *a,
                       std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_ssyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6563,8 +6490,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
                       transpose trans, std::int64_t n, std::int64_t k, std::complex<float> alpha,
                       const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                       std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
-                      std::int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_csyr2k_usm_sycl(
         queue, upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6582,8 +6508,7 @@ cl::sycl::event syr2k(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo u
 cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strmm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6592,8 +6517,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrmm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6622,8 +6546,7 @@ cl::sycl::event trmm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_strsm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);
@@ -6632,8 +6555,7 @@ cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side le
 cl::sycl::event trsm(oneapi::mkl::device libkey, cl::sycl::queue &queue, side left_right,
                      uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
                      std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
-                     std::int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_dtrsm_usm_sycl(queue, left_right, upper_lower, trans,
                                                             unit_diag, m, n, alpha, a, lda, b, ldb,
                                                             dependencies);

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -989,1053 +989,1053 @@ typedef struct {
 
     cl::sycl::event (*column_major_scasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dzasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_saxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-        float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_daxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-        double *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_caxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zaxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_saxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x, std::int64_t *incx,
         float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_daxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, double *alpha, const double **x,
         std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_caxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
         const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zaxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
         const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_saxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
         std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_daxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
         std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_caxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<float> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zaxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<double> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_saxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
         const float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_daxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
         const double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_caxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zaxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_scopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dcopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ccopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zcopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_scopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx, float **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dcopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx, double **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ccopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const std::complex<float> **x, std::int64_t *incx,
         std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zcopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const std::complex<double> **x, std::int64_t *incx,
         std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_scopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
         std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dcopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
         std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ccopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zcopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sdot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
         std::int64_t incy, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ddot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, const double *y,
         std::int64_t incy, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsdot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
         std::int64_t incy, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cdotc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zdotc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cdotu_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zdotu_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_isamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_idamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_icamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_izamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_isamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_idamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_icamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_izamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_scnrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dznrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_snrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dnrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_srot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
         std::complex<float> *y, std::int64_t incy, float c, float s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_drot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
         std::complex<double> *y, std::int64_t incy, double c, double s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csrot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
         std::int64_t incy, float c, float s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zdrot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
         std::int64_t incy, double c, double s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_srotg_usm_sycl)(
         cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_drotg_usm_sycl)(
         cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_crotg_usm_sycl)(
         cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
-        std::complex<float> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::complex<float> *s, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zrotg_usm_sycl)(
         cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
-        std::complex<double> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_srotm_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
         std::int64_t incy, float *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_drotm_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
         std::int64_t incy, double *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_srotmg_usm_sycl)(
         cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_drotmg_usm_sycl)(
         cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, std::complex<float> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha, std::complex<double> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zdscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sdsdot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
         const float *y, std::int64_t incy, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda,
         const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
         const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
         std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
         float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
         double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
         std::int64_t incx, std::int64_t stridex, float beta, float *y, std::int64_t incy,
         std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
         std::int64_t incx, std::int64_t stridex, double beta, double *y, std::int64_t incy,
         std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::int64_t stridea, const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<float> beta, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::int64_t stridea, const std::complex<double> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
         std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         float *alpha, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
         float *beta, float **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         double *alpha, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
         double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
         const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
         std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
         const std::complex<double> **x, std::int64_t *incx, std::complex<double> *beta,
         std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sdgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
         std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ddgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
         std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cdgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
         const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<float> *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zdgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
         const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<double> *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sdgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ddgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cdgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
         std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zdgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
         std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sger_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
         std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dger_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
         std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgerc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
         std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgerc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
         std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgeru_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
         std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgeru_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
         std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_chbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zhbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_chemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zhemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cher_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zher_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cher2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zher2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_chpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
         std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zhpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
         std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_chpr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zhpr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_chpr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zhpr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
         float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
         double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sspmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *a, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dspmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *a, const double *x, std::int64_t incx, double beta, double *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sspr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, float *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dspr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, double *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sspr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dspr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssymv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsymv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta,
-        double *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssyr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, float *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsyr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, double *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssyr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-        std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t lda, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsyr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-        std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t lda, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_stbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
         std::int64_t lda, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
         std::int64_t lda, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
         std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_stbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
         std::int64_t lda, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
         std::int64_t lda, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
         std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_stpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_stpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_strmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtrmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctrmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_strsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtrsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctrsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
         std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
         std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-        std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
         const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
         std::int64_t ldb, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
         const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
         std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
         const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_f16f16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
         std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_bf16bf16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const oneapi::mkl::bfloat16 *a,
         std::int64_t lda, const oneapi::mkl::bfloat16 *b, std::int64_t ldb, float beta, float *c,
-        std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_chemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zhemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cherk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
         float beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zherk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
         std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cher2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zher2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, double beta,
         std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
         const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
         const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zsymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
-        float *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
         double beta, double *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zsyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda,
         float *beta, float **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
         double *beta, double **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
         std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
         std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zsyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, std::complex<double> *alpha,
         const std::complex<double> **a, std::int64_t *lda, std::complex<double> *beta,
         std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
         std::int64_t stride_a, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
         std::int64_t stride_a, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
         std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zsyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
         std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
         const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
         const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zsyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_strmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::complex<double> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_strsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::complex<double> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_strsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, std::int64_t stride_a, float *b,
         std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtrsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, std::int64_t stride_a, double *b,
         std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctrsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_strsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, float *alpha, const float **a, std::int64_t *lda, float **b,
         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dtrsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, double *alpha, const double **a, std::int64_t *lda, double **b,
         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ctrsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, std::complex<float> *alpha, const std::complex<float> **a,
         std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, std::complex<double> *alpha, const std::complex<double> **a,
         std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
         std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
         std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<float> *alpha,
         const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
         std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
         std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<double> *alpha,
         const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **b,
         std::int64_t *ldb, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
         std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
         std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
         std::int64_t lda, std::int64_t stride_a, const float *b, std::int64_t ldb,
         std::int64_t stride_b, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
         std::int64_t lda, std::int64_t stride_a, const double *b, std::int64_t ldb,
         std::int64_t stride_b, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
         const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
         const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
         std::complex<float> beta, std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
         const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
         const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
         std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
         half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a,
         std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha,
         const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
-        double *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
         const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
         std::int64_t ldb, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
         const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
         std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_s8u8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::uint8_t *b,
         std::int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_s8s8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::int8_t *b,
         std::int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_u8s8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::int8_t *b,
         std::int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_u8u8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::uint8_t *b,
         std::int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
 
     // Buffer APIs
 
@@ -2968,1053 +2968,1053 @@ typedef struct {
 
     cl::sycl::event (*row_major_scasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dzasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dasum_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_saxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-        float *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_daxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-        double *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_caxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zaxpy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_saxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x, std::int64_t *incx,
         float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_daxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, double *alpha, const double **x,
         std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_caxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
         const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zaxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
         const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_saxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
         std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_daxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
         std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_caxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<float> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zaxpy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<double> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_saxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
         const float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_daxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
         const double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_caxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zaxpby_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_scopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dcopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ccopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zcopy_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_scopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx, float **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dcopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx, double **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ccopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const std::complex<float> **x, std::int64_t *incx,
         std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zcopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const std::complex<double> **x, std::int64_t *incx,
         std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_scopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
         std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dcopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
         std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ccopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zcopy_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sdot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
         std::int64_t incy, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ddot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, const double *y,
         std::int64_t incy, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsdot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
         std::int64_t incy, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cdotc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zdotc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cdotu_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zdotu_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_isamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_idamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_icamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_izamin_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_isamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_idamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_icamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_izamax_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        std::int64_t *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_scnrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        float *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dznrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        double *result, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_snrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dnrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_srot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
         std::complex<float> *y, std::int64_t incy, float c, float s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_drot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
         std::complex<double> *y, std::int64_t incy, double c, double s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csrot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
         std::int64_t incy, float c, float s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zdrot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
         std::int64_t incy, double c, double s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_srotg_usm_sycl)(
         cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_drotg_usm_sycl)(
         cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_crotg_usm_sycl)(
         cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
-        std::complex<float> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::complex<float> *s, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zrotg_usm_sycl)(
         cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
-        std::complex<double> *s, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_srotm_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
         std::int64_t incy, float *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_drotm_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
         std::int64_t incy, double *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_srotmg_usm_sycl)(
         cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_drotmg_usm_sycl)(
         cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, std::complex<float> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha, std::complex<double> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zdscal_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sdsdot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
         const float *y, std::int64_t incy, float *result,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zswap_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda,
         const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
         const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
         std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
         float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
         double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
         std::int64_t incx, std::int64_t stridex, float beta, float *y, std::int64_t incy,
         std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, std::int64_t stridea, const double *x,
         std::int64_t incx, std::int64_t stridex, double beta, double *y, std::int64_t incy,
         std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::int64_t stridea, const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<float> beta, std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::int64_t stridea, const std::complex<double> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
         std::int64_t stridey, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         float *alpha, const float **a, std::int64_t *lda, const float **x, std::int64_t *incx,
         float *beta, float **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         double *alpha, const double **a, std::int64_t *lda, const double **x, std::int64_t *incx,
         double *beta, double **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
         const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
         std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgemv_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m, std::int64_t *n,
         std::complex<double> *alpha, const std::complex<double> **a, std::int64_t *lda,
         const std::complex<double> **x, std::int64_t *incx, std::complex<double> *beta,
         std::complex<double> **y, std::int64_t *incy, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sdgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const float *a, std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
         std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ddgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const double *a, std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
         std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cdgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
         const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<float> *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zdgmm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
         const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
         const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<double> *c, std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sdgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const float **a, std::int64_t *lda, const float **x, std::int64_t *incx, float **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ddgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const double **a, std::int64_t *lda, const double **x, std::int64_t *incx, double **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cdgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **x,
         std::int64_t *incx, std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zdgmm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m, std::int64_t *n,
         const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
         std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sger_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
         std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dger_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
         std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgerc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
         std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgerc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
         std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgeru_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
         std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgeru_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
         const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
         std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_chbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zhbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_chemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
         std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zhemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cher_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zher_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cher2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zher2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_chpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
         std::int64_t incx, std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zhpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
         std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_chpr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zhpr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_chpr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zhpr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
         const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
         float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
         double beta, double *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sspmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *a, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dspmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *a, const double *x, std::int64_t incx, double beta, double *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sspr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, float *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dspr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, double *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sspr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dspr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssymv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-        std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsymv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta,
-        double *y, std::int64_t incy, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssyr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, float *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsyr_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, double *a, std::int64_t lda,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssyr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-        std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t lda, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsyr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-        std::int64_t lda, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t lda, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_stbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
         std::int64_t lda, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
         std::int64_t lda, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
         std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_stbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
         std::int64_t lda, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
         std::int64_t lda, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
         std::int64_t lda, std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_stpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_stpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztpsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtrmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctrmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtrsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
-        std::int64_t incx, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctrsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
         std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
         std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
-        std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
         const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
         std::int64_t ldb, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
         const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
         std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
         const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_f16f16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
         std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_bf16bf16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const oneapi::mkl::bfloat16 *a,
         std::int64_t lda, const oneapi::mkl::bfloat16 *b, std::int64_t ldb, float beta, float *c,
-        std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_chemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zhemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cherk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a, std::int64_t lda,
         float beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zherk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
         std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cher2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zher2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, double beta,
         std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
         const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
         const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zsymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda, float beta,
-        float *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
         double beta, double *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zsyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, float *alpha, const float **a, std::int64_t *lda,
         float *beta, float **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
         double *beta, double **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
         std::int64_t *lda, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
         std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zsyrk_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
         std::int64_t *n, std::int64_t *k, std::complex<double> *alpha,
         const std::complex<double> **a, std::int64_t *lda, std::complex<double> *beta,
         std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
         std::int64_t stride_a, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
         std::int64_t stride_a, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
         std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zsyrk_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
         std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ssyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
         const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
         const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
         std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zsyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::complex<double> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, float *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, double *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::complex<float> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::complex<double> *b, std::int64_t ldb,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, std::int64_t stride_a, float *b,
         std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtrsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, std::int64_t stride_a, double *b,
         std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctrsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
         std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrsm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
         std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, float *alpha, const float **a, std::int64_t *lda, float **b,
         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dtrsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, double *alpha, const double **a, std::int64_t *lda, double **b,
         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctrsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, std::complex<float> *alpha, const std::complex<float> **a,
         std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrsm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side *left_right, oneapi::mkl::uplo *upper_lower,
         oneapi::mkl::transpose *trans, oneapi::mkl::diag *unit_diag, std::int64_t *m,
         std::int64_t *n, std::complex<double> *alpha, const std::complex<double> **a,
         std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
-        std::int64_t *group_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, float *alpha, const float **a,
         std::int64_t *lda, const float **b, std::int64_t *ldb, float *beta, float **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, double *alpha, const double **a,
         std::int64_t *lda, const double **b, std::int64_t *ldb, double *beta, double **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<float> *alpha,
         const std::complex<float> **a, std::int64_t *lda, const std::complex<float> **b,
         std::int64_t *ldb, std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
         std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, std::complex<double> *alpha,
         const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **b,
         std::int64_t *ldb, std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
         std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
         std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
         std::int64_t lda, std::int64_t stride_a, const float *b, std::int64_t ldb,
         std::int64_t stride_b, float beta, float *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
         std::int64_t lda, std::int64_t stride_a, const double *b, std::int64_t ldb,
         std::int64_t stride_b, double beta, double *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
         const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
         const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
         std::complex<float> beta, std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
         const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
         const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
         std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
-        std::int64_t batch_size, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
         std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
         half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a,
         std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha,
         const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
-        double *c, std::int64_t ldc, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
         const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
         std::int64_t ldb, std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
         oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
         const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
         std::int64_t ldb, std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
-        const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_s8u8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::uint8_t *b,
         std::int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_s8s8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::int8_t *a, std::int64_t lda, std::int8_t ao, const std::int8_t *b,
         std::int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_u8s8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::int8_t *b,
         std::int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_u8u8s32_bias_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
         const std::uint8_t *a, std::int64_t lda, std::uint8_t ao, const std::uint8_t *b,
         std::int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
-        const std::int32_t *co, const cl::sycl::vector_class<cl::sycl::event> &dependencies);
+        const std::int32_t *co, const std::vector<cl::sycl::event> &dependencies);
 
 } blas_function_table_t;
 

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -1113,18 +1113,18 @@ typedef struct {
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
         std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_sdot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
-        std::int64_t incy, float *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_ddot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, const double *y,
-        std::int64_t incy, double *result,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_sdot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                  const float *x, std::int64_t incx, const float *y,
+                                                  std::int64_t incy, float *result,
+                                                  const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_ddot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                  const double *x, std::int64_t incx,
+                                                  const double *y, std::int64_t incy,
+                                                  double *result,
+                                                  const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsdot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
-        std::int64_t incy, double *result,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t incy, double *result, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cdotc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
         const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
@@ -1177,22 +1177,22 @@ typedef struct {
     cl::sycl::event (*column_major_dnrm2_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_srot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
-        std::complex<float> *y, std::int64_t incy, float c, float s,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_drot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
-        std::complex<double> *y, std::int64_t incy, double c, double s,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_srot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                  std::complex<float> *x, std::int64_t incx,
+                                                  std::complex<float> *y, std::int64_t incy,
+                                                  float c, float s,
+                                                  const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_drot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                  std::complex<double> *x, std::int64_t incx,
+                                                  std::complex<double> *y, std::int64_t incy,
+                                                  double c, double s,
+                                                  const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csrot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-        std::int64_t incy, float c, float s,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t incy, float c, float s, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zdrot_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-        std::int64_t incy, double c, double s,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t incy, double c, double s, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_srotg_usm_sycl)(
         cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
         const std::vector<cl::sycl::event> &dependencies);
@@ -1207,12 +1207,10 @@ typedef struct {
         std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_srotm_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-        std::int64_t incy, float *param,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t incy, float *param, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_drotm_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-        std::int64_t incy, double *param,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t incy, double *param, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_srotmg_usm_sycl)(
         cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
         const std::vector<cl::sycl::event> &dependencies);
@@ -1280,8 +1278,7 @@ typedef struct {
     cl::sycl::event (*column_major_sgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
-        float beta, float *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
+        float beta, float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dgemv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
@@ -1388,14 +1385,16 @@ typedef struct {
         const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
         std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
         std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_sger_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
-        std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_dger_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
-        std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_sger_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                                  std::int64_t n, float alpha, const float *x,
+                                                  std::int64_t incx, const float *y,
+                                                  std::int64_t incy, float *a, std::int64_t lda,
+                                                  const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_dger_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                                  std::int64_t n, double alpha, const double *x,
+                                                  std::int64_t incx, const double *y,
+                                                  std::int64_t incy, double *a, std::int64_t lda,
+                                                  const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cgerc_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
         const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
@@ -1440,14 +1439,18 @@ typedef struct {
         const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
         std::complex<double> *y, std::int64_t incy,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_cher_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_zher_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_cher_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  float alpha, const std::complex<float> *x,
+                                                  std::int64_t incx, std::complex<float> *a,
+                                                  std::int64_t lda,
+                                                  const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_zher_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  double alpha, const std::complex<double> *x,
+                                                  std::int64_t incx, std::complex<double> *a,
+                                                  std::int64_t lda,
+                                                  const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_cher2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
@@ -1468,14 +1471,16 @@ typedef struct {
         std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
         std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_chpr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_zhpr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_chpr_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  float alpha, const std::complex<float> *x,
+                                                  std::int64_t incx, std::complex<float> *a,
+                                                  const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_zhpr_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  double alpha, const std::complex<double> *x,
+                                                  std::int64_t incx, std::complex<double> *a,
+                                                  const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_chpr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
@@ -1489,8 +1494,7 @@ typedef struct {
     cl::sycl::event (*column_major_ssbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
-        float beta, float *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
+        float beta, float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_dsbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
         double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
@@ -1504,14 +1508,16 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *a, const double *x, std::int64_t incx, double beta, double *y,
         std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_sspr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *x, std::int64_t incx, float *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_dspr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *x, std::int64_t incx, double *a,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_sspr_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  float alpha, const float *x, std::int64_t incx,
+                                                  float *a,
+                                                  const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_dspr_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  double alpha, const double *x, std::int64_t incx,
+                                                  double *a,
+                                                  const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sspr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
@@ -1528,14 +1534,16 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
         const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta,
         double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_ssyr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *x, std::int64_t incx, float *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*column_major_dsyr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *x, std::int64_t incx, double *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_ssyr_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  float alpha, const float *x, std::int64_t incx,
+                                                  float *a, std::int64_t lda,
+                                                  const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*column_major_dsyr_usm_sycl)(cl::sycl::queue &queue,
+                                                  oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                  double alpha, const double *x, std::int64_t incx,
+                                                  double *a, std::int64_t lda,
+                                                  const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ssyr2_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
         const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
@@ -1697,8 +1705,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zhemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
@@ -1719,8 +1726,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zher2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
@@ -1741,8 +1747,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zsymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
@@ -1756,8 +1761,7 @@ typedef struct {
     cl::sycl::event (*column_major_dsyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-        double beta, double *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        double beta, double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_csyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
@@ -1826,8 +1830,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_zsyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
@@ -1848,8 +1851,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-        std::complex<float> *b, std::int64_t ldb,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
@@ -1870,8 +1872,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-        std::complex<float> *b, std::int64_t ldb,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_ztrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
@@ -2966,32 +2967,38 @@ typedef struct {
 
     // USM APIs
 
-    cl::sycl::event (*row_major_scasum_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        float *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dzasum_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        double *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sasum_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dasum_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_saxpy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-        float *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_daxpy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-        double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_caxpy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zaxpy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
-        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_scasum_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<float> *x, std::int64_t incx,
+                                                 float *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dzasum_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<double> *x, std::int64_t incx,
+                                                 double *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sasum_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const float *x, std::int64_t incx, float *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dasum_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const double *x, std::int64_t incx, double *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_saxpy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                                const float *x, std::int64_t incx, float *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_daxpy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                double alpha, const double *x, std::int64_t incx,
+                                                double *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_caxpy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                std::complex<float> alpha,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                std::complex<float> *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zaxpy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                std::complex<double> alpha,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                std::complex<double> *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_saxpy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, float *alpha, const float **x, std::int64_t *incx,
         float **y, std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
@@ -3028,38 +3035,42 @@ typedef struct {
         const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
         std::complex<double> *y, std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_saxpby_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
-        const float beta, float *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_daxpby_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, double alpha, const double *x, std::int64_t incx,
-        const double beta, double *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_caxpby_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
-        const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
-        std::complex<float> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zaxpby_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
-        const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
-        std::complex<double> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_scopy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
-        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dcopy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
-        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ccopy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        std::complex<float> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zcopy_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        std::complex<double> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_saxpby_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 float alpha, const float *x, std::int64_t incx,
+                                                 const float beta, float *y, std::int64_t incy,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_daxpby_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 double alpha, const double *x, std::int64_t incx,
+                                                 const double beta, double *y, std::int64_t incy,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_caxpby_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 std::complex<float> alpha,
+                                                 const std::complex<float> *x, std::int64_t incx,
+                                                 const std::complex<float> beta,
+                                                 std::complex<float> *y, std::int64_t incy,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zaxpby_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 std::complex<double> alpha,
+                                                 const std::complex<double> *x, std::int64_t incx,
+                                                 const std::complex<double> beta,
+                                                 std::complex<double> *y, std::int64_t incy,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_scopy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const float *x, std::int64_t incx, float *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dcopy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const double *x, std::int64_t incx, double *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ccopy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                std::complex<float> *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zcopy_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                std::complex<double> *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_scopy_batch_group_usm_sycl)(
         cl::sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx, float **y,
         std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
@@ -3092,158 +3103,183 @@ typedef struct {
         cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
         std::int64_t stridex, std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
         std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sdot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
-        std::int64_t incy, float *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ddot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, const double *y,
-        std::int64_t incy, double *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dsdot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, const float *y,
-        std::int64_t incy, double *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cdotc_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zdotc_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cdotu_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        const std::complex<float> *y, std::int64_t incy, std::complex<float> *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zdotu_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        const std::complex<double> *y, std::int64_t incy, std::complex<double> *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_isamin_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_idamin_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_icamin_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_izamin_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_isamax_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_idamax_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_icamax_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_izamax_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        std::int64_t *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_scnrm2_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<float> *x, std::int64_t incx,
-        float *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dznrm2_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const std::complex<double> *x, std::int64_t incx,
-        double *result, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_snrm2_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dnrm2_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_srot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
-        std::complex<float> *y, std::int64_t incy, float c, float s,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_drot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
-        std::complex<double> *y, std::int64_t incy, double c, double s,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_csrot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-        std::int64_t incy, float c, float s,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zdrot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-        std::int64_t incy, double c, double s,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_srotg_usm_sycl)(
-        cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_drotg_usm_sycl)(
-        cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_crotg_usm_sycl)(
-        cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
-        std::complex<float> *s, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zrotg_usm_sycl)(
-        cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
-        std::complex<double> *s, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_srotm_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-        std::int64_t incy, float *param,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_drotm_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-        std::int64_t incy, double *param,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_srotmg_usm_sycl)(
-        cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_drotmg_usm_sycl)(
-        cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sscal_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dscal_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cscal_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<float> alpha, std::complex<float> *x,
-        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_csscal_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<double> alpha, std::complex<double> *x,
-        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zscal_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
-        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zdscal_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
-        std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sdsdot_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
-        const float *y, std::int64_t incy, float *result,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sswap_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
-        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dswap_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
-        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cswap_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
-        std::complex<float> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zswap_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
-        std::complex<double> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sgbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-        std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda,
-        const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dgbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-        std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
-        const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sdot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                               const float *x, std::int64_t incx, const float *y,
+                                               std::int64_t incy, float *result,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ddot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                               const double *x, std::int64_t incx, const double *y,
+                                               std::int64_t incy, double *result,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dsdot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const float *x, std::int64_t incx, const float *y,
+                                                std::int64_t incy, double *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cdotc_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                const std::complex<float> *y, std::int64_t incy,
+                                                std::complex<float> *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zdotc_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                const std::complex<double> *y, std::int64_t incy,
+                                                std::complex<double> *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cdotu_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                const std::complex<float> *y, std::int64_t incy,
+                                                std::complex<float> *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zdotu_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                const std::complex<double> *y, std::int64_t incy,
+                                                std::complex<double> *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_isamin_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const float *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_idamin_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const double *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_icamin_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<float> *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_izamin_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<double> *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_isamax_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const float *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_idamax_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const double *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_icamax_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<float> *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_izamax_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<double> *x, std::int64_t incx,
+                                                 std::int64_t *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_scnrm2_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<float> *x, std::int64_t incx,
+                                                 float *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dznrm2_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 const std::complex<double> *x, std::int64_t incx,
+                                                 double *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_snrm2_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const float *x, std::int64_t incx, float *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dnrm2_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                const double *x, std::int64_t incx, double *result,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_srot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                               std::complex<float> *x, std::int64_t incx,
+                                               std::complex<float> *y, std::int64_t incy, float c,
+                                               float s,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_drot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                               std::complex<double> *x, std::int64_t incx,
+                                               std::complex<double> *y, std::int64_t incy, double c,
+                                               double s,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_csrot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                                std::int64_t incx, float *y, std::int64_t incy,
+                                                float c, float s,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zdrot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                                std::int64_t incx, double *y, std::int64_t incy,
+                                                double c, double s,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_srotg_usm_sycl)(cl::sycl::queue &queue, float *a, float *b,
+                                                float *c, float *s,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_drotg_usm_sycl)(cl::sycl::queue &queue, double *a, double *b,
+                                                double *c, double *s,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_crotg_usm_sycl)(cl::sycl::queue &queue, std::complex<float> *a,
+                                                std::complex<float> *b, float *c,
+                                                std::complex<float> *s,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zrotg_usm_sycl)(cl::sycl::queue &queue, std::complex<double> *a,
+                                                std::complex<double> *b, double *c,
+                                                std::complex<double> *s,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_srotm_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                                std::int64_t incx, float *y, std::int64_t incy,
+                                                float *param,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_drotm_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                                std::int64_t incx, double *y, std::int64_t incy,
+                                                double *param,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_srotmg_usm_sycl)(cl::sycl::queue &queue, float *d1, float *d2,
+                                                 float *x1, float y1, float *param,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_drotmg_usm_sycl)(cl::sycl::queue &queue, double *d1, double *d2,
+                                                 double *x1, double y1, double *param,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sscal_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                                float *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dscal_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                double alpha, double *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cscal_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                std::complex<float> alpha, std::complex<float> *x,
+                                                std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_csscal_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 std::complex<double> alpha,
+                                                 std::complex<double> *x, std::int64_t incx,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zscal_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, float alpha,
+                                                std::complex<float> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zdscal_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                 double alpha, std::complex<double> *x,
+                                                 std::int64_t incx,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sdsdot_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, float sb,
+                                                 const float *x, std::int64_t incx, const float *y,
+                                                 std::int64_t incy, float *result,
+                                                 const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sswap_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, float *x,
+                                                std::int64_t incx, float *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dswap_usm_sycl)(cl::sycl::queue &queue, std::int64_t n, double *x,
+                                                std::int64_t incx, double *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cswap_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                std::complex<float> *x, std::int64_t incx,
+                                                std::complex<float> *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zswap_usm_sycl)(cl::sycl::queue &queue, std::int64_t n,
+                                                std::complex<double> *x, std::int64_t incx,
+                                                std::complex<double> *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sgbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::transpose trans, std::int64_t m,
+                                                std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                                float alpha, const float *a, std::int64_t lda,
+                                                const float *x, std::int64_t incx, float beta,
+                                                float *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dgbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::transpose trans, std::int64_t m,
+                                                std::int64_t n, std::int64_t kl, std::int64_t ku,
+                                                double alpha, const double *a, std::int64_t lda,
+                                                const double *x, std::int64_t incx, double beta,
+                                                double *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_cgbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         std::int64_t kl, std::int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
@@ -3256,28 +3292,35 @@ typedef struct {
         std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
         std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sgemv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-        float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
-        float beta, float *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dgemv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-        double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
-        double beta, double *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cgemv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-        std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-        std::complex<float> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zgemv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
-        std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-        std::complex<double> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sgemv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::transpose trans, std::int64_t m,
+                                                std::int64_t n, float alpha, const float *a,
+                                                std::int64_t lda, const float *x, std::int64_t incx,
+                                                float beta, float *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dgemv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::transpose trans, std::int64_t m,
+                                                std::int64_t n, double alpha, const double *a,
+                                                std::int64_t lda, const double *x,
+                                                std::int64_t incx, double beta, double *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cgemv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::transpose trans, std::int64_t m,
+                                                std::int64_t n, std::complex<float> alpha,
+                                                const std::complex<float> *a, std::int64_t lda,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                std::complex<float> beta, std::complex<float> *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zgemv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::transpose trans, std::int64_t m,
+                                                std::int64_t n, std::complex<double> alpha,
+                                                const std::complex<double> *a, std::int64_t lda,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                std::complex<double> beta, std::complex<double> *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemv_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
         float alpha, const float *a, std::int64_t lda, std::int64_t stridea, const float *x,
@@ -3367,76 +3410,98 @@ typedef struct {
         const std::complex<double> **a, std::int64_t *lda, const std::complex<double> **x,
         std::int64_t *incx, std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
         std::int64_t *group_size, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sger_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
-        std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dger_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
-        std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cgerc_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-        const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-        std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zgerc_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-        const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-        std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cgeru_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
-        const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
-        std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zgeru_usm_sycl)(
-        cl::sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
-        const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
-        std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_chbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-        std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-        std::complex<float> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zhbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-        std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-        std::complex<double> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_chemv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-        std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
-        std::complex<float> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zhemv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-        std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
-        std::complex<double> *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cher_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zher_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_cher2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-        std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-        const std::complex<float> *y, std::int64_t incy, std::complex<float> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zher2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-        std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-        const std::complex<double> *y, std::int64_t incy, std::complex<double> *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sger_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                               std::int64_t n, float alpha, const float *x,
+                                               std::int64_t incx, const float *y, std::int64_t incy,
+                                               float *a, std::int64_t lda,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dger_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                               std::int64_t n, double alpha, const double *x,
+                                               std::int64_t incx, const double *y,
+                                               std::int64_t incy, double *a, std::int64_t lda,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cgerc_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                                std::int64_t n, std::complex<float> alpha,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                const std::complex<float> *y, std::int64_t incy,
+                                                std::complex<float> *a, std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zgerc_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                                std::int64_t n, std::complex<double> alpha,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                const std::complex<double> *y, std::int64_t incy,
+                                                std::complex<double> *a, std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cgeru_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                                std::int64_t n, std::complex<float> alpha,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                const std::complex<float> *y, std::int64_t incy,
+                                                std::complex<float> *a, std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zgeru_usm_sycl)(cl::sycl::queue &queue, std::int64_t m,
+                                                std::int64_t n, std::complex<double> alpha,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                const std::complex<double> *y, std::int64_t incy,
+                                                std::complex<double> *a, std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_chbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::int64_t k, std::complex<float> alpha,
+                                                const std::complex<float> *a, std::int64_t lda,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                std::complex<float> beta, std::complex<float> *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zhbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::int64_t k, std::complex<double> alpha,
+                                                const std::complex<double> *a, std::int64_t lda,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                std::complex<double> beta, std::complex<double> *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_chemv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::complex<float> alpha,
+                                                const std::complex<float> *a, std::int64_t lda,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                std::complex<float> beta, std::complex<float> *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zhemv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::complex<double> alpha,
+                                                const std::complex<double> *a, std::int64_t lda,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                std::complex<double> beta, std::complex<double> *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cher_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               float alpha, const std::complex<float> *x,
+                                               std::int64_t incx, std::complex<float> *a,
+                                               std::int64_t lda,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zher_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               double alpha, const std::complex<double> *x,
+                                               std::int64_t incx, std::complex<double> *a,
+                                               std::int64_t lda,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_cher2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::complex<float> alpha,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                const std::complex<float> *y, std::int64_t incy,
+                                                std::complex<float> *a, std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zher2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::complex<double> alpha,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                const std::complex<double> *y, std::int64_t incy,
+                                                std::complex<double> *a, std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_chpmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, const std::complex<float> *x,
@@ -3447,92 +3512,123 @@ typedef struct {
         std::complex<double> alpha, const std::complex<double> *a, const std::complex<double> *x,
         std::int64_t incx, std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_chpr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zhpr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_chpr2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-        std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
-        const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_zhpr2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
-        std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
-        const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ssbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-        float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
-        float beta, float *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dsbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
-        double alpha, const double *a, std::int64_t lda, const double *x, std::int64_t incx,
-        double beta, double *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sspmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *a, const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dspmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *a, const double *x, std::int64_t incx, double beta, double *y,
-        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sspr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *x, std::int64_t incx, float *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dspr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *x, std::int64_t incx, double *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_sspr2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dspr2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ssymv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
-        std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dsymv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta,
-        double *y, std::int64_t incy, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ssyr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *x, std::int64_t incx, float *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dsyr_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *x, std::int64_t incx, double *a, std::int64_t lda,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ssyr2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
-        const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
-        std::int64_t lda, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dsyr2_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
-        const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
-        std::int64_t lda, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_stbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
-        std::int64_t lda, float *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dtbmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
-        std::int64_t lda, double *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_chpr_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               float alpha, const std::complex<float> *x,
+                                               std::int64_t incx, std::complex<float> *a,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zhpr_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               double alpha, const std::complex<double> *x,
+                                               std::int64_t incx, std::complex<double> *a,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_chpr2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::complex<float> alpha,
+                                                const std::complex<float> *x, std::int64_t incx,
+                                                const std::complex<float> *y, std::int64_t incy,
+                                                std::complex<float> *a,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_zhpr2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::complex<double> alpha,
+                                                const std::complex<double> *x, std::int64_t incx,
+                                                const std::complex<double> *y, std::int64_t incy,
+                                                std::complex<double> *a,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ssbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::int64_t k, float alpha, const float *a,
+                                                std::int64_t lda, const float *x, std::int64_t incx,
+                                                float beta, float *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dsbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                std::int64_t k, double alpha, const double *a,
+                                                std::int64_t lda, const double *x,
+                                                std::int64_t incx, double beta, double *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sspmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                float alpha, const float *a, const float *x,
+                                                std::int64_t incx, float beta, float *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dspmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                double alpha, const double *a, const double *x,
+                                                std::int64_t incx, double beta, double *y,
+                                                std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sspr_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               float alpha, const float *x, std::int64_t incx,
+                                               float *a,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dspr_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               double alpha, const double *x, std::int64_t incx,
+                                               double *a,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_sspr2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                float alpha, const float *x, std::int64_t incx,
+                                                const float *y, std::int64_t incy, float *a,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dspr2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                double alpha, const double *x, std::int64_t incx,
+                                                const double *y, std::int64_t incy, double *a,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ssymv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                float alpha, const float *a, std::int64_t lda,
+                                                const float *x, std::int64_t incx, float beta,
+                                                float *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dsymv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                double alpha, const double *a, std::int64_t lda,
+                                                const double *x, std::int64_t incx, double beta,
+                                                double *y, std::int64_t incy,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ssyr_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               float alpha, const float *x, std::int64_t incx,
+                                               float *a, std::int64_t lda,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dsyr_usm_sycl)(cl::sycl::queue &queue,
+                                               oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                               double alpha, const double *x, std::int64_t incx,
+                                               double *a, std::int64_t lda,
+                                               const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ssyr2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                float alpha, const float *x, std::int64_t incx,
+                                                const float *y, std::int64_t incy, float *a,
+                                                std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dsyr2_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t n,
+                                                double alpha, const double *x, std::int64_t incx,
+                                                const double *y, std::int64_t incy, double *a,
+                                                std::int64_t lda,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_stbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                std::int64_t k, const float *a, std::int64_t lda,
+                                                float *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dtbmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                std::int64_t k, const double *a, std::int64_t lda,
+                                                double *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctbmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
@@ -3543,16 +3639,20 @@ typedef struct {
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_stbsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
-        std::int64_t lda, float *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dtbsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
-        std::int64_t lda, double *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_stbsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                std::int64_t k, const float *a, std::int64_t lda,
+                                                float *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dtbsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                std::int64_t k, const double *a, std::int64_t lda,
+                                                double *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ctbsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
@@ -3563,42 +3663,58 @@ typedef struct {
         oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
         std::int64_t lda, std::complex<double> *x, std::int64_t incx,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_stpmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dtpmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ctpmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
-        std::complex<float> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ztpmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
-        std::complex<double> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_stpsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dtpsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ctpsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
-        std::complex<float> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ztpsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
-        std::complex<double> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_stpmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const float *a, float *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dtpmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const double *a, double *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ctpmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<float> *a,
+                                                std::complex<float> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ztpmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<double> *a,
+                                                std::complex<double> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_stpsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const float *a, float *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dtpsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const double *a, double *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ctpsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<float> *a,
+                                                std::complex<float> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ztpsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<double> *a,
+                                                std::complex<double> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strmv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
@@ -3607,16 +3723,20 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
         std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ctrmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
-        std::complex<float> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ztrmv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
-        std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ctrmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<float> *a, std::int64_t lda,
+                                                std::complex<float> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ztrmv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<double> *a, std::int64_t lda,
+                                                std::complex<double> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_strsv_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
@@ -3625,16 +3745,20 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
         std::int64_t incx, const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ctrsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
-        std::complex<float> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ztrsv_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
-        std::int64_t lda, std::complex<double> *x, std::int64_t incx,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ctrsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<float> *a, std::int64_t lda,
+                                                std::complex<float> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ztrsv_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::uplo upper_lower,
+                                                oneapi::mkl::transpose trans,
+                                                oneapi::mkl::diag unit_diag, std::int64_t n,
+                                                const std::complex<double> *a, std::int64_t lda,
+                                                std::complex<double> *x, std::int64_t incx,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
@@ -3676,8 +3800,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zhemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
@@ -3698,30 +3821,32 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, float beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zher2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
         std::int64_t lda, const std::complex<double> *b, std::int64_t ldb, double beta,
         std::complex<double> *c, std::int64_t ldc,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ssymm_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-        std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
-        const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_dsymm_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
-        std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
-        const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ssymm_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::side left_right,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t m,
+                                                std::int64_t n, float alpha, const float *a,
+                                                std::int64_t lda, const float *b, std::int64_t ldb,
+                                                float beta, float *c, std::int64_t ldc,
+                                                const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_dsymm_usm_sycl)(cl::sycl::queue &queue,
+                                                oneapi::mkl::side left_right,
+                                                oneapi::mkl::uplo upper_lower, std::int64_t m,
+                                                std::int64_t n, double alpha, const double *a,
+                                                std::int64_t lda, const double *b, std::int64_t ldb,
+                                                double beta, double *c, std::int64_t ldc,
+                                                const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zsymm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         std::int64_t m, std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
@@ -3735,8 +3860,7 @@ typedef struct {
     cl::sycl::event (*row_major_dsyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
-        double beta, double *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        double beta, double *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_csyrk_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
@@ -3791,11 +3915,13 @@ typedef struct {
         std::int64_t lda, std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
         std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
         const std::vector<cl::sycl::event> &dependencies);
-    cl::sycl::event (*row_major_ssyr2k_usm_sycl)(
-        cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-        std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
-        const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+    cl::sycl::event (*row_major_ssyr2k_usm_sycl)(cl::sycl::queue &queue,
+                                                 oneapi::mkl::uplo upper_lower,
+                                                 oneapi::mkl::transpose trans, std::int64_t n,
+                                                 std::int64_t k, float alpha, const float *a,
+                                                 std::int64_t lda, const float *b, std::int64_t ldb,
+                                                 float beta, float *c, std::int64_t ldc,
+                                                 const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_dsyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
@@ -3805,8 +3931,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
         std::int64_t lda, const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
-        std::complex<float> *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_zsyr2k_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
         std::int64_t n, std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
@@ -3827,8 +3952,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-        std::complex<float> *b, std::int64_t ldb,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrmm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
@@ -3849,8 +3973,7 @@ typedef struct {
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
         std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
-        std::complex<float> *b, std::int64_t ldb,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::complex<float> *b, std::int64_t ldb, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_ztrsm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
         oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,

--- a/src/lapack/backends/mkl_common/mkl_lapack.cxx
+++ b/src/lapack/backends/mkl_common/mkl_lapack.cxx
@@ -542,21 +542,21 @@ sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::compl
                   std::int64_t lda, float *d, float *e, std::complex<float> *tauq,
                   std::complex<float> *taup, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *d, double *e, double *tauq, double *taup, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *d, float *e, float *tauq, float *taup, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -564,110 +564,110 @@ sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::compl
                   std::int64_t lda, double *d, double *e, std::complex<double> *tauq,
                   std::complex<double> *taup, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   std::int64_t *ipiv, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getri(sycl::queue &queue, std::int64_t n, double *a, std::int64_t lda,
                   std::int64_t *ipiv, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getri(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda,
                   std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -675,21 +675,21 @@ sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t
                   std::int64_t nrhs, std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs(queue, trans, n, nrhs, a, lda, ipiv, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t *ipiv, double *b,
                   std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs(queue, trans, n, nrhs, a, lda, ipiv, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t *ipiv, float *b,
                   std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs(queue, trans, n, nrhs, a, lda, ipiv, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -697,7 +697,7 @@ sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t
                   std::int64_t nrhs, std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs(queue, trans, n, nrhs, a, lda, ipiv, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -705,7 +705,7 @@ sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::job
                   std::int64_t m, std::int64_t n, double *a, std::int64_t lda, double *s, double *u,
                   std::int64_t ldu, double *vt, std::int64_t ldvt, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gesvd(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -713,7 +713,7 @@ sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::job
                   std::int64_t m, std::int64_t n, float *a, std::int64_t lda, float *s, float *u,
                   std::int64_t ldu, float *vt, std::int64_t ldvt, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gesvd(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -721,7 +721,7 @@ sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::job
                   std::int64_t m, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   float *s, std::complex<float> *u, std::int64_t ldu, std::complex<float> *vt,
                   std::int64_t ldvt, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gesvd(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -729,21 +729,21 @@ sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::job
                   std::int64_t m, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   double *s, std::complex<double> *u, std::int64_t ldu, std::complex<double> *vt,
                   std::int64_t ldvt, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gesvd(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, float *w,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::heevd(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, double *w,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::heevd(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -751,7 +751,7 @@ sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *b, std::int64_t ldb, float *w,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hegvd(queue, itype, jobz, uplo, n, a, lda, b, ldb, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -759,7 +759,7 @@ sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *b, std::int64_t ldb, double *w,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hegvd(queue, itype, jobz, uplo, n, a, lda, b, ldb, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -767,7 +767,7 @@ sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, float *d, float *e,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hetrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -775,59 +775,59 @@ sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, double *d, double *e,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hetrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hetrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hetrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, float *a, std::int64_t lda, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, double *a, std::int64_t lda, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                   std::int64_t lda, double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, float *a,
                   std::int64_t lda, float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgtr(queue, uplo, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgtr(queue, uplo, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -835,7 +835,7 @@ sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo 
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, float *a,
                   std::int64_t lda, float *tau, float *c, std::int64_t ldc, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -843,7 +843,7 @@ sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo 
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, double *a,
                   std::int64_t lda, double *tau, double *c, std::int64_t ldc, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -851,7 +851,7 @@ sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormrq(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -859,7 +859,7 @@ sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormrq(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -867,7 +867,7 @@ sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormqr(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -875,157 +875,157 @@ sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormqr(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potri(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potri(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potri(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potri(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   float *a, std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   double *a, std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                   std::int64_t ldb, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                   std::int64_t ldb, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   double *a, std::int64_t lda, double *w, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::syevd(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   float *a, std::int64_t lda, float *w, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::syevd(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda, double *b,
                   std::int64_t ldb, double *w, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sygvd(queue, itype, jobz, uplo, n, a, lda, b, ldb, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda, float *b,
                   std::int64_t ldb, float *w, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sygvd(queue, itype, jobz, uplo, n, a, lda, b, ldb, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *d, double *e, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *d, float *e, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -1033,7 +1033,7 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::trtrs(queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1041,7 +1041,7 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, double *a,
                   std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::trtrs(queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1049,7 +1049,7 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, float *a,
                   std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::trtrs(queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1057,7 +1057,7 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                   std::int64_t ldb, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::trtrs(queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1065,7 +1065,7 @@ sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                   std::int64_t k, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -1073,35 +1073,35 @@ sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                   std::int64_t k, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungtr(queue, uplo, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungtr(queue, uplo, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -1109,7 +1109,7 @@ sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *c,
                   std::int64_t ldc, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmrq(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1117,7 +1117,7 @@ sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *c,
                   std::int64_t ldc, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmrq(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1125,7 +1125,7 @@ sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *c,
                   std::int64_t ldc, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmqr(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1133,7 +1133,7 @@ sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::trans
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *c,
                   std::int64_t ldc, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmqr(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1142,7 +1142,7 @@ sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo 
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1151,7 +1151,7 @@ sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo 
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1371,7 +1371,7 @@ sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, floa
                         std::int64_t lda, std::int64_t stride_a, float *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1380,7 +1380,7 @@ sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, doub
                         std::int64_t lda, std::int64_t stride_a, double *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1389,7 +1389,7 @@ sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t lda, std::int64_t stride_a, std::complex<float> *tau,
                         std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1398,7 +1398,7 @@ sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t lda, std::int64_t stride_a, std::complex<double> *tau,
                         std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1406,14 +1406,14 @@ sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, float **a,
                         std::int64_t *lda, float **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, double **a,
                         std::int64_t *lda, double **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1421,7 +1421,7 @@ sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<float> **a, std::int64_t *lda, std::complex<float> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1429,7 +1429,7 @@ sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<double> **a, std::int64_t *lda, std::complex<double> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1437,7 +1437,7 @@ sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, floa
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1446,7 +1446,7 @@ sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, doub
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1455,7 +1455,7 @@ sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1464,7 +1464,7 @@ sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1472,14 +1472,14 @@ sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, float **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, double **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1487,7 +1487,7 @@ sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<float> **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1495,14 +1495,14 @@ sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<double> **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event getri_batch(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1510,7 +1510,7 @@ sycl::event getri_batch(sycl::queue &queue, std::int64_t n, float *a, std::int64
 sycl::event getri_batch(sycl::queue &queue, std::int64_t n, double *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1519,7 +1519,7 @@ sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::complex<float> 
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1528,7 +1528,7 @@ sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::complex<double>
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1536,14 +1536,14 @@ sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::complex<double>
 sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, float **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::int64_t group_count, std::int64_t *group_sizes,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, double **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1551,7 +1551,7 @@ sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::complex<float>
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1559,7 +1559,7 @@ sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::complex<double
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1568,7 +1568,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::i
                         std::int64_t *ipiv, std::int64_t stride_ipiv, float *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                               stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                               scratchpad_size, dependencies);
@@ -1578,7 +1578,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::i
                         std::int64_t *ipiv, std::int64_t stride_ipiv, double *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                               stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                               scratchpad_size, dependencies);
@@ -1589,7 +1589,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::i
                         std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
                         std::int64_t batch_size, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                               stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                               scratchpad_size, dependencies);
@@ -1600,7 +1600,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::i
                         std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                         std::int64_t batch_size, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, stride_a, ipiv,
                                               stride_ipiv, b, ldb, stride_b, batch_size, scratchpad,
                                               scratchpad_size, dependencies);
@@ -1609,7 +1609,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::
                         std::int64_t *nrhs, float **a, std::int64_t *lda, std::int64_t **ipiv,
                         float **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                               group_count, group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1618,7 +1618,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::
                         std::int64_t *nrhs, double **a, std::int64_t *lda, std::int64_t **ipiv,
                         double **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                               group_count, group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1628,7 +1628,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::
                         std::int64_t **ipiv, std::complex<float> **b, std::int64_t *ldb,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                               group_count, group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1638,7 +1638,7 @@ sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::
                         std::int64_t **ipiv, std::complex<double> **b, std::int64_t *ldb,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs_batch(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                               group_count, group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1647,7 +1647,7 @@ sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         float *a, std::int64_t lda, std::int64_t stride_a, float *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1656,7 +1656,7 @@ sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         double *a, std::int64_t lda, std::int64_t stride_a, double *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1664,28 +1664,28 @@ sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
 sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, std::int64_t *k,
                         float **a, std::int64_t *lda, float **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, std::int64_t *k,
                         double **a, std::int64_t *lda, double **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, stride_a, batch_size,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, stride_a, batch_size,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1693,7 +1693,7 @@ sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t
                         std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t batch_size, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, stride_a, batch_size,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1701,21 +1701,21 @@ sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t
                         std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t batch_size, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, stride_a, batch_size,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n, float **a,
                         std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n, double **a,
                         std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1723,7 +1723,7 @@ sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_
                         std::complex<float> **a, std::int64_t *lda, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1731,7 +1731,7 @@ sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_
                         std::complex<double> **a, std::int64_t *lda, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf_batch(queue, uplo, n, a, lda, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1739,7 +1739,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t
                         std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t stride_a,
                         float *b, std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                               stride_b, batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1748,7 +1748,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t
                         std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t stride_a,
                         double *b, std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                               stride_b, batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1758,7 +1758,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t
                         std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                               stride_b, batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1768,7 +1768,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t
                         std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, stride_a, b, ldb,
                                               stride_b, batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1777,7 +1777,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_
                         std::int64_t *nrhs, float **a, std::int64_t *lda, float **b,
                         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_sizes,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, b, ldb, group_count,
                                               group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1786,7 +1786,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_
                         std::int64_t *nrhs, double **a, std::int64_t *lda, double **b,
                         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, b, ldb, group_count,
                                               group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1796,7 +1796,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_
                         std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, b, ldb, group_count,
                                               group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1806,7 +1806,7 @@ sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_
                         std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, a, lda, b, ldb, group_count,
                                               group_sizes, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1815,7 +1815,7 @@ sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
                         std::complex<float> *tau, std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1824,7 +1824,7 @@ sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std:
                         std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                         std::complex<double> *tau, std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                               batch_size, scratchpad, scratchpad_size,
                                               dependencies);
@@ -1833,7 +1833,7 @@ sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, st
                         std::complex<float> **a, std::int64_t *lda, std::complex<float> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }
@@ -1841,7 +1841,7 @@ sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, st
                         std::complex<double> **a, std::int64_t *lda, std::complex<double> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                               scratchpad, scratchpad_size, dependencies);
 }

--- a/src/lapack/backends/mkl_common/mkl_lapack.cxx
+++ b/src/lapack/backends/mkl_common/mkl_lapack.cxx
@@ -541,30 +541,26 @@ void unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, float *d, float *e, std::complex<float> *tauq,
                   std::complex<float> *taup, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *d, double *e, double *tauq, double *taup, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *d, float *e, float *tauq, float *taup, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, double *d, double *e, std::complex<double> *tauq,
                   std::complex<double> *taup, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -582,22 +578,19 @@ sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
 }
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -615,15 +608,13 @@ sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, 
 }
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -641,8 +632,7 @@ sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, 
 }
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -666,16 +656,14 @@ sycl::event getri(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda
 }
 sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs(queue, trans, n, nrhs, a, lda, ipiv, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -696,24 +684,21 @@ sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::getrs(queue, trans, n, nrhs, a, lda, ipiv, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, double *a, std::int64_t lda, double *s, double *u,
                   std::int64_t ldu, double *vt, std::int64_t ldvt, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gesvd(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, float *a, std::int64_t lda, float *s, float *u,
                   std::int64_t ldu, float *vt, std::int64_t ldvt, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::gesvd(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -766,16 +751,14 @@ sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
 sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, float *d, float *e,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hetrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, double *d, double *e,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::hetrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -795,15 +778,13 @@ sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
 }
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, float *a, std::int64_t lda, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, double *a, std::int64_t lda, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::orgbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -834,48 +815,42 @@ sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, do
 sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, float *a,
                   std::int64_t lda, float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, double *a,
                   std::int64_t lda, double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormrq(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormrq(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormqr(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ormqr(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -893,15 +868,13 @@ sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, do
 }
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrf(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -919,29 +892,25 @@ sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, do
 }
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potri(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potri(queue, uplo, n, a, lda, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   float *a, std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   double *a, std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -961,15 +930,13 @@ sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, st
 }
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   double *a, std::int64_t lda, double *w, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::syevd(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   float *a, std::int64_t lda, float *w, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::syevd(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -989,29 +956,25 @@ sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
 }
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *d, double *e, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *d, float *e, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrd(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::sytrf(queue, uplo, n, a, lda, ipiv, scratchpad, scratchpad_size,
                                         dependencies);
 }
@@ -1040,16 +1003,14 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, double *a,
                   std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::trtrs(queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                                         scratchpad, scratchpad_size, dependencies);
 }
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, float *a,
                   std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::trtrs(queue, uplo, trans, diag, n, nrhs, a, lda, b, ldb,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1064,16 +1025,14 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
 sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
 sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::ungbr(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                         scratchpad_size, dependencies);
 }
@@ -1141,8 +1100,7 @@ sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo 
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }
@@ -1150,8 +1108,7 @@ sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo 
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return ::oneapi::mkl::lapack::unmtr(queue, side, uplo, trans, m, n, a, lda, tau, c, ldc,
                                         scratchpad, scratchpad_size, dependencies);
 }

--- a/src/lapack/backends/mkl_common/mkl_lapack_backend.hpp
+++ b/src/lapack/backends/mkl_common/mkl_lapack_backend.hpp
@@ -475,21 +475,17 @@ void ungqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, float *d, float *e, std::complex<float> *tauq,
                   std::complex<float> *taup, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *d, double *e, double *tauq, double *taup, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *d, float *e, float *tauq, float *taup, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, double *d, double *e, std::complex<double> *tauq,
                   std::complex<double> *taup, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *tau, float *scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event> &dependencies = {});
@@ -498,16 +494,13 @@ sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *tau, double *scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event> &dependencies = {});
@@ -516,12 +509,10 @@ sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, 
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   std::int64_t *ipiv, double *scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event> &dependencies = {});
@@ -530,8 +521,7 @@ sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, 
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event> &dependencies = {});
@@ -543,13 +533,11 @@ sycl::event getri(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t *ipiv, double *b,
                   std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
@@ -561,18 +549,15 @@ sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, double *a, std::int64_t lda, double *s, double *u,
                   std::int64_t ldu, double *vt, std::int64_t ldvt, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, float *a, std::int64_t lda, float *s, float *u,
                   std::int64_t ldu, float *vt, std::int64_t ldvt, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   float *s, std::complex<float> *u, std::int64_t ldu, std::complex<float> *vt,
@@ -604,13 +589,11 @@ sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
 sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, float *d, float *e,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, double *d, double *e,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
@@ -621,12 +604,10 @@ sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, float *a, std::int64_t lda, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, double *a, std::int64_t lda, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                   std::int64_t lda, double *tau, double *scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event> &dependencies = {});
@@ -642,33 +623,27 @@ sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, do
 sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, float *a,
                   std::int64_t lda, float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, double *a,
                   std::int64_t lda, double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event> &dependencies = {});
@@ -677,12 +652,10 @@ sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, do
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event> &dependencies = {});
@@ -691,20 +664,16 @@ sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, do
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   float *a, std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   double *a, std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                   std::int64_t ldb, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
@@ -715,12 +684,10 @@ sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, st
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   double *a, std::int64_t lda, double *w, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   float *a, std::int64_t lda, float *w, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda, double *b,
                   std::int64_t ldb, double *w, double *scratchpad, std::int64_t scratchpad_size,
@@ -731,20 +698,16 @@ sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *d, double *e, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *d, float *e, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
@@ -761,13 +724,11 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, double *a,
                   std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, float *a,
                   std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
@@ -776,13 +737,11 @@ sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::trans
 sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
@@ -823,14 +782,12 @@ sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo 
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies = {});
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                         std::int64_t lda, std::int64_t stride_a, float *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, float *scratchpad,

--- a/src/lapack/backends/mkl_common/mkl_lapack_backend.hpp
+++ b/src/lapack/backends/mkl_common/mkl_lapack_backend.hpp
@@ -476,639 +476,639 @@ sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::compl
                   std::int64_t lda, float *d, float *e, std::complex<float> *tauq,
                   std::complex<float> *taup, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *d, double *e, double *tauq, double *taup, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *d, float *e, float *tauq, float *taup, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gebrd(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, double *d, double *e, std::complex<double> *tauq,
                   std::complex<double> *taup, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gerqf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                   std::int64_t *ipiv, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                   std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                   std::int64_t lda, std::int64_t *ipiv, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getri(sycl::queue &queue, std::int64_t n, double *a, std::int64_t lda,
                   std::int64_t *ipiv, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getri(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda,
                   std::int64_t *ipiv, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getri(sycl::queue &queue, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t *ipiv, double *b,
                   std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t *ipiv, float *b,
                   std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, double *a, std::int64_t lda, double *s, double *u,
                   std::int64_t ldu, double *vt, std::int64_t ldvt, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, float *a, std::int64_t lda, float *s, float *u,
                   std::int64_t ldu, float *vt, std::int64_t ldvt, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   float *s, std::complex<float> *u, std::int64_t ldu, std::complex<float> *vt,
                   std::int64_t ldvt, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event gesvd(sycl::queue &queue, oneapi::mkl::jobsvd jobu, oneapi::mkl::jobsvd jobvt,
                   std::int64_t m, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   double *s, std::complex<double> *u, std::int64_t ldu, std::complex<double> *vt,
                   std::int64_t ldvt, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, float *w,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event heevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, double *w,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *b, std::int64_t ldb, float *w,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event hegvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *b, std::int64_t ldb, double *w,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, float *d, float *e,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event hetrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, double *d, double *e,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event hetrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, float *a, std::int64_t lda, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event orgbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, double *a, std::int64_t lda, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, double *a,
                   std::int64_t lda, double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event orgqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k, float *a,
                   std::int64_t lda, float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event orgtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, float *a,
                   std::int64_t lda, float *tau, float *c, std::int64_t ldc, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ormtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, double *a,
                   std::int64_t lda, double *tau, double *c, std::int64_t ldc, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ormrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *c, std::int64_t ldc, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ormqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *c, std::int64_t ldc, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potri(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   float *a, std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   double *a, std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                   std::int64_t ldb, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                   std::int64_t ldb, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   double *a, std::int64_t lda, double *w, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event syevd(sycl::queue &queue, oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   float *a, std::int64_t lda, float *w, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda, double *b,
                   std::int64_t ldb, double *w, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sygvd(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda, float *b,
                   std::int64_t ldb, float *w, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *d, double *e, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrd(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *d, float *e, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event sytrf(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, double *a,
                   std::int64_t lda, double *b, std::int64_t ldb, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs, float *a,
                   std::int64_t lda, float *b, std::int64_t ldb, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event trtrs(sycl::queue &queue, oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                   oneapi::mkl::diag diag, std::int64_t n, std::int64_t nrhs,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                   std::int64_t ldb, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ungbr(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ungqr(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event ungtr(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *c,
                   std::int64_t ldc, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event unmrq(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *c,
                   std::int64_t ldc, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *c,
                   std::int64_t ldc, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event unmqr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *c,
                   std::int64_t ldc, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event unmtr(sycl::queue &queue, oneapi::mkl::side side, oneapi::mkl::uplo uplo,
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies = {});
+                  const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                         std::int64_t lda, std::int64_t stride_a, float *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                         std::int64_t lda, std::int64_t stride_a, double *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                         std::int64_t lda, std::int64_t stride_a, std::complex<float> *tau,
                         std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                         std::int64_t lda, std::int64_t stride_a, std::complex<double> *tau,
                         std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, float **a,
                         std::int64_t *lda, float **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, double **a,
                         std::int64_t *lda, double **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<float> **a, std::int64_t *lda, std::complex<float> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event geqrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<double> **a, std::int64_t *lda, std::complex<double> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, float **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, double **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<float> **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrf_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                         std::complex<double> **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t n, double *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::complex<float> *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t n, std::complex<double> *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, float **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::int64_t group_count, std::int64_t *group_sizes,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, double **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::complex<float> **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getri_batch(sycl::queue &queue, std::int64_t *n, std::complex<double> **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                         std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, float *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                         std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, double *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                         std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
                         std::int64_t batch_size, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                         std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                         std::int64_t batch_size, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n,
                         std::int64_t *nrhs, float **a, std::int64_t *lda, std::int64_t **ipiv,
                         float **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n,
                         std::int64_t *nrhs, double **a, std::int64_t *lda, std::int64_t **ipiv,
                         double **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n,
                         std::int64_t *nrhs, std::complex<float> **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::complex<float> **b, std::int64_t *ldb,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event getrs_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n,
                         std::int64_t *nrhs, std::complex<double> **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::complex<double> **b, std::int64_t *ldb,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                         float *a, std::int64_t lda, std::int64_t stride_a, float *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event orgqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                         double *a, std::int64_t lda, std::int64_t stride_a, double *tau,
                         std::int64_t stride_tau, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, std::int64_t *k,
                         float **a, std::int64_t *lda, float **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event orgqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, std::int64_t *k,
                         double **a, std::int64_t *lda, double **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                         std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t batch_size, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                         std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t batch_size, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n, float **a,
                         std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n, double **a,
                         std::int64_t *lda, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                         std::complex<float> **a, std::int64_t *lda, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrf_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                         std::complex<double> **a, std::int64_t *lda, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                         std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t stride_a,
                         float *b, std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                         std::int64_t nrhs, double *a, std::int64_t lda, std::int64_t stride_a,
                         double *b, std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                         std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                         std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                         std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                         std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                         std::int64_t *nrhs, float **a, std::int64_t *lda, float **b,
                         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_sizes,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                         std::int64_t *nrhs, double **a, std::int64_t *lda, double **b,
                         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                         std::int64_t *nrhs, std::complex<float> **a, std::int64_t *lda,
                         std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event potrs_batch(sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n,
                         std::int64_t *nrhs, std::complex<double> **a, std::int64_t *lda,
                         std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                         std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
                         std::complex<float> *tau, std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event ungqr_batch(sycl::queue &queue, std::int64_t m, std::int64_t n, std::int64_t k,
                         std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                         std::complex<double> *tau, std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, std::int64_t *k,
                         std::complex<float> **a, std::int64_t *lda, std::complex<float> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 sycl::event ungqr_batch(sycl::queue &queue, std::int64_t *m, std::int64_t *n, std::int64_t *k,
                         std::complex<double> **a, std::int64_t *lda, std::complex<double> **tau,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies = {});
+                        const std::vector<sycl::event> &dependencies = {});
 
 template <typename fp_type, internal::is_floating_point<fp_type> = nullptr>
 std::int64_t gebrd_scratchpad_size(sycl::queue &queue, std::int64_t m, std::int64_t n,

--- a/src/lapack/function_table.hpp
+++ b/src/lapack/function_table.hpp
@@ -432,426 +432,426 @@ typedef struct {
                                    std::complex<float> *a, std::int64_t lda, float *d, float *e,
                                    std::complex<float> *tauq, std::complex<float> *taup,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dgebrd_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                    std::int64_t lda, double *d, double *e, double *tauq,
                                    double *taup, double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sgebrd_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                    std::int64_t lda, float *d, float *e, float *tauq, float *taup,
                                    float *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zgebrd_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda, double *d, double *e,
                                    std::complex<double> *tauq, std::complex<double> *taup,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sgerqf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                    std::int64_t lda, float *tau, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dgerqf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                    std::int64_t lda, double *tau, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cgerqf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *tau, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zgerqf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *tau, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cgeqrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *tau, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dgeqrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                    std::int64_t lda, double *tau, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sgeqrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                    std::int64_t lda, float *tau, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zgeqrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *tau, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, double *a,
                                    std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n, float *a,
                                    std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetrf_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetri_usm_sycl)(sycl::queue &queue, std::int64_t n, std::complex<float> *a,
                                    std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetri_usm_sycl)(sycl::queue &queue, std::int64_t n, double *a, std::int64_t lda,
                                    std::int64_t *ipiv, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetri_usm_sycl)(sycl::queue &queue, std::int64_t n, float *a, std::int64_t lda,
                                    std::int64_t *ipiv, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetri_usm_sycl)(sycl::queue &queue, std::int64_t n, std::complex<double> *a,
                                    std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                    std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                                    std::int64_t *ipiv, std::complex<float> *b, std::int64_t ldb,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                    std::int64_t nrhs, double *a, std::int64_t lda,
                                    std::int64_t *ipiv, double *b, std::int64_t ldb,
                                    double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                    std::int64_t nrhs, float *a, std::int64_t lda,
                                    std::int64_t *ipiv, float *b, std::int64_t ldb,
                                    float *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n,
                                    std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                                    std::int64_t *ipiv, std::complex<double> *b, std::int64_t ldb,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dgesvd_usm_sycl)(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                    oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n,
                                    double *a, std::int64_t lda, double *s, double *u,
                                    std::int64_t ldu, double *vt, std::int64_t ldvt,
                                    double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sgesvd_usm_sycl)(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                    oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n,
                                    float *a, std::int64_t lda, float *s, float *u, std::int64_t ldu,
                                    float *vt, std::int64_t ldvt, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cgesvd_usm_sycl)(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                    oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda, float *s,
                                    std::complex<float> *u, std::int64_t ldu,
                                    std::complex<float> *vt, std::int64_t ldvt,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zgesvd_usm_sycl)(sycl::queue &queue, oneapi::mkl::jobsvd jobu,
                                    oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda, double *s,
                                    std::complex<double> *u, std::int64_t ldu,
                                    std::complex<double> *vt, std::int64_t ldvt,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cheevd_usm_sycl)(sycl::queue &queue, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                    std::int64_t lda, float *w, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zheevd_usm_sycl)(sycl::queue &queue, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                    std::int64_t lda, double *w, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*chegvd_usm_sycl)(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a,
                                    std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                                    float *w, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zhegvd_usm_sycl)(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a,
                                    std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                                    double *w, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*chetrd_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda, float *d, float *e,
                                    std::complex<float> *tau, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zhetrd_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda, double *d, double *e,
                                    std::complex<double> *tau, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*chetrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zhetrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sorgbr_usm_sycl)(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                    std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                                    float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dorgbr_usm_sycl)(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                    std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                                    double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dorgqr_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::int64_t k, double *a, std::int64_t lda, double *tau,
                                    double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sorgqr_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::int64_t k, float *a, std::int64_t lda, float *tau,
                                    float *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sorgtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    float *a, std::int64_t lda, float *tau, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dorgtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    double *a, std::int64_t lda, double *tau, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sormtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                    std::int64_t m, std::int64_t n, float *a, std::int64_t lda,
                                    float *tau, float *c, std::int64_t ldc, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dormtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                    std::int64_t m, std::int64_t n, double *a, std::int64_t lda,
                                    double *tau, double *c, std::int64_t ldc, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sormrq_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, float *a, std::int64_t lda, float *tau, float *c,
                                    std::int64_t ldc, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dormrq_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, double *a, std::int64_t lda, double *tau,
                                    double *c, std::int64_t ldc, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dormqr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, double *a, std::int64_t lda, double *tau,
                                    double *c, std::int64_t ldc, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*sormqr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, float *a, std::int64_t lda, float *tau, float *c,
                                    std::int64_t ldc, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*spotrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    float *a, std::int64_t lda, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dpotrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    double *a, std::int64_t lda, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cpotrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zpotrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*spotri_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    float *a, std::int64_t lda, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dpotri_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    double *a, std::int64_t lda, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cpotri_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zpotri_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*spotrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::int64_t nrhs, float *a, std::int64_t lda, float *b,
                                    std::int64_t ldb, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dpotrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::int64_t nrhs, double *a, std::int64_t lda, double *b,
                                    std::int64_t ldb, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cpotrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *b, std::int64_t ldb,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zpotrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *b, std::int64_t ldb,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dsyevd_usm_sycl)(sycl::queue &queue, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                                    std::int64_t lda, double *w, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*ssyevd_usm_sycl)(sycl::queue &queue, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                                    std::int64_t lda, float *w, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dsygvd_usm_sycl)(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                                    std::int64_t lda, double *b, std::int64_t ldb, double *w,
                                    double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*ssygvd_usm_sycl)(sycl::queue &queue, std::int64_t itype, oneapi::mkl::job jobz,
                                    oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                                    std::int64_t lda, float *b, std::int64_t ldb, float *w,
                                    float *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dsytrd_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    double *a, std::int64_t lda, double *d, double *e, double *tau,
                                    double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*ssytrd_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    float *a, std::int64_t lda, float *d, float *e, float *tau,
                                    float *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*ssytrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    float *a, std::int64_t lda, std::int64_t *ipiv,
                                    float *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dsytrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    double *a, std::int64_t lda, std::int64_t *ipiv,
                                    double *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*csytrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zsytrf_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*ctrtrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                    oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                    std::int64_t n, std::int64_t nrhs, std::complex<float> *a,
                                    std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*dtrtrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                    oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                    std::int64_t n, std::int64_t nrhs, double *a, std::int64_t lda,
                                    double *b, std::int64_t ldb, double *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*strtrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                    oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                    std::int64_t n, std::int64_t nrhs, float *a, std::int64_t lda,
                                    float *b, std::int64_t ldb, float *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*ztrtrs_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo,
                                    oneapi::mkl::transpose trans, oneapi::mkl::diag diag,
                                    std::int64_t n, std::int64_t nrhs, std::complex<double> *a,
                                    std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cungbr_usm_sycl)(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                    std::int64_t n, std::int64_t k, std::complex<float> *a,
                                    std::int64_t lda, std::complex<float> *tau,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zungbr_usm_sycl)(sycl::queue &queue, oneapi::mkl::generate vec, std::int64_t m,
                                    std::int64_t n, std::int64_t k, std::complex<double> *a,
                                    std::int64_t lda, std::complex<double> *tau,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cungqr_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *tau, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zungqr_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                    std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *tau, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cungtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *tau, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zungtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                    std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *tau, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cunmrq_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *tau, std::complex<float> *c,
                                    std::int64_t ldc, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zunmrq_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *tau, std::complex<double> *c,
                                    std::int64_t ldc, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cunmqr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                    std::complex<float> *tau, std::complex<float> *c,
                                    std::int64_t ldc, std::complex<float> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zunmqr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                                    std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                    std::complex<double> *tau, std::complex<double> *c,
                                    std::int64_t ldc, std::complex<double> *scratchpad,
                                    std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*cunmtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                    std::int64_t m, std::int64_t n, std::complex<float> *a,
                                    std::int64_t lda, std::complex<float> *tau,
                                    std::complex<float> *c, std::int64_t ldc,
                                    std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     sycl::event (*zunmtr_usm_sycl)(sycl::queue &queue, oneapi::mkl::side side,
                                    oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans,
                                    std::int64_t m, std::int64_t n, std::complex<double> *a,
                                    std::int64_t lda, std::complex<double> *tau,
                                    std::complex<double> *c, std::int64_t ldc,
                                    std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                                   const sycl::vector_class<sycl::event> &dependencies);
+                                   const std::vector<sycl::event> &dependencies);
     void (*sgeqrf_batch_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                               sycl::buffer<float> &a, std::int64_t lda, std::int64_t stride_a,
                               sycl::buffer<float> &tau, std::int64_t stride_tau,
@@ -1015,78 +1015,78 @@ typedef struct {
                                          float *tau, std::int64_t stride_tau,
                                          std::int64_t batch_size, float *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgeqrf_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          double *a, std::int64_t lda, std::int64_t stride_a,
                                          double *tau, std::int64_t stride_tau,
                                          std::int64_t batch_size, double *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgeqrf_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::complex<float> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::complex<float> *tau,
                                          std::int64_t stride_tau, std::int64_t batch_size,
                                          std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zgeqrf_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::complex<double> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::complex<double> *tau,
                                          std::int64_t stride_tau, std::int64_t batch_size,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetrf_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          float *a, std::int64_t lda, std::int64_t stride_a,
                                          std::int64_t *ipiv, std::int64_t stride_ipiv,
                                          std::int64_t batch_size, float *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetrf_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          double *a, std::int64_t lda, std::int64_t stride_a,
                                          std::int64_t *ipiv, std::int64_t stride_ipiv,
                                          std::int64_t batch_size, double *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetrf_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::complex<float> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::int64_t *ipiv,
                                          std::int64_t stride_ipiv, std::int64_t batch_size,
                                          std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetrf_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::complex<double> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::int64_t *ipiv,
                                          std::int64_t stride_ipiv, std::int64_t batch_size,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetri_batch_usm_sycl)(sycl::queue &queue, std::int64_t n, float *a,
                                          std::int64_t lda, std::int64_t stride_a,
                                          std::int64_t *ipiv, std::int64_t stride_ipiv,
                                          std::int64_t batch_size, float *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetri_batch_usm_sycl)(sycl::queue &queue, std::int64_t n, double *a,
                                          std::int64_t lda, std::int64_t stride_a,
                                          std::int64_t *ipiv, std::int64_t stride_ipiv,
                                          std::int64_t batch_size, double *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetri_batch_usm_sycl)(sycl::queue &queue, std::int64_t n, std::complex<float> *a,
                                          std::int64_t lda, std::int64_t stride_a,
                                          std::int64_t *ipiv, std::int64_t stride_ipiv,
                                          std::int64_t batch_size, std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetri_batch_usm_sycl)(sycl::queue &queue, std::int64_t n,
                                          std::complex<double> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::int64_t *ipiv,
                                          std::int64_t stride_ipiv, std::int64_t batch_size,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetrs_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose trans,
                                          std::int64_t n, std::int64_t nrhs, float *a,
                                          std::int64_t lda, std::int64_t stride_a,
@@ -1094,7 +1094,7 @@ typedef struct {
                                          std::int64_t ldb, std::int64_t stride_b,
                                          std::int64_t batch_size, float *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetrs_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose trans,
                                          std::int64_t n, std::int64_t nrhs, double *a,
                                          std::int64_t lda, std::int64_t stride_a,
@@ -1102,65 +1102,65 @@ typedef struct {
                                          std::int64_t ldb, std::int64_t stride_b,
                                          std::int64_t batch_size, double *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetrs_batch_usm_sycl)(
         sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
         std::complex<float> *a, std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
         std::int64_t stride_ipiv, std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
         std::int64_t batch_size, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-        const sycl::vector_class<sycl::event> &dependencies);
+        const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetrs_batch_usm_sycl)(
         sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t n, std::int64_t nrhs,
         std::complex<double> *a, std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
         std::int64_t stride_ipiv, std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
         std::int64_t batch_size, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-        const sycl::vector_class<sycl::event> &dependencies);
+        const std::vector<sycl::event> &dependencies);
     sycl::event (*sorgqr_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::int64_t k, float *a, std::int64_t lda,
                                          std::int64_t stride_a, float *tau, std::int64_t stride_tau,
                                          std::int64_t batch_size, float *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dorgqr_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::int64_t k, double *a, std::int64_t lda,
                                          std::int64_t stride_a, double *tau,
                                          std::int64_t stride_tau, std::int64_t batch_size,
                                          double *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*spotrf_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          float *a, std::int64_t lda, std::int64_t stride_a,
                                          std::int64_t batch_size, float *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dpotrf_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          double *a, std::int64_t lda, std::int64_t stride_a,
                                          std::int64_t batch_size, double *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cpotrf_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          std::complex<float> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::int64_t batch_size,
                                          std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zpotrf_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          std::complex<double> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::int64_t batch_size,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*spotrs_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          std::int64_t nrhs, float *a, std::int64_t lda,
                                          std::int64_t stride_a, float *b, std::int64_t ldb,
                                          std::int64_t stride_b, std::int64_t batch_size,
                                          float *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dpotrs_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          std::int64_t nrhs, double *a, std::int64_t lda,
                                          std::int64_t stride_a, double *b, std::int64_t ldb,
                                          std::int64_t stride_b, std::int64_t batch_size,
                                          double *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cpotrs_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          std::int64_t nrhs, std::complex<float> *a,
                                          std::int64_t lda, std::int64_t stride_a,
@@ -1168,7 +1168,7 @@ typedef struct {
                                          std::int64_t stride_b, std::int64_t batch_size,
                                          std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zpotrs_batch_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo uplo, std::int64_t n,
                                          std::int64_t nrhs, std::complex<double> *a,
                                          std::int64_t lda, std::int64_t stride_a,
@@ -1176,104 +1176,104 @@ typedef struct {
                                          std::int64_t stride_b, std::int64_t batch_size,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cungqr_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::int64_t k, std::complex<float> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::complex<float> *tau,
                                          std::int64_t stride_tau, std::int64_t batch_size,
                                          std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zungqr_batch_usm_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                          std::int64_t k, std::complex<double> *a, std::int64_t lda,
                                          std::int64_t stride_a, std::complex<double> *tau,
                                          std::int64_t stride_tau, std::int64_t batch_size,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*sgeqrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          float **a, std::int64_t *lda, float **tau,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          float *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgeqrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          double **a, std::int64_t *lda, double **tau,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          double *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgeqrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::complex<float> **a, std::int64_t *lda,
                                          std::complex<float> **tau, std::int64_t group_count,
                                          std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zgeqrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::complex<double> **a, std::int64_t *lda,
                                          std::complex<double> **tau, std::int64_t group_count,
                                          std::int64_t *group_sizes,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          float **a, std::int64_t *lda, std::int64_t **ipiv,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          float *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          double **a, std::int64_t *lda, std::int64_t **ipiv,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          double *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::complex<float> **a, std::int64_t *lda,
                                          std::int64_t **ipiv, std::int64_t group_count,
                                          std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetrf_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::complex<double> **a, std::int64_t *lda,
                                          std::int64_t **ipiv, std::int64_t group_count,
                                          std::int64_t *group_sizes,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetri_group_usm_sycl)(sycl::queue &queue, std::int64_t *n, float **a,
                                          std::int64_t *lda, std::int64_t **ipiv,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          float *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetri_group_usm_sycl)(sycl::queue &queue, std::int64_t *n, double **a,
                                          std::int64_t *lda, std::int64_t **ipiv,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          double *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetri_group_usm_sycl)(sycl::queue &queue, std::int64_t *n,
                                          std::complex<float> **a, std::int64_t *lda,
                                          std::int64_t **ipiv, std::int64_t group_count,
                                          std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetri_group_usm_sycl)(sycl::queue &queue, std::int64_t *n,
                                          std::complex<double> **a, std::int64_t *lda,
                                          std::int64_t **ipiv, std::int64_t group_count,
                                          std::int64_t *group_sizes,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*sgetrs_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose *trans,
                                          std::int64_t *n, std::int64_t *nrhs, float **a,
                                          std::int64_t *lda, std::int64_t **ipiv, float **b,
                                          std::int64_t *ldb, std::int64_t group_count,
                                          std::int64_t *group_sizes, float *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dgetrs_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose *trans,
                                          std::int64_t *n, std::int64_t *nrhs, double **a,
                                          std::int64_t *lda, std::int64_t **ipiv, double **b,
                                          std::int64_t *ldb, std::int64_t group_count,
                                          std::int64_t *group_sizes, double *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cgetrs_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::transpose *trans,
                                          std::int64_t *n, std::int64_t *nrhs,
                                          std::complex<float> **a, std::int64_t *lda,
@@ -1281,83 +1281,83 @@ typedef struct {
                                          std::int64_t *ldb, std::int64_t group_count,
                                          std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zgetrs_group_usm_sycl)(
         sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *n, std::int64_t *nrhs,
         std::complex<double> **a, std::int64_t *lda, std::int64_t **ipiv, std::complex<double> **b,
         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_sizes,
         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-        const sycl::vector_class<sycl::event> &dependencies);
+        const std::vector<sycl::event> &dependencies);
     sycl::event (*sorgqr_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::int64_t *k, float **a, std::int64_t *lda, float **tau,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          float *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dorgqr_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::int64_t *k, double **a, std::int64_t *lda,
                                          double **tau, std::int64_t group_count,
                                          std::int64_t *group_sizes, double *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*spotrf_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo *uplo,
                                          std::int64_t *n, float **a, std::int64_t *lda,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          float *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dpotrf_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo *uplo,
                                          std::int64_t *n, double **a, std::int64_t *lda,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          double *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cpotrf_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo *uplo,
                                          std::int64_t *n, std::complex<float> **a,
                                          std::int64_t *lda, std::int64_t group_count,
                                          std::int64_t *group_sizes, std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zpotrf_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo *uplo,
                                          std::int64_t *n, std::complex<double> **a,
                                          std::int64_t *lda, std::int64_t group_count,
                                          std::int64_t *group_sizes,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*spotrs_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo *uplo,
                                          std::int64_t *n, std::int64_t *nrhs, float **a,
                                          std::int64_t *lda, float **b, std::int64_t *ldb,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          float *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*dpotrs_group_usm_sycl)(sycl::queue &queue, oneapi::mkl::uplo *uplo,
                                          std::int64_t *n, std::int64_t *nrhs, double **a,
                                          std::int64_t *lda, double **b, std::int64_t *ldb,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          double *scratchpad, std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*cpotrs_group_usm_sycl)(
         sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n, std::int64_t *nrhs,
         std::complex<float> **a, std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb,
         std::int64_t group_count, std::int64_t *group_sizes, std::complex<float> *scratchpad,
-        std::int64_t scratchpad_size, const sycl::vector_class<sycl::event> &dependencies);
+        std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies);
     sycl::event (*zpotrs_group_usm_sycl)(
         sycl::queue &queue, oneapi::mkl::uplo *uplo, std::int64_t *n, std::int64_t *nrhs,
         std::complex<double> **a, std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb,
         std::int64_t group_count, std::int64_t *group_sizes, std::complex<double> *scratchpad,
-        std::int64_t scratchpad_size, const sycl::vector_class<sycl::event> &dependencies);
+        std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies);
     sycl::event (*cungqr_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::int64_t *k, std::complex<float> **a,
                                          std::int64_t *lda, std::complex<float> **tau,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          std::complex<float> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
     sycl::event (*zungqr_group_usm_sycl)(sycl::queue &queue, std::int64_t *m, std::int64_t *n,
                                          std::int64_t *k, std::complex<double> **a,
                                          std::int64_t *lda, std::complex<double> **tau,
                                          std::int64_t group_count, std::int64_t *group_sizes,
                                          std::complex<double> *scratchpad,
                                          std::int64_t scratchpad_size,
-                                         const sycl::vector_class<sycl::event> &dependencies);
+                                         const std::vector<sycl::event> &dependencies);
 
     std::int64_t (*sgebrd_scratchpad_size_sycl)(sycl::queue &queue, std::int64_t m, std::int64_t n,
                                                 std::int64_t lda);

--- a/src/lapack/lapack_loader.cpp
+++ b/src/lapack/lapack_loader.cpp
@@ -629,15 +629,13 @@ sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m
 }
 sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   float *a, std::int64_t lda, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgerqf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   double *a, std::int64_t lda, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgerqf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -664,15 +662,13 @@ sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m
 }
 sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   double *a, std::int64_t lda, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgeqrf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   float *a, std::int64_t lda, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgeqrf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -692,15 +688,13 @@ sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m
 }
 sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   double *a, std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrf_usm_sycl(queue, m, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetrf_usm_sycl(queue, m, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -720,15 +714,13 @@ sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n
 }
 sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n, double *a,
                   std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetri_usm_sycl(queue, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n, float *a,
                   std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetri_usm_sycl(queue, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -750,8 +742,7 @@ sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::t
 sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans,
                   std::int64_t n, std::int64_t nrhs, double *a, std::int64_t lda,
                   std::int64_t *ipiv, double *b, std::int64_t ldb, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrs_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -790,8 +781,7 @@ sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::j
                   oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n, std::complex<float> *a,
                   std::int64_t lda, float *s, std::complex<float> *u, std::int64_t ldu,
                   std::complex<float> *vt, std::int64_t ldvt, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgesvd_usm_sycl(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                                                    ldvt, scratchpad, scratchpad_size, dependencies);
 }
@@ -822,8 +812,7 @@ sycl::event hegvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t i
                   oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                   std::int64_t ldb, float *w, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].chegvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -831,24 +820,21 @@ sycl::event hegvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t i
                   oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                   std::int64_t ldb, double *w, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zhegvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event hetrd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<float> *a, std::int64_t lda, float *d, float *e,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].chetrd_usm_sycl(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event hetrd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<double> *a, std::int64_t lda, double *d, double *e,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zhetrd_usm_sycl(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -882,29 +868,25 @@ sycl::event orgbr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::g
 }
 sycl::event orgqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::int64_t k, double *a, std::int64_t lda, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dorgqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::int64_t k, float *a, std::int64_t lda, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sorgqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, float *tau, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sorgtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, double *tau, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dorgtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -958,15 +940,13 @@ sycl::event ormqr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
 }
 sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotrf_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotrf_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -986,15 +966,13 @@ sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
 }
 sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotri_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotri_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1029,16 +1007,14 @@ sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
 sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotrs_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotrs_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1059,16 +1035,14 @@ sycl::event syevd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::j
 sycl::event sygvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype,
                   oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *b, std::int64_t ldb, double *w, double *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dsygvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event sygvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t itype,
                   oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *b, std::int64_t ldb, float *w, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ssygvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1088,8 +1062,7 @@ sycl::event sytrd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
 }
 sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ssytrf_usm_sycl(queue, uplo, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1118,8 +1091,7 @@ sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   oneapi::mkl::transpose trans, oneapi::mkl::diag diag, std::int64_t n,
                   std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ctrtrs_usm_sycl(queue, uplo, trans, diag, n, nrhs, a, lda, b,
                                                    ldb, scratchpad, scratchpad_size, dependencies);
 }
@@ -1143,56 +1115,49 @@ sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   oneapi::mkl::transpose trans, oneapi::mkl::diag diag, std::int64_t n,
                   std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ztrtrs_usm_sycl(queue, uplo, trans, diag, n, nrhs, a, lda, b,
                                                    ldb, scratchpad, scratchpad_size, dependencies);
 }
 sycl::event ungbr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::generate vec,
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungbr_usm_sycl(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event ungbr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::generate vec,
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungbr_usm_sycl(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event ungqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event ungqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::int64_t k, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event ungtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event ungtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1200,8 +1165,7 @@ sycl::event unmrq(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cunmrq_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1209,8 +1173,7 @@ sycl::event unmrq(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zunmrq_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1218,8 +1181,7 @@ sycl::event unmqr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cunmqr_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1227,8 +1189,7 @@ sycl::event unmqr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
-                  std::int64_t scratchpad_size,
-                  const std::vector<sycl::event> &dependencies) {
+                  std::int64_t scratchpad_size, const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zunmqr_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }

--- a/src/lapack/lapack_loader.cpp
+++ b/src/lapack/lapack_loader.cpp
@@ -601,21 +601,21 @@ sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m
                   std::complex<float> *a, std::int64_t lda, float *d, float *e,
                   std::complex<float> *tauq, std::complex<float> *taup,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgebrd_usm_sycl(queue, m, n, a, lda, d, e, tauq, taup,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   double *a, std::int64_t lda, double *d, double *e, double *tauq, double *taup,
                   double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgebrd_usm_sycl(queue, m, n, a, lda, d, e, tauq, taup,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   float *a, std::int64_t lda, float *d, float *e, float *tauq, float *taup,
                   float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgebrd_usm_sycl(queue, m, n, a, lda, d, e, tauq, taup,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -623,119 +623,119 @@ sycl::event gebrd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m
                   std::complex<double> *a, std::int64_t lda, double *d, double *e,
                   std::complex<double> *tauq, std::complex<double> *taup,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgebrd_usm_sycl(queue, m, n, a, lda, d, e, tauq, taup,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   float *a, std::int64_t lda, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgerqf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   double *a, std::int64_t lda, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgerqf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgerqf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event gerqf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgerqf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgeqrf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   double *a, std::int64_t lda, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgeqrf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   float *a, std::int64_t lda, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgeqrf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event geqrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgeqrf_usm_sycl(queue, m, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetrf_usm_sycl(queue, m, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   double *a, std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrf_usm_sycl(queue, m, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetrf_usm_sycl(queue, m, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getrf(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetrf_usm_sycl(queue, m, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n,
                   std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetri_usm_sycl(queue, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n, double *a,
                   std::int64_t lda, std::int64_t *ipiv, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetri_usm_sycl(queue, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n, float *a,
                   std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetri_usm_sycl(queue, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event getri(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t n,
                   std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetri_usm_sycl(queue, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -743,7 +743,7 @@ sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::t
                   std::int64_t n, std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<float> *b, std::int64_t ldb,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetrs_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -751,14 +751,14 @@ sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::t
                   std::int64_t n, std::int64_t nrhs, double *a, std::int64_t lda,
                   std::int64_t *ipiv, double *b, std::int64_t ldb, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrs_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::transpose trans,
                   std::int64_t n, std::int64_t nrhs, float *a, std::int64_t lda, std::int64_t *ipiv,
                   float *b, std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetrs_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -766,7 +766,7 @@ sycl::event getrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::t
                   std::int64_t n, std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                   std::int64_t *ipiv, std::complex<double> *b, std::int64_t ldb,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetrs_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b, ldb,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -774,7 +774,7 @@ sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::j
                   oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n, double *a,
                   std::int64_t lda, double *s, double *u, std::int64_t ldu, double *vt,
                   std::int64_t ldvt, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgesvd_usm_sycl(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                                                    ldvt, scratchpad, scratchpad_size, dependencies);
 }
@@ -782,7 +782,7 @@ sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::j
                   oneapi::mkl::jobsvd jobvt, std::int64_t m, std::int64_t n, float *a,
                   std::int64_t lda, float *s, float *u, std::int64_t ldu, float *vt,
                   std::int64_t ldvt, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgesvd_usm_sycl(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                                                    ldvt, scratchpad, scratchpad_size, dependencies);
 }
@@ -791,7 +791,7 @@ sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::j
                   std::int64_t lda, float *s, std::complex<float> *u, std::int64_t ldu,
                   std::complex<float> *vt, std::int64_t ldvt, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgesvd_usm_sycl(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                                                    ldvt, scratchpad, scratchpad_size, dependencies);
 }
@@ -800,21 +800,21 @@ sycl::event gesvd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::j
                   std::complex<double> *a, std::int64_t lda, double *s, std::complex<double> *u,
                   std::int64_t ldu, std::complex<double> *vt, std::int64_t ldvt,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgesvd_usm_sycl(queue, jobu, jobvt, m, n, a, lda, s, u, ldu, vt,
                                                    ldvt, scratchpad, scratchpad_size, dependencies);
 }
 sycl::event heevd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   float *w, std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cheevd_usm_sycl(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event heevd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   double *w, std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zheevd_usm_sycl(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -823,7 +823,7 @@ sycl::event hegvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t i
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *b,
                   std::int64_t ldb, float *w, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].chegvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -832,7 +832,7 @@ sycl::event hegvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t i
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *b,
                   std::int64_t ldb, double *w, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zhegvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -840,7 +840,7 @@ sycl::event hetrd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t n, std::complex<float> *a, std::int64_t lda, float *d, float *e,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].chetrd_usm_sycl(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -848,63 +848,63 @@ sycl::event hetrd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t n, std::complex<double> *a, std::int64_t lda, double *d, double *e,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zhetrd_usm_sycl(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event hetrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].chetrf_usm_sycl(queue, uplo, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event hetrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zhetrf_usm_sycl(queue, uplo, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgbr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::generate vec,
                   std::int64_t m, std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                   float *tau, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sorgbr_usm_sycl(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgbr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::generate vec,
                   std::int64_t m, std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                   double *tau, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dorgbr_usm_sycl(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::int64_t k, double *a, std::int64_t lda, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dorgqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m, std::int64_t n,
                   std::int64_t k, float *a, std::int64_t lda, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sorgqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, float *tau, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sorgtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event orgtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, double *tau, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dorgtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -912,7 +912,7 @@ sycl::event ormtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans, std::int64_t m,
                   std::int64_t n, float *a, std::int64_t lda, float *tau, float *c,
                   std::int64_t ldc, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sormtr_usm_sycl(queue, side, uplo, trans, m, n, a, lda, tau, c,
                                                    ldc, scratchpad, scratchpad_size, dependencies);
 }
@@ -920,7 +920,7 @@ sycl::event ormtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::uplo uplo, oneapi::mkl::transpose trans, std::int64_t m,
                   std::int64_t n, double *a, std::int64_t lda, double *tau, double *c,
                   std::int64_t ldc, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dormtr_usm_sycl(queue, side, uplo, trans, m, n, a, lda, tau, c,
                                                    ldc, scratchpad, scratchpad_size, dependencies);
 }
@@ -928,7 +928,7 @@ sycl::event ormrq(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   float *a, std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                   float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sormrq_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -936,7 +936,7 @@ sycl::event ormrq(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   double *a, std::int64_t lda, double *tau, double *c, std::int64_t ldc,
                   double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dormrq_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -944,7 +944,7 @@ sycl::event ormqr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   double *a, std::int64_t lda, double *tau, double *c, std::int64_t ldc,
                   double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dormqr_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -952,77 +952,77 @@ sycl::event ormqr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n, std::int64_t k,
                   float *a, std::int64_t lda, float *tau, float *c, std::int64_t ldc,
                   float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sormqr_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotrf_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotrf_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotrf_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotrf_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotri_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotri_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotri_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potri(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotri_usm_sycl(queue, uplo, n, a, lda, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::int64_t nrhs, float *a, std::int64_t lda, float *b,
                   std::int64_t ldb, float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotrs_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::int64_t nrhs, double *a, std::int64_t lda, double *b,
                   std::int64_t ldb, double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotrs_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1030,7 +1030,7 @@ sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t n, std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotrs_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1038,21 +1038,21 @@ sycl::event potrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t n, std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotrs_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event syevd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, double *a, std::int64_t lda, double *w,
                   double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dsyevd_usm_sycl(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event syevd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::job jobz,
                   oneapi::mkl::uplo uplo, std::int64_t n, float *a, std::int64_t lda, float *w,
                   float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ssyevd_usm_sycl(queue, jobz, uplo, n, a, lda, w, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1060,7 +1060,7 @@ sycl::event sygvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t i
                   oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n, double *a,
                   std::int64_t lda, double *b, std::int64_t ldb, double *w, double *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dsygvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1068,49 +1068,49 @@ sycl::event sygvd(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t i
                   oneapi::mkl::job jobz, oneapi::mkl::uplo uplo, std::int64_t n, float *a,
                   std::int64_t lda, float *b, std::int64_t ldb, float *w, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ssygvd_usm_sycl(queue, itype, jobz, uplo, n, a, lda, b, ldb, w,
                                                    scratchpad, scratchpad_size, dependencies);
 }
 sycl::event sytrd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, double *d, double *e, double *tau,
                   double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dsytrd_usm_sycl(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event sytrd(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, float *d, float *e, float *tau,
                   float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ssytrd_usm_sycl(queue, uplo, n, a, lda, d, e, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, float *a, std::int64_t lda, std::int64_t *ipiv, float *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ssytrf_usm_sycl(queue, uplo, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, double *a, std::int64_t lda, std::int64_t *ipiv,
                   double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dsytrf_usm_sycl(queue, uplo, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<float> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].csytrf_usm_sycl(queue, uplo, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
 sycl::event sytrf(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                   std::int64_t n, std::complex<double> *a, std::int64_t lda, std::int64_t *ipiv,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zsytrf_usm_sycl(queue, uplo, n, a, lda, ipiv, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1119,7 +1119,7 @@ sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t nrhs, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *b, std::int64_t ldb, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ctrtrs_usm_sycl(queue, uplo, trans, diag, n, nrhs, a, lda, b,
                                                    ldb, scratchpad, scratchpad_size, dependencies);
 }
@@ -1127,7 +1127,7 @@ sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   oneapi::mkl::transpose trans, oneapi::mkl::diag diag, std::int64_t n,
                   std::int64_t nrhs, double *a, std::int64_t lda, double *b, std::int64_t ldb,
                   double *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dtrtrs_usm_sycl(queue, uplo, trans, diag, n, nrhs, a, lda, b,
                                                    ldb, scratchpad, scratchpad_size, dependencies);
 }
@@ -1135,7 +1135,7 @@ sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   oneapi::mkl::transpose trans, oneapi::mkl::diag diag, std::int64_t n,
                   std::int64_t nrhs, float *a, std::int64_t lda, float *b, std::int64_t ldb,
                   float *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].strtrs_usm_sycl(queue, uplo, trans, diag, n, nrhs, a, lda, b,
                                                    ldb, scratchpad, scratchpad_size, dependencies);
 }
@@ -1144,7 +1144,7 @@ sycl::event trtrs(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t nrhs, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *b, std::int64_t ldb, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].ztrtrs_usm_sycl(queue, uplo, trans, diag, n, nrhs, a, lda, b,
                                                    ldb, scratchpad, scratchpad_size, dependencies);
 }
@@ -1152,7 +1152,7 @@ sycl::event ungbr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::g
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> *a,
                   std::int64_t lda, std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungbr_usm_sycl(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1160,7 +1160,7 @@ sycl::event ungbr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::g
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> *a,
                   std::int64_t lda, std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungbr_usm_sycl(queue, vec, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1168,7 +1168,7 @@ sycl::event ungqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m
                   std::int64_t k, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1176,7 +1176,7 @@ sycl::event ungqr(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t m
                   std::int64_t k, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungqr_usm_sycl(queue, m, n, k, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1184,7 +1184,7 @@ sycl::event ungtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1192,7 +1192,7 @@ sycl::event ungtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::u
                   std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungtr_usm_sycl(queue, uplo, n, a, lda, tau, scratchpad,
                                                    scratchpad_size, dependencies);
 }
@@ -1201,7 +1201,7 @@ sycl::event unmrq(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cunmrq_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1210,7 +1210,7 @@ sycl::event unmrq(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zunmrq_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1219,7 +1219,7 @@ sycl::event unmqr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   std::complex<float> *a, std::int64_t lda, std::complex<float> *tau,
                   std::complex<float> *c, std::int64_t ldc, std::complex<float> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cunmqr_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1228,7 +1228,7 @@ sycl::event unmqr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   std::complex<double> *a, std::int64_t lda, std::complex<double> *tau,
                   std::complex<double> *c, std::int64_t ldc, std::complex<double> *scratchpad,
                   std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zunmqr_usm_sycl(queue, side, trans, m, n, k, a, lda, tau, c, ldc,
                                                    scratchpad, scratchpad_size, dependencies);
 }
@@ -1237,7 +1237,7 @@ sycl::event unmtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   std::int64_t n, std::complex<float> *a, std::int64_t lda,
                   std::complex<float> *tau, std::complex<float> *c, std::int64_t ldc,
                   std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cunmtr_usm_sycl(queue, side, uplo, trans, m, n, a, lda, tau, c,
                                                    ldc, scratchpad, scratchpad_size, dependencies);
 }
@@ -1246,7 +1246,7 @@ sycl::event unmtr(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::s
                   std::int64_t n, std::complex<double> *a, std::int64_t lda,
                   std::complex<double> *tau, std::complex<double> *c, std::int64_t ldc,
                   std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                  const sycl::vector_class<sycl::event> &dependencies) {
+                  const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zunmtr_usm_sycl(queue, side, uplo, trans, m, n, a, lda, tau, c,
                                                    ldc, scratchpad, scratchpad_size, dependencies);
 }
@@ -1478,7 +1478,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t n, float *a, std::int64_t lda, std::int64_t stride_a,
                         float *tau, std::int64_t stride_tau, std::int64_t batch_size,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgeqrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1487,7 +1487,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t n, double *a, std::int64_t lda, std::int64_t stride_a,
                         double *tau, std::int64_t stride_tau, std::int64_t batch_size,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgeqrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1497,7 +1497,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t stride_a, std::complex<float> *tau, std::int64_t stride_tau,
                         std::int64_t batch_size, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgeqrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1507,7 +1507,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t stride_a, std::complex<double> *tau, std::int64_t stride_tau,
                         std::int64_t batch_size, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgeqrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1516,7 +1516,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t n, float *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, std::int64_t batch_size,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1525,7 +1525,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t n, double *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, std::int64_t batch_size,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1535,7 +1535,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1545,7 +1545,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t stride_a, std::int64_t *ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetrf_batch_usm_sycl(queue, m, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1554,7 +1554,7 @@ sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetri_batch_usm_sycl(queue, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1563,7 +1563,7 @@ sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetri_batch_usm_sycl(queue, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1572,7 +1572,7 @@ sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetri_batch_usm_sycl(queue, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1581,7 +1581,7 @@ sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetri_batch_usm_sycl(queue, n, a, lda, stride_a, ipiv,
                                                          stride_ipiv, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1591,7 +1591,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         std::int64_t lda, std::int64_t stride_a, std::int64_t *ipiv,
                         std::int64_t stride_ipiv, float *b, std::int64_t ldb, std::int64_t stride_b,
                         std::int64_t batch_size, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetrs_batch_usm_sycl(
         queue, trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -1602,7 +1602,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         std::int64_t stride_ipiv, double *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrs_batch_usm_sycl(
         queue, trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -1613,7 +1613,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, std::complex<float> *b,
                         std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetrs_batch_usm_sycl(
         queue, trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -1624,7 +1624,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         std::int64_t *ipiv, std::int64_t stride_ipiv, std::complex<double> *b,
                         std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetrs_batch_usm_sycl(
         queue, trans, n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b, ldb, stride_b, batch_size,
         scratchpad, scratchpad_size, dependencies);
@@ -1633,7 +1633,7 @@ sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t n, std::int64_t k, float *a, std::int64_t lda,
                         std::int64_t stride_a, float *tau, std::int64_t stride_tau,
                         std::int64_t batch_size, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sorgqr_batch_usm_sycl(queue, m, n, k, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1642,7 +1642,7 @@ sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t n, std::int64_t k, double *a, std::int64_t lda,
                         std::int64_t stride_a, double *tau, std::int64_t stride_tau,
                         std::int64_t batch_size, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dorgqr_batch_usm_sycl(queue, m, n, k, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1650,14 +1650,14 @@ sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
 sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                         std::int64_t n, float *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t batch_size, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotrf_batch_usm_sycl(
         queue, uplo, n, a, lda, stride_a, batch_size, scratchpad, scratchpad_size, dependencies);
 }
 sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo uplo,
                         std::int64_t n, double *a, std::int64_t lda, std::int64_t stride_a,
                         std::int64_t batch_size, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotrf_batch_usm_sycl(
         queue, uplo, n, a, lda, stride_a, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1665,7 +1665,7 @@ sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t n, std::complex<float> *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotrf_batch_usm_sycl(
         queue, uplo, n, a, lda, stride_a, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1673,7 +1673,7 @@ sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t n, std::complex<double> *a, std::int64_t lda,
                         std::int64_t stride_a, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotrf_batch_usm_sycl(
         queue, uplo, n, a, lda, stride_a, batch_size, scratchpad, scratchpad_size, dependencies);
 }
@@ -1681,7 +1681,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t n, std::int64_t nrhs, float *a, std::int64_t lda,
                         std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                         std::int64_t batch_size, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotrs_batch_usm_sycl(queue, uplo, n, nrhs, a, lda, stride_a, b,
                                                          ldb, stride_b, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1690,7 +1690,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t n, std::int64_t nrhs, double *a, std::int64_t lda,
                         std::int64_t stride_a, double *b, std::int64_t ldb, std::int64_t stride_b,
                         std::int64_t batch_size, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotrs_batch_usm_sycl(queue, uplo, n, nrhs, a, lda, stride_a, b,
                                                          ldb, stride_b, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1700,7 +1700,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb,
                         std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotrs_batch_usm_sycl(queue, uplo, n, nrhs, a, lda, stride_a, b,
                                                          ldb, stride_b, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1710,7 +1710,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t lda, std::int64_t stride_a, std::complex<double> *b,
                         std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotrs_batch_usm_sycl(queue, uplo, n, nrhs, a, lda, stride_a, b,
                                                          ldb, stride_b, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1720,7 +1720,7 @@ sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t stride_a, std::complex<float> *tau, std::int64_t stride_tau,
                         std::int64_t batch_size, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungqr_batch_usm_sycl(queue, m, n, k, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1730,7 +1730,7 @@ sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t stride_a, std::complex<double> *tau, std::int64_t stride_tau,
                         std::int64_t batch_size, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungqr_batch_usm_sycl(queue, m, n, k, a, lda, stride_a, tau,
                                                          stride_tau, batch_size, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1739,7 +1739,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, float **a, std::int64_t *lda, float **tau,
                         std::int64_t group_count, std::int64_t *group_sizes, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgeqrf_group_usm_sycl(queue, m, n, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1748,7 +1748,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, double **a, std::int64_t *lda, double **tau,
                         std::int64_t group_count, std::int64_t *group_sizes, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgeqrf_group_usm_sycl(queue, m, n, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1758,7 +1758,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::complex<float> **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgeqrf_group_usm_sycl(queue, m, n, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1768,7 +1768,7 @@ sycl::event geqrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::complex<double> **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgeqrf_group_usm_sycl(queue, m, n, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1777,7 +1777,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, float **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetrf_group_usm_sycl(queue, m, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1786,7 +1786,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, double **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes, double *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrf_group_usm_sycl(queue, m, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1795,7 +1795,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, std::complex<float> **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetrf_group_usm_sycl(queue, m, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1804,7 +1804,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, std::complex<double> **a, std::int64_t *lda,
                         std::int64_t **ipiv, std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetrf_group_usm_sycl(queue, m, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1812,7 +1812,7 @@ sycl::event getrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
 sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *n, float **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetri_group_usm_sycl(queue, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1820,7 +1820,7 @@ sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
 sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int64_t *n, double **a,
                         std::int64_t *lda, std::int64_t **ipiv, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetri_group_usm_sycl(queue, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1829,7 +1829,7 @@ sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::complex<float> **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetri_group_usm_sycl(queue, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1838,7 +1838,7 @@ sycl::event getri_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::complex<double> **a, std::int64_t *lda, std::int64_t **ipiv,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetri_group_usm_sycl(queue, n, a, lda, ipiv, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1848,7 +1848,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         float **a, std::int64_t *lda, std::int64_t **ipiv, float **b,
                         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_sizes,
                         float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sgetrs_group_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b,
                                                          ldb, group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1858,7 +1858,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         double **a, std::int64_t *lda, std::int64_t **ipiv, double **b,
                         std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dgetrs_group_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b,
                                                          ldb, group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1869,7 +1869,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cgetrs_group_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b,
                                                          ldb, group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1880,7 +1880,7 @@ sycl::event getrs_batch(oneapi::mkl::device libkey, sycl::queue &queue,
                         std::complex<double> **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zgetrs_group_usm_sycl(queue, trans, n, nrhs, a, lda, ipiv, b,
                                                          ldb, group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1889,7 +1889,7 @@ sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, std::int64_t *k, float **a, std::int64_t *lda, float **tau,
                         std::int64_t group_count, std::int64_t *group_sizes, float *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].sorgqr_group_usm_sycl(queue, m, n, k, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1898,7 +1898,7 @@ sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *n, std::int64_t *k, double **a, std::int64_t *lda,
                         double **tau, std::int64_t group_count, std::int64_t *group_sizes,
                         double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dorgqr_group_usm_sycl(queue, m, n, k, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1906,7 +1906,7 @@ sycl::event orgqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
 sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo *uplo,
                         std::int64_t *n, float **a, std::int64_t *lda, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotrf_group_usm_sycl(queue, uplo, n, a, lda, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1914,7 +1914,7 @@ sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
 sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::mkl::uplo *uplo,
                         std::int64_t *n, double **a, std::int64_t *lda, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotrf_group_usm_sycl(queue, uplo, n, a, lda, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1923,7 +1923,7 @@ sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t *n, std::complex<float> **a, std::int64_t *lda,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotrf_group_usm_sycl(queue, uplo, n, a, lda, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1932,7 +1932,7 @@ sycl::event potrf_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t *n, std::complex<double> **a, std::int64_t *lda,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotrf_group_usm_sycl(queue, uplo, n, a, lda, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1941,7 +1941,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t *n, std::int64_t *nrhs, float **a, std::int64_t *lda,
                         float **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, float *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].spotrs_group_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb,
                                                          group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1950,7 +1950,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t *n, std::int64_t *nrhs, double **a, std::int64_t *lda,
                         double **b, std::int64_t *ldb, std::int64_t group_count,
                         std::int64_t *group_sizes, double *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].dpotrs_group_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb,
                                                          group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1960,7 +1960,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<float> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cpotrs_group_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb,
                                                          group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1970,7 +1970,7 @@ sycl::event potrs_batch(oneapi::mkl::device libkey, sycl::queue &queue, oneapi::
                         std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb,
                         std::int64_t group_count, std::int64_t *group_sizes,
                         std::complex<double> *scratchpad, std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zpotrs_group_usm_sycl(queue, uplo, n, nrhs, a, lda, b, ldb,
                                                          group_count, group_sizes, scratchpad,
                                                          scratchpad_size, dependencies);
@@ -1980,7 +1980,7 @@ sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *lda, std::complex<float> **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<float> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].cungqr_group_usm_sycl(queue, m, n, k, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);
@@ -1990,7 +1990,7 @@ sycl::event ungqr_batch(oneapi::mkl::device libkey, sycl::queue &queue, std::int
                         std::int64_t *lda, std::complex<double> **tau, std::int64_t group_count,
                         std::int64_t *group_sizes, std::complex<double> *scratchpad,
                         std::int64_t scratchpad_size,
-                        const sycl::vector_class<sycl::event> &dependencies) {
+                        const std::vector<sycl::event> &dependencies) {
     return function_tables[libkey].zungqr_group_usm_sycl(queue, m, n, k, a, lda, tau, group_count,
                                                          group_sizes, scratchpad, scratchpad_size,
                                                          dependencies);

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -327,8 +327,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -343,8 +342,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -377,8 +375,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -393,8 +390,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -410,8 +406,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -425,8 +420,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -439,8 +433,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -449,8 +442,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -460,8 +452,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -474,8 +465,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -488,8 +478,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -498,26 +487,25 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -542,9 +530,9 @@ public:
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -706,16 +694,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -731,16 +717,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -748,8 +732,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -757,24 +740,21 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -782,8 +762,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -791,38 +770,35 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -841,9 +817,9 @@ public:
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -328,7 +328,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -344,7 +344,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -361,7 +361,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         std::uint32_t* ib = (std::uint32_t*)malloc_device(
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
@@ -378,7 +378,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -394,7 +394,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -411,7 +411,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -426,7 +426,7 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -440,7 +440,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -450,7 +450,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -461,7 +461,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -475,7 +475,7 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -489,7 +489,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -499,7 +499,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -508,7 +508,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -517,7 +517,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -526,7 +526,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -535,7 +535,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -544,7 +544,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -707,7 +707,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -715,7 +715,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -724,7 +724,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -732,7 +732,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -740,7 +740,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -749,7 +749,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -758,7 +758,7 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -766,7 +766,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -774,7 +774,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -783,7 +783,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -792,7 +792,7 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -800,7 +800,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
@@ -808,42 +808,42 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine");
         return cl::sycl::event{};
     }

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -350,8 +350,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -366,8 +365,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -400,8 +398,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -416,8 +413,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -433,8 +429,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -448,8 +443,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -462,8 +456,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -472,8 +465,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -483,8 +475,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -497,8 +488,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -511,8 +501,7 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -521,26 +510,25 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -565,9 +553,9 @@ public:
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -729,16 +717,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -754,16 +740,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -771,8 +755,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -780,24 +763,21 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -805,8 +785,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -814,38 +793,35 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -864,9 +840,9 @@ public:
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -351,7 +351,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -367,7 +367,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -384,7 +384,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         std::uint32_t* ib = (std::uint32_t*)malloc_device(
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
@@ -401,7 +401,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -417,7 +417,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
@@ -434,7 +434,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -449,7 +449,7 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -463,7 +463,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -473,7 +473,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -484,7 +484,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -498,7 +498,7 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -512,7 +512,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -522,7 +522,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -531,7 +531,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -540,7 +540,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -549,7 +549,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -558,7 +558,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "philox4x32x10 engine",
             "ICDF method not used for pseudorandom generators in cuRAND backend");
@@ -567,7 +567,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
             cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
@@ -730,7 +730,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -738,7 +738,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -747,7 +747,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -755,7 +755,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -763,7 +763,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -772,7 +772,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -781,7 +781,7 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -789,7 +789,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -797,7 +797,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -806,7 +806,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -815,7 +815,7 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -823,7 +823,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -831,42 +831,42 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -317,9 +317,9 @@ public:
 
     // USM APIs
 
-    virtual cl::sycl::event generate(
-        const uniform<float, uniform_method::standard>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<float, uniform_method::standard>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -329,9 +329,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<double, uniform_method::standard>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<double, uniform_method::standard>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -341,9 +341,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<std::int32_t, uniform_method::standard>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<std::int32_t, uniform_method::standard>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -353,9 +353,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<float, uniform_method::accurate>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<float, uniform_method::accurate>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -366,9 +366,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<double, uniform_method::accurate>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<double, uniform_method::accurate>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -379,9 +379,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<float, gaussian_method::box_muller2>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<float, gaussian_method::box_muller2>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -392,9 +392,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<double, gaussian_method::box_muller2>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<double, gaussian_method::box_muller2>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -405,9 +405,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<float, gaussian_method::icdf>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<float, gaussian_method::icdf>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -418,9 +418,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<double, gaussian_method::icdf>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -431,9 +431,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<float, lognormal_method::box_muller2>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<float, lognormal_method::box_muller2>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -444,9 +444,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<double, lognormal_method::box_muller2>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<double, lognormal_method::box_muller2>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -457,9 +457,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<float, lognormal_method::icdf>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -470,9 +470,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<double, lognormal_method::icdf>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -483,9 +483,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -495,9 +495,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -533,9 +533,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -319,7 +319,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<float, uniform_method::standard>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -331,7 +331,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<double, uniform_method::standard>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -343,7 +343,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<std::int32_t, uniform_method::standard>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -355,7 +355,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<float, uniform_method::accurate>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -368,7 +368,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<double, uniform_method::accurate>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -381,7 +381,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<float, gaussian_method::box_muller2>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -394,7 +394,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<double, gaussian_method::box_muller2>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -407,7 +407,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<float, gaussian_method::icdf>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -420,7 +420,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -433,7 +433,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<float, lognormal_method::box_muller2>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -446,7 +446,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<double, lognormal_method::box_muller2>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -459,7 +459,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -472,7 +472,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -485,7 +485,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -497,7 +497,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -510,7 +510,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -522,7 +522,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -535,7 +535,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -321,7 +321,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<float, uniform_method::standard>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -333,7 +333,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<double, uniform_method::standard>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -345,7 +345,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<std::int32_t, uniform_method::standard>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -357,7 +357,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<float, uniform_method::accurate>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -370,7 +370,7 @@ public:
 
     virtual cl::sycl::event generate(
         const uniform<double, uniform_method::accurate>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -383,7 +383,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<float, gaussian_method::box_muller2>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -396,7 +396,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<double, gaussian_method::box_muller2>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -409,7 +409,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<float, gaussian_method::icdf>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -422,7 +422,7 @@ public:
 
     virtual cl::sycl::event generate(
         const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -435,7 +435,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<float, lognormal_method::box_muller2>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -448,7 +448,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<double, lognormal_method::box_muller2>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -461,7 +461,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -474,7 +474,7 @@ public:
 
     virtual cl::sycl::event generate(
         const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -487,7 +487,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -499,7 +499,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -512,7 +512,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -524,7 +524,7 @@ public:
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -537,7 +537,7 @@ public:
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -319,9 +319,9 @@ public:
 
     // USM APIs
 
-    virtual cl::sycl::event generate(
-        const uniform<float, uniform_method::standard>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<float, uniform_method::standard>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -331,9 +331,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<double, uniform_method::standard>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<double, uniform_method::standard>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -343,9 +343,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<std::int32_t, uniform_method::standard>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<std::int32_t, uniform_method::standard>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -355,9 +355,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<float, uniform_method::accurate>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<float, uniform_method::accurate>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -368,9 +368,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const uniform<double, uniform_method::accurate>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const uniform<double, uniform_method::accurate>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -381,9 +381,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<float, gaussian_method::box_muller2>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<float, gaussian_method::box_muller2>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -394,9 +394,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<double, gaussian_method::box_muller2>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<double, gaussian_method::box_muller2>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -407,9 +407,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<float, gaussian_method::icdf>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<float, gaussian_method::icdf>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -420,9 +420,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const gaussian<double, gaussian_method::icdf>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const gaussian<double, gaussian_method::icdf>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -433,9 +433,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<float, lognormal_method::box_muller2>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<float, lognormal_method::box_muller2>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -446,9 +446,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<double, lognormal_method::box_muller2>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<double, lognormal_method::box_muller2>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -459,9 +459,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<float, lognormal_method::icdf>& distr, std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<float, lognormal_method::icdf>& distr,
+                                     std::int64_t n, float* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -472,9 +472,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const lognormal<double, lognormal_method::icdf>& distr, std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const lognormal<double, lognormal_method::icdf>& distr,
+                                     std::int64_t n, double* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -485,9 +485,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -497,9 +497,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;
@@ -535,9 +535,9 @@ public:
         });
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
             VSLStreamStatePtr stream = stream_;

--- a/src/rng/backends/mklgpu/mkl_internal_rng_gpu.hpp
+++ b/src/rng/backends/mklgpu/mkl_internal_rng_gpu.hpp
@@ -66,7 +66,7 @@ template <typename EngineType, typename DistrType>
 sycl::event generate(sycl::queue& queue, const DistrType& distr,
                      engine_base_impl<EngineType>* engine, std::int64_t n,
                      typename DistrType::result_type* r,
-                     const sycl::vector_class<sycl::event>& dependencies = {});
+                     const std::vector<sycl::event>& dependencies = {});
 
 } // namespace gpu
 } // namespace detail

--- a/src/rng/backends/mklgpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklgpu/mrg32k3a.cpp
@@ -164,15 +164,13 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -187,87 +185,77 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -283,9 +271,9 @@ public:
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -438,16 +426,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -463,16 +449,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -480,8 +464,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -489,24 +472,21 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -514,8 +494,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -523,38 +502,35 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -573,9 +549,9 @@ public:
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }

--- a/src/rng/backends/mklgpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklgpu/mrg32k3a.cpp
@@ -165,14 +165,14 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -180,7 +180,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         ;
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
@@ -188,14 +188,14 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -203,7 +203,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -211,21 +211,21 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -233,7 +233,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -241,51 +241,51 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -439,7 +439,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -447,7 +447,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -456,7 +456,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -464,7 +464,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -472,7 +472,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -481,7 +481,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -490,7 +490,7 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -498,7 +498,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -506,7 +506,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -515,7 +515,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -524,7 +524,7 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -532,7 +532,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
@@ -540,42 +540,42 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "mrg32k3a engine");
         return cl::sycl::event{};
     }

--- a/src/rng/backends/mklgpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklgpu/philox4x32x10.cpp
@@ -165,15 +165,13 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -188,87 +186,77 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -284,9 +272,9 @@ public:
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -440,16 +428,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -465,16 +451,14 @@ public:
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -482,8 +466,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -491,24 +474,21 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -516,8 +496,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -525,38 +504,35 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, float* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
-        std::int64_t n, double* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+        std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::int32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
+                                     std::int64_t n, std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -575,9 +551,9 @@ public:
         return cl::sycl::event{};
     }
 
-    virtual cl::sycl::event generate(
-        const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const std::vector<cl::sycl::event>& dependencies) override {
+    virtual cl::sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n,
+                                     std::uint32_t* r,
+                                     const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }

--- a/src/rng/backends/mklgpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklgpu/philox4x32x10.cpp
@@ -166,14 +166,14 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -181,7 +181,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         ;
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
@@ -189,14 +189,14 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -204,7 +204,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -212,21 +212,21 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -234,7 +234,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -242,51 +242,51 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         return oneapi::mkl::rng::detail::gpu::generate(queue_, distr, engine_, n, r, dependencies);
     }
 
@@ -441,7 +441,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -449,7 +449,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -458,7 +458,7 @@ public:
         const oneapi::mkl::rng::uniform<std::int32_t, oneapi::mkl::rng::uniform_method::standard>&
             distr,
         std::int64_t n, std::int32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -466,7 +466,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -474,7 +474,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -483,7 +483,7 @@ public:
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -492,7 +492,7 @@ public:
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -500,7 +500,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -508,7 +508,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -517,7 +517,7 @@ public:
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -526,7 +526,7 @@ public:
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>&
             distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -534,7 +534,7 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
@@ -542,42 +542,42 @@ public:
     virtual cl::sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::int32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::int32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::int32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
-        std::uint32_t* r, const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        std::uint32_t* r, const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }
 
     virtual cl::sycl::event generate(
         const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
-        const cl::sycl::vector_class<cl::sycl::event>& dependencies) override {
+        const std::vector<cl::sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented("rng", "philox4x32x10 engine");
         return cl::sycl::event{};
     }

--- a/tests/unit_tests/lapack/source/gebrd.cpp
+++ b/tests/unit_tests/lapack/source/gebrd.cpp
@@ -155,12 +155,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::gebrd(
             queue, m, n, A_dev, lda, d_dev, e_dev, tauq_dev, taup_dev, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::gebrd, m, n, A_dev,
                            lda, d_dev, e_dev, tauq_dev, taup_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/geqrf.cpp
+++ b/tests/unit_tests/lapack/source/geqrf.cpp
@@ -129,9 +129,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::geqrf(
-            queue, m, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::geqrf(queue, m, n, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::geqrf, m, n, A_dev,

--- a/tests/unit_tests/lapack/source/geqrf.cpp
+++ b/tests/unit_tests/lapack/source/geqrf.cpp
@@ -131,12 +131,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::geqrf(
             queue, m, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::geqrf, m, n, A_dev,
                            lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
@@ -248,13 +248,13 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         sycl::event func_event = oneapi::mkl::lapack::geqrf_batch(
             queue, m_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
             tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::geqrf_batch,
                            m_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
                            tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/geqrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/geqrf_batch_stride.cpp
@@ -147,12 +147,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::geqrf_batch(
             queue, m, n, A_dev, lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::geqrf_batch, m, n,
                            A_dev, lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/gerqf.cpp
+++ b/tests/unit_tests/lapack/source/gerqf.cpp
@@ -129,9 +129,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::gerqf(
-            queue, m, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::gerqf(queue, m, n, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::gerqf, m, n, A_dev,

--- a/tests/unit_tests/lapack/source/gerqf.cpp
+++ b/tests/unit_tests/lapack/source/gerqf.cpp
@@ -131,12 +131,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::gerqf(
             queue, m, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::gerqf, m, n, A_dev,
                            lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/gesvd.cpp
+++ b/tests/unit_tests/lapack/source/gesvd.cpp
@@ -205,12 +205,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::jobsvd jobu, oneapi::m
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::gesvd(
             queue, jobu, jobvt, m, n, A_dev, lda, s_dev, U_dev, ldu, Vt_dev, ldvt, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::gesvd, jobu, jobvt,
                            m, n, A_dev, lda, s_dev, U_dev, ldu, Vt_dev, ldvt, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrf.cpp
+++ b/tests/unit_tests/lapack/source/getrf.cpp
@@ -132,9 +132,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::getrf(
-            queue, m, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::getrf(queue, m, n, A_dev, lda, ipiv_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrf, m, n, A_dev,

--- a/tests/unit_tests/lapack/source/getrf.cpp
+++ b/tests/unit_tests/lapack/source/getrf.cpp
@@ -134,12 +134,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::getrf(
             queue, m, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrf, m, n, A_dev,
                            lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrf_batch_group.cpp
@@ -257,14 +257,14 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         sycl::event func_event = oneapi::mkl::lapack::getrf_batch(
             queue, m_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
             ipiv_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrf_batch,
                            m_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
                            ipiv_dev_ptrs.data(), group_count, group_sizes_vec.data(),
                            scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrf_batch_group.cpp
@@ -263,8 +263,7 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrf_batch,
                            m_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
                            ipiv_dev_ptrs.data(), group_count, group_sizes_vec.data(),
-                           scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getrf_batch_stride.cpp
@@ -147,12 +147,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::getrf_batch(
             queue, m, n, A_dev, lda, stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrf_batch, m, n,
                            A_dev, lda, stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getri.cpp
+++ b/tests/unit_tests/lapack/source/getri.cpp
@@ -143,9 +143,9 @@ bool usm_dependency(const sycl::device& dev, int64_t n, int64_t lda, uint64_t se
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::getri(
-            queue, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::getri(queue, n, A_dev, lda, ipiv_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getri, n, A_dev,

--- a/tests/unit_tests/lapack/source/getri.cpp
+++ b/tests/unit_tests/lapack/source/getri.cpp
@@ -145,12 +145,12 @@ bool usm_dependency(const sycl::device& dev, int64_t n, int64_t lda, uint64_t se
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::getri(
             queue, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getri, n, A_dev,
                            lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getri_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getri_batch_group.cpp
@@ -273,13 +273,13 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         sycl::event func_event = oneapi::mkl::lapack::getri_batch(
             queue, n_vec.data(), A_dev_ptrs.data(), lda_vec.data(), ipiv_dev_ptrs.data(),
             group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getri_batch,
                            n_vec.data(), A_dev_ptrs.data(), lda_vec.data(), ipiv_dev_ptrs.data(),
                            group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getri_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getri_batch_stride.cpp
@@ -162,12 +162,12 @@ bool usm_dependency(const sycl::device& dev, int64_t n, int64_t lda, int64_t str
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::getri_batch(
             queue, n, A_dev, lda, stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getri_batch, n,
                            A_dev, lda, stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrs.cpp
+++ b/tests/unit_tests/lapack/source/getrs.cpp
@@ -155,12 +155,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::transpose trans, int64
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::getrs(
             queue, trans, n, nrhs, A_dev, lda, ipiv_dev, B_dev, ldb, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrs, trans, n,
                            nrhs, A_dev, lda, ipiv_dev, B_dev, ldb, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrs_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrs_batch_group.cpp
@@ -337,14 +337,14 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             queue, trans_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs.data(),
             lda_vec.data(), ipiv_dev_ptrs.data(), B_dev_ptrs.data(), ldb_vec.data(), group_count,
             group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrs_batch,
                            trans_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs.data(),
                            lda_vec.data(), ipiv_dev_ptrs.data(), B_dev_ptrs.data(), ldb_vec.data(),
                            group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrs_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getrs_batch_stride.cpp
@@ -180,13 +180,13 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::transpose trans, int64
         sycl::event func_event = oneapi::mkl::lapack::getrs_batch(
             queue, trans, n, nrhs, A_dev, lda, stride_a, ipiv_dev, stride_ipiv, B_dev, ldb,
             stride_b, batch_size, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::getrs_batch, trans,
                            n, nrhs, A_dev, lda, stride_a, ipiv_dev, stride_ipiv, B_dev, ldb,
                            stride_b, batch_size, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/heevd.cpp
+++ b/tests/unit_tests/lapack/source/heevd.cpp
@@ -128,12 +128,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::heevd(
             queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::heevd, jobz, uplo,
                            n, A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/heevd.cpp
+++ b/tests/unit_tests/lapack/source/heevd.cpp
@@ -126,9 +126,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::heevd(
-            queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::heevd(queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::heevd, jobz, uplo,

--- a/tests/unit_tests/lapack/source/hegvd.cpp
+++ b/tests/unit_tests/lapack/source/hegvd.cpp
@@ -265,12 +265,12 @@ bool usm_dependency(const sycl::device& dev, int64_t itype, oneapi::mkl::job job
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::hegvd(
             queue, itype, jobz, uplo, n, A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::hegvd, itype, jobz,
                            uplo, n, A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/hetrd.cpp
+++ b/tests/unit_tests/lapack/source/hetrd.cpp
@@ -191,12 +191,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::hetrd(
             queue, uplo, n, A_dev, lda, d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::hetrd, uplo, n,
                            A_dev, lda, d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/hetrf.cpp
+++ b/tests/unit_tests/lapack/source/hetrf.cpp
@@ -247,9 +247,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::hetrf(
-            queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::hetrf(queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::hetrf, uplo, n,

--- a/tests/unit_tests/lapack/source/hetrf.cpp
+++ b/tests/unit_tests/lapack/source/hetrf.cpp
@@ -249,12 +249,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::hetrf(
             queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::hetrf, uplo, n,
                            A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgbr.cpp
+++ b/tests/unit_tests/lapack/source/orgbr.cpp
@@ -166,12 +166,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::orgbr(
             queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgbr, vect, m, n,
                            k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgbr.cpp
+++ b/tests/unit_tests/lapack/source/orgbr.cpp
@@ -164,9 +164,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::orgbr(
-            queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::orgbr(queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgbr, vect, m, n,

--- a/tests/unit_tests/lapack/source/orgqr.cpp
+++ b/tests/unit_tests/lapack/source/orgqr.cpp
@@ -140,9 +140,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::orgqr(
-            queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::orgqr(queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgqr, m, n, k,

--- a/tests/unit_tests/lapack/source/orgqr.cpp
+++ b/tests/unit_tests/lapack/source/orgqr.cpp
@@ -142,12 +142,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::orgqr(
             queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgqr, m, n, k,
                            A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
@@ -272,8 +272,7 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgqr_batch,
                            m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(),
                            lda_vec.data(), tau_dev_ptrs.data(), group_count, group_sizes_vec.data(),
-                           scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
@@ -266,14 +266,14 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         sycl::event func_event = oneapi::mkl::lapack::orgqr_batch(
             queue, m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
             tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgqr_batch,
                            m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(),
                            lda_vec.data(), tau_dev_ptrs.data(), group_count, group_sizes_vec.data(),
                            scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgqr_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_stride.cpp
@@ -159,12 +159,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::orgqr_batch(
             queue, m, n, k, A_dev, lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgqr_batch, m, n,
                            k, A_dev, lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgtr.cpp
+++ b/tests/unit_tests/lapack/source/orgtr.cpp
@@ -143,12 +143,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::orgtr(
             queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgtr, uplo, n,
                            A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();

--- a/tests/unit_tests/lapack/source/orgtr.cpp
+++ b/tests/unit_tests/lapack/source/orgtr.cpp
@@ -141,9 +141,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::orgtr(
-            queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::orgtr(queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::orgtr, uplo, n,

--- a/tests/unit_tests/lapack/source/ormqr.cpp
+++ b/tests/unit_tests/lapack/source/ormqr.cpp
@@ -176,12 +176,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ormqr(
             queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ormqr, left_right,
                            trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ormrq.cpp
+++ b/tests/unit_tests/lapack/source/ormrq.cpp
@@ -185,12 +185,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ormrq(
             queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ormrq, left_right,
                            trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ormtr.cpp
+++ b/tests/unit_tests/lapack/source/ormtr.cpp
@@ -175,12 +175,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ormtr(
             queue, side, uplo, trans, m, n, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ormtr, side, uplo,
                            trans, m, n, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();

--- a/tests/unit_tests/lapack/source/potrf.cpp
+++ b/tests/unit_tests/lapack/source/potrf.cpp
@@ -126,12 +126,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event =
             oneapi::mkl::lapack::potrf(queue, uplo, n, A_dev, lda, scratchpad_dev, scratchpad_size,
-                                       sycl::vector_class<sycl::event>{ in_event });
+                                       std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrf, uplo, n,
                            A_dev, lda, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/potrf_batch_group.cpp
@@ -230,13 +230,13 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         sycl::event func_event = oneapi::mkl::lapack::potrf_batch(
             queue, uplo_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(), group_count,
             group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrf_batch,
                            uplo_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
                            group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/potrf_batch_stride.cpp
@@ -138,12 +138,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::potrf_batch(
             queue, uplo, n, A_dev, lda, stride_a, batch_size, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrf_batch, uplo,
                            n, A_dev, lda, stride_a, batch_size, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potri.cpp
+++ b/tests/unit_tests/lapack/source/potri.cpp
@@ -160,12 +160,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event =
             oneapi::mkl::lapack::potri(queue, uplo, n, A_dev, lda, scratchpad_dev, scratchpad_size,
-                                       sycl::vector_class<sycl::event>{ in_event });
+                                       std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potri, uplo, n,
                            A_dev, lda, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrs.cpp
+++ b/tests/unit_tests/lapack/source/potrs.cpp
@@ -147,12 +147,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::potrs(
             queue, uplo, n, nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrs, uplo, n,
                            nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrs.cpp
+++ b/tests/unit_tests/lapack/source/potrs.cpp
@@ -145,9 +145,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::potrs(
-            queue, uplo, n, nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrs, uplo, n,

--- a/tests/unit_tests/lapack/source/potrs_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/potrs_batch_group.cpp
@@ -297,14 +297,14 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         sycl::event func_event = oneapi::mkl::lapack::potrs_batch(
             queue, uplo_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs.data(),
             lda_vec.data(), B_dev_ptrs.data(), ldb_vec.data(), group_count, group_sizes_vec.data(),
-            scratchpad_dev, scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrs_batch,
                            uplo_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs.data(),
                            lda_vec.data(), B_dev_ptrs.data(), ldb_vec.data(), group_count,
                            group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
@@ -177,8 +177,7 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrs_batch, uplo,
                            n, nrhs, A_dev, lda, stride_a, B_dev, ldb, stride_b, batch_size,
-                           scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
@@ -172,13 +172,13 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::potrs_batch(
             queue, uplo, n, nrhs, A_dev, lda, stride_a, B_dev, ldb, stride_b, batch_size,
-            scratchpad_dev, scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::potrs_batch, uplo,
                            n, nrhs, A_dev, lda, stride_a, B_dev, ldb, stride_b, batch_size,
                            scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/syevd.cpp
+++ b/tests/unit_tests/lapack/source/syevd.cpp
@@ -128,12 +128,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::syevd(
             queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::syevd, jobz, uplo,
                            n, A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/syevd.cpp
+++ b/tests/unit_tests/lapack/source/syevd.cpp
@@ -126,9 +126,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::syevd(
-            queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::syevd(queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::syevd, jobz, uplo,

--- a/tests/unit_tests/lapack/source/sygvd.cpp
+++ b/tests/unit_tests/lapack/source/sygvd.cpp
@@ -270,12 +270,12 @@ bool usm_dependency(const sycl::device& dev, int64_t itype, oneapi::mkl::job job
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::sygvd(
             queue, itype, jobz, uplo, n, A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::sygvd, itype, jobz,
                            uplo, n, A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/sytrd.cpp
+++ b/tests/unit_tests/lapack/source/sytrd.cpp
@@ -191,12 +191,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::sytrd(
             queue, uplo, n, A_dev, lda, d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::sytrd, uplo, n,
                            A_dev, lda, d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/sytrf.cpp
+++ b/tests/unit_tests/lapack/source/sytrf.cpp
@@ -244,9 +244,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::sytrf(
-            queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::sytrf(queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::sytrf, uplo, n,

--- a/tests/unit_tests/lapack/source/sytrf.cpp
+++ b/tests/unit_tests/lapack/source/sytrf.cpp
@@ -246,12 +246,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::sytrf(
             queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::sytrf, uplo, n,
                            A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/trtrs.cpp
+++ b/tests/unit_tests/lapack/source/trtrs.cpp
@@ -146,12 +146,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, oneapi::mkl
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::trtrs(
             queue, uplo, trans, diag, n, nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::trtrs, uplo, trans,
                            diag, n, nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungbr.cpp
+++ b/tests/unit_tests/lapack/source/ungbr.cpp
@@ -164,9 +164,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::ungbr(
-            queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::ungbr(queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungbr, vect, m, n,

--- a/tests/unit_tests/lapack/source/ungbr.cpp
+++ b/tests/unit_tests/lapack/source/ungbr.cpp
@@ -166,12 +166,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ungbr(
             queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungbr, vect, m, n,
                            k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungqr.cpp
+++ b/tests/unit_tests/lapack/source/ungqr.cpp
@@ -141,12 +141,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ungqr(
             queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungqr, m, n, k,
                            A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungqr.cpp
+++ b/tests/unit_tests/lapack/source/ungqr.cpp
@@ -139,9 +139,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::ungqr(
-            queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::ungqr(queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungqr, m, n, k,

--- a/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
@@ -266,14 +266,14 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         sycl::event func_event = oneapi::mkl::lapack::ungqr_batch(
             queue, m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
             tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungqr_batch,
                            m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(),
                            lda_vec.data(), tau_dev_ptrs.data(), group_count, group_sizes_vec.data(),
                            scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
@@ -272,8 +272,7 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungqr_batch,
                            m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(),
                            lda_vec.data(), tau_dev_ptrs.data(), group_count, group_sizes_vec.data(),
-                           scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungqr_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_stride.cpp
@@ -159,12 +159,12 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ungqr_batch(
             queue, m, n, k, A_dev, lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungqr_batch, m, n,
                            k, A_dev, lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungtr.cpp
+++ b/tests/unit_tests/lapack/source/ungtr.cpp
@@ -141,9 +141,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
         /* Check dependency handling */
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
-        sycl::event func_event = oneapi::mkl::lapack::ungtr(
-            queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+        sycl::event func_event =
+            oneapi::mkl::lapack::ungtr(queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev,
+                                       scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungtr, uplo, n,

--- a/tests/unit_tests/lapack/source/ungtr.cpp
+++ b/tests/unit_tests/lapack/source/ungtr.cpp
@@ -143,12 +143,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ungtr(
             queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-            sycl::vector_class<sycl::event>{ in_event });
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::ungtr, uplo, n,
                            A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           sycl::vector_class<sycl::event>{ in_event });
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();

--- a/tests/unit_tests/lapack/source/unmqr.cpp
+++ b/tests/unit_tests/lapack/source/unmqr.cpp
@@ -176,12 +176,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::unmqr(
             queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::unmqr, left_right,
                            trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/unmrq.cpp
+++ b/tests/unit_tests/lapack/source/unmrq.cpp
@@ -185,12 +185,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::unmrq(
             queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::unmrq, left_right,
                            trans, m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/unmtr.cpp
+++ b/tests/unit_tests/lapack/source/unmtr.cpp
@@ -175,12 +175,12 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, 
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::unmtr(
             queue, side, uplo, trans, m, n, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-            scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+            scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, sycl::event func_event = oneapi::mkl::lapack::unmtr, side, uplo,
                            trans, m, n, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
-                           scratchpad_size, sycl::vector_class<sycl::event>{ in_event });
+                           scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();


### PR DESCRIPTION
# Description

As DPC++ compiler moves from SYCL1.2.1 spec to SYCL2020, it doesn't support `sycl::vector_class` anymore. Initially it was an alias for `std::vector`, so this PR updates all sources to use `std::vector` to fix build with the latest compiler.
Please note since `sycl::vector_class` was an alias, these changes are compatible with older compilers. 
USM API from oneMKL Spec will be also updated.

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? Attach a log.
- [X] Have you formatted the code using clang-format?
