### PR TITLE
[curand] Use host_task rather than codeplay_host_task

### DIFF
--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -100,7 +100,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -117,7 +117,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -135,7 +135,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = ib.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto ib_ptr = reinterpret_cast<std::uint32_t*>(
                         ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -152,7 +152,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -169,7 +169,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -186,7 +186,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -203,7 +203,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -236,7 +236,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -253,7 +253,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -313,7 +313,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr = reinterpret_cast<std::uint32_t*>(
                         ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -331,7 +331,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -346,7 +346,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -364,7 +364,7 @@ public:
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
@@ -379,7 +379,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -394,7 +394,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -409,7 +409,7 @@ public:
         std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -423,7 +423,7 @@ public:
         std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -455,7 +455,7 @@ public:
         std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
@@ -468,7 +468,7 @@ public:
         std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
@@ -535,7 +535,7 @@ public:
                                      const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -123,7 +123,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -140,7 +140,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -158,7 +158,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = ib.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr = reinterpret_cast<std::uint32_t*>(
                         ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -175,7 +175,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -192,7 +192,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -209,7 +209,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -226,7 +226,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -259,7 +259,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<float*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -276,7 +276,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr =
                         reinterpret_cast<double*>(ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -336,7 +336,7 @@ public:
         queue_
             .submit([&](cl::sycl::handler& cgh) {
                 auto acc = r.template get_access<cl::sycl::access::mode::read_write>(cgh);
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     auto r_ptr = reinterpret_cast<std::uint32_t*>(
                         ih.get_native_mem<cl::sycl::backend::cuda>(acc));
                     curandStatus_t status;
@@ -354,7 +354,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -369,7 +369,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -387,7 +387,7 @@ public:
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
@@ -402,7 +402,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -417,7 +417,7 @@ public:
         cl::sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](cl::sycl::handler& cgh) {
-                cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+                cgh.host_task([=](cl::sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -432,7 +432,7 @@ public:
         std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -446,7 +446,7 @@ public:
         std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -478,7 +478,7 @@ public:
         std::int64_t n, float* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
@@ -491,7 +491,7 @@ public:
         std::int64_t n, double* r, const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
@@ -558,7 +558,7 @@ public:
                                      const std::vector<cl::sycl::event>& dependencies) override {
         cl::sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](cl::sycl::handler& cgh) {
-            cgh.codeplay_host_task([=](cl::sycl::interop_handle ih) {
+            cgh.host_task([=](cl::sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });


### PR DESCRIPTION
`codeplay_host_task` is deprecated in SYCL 2020, `host_task` should be
used instead, this is already what is used by the cublas backend.

Additionally support for `codeplay_host_task` was recently removed from
DPC++, https://github.com/intel/llvm/pull/4426 so this code wouldn't
build with recent DPC++.

Here's a log file running the curand tests with this patch: 
[curand.log](https://github.com/oneapi-src/oneMKL/files/7379419/curand.log)
