### PR TITLE
Replace half with sycl::half to align with SYCL standard

### DIFF
--- a/include/oneapi/mkl/blas.hxx
+++ b/include/oneapi/mkl/blas.hxx
@@ -377,9 +377,10 @@ static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose tran
 }
 
 static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                        std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                        std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+                        std::int64_t n, std::int64_t k, sycl::half alpha,
+                        cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+                        cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
     detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                  c, ldc);
@@ -387,9 +388,10 @@ static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose tran
 }
 
 static inline void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                        std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-                        std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
-                        float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+                        std::int64_t n, std::int64_t k, float alpha,
+                        cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
+                        cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
     detail::gemm(get_device_id(queue), queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
                  c, ldc);
@@ -470,10 +472,11 @@ static inline void gemm_batch(cl::sycl::queue &queue, transpose transa, transpos
 }
 
 static inline void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
-                              std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                              cl::sycl::buffer<half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                              cl::sycl::buffer<half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
-                              half beta, cl::sycl::buffer<half, 1> &c, std::int64_t ldc,
+                              std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                              cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                              std::int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b,
+                              std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+                              cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
                               std::int64_t stride_c, std::int64_t batch_size) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size);
@@ -2509,9 +2512,10 @@ static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, tra
 }
 
 static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
-                                   std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                                   const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                                   half beta, half *c, std::int64_t ldc,
+                                   std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                                   const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                                   std::int64_t ldb, sycl::half beta, sycl::half *c,
+                                   std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
@@ -2524,8 +2528,8 @@ static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, tra
 
 static inline cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                                    std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                                   const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                                   float beta, float *c, std::int64_t ldc,
+                                   const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
                       dependencies);
@@ -2618,9 +2622,9 @@ static inline cl::sycl::event gemm_batch(
 
 static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa,
                                          transpose *transb, std::int64_t *m, std::int64_t *n,
-                                         std::int64_t *k, half *alpha, const half **a,
-                                         std::int64_t *lda, const half **b, std::int64_t *ldb,
-                                         half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t *k, sycl::half *alpha, const sycl::half **a,
+                                         std::int64_t *lda, const sycl::half **b, std::int64_t *ldb,
+                                         sycl::half *beta, sycl::half **c, std::int64_t *ldc,
                                          std::int64_t group_count, std::int64_t *group_size,
                                          const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
@@ -2702,11 +2706,12 @@ static inline cl::sycl::event gemm_batch(
 }
 
 static inline cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
-                                         std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                                         const half *a, std::int64_t lda, std::int64_t stride_a,
-                                         const half *b, std::int64_t ldb, std::int64_t stride_b,
-                                         half beta, half *c, std::int64_t ldc,
-                                         std::int64_t stride_c, std::int64_t batch_size,
+                                         std::int64_t m, std::int64_t n, std::int64_t k,
+                                         sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                                         std::int64_t stride_a, const sycl::half *b,
+                                         std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+                                         sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
+                                         std::int64_t batch_size,
                                          const std::vector<cl::sycl::event> &dependencies = {}) {
     gemm_batch_precondition(queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb,
                             stride_b, beta, c, ldc, stride_c, batch_size, dependencies);

--- a/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_ct_backends.hxx
@@ -457,10 +457,12 @@ static inline void gemm_batch(backend_selector<backend::BACKEND> selector, trans
 
 static inline void gemm_batch(backend_selector<backend::BACKEND> selector, transpose transa,
                               transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                              half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                              std::int64_t stride_a, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
-                              std::int64_t stride_b, half beta, cl::sycl::buffer<half, 1> &c,
-                              std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size);
+                              sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                              std::int64_t lda, std::int64_t stride_a,
+                              cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                              std::int64_t stride_b, sycl::half beta,
+                              cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                              std::int64_t stride_c, std::int64_t batch_size);
 
 static inline void spmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                         std::int64_t n, float alpha, cl::sycl::buffer<float, 1> &a,
@@ -576,14 +578,14 @@ static inline void gemm(backend_selector<backend::BACKEND> selector, transpose t
 
 static inline void gemm(backend_selector<backend::BACKEND> selector, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                        sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+                        cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc);
 
 static inline void gemm(backend_selector<backend::BACKEND> selector, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        float alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                        float alpha, cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
                         cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 
 static inline void gemm(backend_selector<backend::BACKEND> selector, transpose transa,
@@ -1700,9 +1702,10 @@ static inline cl::sycl::event gemm_batch(
 
 static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
                                          transpose *transa, transpose *transb, std::int64_t *m,
-                                         std::int64_t *n, std::int64_t *k, half *alpha,
-                                         const half **a, std::int64_t *lda, const half **b,
-                                         std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t *n, std::int64_t *k, sycl::half *alpha,
+                                         const sycl::half **a, std::int64_t *lda,
+                                         const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                                         sycl::half **c, std::int64_t *ldc,
                                          std::int64_t group_count, std::int64_t *group_size,
                                          const std::vector<cl::sycl::event> &dependencies = {});
 
@@ -1740,14 +1743,12 @@ static inline cl::sycl::event gemm_batch(
     std::int64_t stride_c, std::int64_t batch_size,
     const std::vector<cl::sycl::event> &dependencies = {});
 
-static inline cl::sycl::event gemm_batch(backend_selector<backend::BACKEND> selector,
-                                         transpose transa, transpose transb, std::int64_t m,
-                                         std::int64_t n, std::int64_t k, half alpha, const half *a,
-                                         std::int64_t lda, std::int64_t stride_a, const half *b,
-                                         std::int64_t ldb, std::int64_t stride_b, half beta,
-                                         half *c, std::int64_t ldc, std::int64_t stride_c,
-                                         std::int64_t batch_size,
-                                         const std::vector<cl::sycl::event> &dependencies = {});
+static inline cl::sycl::event gemm_batch(
+    backend_selector<backend::BACKEND> selector, transpose transa, transpose transb, std::int64_t m,
+    std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
+    std::int64_t stride_a, const sycl::half *b, std::int64_t ldb, std::int64_t stride_b,
+    sycl::half beta, sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event spmv(backend_selector<backend::BACKEND> selector, uplo upper_lower,
                                    std::int64_t n, float alpha, const float *a, const float *x,
@@ -1837,14 +1838,16 @@ static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, 
 
 static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
                                    transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                                   half alpha, const half *a, std::int64_t lda, const half *b,
-                                   std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+                                   sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                                   const sycl::half *b, std::int64_t ldb, sycl::half beta,
+                                   sycl::half *c, std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,
                                    transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                                   float alpha, const half *a, std::int64_t lda, const half *b,
-                                   std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                                   float alpha, const sycl::half *a, std::int64_t lda,
+                                   const sycl::half *b, std::int64_t ldb, float beta, float *c,
+                                   std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {});
 
 static inline cl::sycl::event gemm(backend_selector<backend::BACKEND> selector, transpose transa,

--- a/include/oneapi/mkl/blas/detail/blas_loader.hxx
+++ b/include/oneapi/mkl/blas/detail/blas_loader.hxx
@@ -118,10 +118,12 @@ ONEMKL_EXPORT void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue
                               std::int64_t stride_c, std::int64_t batch_size);
 ONEMKL_EXPORT void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                               transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                              half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                              std::int64_t stride_a, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
-                              std::int64_t stride_b, half beta, cl::sycl::buffer<half, 1> &c,
-                              std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size);
+                              sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                              std::int64_t lda, std::int64_t stride_a,
+                              cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                              std::int64_t stride_b, sycl::half beta,
+                              cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                              std::int64_t stride_c, std::int64_t batch_size);
 
 ONEMKL_EXPORT void syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue, uplo upper_lower,
                         transpose trans, std::int64_t n, std::int64_t k, float alpha,
@@ -545,13 +547,13 @@ ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, tran
                         cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
 ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                        sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+                        cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc);
 ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                        float alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                        float alpha, cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
                         cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 ONEMKL_EXPORT void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                         transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
@@ -1079,9 +1081,10 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                          transpose *transa, transpose *transb, std::int64_t *m,
-                                         std::int64_t *n, std::int64_t *k, half *alpha,
-                                         const half **a, std::int64_t *lda, const half **b,
-                                         std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t *n, std::int64_t *k, sycl::half *alpha,
+                                         const sycl::half **a, std::int64_t *lda,
+                                         const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                                         sycl::half **c, std::int64_t *ldc,
                                          std::int64_t group_count, std::int64_t *group_size,
                                          const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
@@ -1114,14 +1117,12 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
-ONEMKL_EXPORT cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue,
-                                         transpose transa, transpose transb, std::int64_t m,
-                                         std::int64_t n, std::int64_t k, half alpha, const half *a,
-                                         std::int64_t lda, std::int64_t stride_a, const half *b,
-                                         std::int64_t ldb, std::int64_t stride_b, half beta,
-                                         half *c, std::int64_t ldc, std::int64_t stride_c,
-                                         std::int64_t batch_size,
-                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(
+    oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
+    std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+    std::int64_t lda, std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+    std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event syrk(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                    uplo upper_lower, transpose trans, std::int64_t n,
@@ -1701,15 +1702,16 @@ ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &
                                    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                    transpose transa, transpose transb, std::int64_t m,
-                                   std::int64_t n, std::int64_t k, half alpha, const half *a,
-                                   std::int64_t lda, const half *b, std::int64_t ldb, half beta,
-                                   half *c, std::int64_t ldc,
+                                   std::int64_t n, std::int64_t k, sycl::half alpha,
+                                   const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                                   std::int64_t ldb, sycl::half beta, sycl::half *c,
+                                   std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                    transpose transa, transpose transb, std::int64_t m,
-                                   std::int64_t n, std::int64_t k, float alpha, const half *a,
-                                   std::int64_t lda, const half *b, std::int64_t ldb, float beta,
-                                   float *c, std::int64_t ldc,
+                                   std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
+                                   std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                                   float beta, float *c, std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {});
 ONEMKL_EXPORT cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue,
                                    transpose transa, transpose transb, std::int64_t m,

--- a/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/blas_ct.hxx
@@ -228,11 +228,11 @@ void gemm_batch(backend_selector<backend::cublas> selector, transpose transa, tr
 }
 
 void gemm_batch(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-                std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                cl::sycl::buffer<half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
-                std::int64_t batch_size) {
+                std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
     oneapi::mkl::blas::cublas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
@@ -1060,9 +1060,9 @@ void gemm(backend_selector<backend::cublas> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::cublas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1072,9 +1072,9 @@ void gemm(backend_selector<backend::cublas> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::cublas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -3278,9 +3278,10 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
 
 cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           half *alpha, const half **a, std::int64_t *lda, const half **b,
-                           std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-                           std::int64_t group_count, std::int64_t *group_size,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                           const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                           std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
@@ -3364,10 +3365,10 @@ cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose
 
 cl::sycl::event gemm_batch(backend_selector<backend::cublas> selector, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
-                           const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                           half *c, std::int64_t ldc, std::int64_t stride_c,
-                           std::int64_t batch_size,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                           std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                           std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                           std::int64_t stride_c, std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -3566,9 +3567,10 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     sycl::half beta, sycl::half *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3580,9 +3582,10 @@ cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::cublas> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     float beta, float *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =

--- a/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
+++ b/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hxx
@@ -602,13 +602,13 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64
           cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+          std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+          cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc);
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
@@ -798,10 +798,11 @@ void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, std:
                 std::int64_t stride_c, std::int64_t batch_size);
 
 void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<half, 1> &b,
-                std::int64_t ldb, std::int64_t stride_b, half beta, cl::sycl::buffer<half, 1> &c,
-                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size);
+                std::int64_t n, std::int64_t k, sycl::half alpha,
+                cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size);
 
 void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                 diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
@@ -1624,14 +1625,15 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
                      std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-                     const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+                     std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+                     std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta,
+                     sycl::half *c, std::int64_t ldc,
                      const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
-                     const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+                     std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
+                     std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c,
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
                      std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
@@ -1913,10 +1915,10 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                            const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,
-                           std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha,
-                           const half **a, std::int64_t *lda, const half **b, std::int64_t *ldb,
-                           half *beta, half **c, std::int64_t *ldc, std::int64_t group_count,
-                           std::int64_t *group_size,
+                           std::int64_t *m, std::int64_t *n, std::int64_t *k, sycl::half *alpha,
+                           const sycl::half **a, std::int64_t *lda, const sycl::half **b,
+                           std::int64_t *ldb, sycl::half *beta, sycl::half **c, std::int64_t *ldc,
+                           std::int64_t group_count, std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
@@ -1953,10 +1955,11 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                            const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb,
-                           std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                           const half *a, std::int64_t lda, std::int64_t stride_a, const half *b,
-                           std::int64_t ldb, std::int64_t stride_b, half beta, half *c,
-                           std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                           std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                           const sycl::half *a, std::int64_t lda, std::int64_t stride_a,
+                           const sycl::half *b, std::int64_t ldb, std::int64_t stride_b,
+                           sycl::half beta, sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
+                           std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies = {});
 
 cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,

--- a/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hxx
@@ -230,11 +230,11 @@ void gemm_batch(backend_selector<backend::mklcpu> selector, transpose transa, tr
 }
 
 void gemm_batch(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-                std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                cl::sycl::buffer<half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
-                std::int64_t batch_size) {
+                std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
     oneapi::mkl::blas::mklcpu::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
@@ -1062,9 +1062,9 @@ void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::mklcpu::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1074,9 +1074,9 @@ void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::mklcpu::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -3280,9 +3280,10 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
 
 cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           half *alpha, const half **a, std::int64_t *lda, const half **b,
-                           std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-                           std::int64_t group_count, std::int64_t *group_size,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                           const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                           std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
@@ -3366,10 +3367,10 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose
 
 cl::sycl::event gemm_batch(backend_selector<backend::mklcpu> selector, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
-                           const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                           half *c, std::int64_t ldc, std::int64_t stride_c,
-                           std::int64_t batch_size,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                           std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                           std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                           std::int64_t stride_c, std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -3568,9 +3569,10 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     sycl::half beta, sycl::half *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3582,9 +3584,10 @@ cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::mklcpu> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     float beta, float *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =

--- a/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hxx
@@ -230,11 +230,11 @@ void gemm_batch(backend_selector<backend::mklgpu> selector, transpose transa, tr
 }
 
 void gemm_batch(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-                std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                cl::sycl::buffer<half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
-                std::int64_t batch_size) {
+                std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
     oneapi::mkl::blas::mklgpu::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
@@ -1062,9 +1062,9 @@ void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::mklgpu::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1074,9 +1074,9 @@ void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::mklgpu::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -3214,9 +3214,10 @@ cl::sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n
 
 cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           half *alpha, const half **a, std::int64_t *lda, const half **b,
-                           std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-                           std::int64_t group_count, std::int64_t *group_size,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                           const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                           std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
@@ -3296,10 +3297,10 @@ cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose
 
 cl::sycl::event gemm_batch(backend_selector<backend::mklgpu> selector, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
-                           const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                           half *c, std::int64_t ldc, std::int64_t stride_c,
-                           std::int64_t batch_size,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                           std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                           std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                           std::int64_t stride_c, std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -3568,9 +3569,10 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     sycl::half beta, sycl::half *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3582,9 +3584,10 @@ cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::mklgpu> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     float beta, float *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =

--- a/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
@@ -230,11 +230,11 @@ void gemm_batch(backend_selector<backend::netlib> selector, transpose transa, tr
 }
 
 void gemm_batch(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-                std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                cl::sycl::buffer<half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
-                std::int64_t batch_size) {
+                std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
     oneapi::mkl::blas::netlib::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
@@ -1062,9 +1062,9 @@ void gemm(backend_selector<backend::netlib> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::netlib::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1074,9 +1074,9 @@ void gemm(backend_selector<backend::netlib> selector, transpose transa, transpos
 }
 
 void gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::netlib::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -3280,9 +3280,10 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
 
 cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           half *alpha, const half **a, std::int64_t *lda, const half **b,
-                           std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-                           std::int64_t group_count, std::int64_t *group_size,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                           const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                           std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
@@ -3366,10 +3367,10 @@ cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose
 
 cl::sycl::event gemm_batch(backend_selector<backend::netlib> selector, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
-                           const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                           half *c, std::int64_t ldc, std::int64_t stride_c,
-                           std::int64_t batch_size,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                           std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                           std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                           std::int64_t stride_c, std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -3568,9 +3569,10 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, half beta, half *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     sycl::half beta, sycl::half *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3582,9 +3584,10 @@ cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose trans
 }
 
 cl::sycl::event gemm(backend_selector<backend::netlib> selector, transpose transa, transpose transb,
-                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
-                     std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c,
-                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     float beta, float *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =

--- a/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
+++ b/include/oneapi/mkl/blas/detail/onemkl_blas_backends.hxx
@@ -49,15 +49,15 @@ ONEMKL_EXPORT void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
 
 ONEMKL_EXPORT void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                         oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                        std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                        cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                        std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                        std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                        sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc);
 
 ONEMKL_EXPORT void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                         oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                        std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                        cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
-                        cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
+                        std::int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                        std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                        float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc);
 
 ONEMKL_EXPORT void gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                         oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
@@ -966,11 +966,12 @@ ONEMKL_EXPORT void gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose tra
 
 ONEMKL_EXPORT void gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                               oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                              std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                              std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<half, 1> &b,
-                              std::int64_t ldb, std::int64_t stride_b, half beta,
-                              cl::sycl::buffer<half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
-                              std::int64_t batch_size);
+                              std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                              std::int64_t lda, std::int64_t stride_a,
+                              cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                              std::int64_t stride_b, sycl::half beta,
+                              cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                              std::int64_t stride_c, std::int64_t batch_size);
 
 ONEMKL_EXPORT void trsm_batch(cl::sycl::queue &queue, oneapi::mkl::side left_right,
                               oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -1099,16 +1100,16 @@ ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpos
 
 ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                    oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                   std::int64_t k, half alpha, const half *a, std::int64_t lda,
-                                   const half *b, std::int64_t ldb, half beta, half *c,
-                                   std::int64_t ldc,
+                                   std::int64_t k, sycl::half alpha, const sycl::half *a,
+                                   std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                                   sycl::half beta, sycl::half *c, std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                    oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                   std::int64_t k, float alpha, const half *a, std::int64_t lda,
-                                   const half *b, std::int64_t ldb, float beta, float *c,
-                                   std::int64_t ldc,
+                                   std::int64_t k, float alpha, const sycl::half *a,
+                                   std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                                   float beta, float *c, std::int64_t ldc,
                                    const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemm(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -2390,9 +2391,10 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
 
 ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose *transa,
                                          oneapi::mkl::transpose *transb, std::int64_t *m,
-                                         std::int64_t *n, std::int64_t *k, half *alpha,
-                                         const half **a, std::int64_t *lda, const half **b,
-                                         std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                                         std::int64_t *n, std::int64_t *k, sycl::half *alpha,
+                                         const sycl::half **a, std::int64_t *lda,
+                                         const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                                         sycl::half **c, std::int64_t *ldc,
                                          std::int64_t group_count, std::int64_t *group_size,
                                          const std::vector<cl::sycl::event> &dependencies = {});
 
@@ -2430,14 +2432,12 @@ ONEMKL_EXPORT cl::sycl::event gemm_batch(
     std::complex<double> beta, std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
     std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
-ONEMKL_EXPORT cl::sycl::event gemm_batch(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
-                                         oneapi::mkl::transpose transb, std::int64_t m,
-                                         std::int64_t n, std::int64_t k, half alpha, const half *a,
-                                         std::int64_t lda, std::int64_t stride_a, const half *b,
-                                         std::int64_t ldb, std::int64_t stride_b, half beta,
-                                         half *c, std::int64_t ldc, std::int64_t stride_c,
-                                         std::int64_t batch_size,
-                                         const std::vector<cl::sycl::event> &dependencies = {});
+ONEMKL_EXPORT cl::sycl::event gemm_batch(
+    cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+    std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+    std::int64_t lda, std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+    std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
+    std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies = {});
 
 ONEMKL_EXPORT cl::sycl::event gemmt(cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                                     oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,

--- a/include/oneapi/mkl/blas/predicates.hxx
+++ b/include/oneapi/mkl/blas/predicates.hxx
@@ -417,11 +417,12 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose transa, t
 }
 
 inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                                    std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                                    cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                                    std::int64_t stride_a, cl::sycl::buffer<half, 1> &b,
-                                    std::int64_t ldb, std::int64_t stride_b, half beta,
-                                    cl::sycl::buffer<half, 1> &c, std::int64_t ldc,
+                                    std::int64_t m, std::int64_t n, std::int64_t k,
+                                    sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                                    std::int64_t lda, std::int64_t stride_a,
+                                    cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                                    std::int64_t stride_b, sycl::half beta,
+                                    cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
                                     std::int64_t stride_c, std::int64_t batch_size) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -429,11 +430,12 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose transa, tr
 }
 
 inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                                     std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                                     cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                                     std::int64_t stride_a, cl::sycl::buffer<half, 1> &b,
-                                     std::int64_t ldb, std::int64_t stride_b, half beta,
-                                     cl::sycl::buffer<half, 1> &c, std::int64_t ldc,
+                                     std::int64_t m, std::int64_t n, std::int64_t k,
+                                     sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                                     std::int64_t lda, std::int64_t stride_a,
+                                     cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                                     std::int64_t stride_b, sycl::half beta,
+                                     cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
                                      std::int64_t stride_c, std::int64_t batch_size) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
@@ -2043,20 +2045,21 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 }
 
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                              std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                              cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                              cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                              cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+                              std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                              cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                              cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+                              cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
 #endif
 }
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                               std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                               cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                               cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-                               cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+                               std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                               cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                               cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                               sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c,
+                               std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
 #endif
@@ -2064,8 +2067,8 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                               std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                              cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                              cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                              cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                              cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
                               cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -2074,8 +2077,8 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                               cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                               cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+                               cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                               cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
                                cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
@@ -4106,10 +4109,11 @@ inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose *transa, 
 }
 
 inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose *transa, transpose *transb,
-                                    std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha,
-                                    const half **a, std::int64_t *lda, const half **b,
-                                    std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-                                    std::int64_t group_count, std::int64_t *group_size,
+                                    std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                                    sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                                    const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                                    sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                                    std::int64_t *group_size,
                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -4117,10 +4121,11 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose *transa, t
 }
 
 inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose *transa, transpose *transb,
-                                     std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha,
-                                     const half **a, std::int64_t *lda, const half **b,
-                                     std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
-                                     std::int64_t group_count, std::int64_t *group_size,
+                                     std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                                     sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                                     const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                                     sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                                     std::int64_t *group_size,
                                      const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
@@ -4220,10 +4225,11 @@ inline void gemm_batch_postcondition(
 }
 
 inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                                    std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                                    const half *a, std::int64_t lda, std::int64_t stride_a,
-                                    const half *b, std::int64_t ldb, std::int64_t stride_b,
-                                    half beta, half *c, std::int64_t ldc, std::int64_t stride_c,
+                                    std::int64_t m, std::int64_t n, std::int64_t k,
+                                    sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                                    std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                                    std::int64_t stride_b, sycl::half beta, sycl::half *c,
+                                    std::int64_t ldc, std::int64_t stride_c,
                                     std::int64_t batch_size,
                                     const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
@@ -4232,10 +4238,11 @@ inline void gemm_batch_precondition(cl::sycl::queue &queue, transpose transa, tr
 }
 
 inline void gemm_batch_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                                     std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                                     const half *a, std::int64_t lda, std::int64_t stride_a,
-                                     const half *b, std::int64_t ldb, std::int64_t stride_b,
-                                     half beta, half *c, std::int64_t ldc, std::int64_t stride_c,
+                                     std::int64_t m, std::int64_t n, std::int64_t k,
+                                     sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                                     std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                                     std::int64_t stride_b, sycl::half beta, sycl::half *c,
+                                     std::int64_t ldc, std::int64_t stride_c,
                                      std::int64_t batch_size,
                                      const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
@@ -6119,9 +6126,9 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 }
 
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                              std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                              const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                              half beta, half *c, std::int64_t ldc,
+                              std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                              const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                              std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -6129,9 +6136,9 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
 }
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
-                               std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                               const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                               half beta, half *c, std::int64_t ldc,
+                               std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                               const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                               std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */
@@ -6140,8 +6147,8 @@ inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpo
 
 inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                               std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                              const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                              float beta, float *c, std::int64_t ldc,
+                              const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                              std::int64_t ldb, float beta, float *c, std::int64_t ldc,
                               const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add prechecks to queue here for input args.  */
@@ -6150,8 +6157,8 @@ inline void gemm_precondition(cl::sycl::queue &queue, transpose transa, transpos
 
 inline void gemm_postcondition(cl::sycl::queue &queue, transpose transa, transpose transb,
                                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                               const half *a, std::int64_t lda, const half *b, std::int64_t ldb,
-                               float beta, float *c, std::int64_t ldc,
+                               const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                               std::int64_t ldb, float beta, float *c, std::int64_t ldc,
                                const std::vector<cl::sycl::event> &dependencies) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     /* add postchecks to queue here for input args.  */

--- a/include/oneapi/mkl/types.hpp
+++ b/include/oneapi/mkl/types.hpp
@@ -108,8 +108,4 @@ enum class order : char {
 } //namespace mkl
 } //namespace oneapi
 
-// Workaround for supporting ::half for hipSYCL and DPC++
-// TODO: This should be removed after the interface is SYCL2020 conformant
-using ::cl::sycl::half;
-
 #endif //_ONEMKL_TYPES_HPP_

--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -183,7 +183,7 @@ inline void gemm_batch(Func func, cl::sycl::queue &queue, transpose transa, tran
                    ldb, stride_b, beta, c, ldc, stride_c, batch_size);                             \
     }
 
-GEMM_STRIDED_BATCH_LAUNCHER(half, cublasHgemmStridedBatched)
+GEMM_STRIDED_BATCH_LAUNCHER(sycl::half, cublasHgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER(float, cublasSgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER(double, cublasDgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, cublasCgemmStridedBatched)
@@ -530,7 +530,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
                           b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);     \
     }
 
-GEMM_STRIDED_BATCH_LAUNCHER_USM(half, cublasHgemmStridedBatched)
+GEMM_STRIDED_BATCH_LAUNCHER_USM(sycl::half, cublasHgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER_USM(float, cublasSgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER_USM(double, cublasDgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, cublasCgemmStridedBatched)
@@ -588,7 +588,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                           beta, c, ldc, group_count, group_size, dependencies);                  \
     }
 
-GEMM_BATCH_LAUNCHER_USM(half, cublasHgemmBatched)
+GEMM_BATCH_LAUNCHER_USM(sycl::half, cublasHgemmBatched)
 GEMM_BATCH_LAUNCHER_USM(float, cublasSgemmBatched)
 GEMM_BATCH_LAUNCHER_USM(double, cublasDgemmBatched)
 GEMM_BATCH_LAUNCHER_USM(std::complex<float>, cublasCgemmBatched)
@@ -877,7 +877,7 @@ inline void gemm_batch(Func func, cl::sycl::queue &queue, transpose transa, tran
                    ldb, stride_b, beta, c, ldc, stride_c, batch_size);                             \
     }
 
-GEMM_STRIDED_BATCH_LAUNCHER(half, cublasHgemmStridedBatched)
+GEMM_STRIDED_BATCH_LAUNCHER(sycl::half, cublasHgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER(float, cublasSgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER(double, cublasDgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER(std::complex<float>, cublasCgemmStridedBatched)
@@ -1200,7 +1200,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
                           b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);     \
     }
 
-GEMM_STRIDED_BATCH_LAUNCHER_USM(half, cublasHgemmStridedBatched)
+GEMM_STRIDED_BATCH_LAUNCHER_USM(sycl::half, cublasHgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER_USM(float, cublasSgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER_USM(double, cublasDgemmStridedBatched)
 GEMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<float>, cublasCgemmStridedBatched)
@@ -1227,7 +1227,7 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
                           beta, c, ldc, group_count, group_size, dependencies);                  \
     }
 
-GEMM_BATCH_LAUNCHER_USM(half, cublasHgemmBatched)
+GEMM_BATCH_LAUNCHER_USM(sycl::half, cublasHgemmBatched)
 GEMM_BATCH_LAUNCHER_USM(float, cublasSgemmBatched)
 GEMM_BATCH_LAUNCHER_USM(double, cublasDgemmBatched)
 GEMM_BATCH_LAUNCHER_USM(std::complex<float>, cublasCgemmBatched)

--- a/src/blas/backends/cublas/cublas_handle.hpp
+++ b/src/blas/backends/cublas/cublas_handle.hpp
@@ -18,8 +18,8 @@
 **************************************************************************/
 #ifndef CUBLAS_HANDLE_HPP
 #define CUBLAS_HANDLE_HPP
-#include<atomic>
-#include<unordered_map>
+#include <atomic>
+#include <unordered_map>
 
 namespace oneapi {
 namespace mkl {

--- a/src/blas/backends/cublas/cublas_helper.hpp
+++ b/src/blas/backends/cublas/cublas_helper.hpp
@@ -216,7 +216,7 @@ struct CudaEquivalentType {
     using Type = T;
 };
 template <>
-struct CudaEquivalentType<half> {
+struct CudaEquivalentType<sycl::half> {
     using Type = __half;
 };
 template <>

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -111,8 +111,8 @@ inline void gemm_ex(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C, cl::sycl:
                 alpha, a, lda, b, ldb, beta, c, ldc);                                            \
     }
 
-GEMM_EX_LAUNCHER(half, half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER(half, half, half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER(sycl::half, sycl::half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
+GEMM_EX_LAUNCHER(sycl::half, sycl::half, sycl::half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER
 
@@ -506,8 +506,8 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
                            m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);           \
     }
 
-GEMM_EX_LAUNCHER_USM(half, half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER_USM(half, half, half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER_USM(sycl::half, sycl::half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
+GEMM_EX_LAUNCHER_USM(sycl::half, sycl::half, sycl::half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER_USM
 
@@ -893,8 +893,8 @@ inline void gemm_ex(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C, cl::sycl:
                 alpha, a, lda, b, ldb, beta, c, ldc);                                            \
     }
 
-GEMM_EX_LAUNCHER(half, half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER(half, half, half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER(sycl::half, sycl::half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
+GEMM_EX_LAUNCHER(sycl::half, sycl::half, sycl::half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER
 
@@ -1125,8 +1125,8 @@ inline cl::sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C 
                            m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);           \
     }
 
-GEMM_EX_LAUNCHER_USM(half, half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
-GEMM_EX_LAUNCHER_USM(half, half, half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
+GEMM_EX_LAUNCHER_USM(sycl::half, sycl::half, float, CUDA_R_16F, CUDA_R_16F, CUDA_R_32F)
+GEMM_EX_LAUNCHER_USM(sycl::half, sycl::half, sycl::half, CUDA_R_16F, CUDA_R_16F, CUDA_R_16F)
 
 #undef GEMM_EX_LAUNCHER_USM
 

--- a/src/blas/backends/mklcpu/mklcpu_batch.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_batch.cxx
@@ -632,9 +632,10 @@ void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int6
 }
 
 void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, int64_t ldb, int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+                int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+                int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c,
+                int64_t batch_size) {
     queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
             throw oneapi::mkl::unimplemented(
@@ -686,9 +687,9 @@ void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int6
                 (const float **)b_array, (const MKL_INT *)&ldb, &betaf, (float **)c_array,
                 (const MKL_INT *)&ldc, one, (const MKL_INT *)&batch_size);
             // copy C back to half
-            half co = 0.0f;
+            sycl::half co = 0.0f;
             copy_mat(f32_c, MKL_COL_MAJOR, totalsize_c, 1, totalsize_c, offset::F, &co,
-                     (half *)c_acc.get_pointer());
+                     (sycl::half *)c_acc.get_pointer());
             ::free(a_array);
             ::free(b_array);
             ::free(c_array);
@@ -1961,9 +1962,9 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
 }
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, half *alpha, const half **a, int64_t *lda,
-                           const half **b, int64_t *ldb, half *beta, half **c, int64_t *ldc,
-                           int64_t group_count, int64_t *groupsize,
+                           int64_t *n, int64_t *k, sycl::half *alpha, const sycl::half **a,
+                           int64_t *lda, const sycl::half **b, int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
                            const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
@@ -2009,7 +2010,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
                 return;
             }
             int64_t sizea, sizeb, sizec, idx;
-            half co = 0.0f;
+            sycl::half co = 0.0f;
             for (int64_t i = 0, idx = 0; i < group_count; i++) {
 #ifdef COLUMN_MAJOR
                 sizea = (transa[i] == transpose::N) ? lda[i] * k[i] : lda[i] * m[i];
@@ -2240,10 +2241,10 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
 }
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, half alpha, const half *a, int64_t lda,
-                           int64_t stride_a, const half *b, int64_t ldb, int64_t stride_b,
-                           half beta, half *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
+                           int64_t stride_a, const sycl::half *b, int64_t ldb, int64_t stride_b,
+                           sycl::half beta, sycl::half *c, int64_t ldc, int64_t stride_c,
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
             throw oneapi::mkl::unimplemented(
@@ -2311,7 +2312,7 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
                 (const float **)b_array, (const MKL_INT *)&ldb, &betaf, (float **)c_array,
                 (const MKL_INT *)&ldc, one, (const MKL_INT *)&batch_size);
 
-            half co = 0.0f;
+            sycl::half co = 0.0f;
             copy_mat(f32_c, MKL_COL_MAJOR, totalsize_c, 1, totalsize_c, offset::F, &co, c);
             ::free(a_array);
             ::free(b_array);

--- a/src/blas/backends/mklcpu/mklcpu_level3.cxx
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cxx
@@ -98,9 +98,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-          cl::sycl::buffer<half, 1> &b, int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
-          int64_t ldc) {
+          int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+          cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
+          cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc) {
     queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
             throw oneapi::mkl::unimplemented(
@@ -136,8 +136,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
             ::cblas_sgemm(CBLASMAJOR, transa_, transb_, m, n, k, f32_alpha, f32_a, lda, f32_b, ldb,
                           f32_beta, f32_c, ldc);
             // copy C back to half
-            half co = 0.0f;
-            copy_mat(f32_c, MKLMAJOR, m, n, ldc, offset::F, &co, (half *)accessor_c.get_pointer());
+            sycl::half co = 0.0f;
+            copy_mat(f32_c, MKLMAJOR, m, n, ldc, offset::F, &co,
+                     (sycl::half *)accessor_c.get_pointer());
             ::free(f32_a);
             ::free(f32_b);
             ::free(f32_c);
@@ -146,9 +147,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-          cl::sycl::buffer<half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
-          int64_t ldc) {
+          int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+          cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, float beta,
+          cl::sycl::buffer<float, 1> &c, int64_t ldc) {
     if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
         throw oneapi::mkl::unimplemented(
             "blas", "cl::sycl::half", "half is not supported by the device or the sycl compiler");
@@ -781,8 +782,8 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 }
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, half alpha, const half *a, int64_t lda, const half *b,
-                     int64_t ldb, half beta, half *c, int64_t ldc,
+                     int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
+                     const sycl::half *b, int64_t ldb, sycl::half beta, sycl::half *c, int64_t ldc,
                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {
@@ -820,7 +821,7 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
             ::cblas_sgemm(CBLASMAJOR, transa_, transb_, m, n, k, f32_alpha, f32_a, lda, f32_b, ldb,
                           f32_beta, f32_c, ldc);
             // copy C back to half
-            half co = 0.0f;
+            sycl::half co = 0.0f;
             copy_mat(f32_c, MKLMAJOR, m, n, ldc, offset::F, &co, c);
             ::free(f32_a);
             ::free(f32_b);
@@ -831,8 +832,8 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 }
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const half *a, int64_t lda, const half *b,
-                     int64_t ldb, float beta, float *c, int64_t ldc,
+                     int64_t n, int64_t k, float alpha, const sycl::half *a, int64_t lda,
+                     const sycl::half *b, int64_t ldb, float beta, float *c, int64_t ldc,
                      const std::vector<cl::sycl::event> &dependencies) {
     auto done = queue.submit([&](cl::sycl::handler &cgh) {
         if (!verify_support<cl::sycl::half, cl::sycl::half>(queue, cl::sycl::aspect::fp16)) {

--- a/src/blas/backends/mklgpu/mklgpu_batch.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_batch.cxx
@@ -199,9 +199,10 @@ void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int6
 }
 
 void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, int64_t ldb, int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+                int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+                int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c,
+                int64_t batch_size) {
     ::oneapi::mkl::gpu::hgemm_batch(queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k,
                                     alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
                                     stride_c, batch_size);
@@ -773,10 +774,10 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
 }
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, half alpha, const half *a, int64_t lda,
-                           int64_t stride_a, const half *b, int64_t ldb, int64_t stride_b,
-                           half beta, half *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
+                           int64_t stride_a, const sycl::half *b, int64_t ldb, int64_t stride_b,
+                           sycl::half beta, sycl::half *c, int64_t ldc, int64_t stride_c,
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::hgemm_batch_sycl(
         &queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k, alpha, a, lda, stride_a,
         b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
@@ -865,9 +866,9 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
 }
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, half *alpha, const half **a, int64_t *lda,
-                           const half **b, int64_t *ldb, half *beta, half **c, int64_t *ldc,
-                           int64_t group_count, int64_t *groupsize,
+                           int64_t *n, int64_t *k, sycl::half *alpha, const sycl::half **a,
+                           int64_t *lda, const sycl::half **b, int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
                            const std::vector<cl::sycl::event> &dependencies) {
     std::vector<cl::sycl::event *> coalesced_events;
     coalesced_events.reserve(group_count);

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -888,8 +888,9 @@ void hgemm_batch(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa
                  MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
                  cl::sycl::buffer<sycl::half, 1> &a, int64_t lda, int64_t stride_a,
                  cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b, sycl::half beta,
-                 cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                 int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                 cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c,
+                 int64_t batch_size, int64_t offset_a = 0, int64_t offset_b = 0,
+                 int64_t offset_c = 0);
 
 void strsm_batch(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_SIDE left_right,
                  MKL_UPLO upper_lower, MKL_TRANSPOSE trans, MKL_DIAG unit_diag, int64_t m,
@@ -940,14 +941,15 @@ void cgemmt(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_UPLO upper_lower, MKL
             cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
 
 void hgemm(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa, MKL_TRANSPOSE transb,
-           int64_t m, int64_t n, int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
-           cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c,
-           int64_t ldc);
+           int64_t m, int64_t n, int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+           int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
+           cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc);
 
 void gemm_f16f16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                     MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
-                    cl::sycl::buffer<sycl::half, 1> &a, int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
-                    int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
+                    cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+                    cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, float beta,
+                    cl::sycl::buffer<float, 1> &c, int64_t ldc);
 
 void gemm_bf16bf16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                       MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
@@ -1027,15 +1029,16 @@ cl::sycl::event zgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
 
 cl::sycl::event hgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                            MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
-                           const sycl::half *a, int64_t lda, const sycl::half *b, int64_t ldb, sycl::half beta,
-                           sycl::half *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
-                           int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
+                           const sycl::half *a, int64_t lda, const sycl::half *b, int64_t ldb,
+                           sycl::half beta, sycl::half *c, int64_t ldc,
+                           const std::vector<cl::sycl::event> &dependencies, int64_t offset_a = 0,
+                           int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event gemm_f16f16f32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                     MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k,
-                                    float alpha, const sycl::half *a, int64_t lda, const sycl::half *b,
-                                    int64_t ldb, float beta, float *c, int64_t ldc,
-                                    const std::vector<cl::sycl::event> &dependencies,
+                                    float alpha, const sycl::half *a, int64_t lda,
+                                    const sycl::half *b, int64_t ldb, float beta, float *c,
+                                    int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                                     int64_t offset_a = 0, int64_t offset_b = 0,
                                     int64_t offset_c = 0);
 
@@ -2102,10 +2105,11 @@ cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
-                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
-                                 const sycl::half *a, int64_t lda, int64_t strideA, const sycl::half *b,
-                                 int64_t ldb, int64_t strideB, sycl::half beta, sycl::half *c, int64_t ldc,
-                                 int64_t strideC, int64_t groupsize,
+                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k,
+                                 sycl::half alpha, const sycl::half *a, int64_t lda,
+                                 int64_t strideA, const sycl::half *b, int64_t ldb, int64_t strideB,
+                                 sycl::half beta, sycl::half *c, int64_t ldc, int64_t strideC,
+                                 int64_t groupsize,
                                  const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
@@ -2144,10 +2148,10 @@ cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
-                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
-                                 const sycl::half **a, int64_t lda, const sycl::half **b, int64_t ldb,
-                                 sycl::half beta, sycl::half **c, int64_t ldc, int64_t offset_batch,
-                                 int64_t groupsize,
+                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k,
+                                 sycl::half alpha, const sycl::half **a, int64_t lda,
+                                 const sycl::half **b, int64_t ldb, sycl::half beta, sycl::half **c,
+                                 int64_t ldc, int64_t offset_batch, int64_t groupsize,
                                  const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -885,10 +885,10 @@ void zgemm_batch(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa
                  int64_t offset_b = 0, int64_t offset_c = 0);
 
 void hgemm_batch(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
-                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, half alpha,
-                 cl::sycl::buffer<half, 1> &a, int64_t lda, int64_t stride_a,
-                 cl::sycl::buffer<half, 1> &b, int64_t ldb, int64_t stride_b, half beta,
-                 cl::sycl::buffer<half, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
+                 cl::sycl::buffer<sycl::half, 1> &a, int64_t lda, int64_t stride_a,
+                 cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b, sycl::half beta,
+                 cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size,
                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 void strsm_batch(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_SIDE left_right,
@@ -940,13 +940,13 @@ void cgemmt(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_UPLO upper_lower, MKL
             cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
 
 void hgemm(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa, MKL_TRANSPOSE transb,
-           int64_t m, int64_t n, int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-           cl::sycl::buffer<half, 1> &b, int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
+           int64_t m, int64_t n, int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+           cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c,
            int64_t ldc);
 
 void gemm_f16f16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                     MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha,
-                    cl::sycl::buffer<half, 1> &a, int64_t lda, cl::sycl::buffer<half, 1> &b,
+                    cl::sycl::buffer<sycl::half, 1> &a, int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
                     int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
 
 void gemm_bf16bf16f32(cl::sycl::queue &queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
@@ -1026,14 +1026,14 @@ cl::sycl::event zgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSP
                            int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
-                           MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, half alpha,
-                           const half *a, int64_t lda, const half *b, int64_t ldb, half beta,
-                           half *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
+                           MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
+                           const sycl::half *a, int64_t lda, const sycl::half *b, int64_t ldb, sycl::half beta,
+                           sycl::half *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies,
                            int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event gemm_f16f16f32_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
                                     MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k,
-                                    float alpha, const half *a, int64_t lda, const half *b,
+                                    float alpha, const sycl::half *a, int64_t lda, const sycl::half *b,
                                     int64_t ldb, float beta, float *c, int64_t ldc,
                                     const std::vector<cl::sycl::event> &dependencies,
                                     int64_t offset_a = 0, int64_t offset_b = 0,
@@ -2102,9 +2102,9 @@ cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
-                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, half alpha,
-                                 const half *a, int64_t lda, int64_t strideA, const half *b,
-                                 int64_t ldb, int64_t strideB, half beta, half *c, int64_t ldc,
+                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
+                                 const sycl::half *a, int64_t lda, int64_t strideA, const sycl::half *b,
+                                 int64_t ldb, int64_t strideB, sycl::half beta, sycl::half *c, int64_t ldc,
                                  int64_t strideC, int64_t groupsize,
                                  const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
@@ -2144,9 +2144,9 @@ cl::sycl::event zgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);
 
 cl::sycl::event hgemm_batch_sycl(cl::sycl::queue *queue, MKL_LAYOUT layout, MKL_TRANSPOSE transa,
-                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, half alpha,
-                                 const half **a, int64_t lda, const half **b, int64_t ldb,
-                                 half beta, half **c, int64_t ldc, int64_t offset_batch,
+                                 MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
+                                 const sycl::half **a, int64_t lda, const sycl::half **b, int64_t ldb,
+                                 sycl::half beta, sycl::half **c, int64_t ldc, int64_t offset_batch,
                                  int64_t groupsize,
                                  const std::vector<cl::sycl::event> &dependencies,
                                  int64_t offset_a = 0, int64_t offset_b = 0, int64_t offset_c = 0);

--- a/src/blas/backends/mklgpu/mklgpu_level3.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_level3.cxx
@@ -54,16 +54,16 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+          cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     ::oneapi::mkl::gpu::hgemm(queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n, k,
                               alpha, a, lda, b, ldb, beta, c, ldc);
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-          std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     ::oneapi::mkl::gpu::gemm_f16f16f32(queue, MAJOR, mkl_convert(transa), mkl_convert(transb), m, n,
                                        k, alpha, a, lda, b, ldb, beta, c, ldc);
@@ -333,8 +333,9 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 }
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-                     const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+                     std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+                     std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta,
+                     sycl::half *c, std::int64_t ldc,
                      const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::hgemm_sycl(&queue, MAJOR, mkl_convert(transa), mkl_convert(transb),
                                           m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
@@ -342,9 +343,9 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 }
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, std::int64_t m,
-                     std::int64_t n, std::int64_t k, float alpha, const half *a, std::int64_t lda,
-                     const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+                     std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
+                     std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c,
+                     std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return ::oneapi::mkl::gpu::gemm_f16f16f32_sycl(&queue, MAJOR, mkl_convert(transa),
                                                    mkl_convert(transb), m, n, k, alpha, a, lda, b,
                                                    ldb, beta, c, ldc, dependencies);

--- a/src/blas/backends/netlib/netlib_batch.cxx
+++ b/src/blas/backends/netlib/netlib_batch.cxx
@@ -267,9 +267,10 @@ void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int6
 }
 
 void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, int64_t ldb, int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+                int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+                int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c,
+                int64_t batch_size) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif
@@ -828,9 +829,9 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose 
 }
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, half *alpha, const half **a, int64_t *lda,
-                           const half **b, int64_t *ldb, half *beta, half **c, int64_t *ldc,
-                           int64_t group_count, int64_t *groupsize,
+                           int64_t *n, int64_t *k, sycl::half *alpha, const sycl::half **a,
+                           int64_t *lda, const sycl::half **b, int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
                            const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
@@ -897,10 +898,10 @@ cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose t
 }
 
 cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, half alpha, const half *a, int64_t lda,
-                           int64_t stride_a, const half *b, int64_t ldb, int64_t stride_b,
-                           half beta, half *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+                           int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
+                           int64_t stride_a, const sycl::half *b, int64_t ldb, int64_t stride_b,
+                           sycl::half beta, sycl::half *c, int64_t ldc, int64_t stride_c,
+                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm_batch", "for column_major layout");
 #endif

--- a/src/blas/backends/netlib/netlib_level3.cxx
+++ b/src/blas/backends/netlib/netlib_level3.cxx
@@ -92,9 +92,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, half alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-          cl::sycl::buffer<half, 1> &b, int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
-          int64_t ldc) {
+          int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+          cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
+          cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -104,9 +104,9 @@ void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
 }
 
 void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<half, 1> &a, int64_t lda,
-          cl::sycl::buffer<half, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
-          int64_t ldc) {
+          int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
+          cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, float beta,
+          cl::sycl::buffer<float, 1> &c, int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -640,8 +640,8 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 }
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, half alpha, const half *a, int64_t lda, const half *b,
-                     int64_t ldb, half beta, half *c, int64_t ldc,
+                     int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
+                     const sycl::half *b, int64_t ldb, sycl::half beta, sycl::half *c, int64_t ldc,
                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
@@ -652,8 +652,8 @@ cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb,
 }
 
 cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const half *a, int64_t lda, const half *b,
-                     int64_t ldb, float beta, float *c, int64_t ldc,
+                     int64_t n, int64_t k, float alpha, const sycl::half *a, int64_t lda,
+                     const sycl::half *b, int64_t ldb, float beta, float *c, int64_t ldc,
                      const std::vector<cl::sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -1053,17 +1053,17 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
-          cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda,
                                                     b, ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha,
                                                              a, lda, b, ldb, beta, c, ldc);
 }
@@ -1384,9 +1384,9 @@ void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose tr
 void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                 transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
                 cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
-                cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
-                std::int64_t batch_size) {
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
     function_tables[libkey].column_major_hgemm_batch_strided_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size);
@@ -2810,17 +2810,19 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
-                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
-                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta,
-                     sycl::half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                     sycl::half alpha, const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                     std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta,
-                     float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     float beta, float *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -3297,9 +3299,10 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda, const sycl::half **b,
-                           std::int64_t *ldb, sycl::half *beta, sycl::half **c, std::int64_t *ldc,
-                           std::int64_t group_count, std::int64_t *group_size,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                           const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                           std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
@@ -3358,10 +3361,10 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           sycl::half alpha, const sycl::half *a, std::int64_t lda, std::int64_t stride_a,
-                           const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
-                           sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
-                           std::int64_t batch_size,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                           std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                           std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                           std::int64_t stride_c, std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
@@ -4480,17 +4483,17 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
-          cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda, b,
                                                  ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha, a,
                                                           lda, b, ldb, beta, c, ldc);
 }
@@ -4811,9 +4814,9 @@ void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose tr
 void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                 transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
                 cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
-                cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
-                std::int64_t batch_size) {
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
     function_tables[libkey].row_major_hgemm_batch_strided_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
         stride_c, batch_size);
@@ -6233,17 +6236,19 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
-                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
-                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta,
-                     sycl::half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                     sycl::half alpha, const sycl::half *a, std::int64_t lda, const sycl::half *b,
+                     std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta,
-                     float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                     float beta, float *c, std::int64_t ldc,
+                     const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
@@ -6720,9 +6725,10 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda, const sycl::half **b,
-                           std::int64_t *ldb, sycl::half *beta, sycl::half **c, std::int64_t *ldc,
-                           std::int64_t group_count, std::int64_t *group_size,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                           const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+                           sycl::half **c, std::int64_t *ldc, std::int64_t group_count,
+                           std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_batch_group_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, group_count,
@@ -6781,10 +6787,10 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           sycl::half alpha, const sycl::half *a, std::int64_t lda, std::int64_t stride_a,
-                           const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
-                           sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
-                           std::int64_t batch_size,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                           std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                           std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                           std::int64_t stride_c, std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_batch_strided_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -1053,16 +1053,16 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+          cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda,
                                                     b, ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].column_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha,
                                                              a, lda, b, ldb, beta, c, ldc);
@@ -1382,10 +1382,10 @@ void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose tr
 }
 
 void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
-                transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                cl::sycl::buffer<half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
+                transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+                cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
                 std::int64_t batch_size) {
     function_tables[libkey].column_major_hgemm_batch_strided_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
@@ -2810,16 +2810,16 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
-                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                     const half *a, std::int64_t lda, const half *b, std::int64_t ldb, half beta,
-                     half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta,
+                     sycl::half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                     const half *a, std::int64_t lda, const half *b, std::int64_t ldb, float beta,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta,
                      float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
@@ -3297,8 +3297,8 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           half *alpha, const half **a, std::int64_t *lda, const half **b,
-                           std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda, const sycl::half **b,
+                           std::int64_t *ldb, sycl::half *beta, sycl::half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_batch_group_usm_sycl(
@@ -3358,9 +3358,9 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
-                           const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                           half *c, std::int64_t ldc, std::int64_t stride_c,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda, std::int64_t stride_a,
+                           const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+                           sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].column_major_hgemm_batch_strided_usm_sycl(
@@ -4480,16 +4480,16 @@ void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, 
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, half beta,
-          cl::sycl::buffer<half, 1> &c, std::int64_t ldc) {
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, sycl::half beta,
+          cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_hgemm_sycl(queue, transa, transb, m, n, k, alpha, a, lda, b,
                                                  ldb, beta, c, ldc);
 }
 
 void gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa, transpose transb,
-          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<half, 1> &a,
-          std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb, float beta,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
+          std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, float beta,
           cl::sycl::buffer<float, 1> &c, std::int64_t ldc) {
     function_tables[libkey].row_major_gemm_f16f16f32_sycl(queue, transa, transb, m, n, k, alpha, a,
                                                           lda, b, ldb, beta, c, ldc);
@@ -4809,10 +4809,10 @@ void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose tr
 }
 
 void gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
-                transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                cl::sycl::buffer<half, 1> &a, std::int64_t lda, std::int64_t stride_a,
-                cl::sycl::buffer<half, 1> &b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                cl::sycl::buffer<half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
+                transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+                cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc, std::int64_t stride_c,
                 std::int64_t batch_size) {
     function_tables[libkey].row_major_hgemm_batch_strided_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta, c, ldc,
@@ -6233,16 +6233,16 @@ cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpo
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
-                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, half alpha,
-                     const half *a, std::int64_t lda, const half *b, std::int64_t ldb, half beta,
-                     half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+                     transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta,
+                     sycl::half *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
 }
 
 cl::sycl::event gemm(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                      transpose transb, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
-                     const half *a, std::int64_t lda, const half *b, std::int64_t ldb, float beta,
+                     const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta,
                      float *c, std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_gemm_f16f16f32_usm_sycl(
         queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
@@ -6720,8 +6720,8 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose *transa,
                            transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
-                           half *alpha, const half **a, std::int64_t *lda, const half **b,
-                           std::int64_t *ldb, half *beta, half **c, std::int64_t *ldc,
+                           sycl::half *alpha, const sycl::half **a, std::int64_t *lda, const sycl::half **b,
+                           std::int64_t *ldb, sycl::half *beta, sycl::half **c, std::int64_t *ldc,
                            std::int64_t group_count, std::int64_t *group_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_batch_group_usm_sycl(
@@ -6781,9 +6781,9 @@ cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, t
 
 cl::sycl::event gemm_batch(oneapi::mkl::device libkey, cl::sycl::queue &queue, transpose transa,
                            transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
-                           half alpha, const half *a, std::int64_t lda, std::int64_t stride_a,
-                           const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-                           half *c, std::int64_t ldc, std::int64_t stride_c,
+                           sycl::half alpha, const sycl::half *a, std::int64_t lda, std::int64_t stride_a,
+                           const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+                           sycl::half *c, std::int64_t ldc, std::int64_t stride_c,
                            std::int64_t batch_size,
                            const std::vector<cl::sycl::event> &dependencies) {
     return function_tables[libkey].row_major_hgemm_batch_strided_usm_sycl(

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -686,15 +686,15 @@ typedef struct {
                                     cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*column_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                     oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                    std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                                    std::int64_t lda, cl::sycl::buffer<half, 1> &b,
-                                    std::int64_t ldb, half beta, cl::sycl::buffer<half, 1> &c,
+                                    std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                                    std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
+                                    std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c,
                                     std::int64_t ldc);
     void (*column_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                              oneapi::mkl::transpose transb, std::int64_t m,
                                              std::int64_t n, std::int64_t k, float alpha,
-                                             cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                                             cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
+                                             cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                                             cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
                                              float beta, cl::sycl::buffer<float, 1> &c,
                                              std::int64_t ldc);
     void (*column_major_gemm_bf16bf16f32_sycl)(
@@ -905,9 +905,9 @@ typedef struct {
         std::int64_t stride_c, std::int64_t batch_size);
     void (*column_major_hgemm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-        std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
-        std::int64_t stride_b, half beta, cl::sycl::buffer<half, 1> &c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+        std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+        std::int64_t stride_b, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
         std::int64_t stride_c, std::int64_t batch_size);
     void (*column_major_strsm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -1688,13 +1688,13 @@ typedef struct {
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-        const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
+        const sycl::half *b, std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_f16f16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
-        std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
+        std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_bf16bf16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -1955,8 +1955,8 @@ typedef struct {
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
-        std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
-        std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c,
+        std::int64_t *m, std::int64_t *n, std::int64_t *k, sycl::half *alpha, const sycl::half **a,
+        std::int64_t *lda, const sycl::half **b, std::int64_t *ldb, sycl::half *beta, sycl::half **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemm_batch_strided_usm_sycl)(
@@ -1987,9 +1987,9 @@ typedef struct {
         std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-        std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-        half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
+        std::int64_t stride_a, const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+        sycl::half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
@@ -2667,14 +2667,14 @@ typedef struct {
                                  cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*row_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                  oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                 std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-                                 std::int64_t lda, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
-                                 half beta, cl::sycl::buffer<half, 1> &c, std::int64_t ldc);
+                                 std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+                                 std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                                 sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc);
     void (*row_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                           oneapi::mkl::transpose transb, std::int64_t m,
                                           std::int64_t n, std::int64_t k, float alpha,
-                                          cl::sycl::buffer<half, 1> &a, std::int64_t lda,
-                                          cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
+                                          cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                                          cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
                                           float beta, cl::sycl::buffer<float, 1> &c,
                                           std::int64_t ldc);
     void (*row_major_gemm_bf16bf16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -2886,9 +2886,9 @@ typedef struct {
         std::int64_t stride_c, std::int64_t batch_size);
     void (*row_major_hgemm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, half alpha, cl::sycl::buffer<half, 1> &a,
-        std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<half, 1> &b, std::int64_t ldb,
-        std::int64_t stride_b, half beta, cl::sycl::buffer<half, 1> &c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
+        std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+        std::int64_t stride_b, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
         std::int64_t stride_c, std::int64_t batch_size);
     void (*row_major_strsm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -3783,13 +3783,13 @@ typedef struct {
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-        const half *b, std::int64_t ldb, half beta, half *c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
+        const sycl::half *b, std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_f16f16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const half *a,
-        std::int64_t lda, const half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
+        std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_bf16bf16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -4056,8 +4056,8 @@ typedef struct {
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
-        std::int64_t *m, std::int64_t *n, std::int64_t *k, half *alpha, const half **a,
-        std::int64_t *lda, const half **b, std::int64_t *ldb, half *beta, half **c,
+        std::int64_t *m, std::int64_t *n, std::int64_t *k, sycl::half *alpha, const sycl::half **a,
+        std::int64_t *lda, const sycl::half **b, std::int64_t *ldb, sycl::half *beta, sycl::half **c,
         std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemm_batch_strided_usm_sycl)(
@@ -4088,9 +4088,9 @@ typedef struct {
         std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, half alpha, const half *a, std::int64_t lda,
-        std::int64_t stride_a, const half *b, std::int64_t ldb, std::int64_t stride_b, half beta,
-        half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
+        std::int64_t stride_a, const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
+        sycl::half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -686,9 +686,10 @@ typedef struct {
                                     cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*column_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                     oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                    std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
-                                    std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b,
-                                    std::int64_t ldb, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c,
+                                    std::int64_t k, sycl::half alpha,
+                                    cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                                    cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                                    sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c,
                                     std::int64_t ldc);
     void (*column_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                              oneapi::mkl::transpose transb, std::int64_t m,
@@ -905,9 +906,10 @@ typedef struct {
         std::int64_t stride_c, std::int64_t batch_size);
     void (*column_major_hgemm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
-        std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
-        std::int64_t stride_b, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+        cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+        sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
         std::int64_t stride_c, std::int64_t batch_size);
     void (*column_major_strsm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -1688,14 +1690,14 @@ typedef struct {
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
-        const sycl::half *b, std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+        std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta, sycl::half *c,
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_f16f16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
-        std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c,
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_gemm_bf16bf16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const oneapi::mkl::bfloat16 *a,
@@ -1956,8 +1958,8 @@ typedef struct {
     cl::sycl::event (*column_major_hgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, sycl::half *alpha, const sycl::half **a,
-        std::int64_t *lda, const sycl::half **b, std::int64_t *ldb, sycl::half *beta, sycl::half **c,
-        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+        std::int64_t *lda, const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+        sycl::half **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -1987,9 +1989,10 @@ typedef struct {
         std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_hgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
-        std::int64_t stride_a, const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
-        sycl::half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+        std::int64_t lda, std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+        std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+        std::int64_t stride_c, std::int64_t batch_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*column_major_sgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
@@ -2667,9 +2670,11 @@ typedef struct {
                                  cl::sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc);
     void (*row_major_hgemm_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                  oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
-                                 std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
-                                 std::int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
-                                 sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc);
+                                 std::int64_t k, sycl::half alpha,
+                                 cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda,
+                                 cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
+                                 sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c,
+                                 std::int64_t ldc);
     void (*row_major_gemm_f16f16f32_sycl)(cl::sycl::queue &queue, oneapi::mkl::transpose transa,
                                           oneapi::mkl::transpose transb, std::int64_t m,
                                           std::int64_t n, std::int64_t k, float alpha,
@@ -2886,9 +2891,10 @@ typedef struct {
         std::int64_t stride_c, std::int64_t batch_size);
     void (*row_major_hgemm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
-        std::int64_t lda, std::int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb,
-        std::int64_t stride_b, sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+        cl::sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+        cl::sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+        sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
         std::int64_t stride_c, std::int64_t batch_size);
     void (*row_major_strsm_batch_strided_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -3783,14 +3789,14 @@ typedef struct {
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
-        const sycl::half *b, std::int64_t ldb, sycl::half beta, sycl::half *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+        std::int64_t lda, const sycl::half *b, std::int64_t ldb, sycl::half beta, sycl::half *c,
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_f16f16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
-        std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
-        const std::vector<cl::sycl::event> &dependencies);
+        std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c,
+        std::int64_t ldc, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_gemm_bf16bf16f32_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
         std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const oneapi::mkl::bfloat16 *a,
@@ -4057,8 +4063,8 @@ typedef struct {
     cl::sycl::event (*row_major_hgemm_batch_group_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose *transa, oneapi::mkl::transpose *transb,
         std::int64_t *m, std::int64_t *n, std::int64_t *k, sycl::half *alpha, const sycl::half **a,
-        std::int64_t *lda, const sycl::half **b, std::int64_t *ldb, sycl::half *beta, sycl::half **c,
-        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+        std::int64_t *lda, const sycl::half **b, std::int64_t *ldb, sycl::half *beta,
+        sycl::half **c, std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -4088,9 +4094,10 @@ typedef struct {
         std::int64_t batch_size, const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_hgemm_batch_strided_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
-        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
-        std::int64_t stride_a, const sycl::half *b, std::int64_t ldb, std::int64_t stride_b, sycl::half beta,
-        sycl::half *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+        std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha, const sycl::half *a,
+        std::int64_t lda, std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+        std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+        std::int64_t stride_c, std::int64_t batch_size,
         const std::vector<cl::sycl::event> &dependencies);
     cl::sycl::event (*row_major_sgemmt_usm_sycl)(
         cl::sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -207,7 +207,7 @@ class GemmBatchStrideTests
         : public ::testing::TestWithParam<std::tuple<cl::sycl::device *, oneapi::mkl::layout>> {};
 
 TEST_P(GemmBatchStrideTests, RealHalfPrecision) {
-    EXPECT_TRUEORSKIP(test<half>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
+    EXPECT_TRUEORSKIP(test<sycl::half>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
 TEST_P(GemmBatchStrideTests, RealSinglePrecision) {

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -241,7 +241,7 @@ class GemmBatchStrideUsmTests
         : public ::testing::TestWithParam<std::tuple<cl::sycl::device *, oneapi::mkl::layout>> {};
 
 TEST_P(GemmBatchStrideUsmTests, RealHalfPrecision) {
-    EXPECT_TRUEORSKIP(test<half>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
+    EXPECT_TRUEORSKIP(test<sycl::half>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
 TEST_P(GemmBatchStrideUsmTests, RealSinglePrecision) {

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -330,7 +330,7 @@ class GemmBatchUsmTests
         : public ::testing::TestWithParam<std::tuple<cl::sycl::device *, oneapi::mkl::layout>> {};
 
 TEST_P(GemmBatchUsmTests, RealHalfPrecision) {
-    EXPECT_TRUEORSKIP(test<half>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
+    EXPECT_TRUEORSKIP(test<sycl::half>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
 TEST_P(GemmBatchUsmTests, RealSinglePrecision) {

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -228,7 +228,8 @@ static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE tr
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
           const int *n, const int *k, const sycl::half *alpha, const sycl::half *a, const int *lda,
-          const sycl::half *b, const int *ldb, const sycl::half *beta, sycl::half *c, const int *ldc) {
+          const sycl::half *b, const int *ldb, const sycl::half *beta, sycl::half *c,
+          const int *ldc) {
     // Not supported in NETLIB. SGEMM is used as reference.
     int sizea, sizeb, sizec;
     const float alphaf = *alpha;

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -227,8 +227,8 @@ static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE tr
 
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
-          const int *n, const int *k, const half *alpha, const half *a, const int *lda,
-          const half *b, const int *ldb, const half *beta, half *c, const int *ldc) {
+          const int *n, const int *k, const sycl::half *alpha, const sycl::half *a, const int *lda,
+          const sycl::half *b, const int *ldb, const sycl::half *beta, sycl::half *c, const int *ldc) {
     // Not supported in NETLIB. SGEMM is used as reference.
     int sizea, sizeb, sizec;
     const float alphaf = *alpha;
@@ -294,8 +294,8 @@ static void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE tr
 
 template <>
 void gemm(CBLAS_LAYOUT layout, CBLAS_TRANSPOSE transa, CBLAS_TRANSPOSE transb, const int *m,
-          const int *n, const int *k, const float *alpha, const half *a, const int *lda,
-          const half *b, const int *ldb, const float *beta, float *c, const int *ldc) {
+          const int *n, const int *k, const float *alpha, const sycl::half *a, const int *lda,
+          const sycl::half *b, const int *ldb, const float *beta, float *c, const int *ldc) {
     // Not supported in NETLIB. SGEMM is used as reference.
     int sizea, sizeb;
     if (layout == CblasColMajor) {

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -29,8 +29,8 @@
 #include <CL/sycl.hpp>
 
 namespace std {
-static cl::sycl::half abs(cl::sycl::half v) {
-    if (v < cl::sycl::half(0))
+static sycl::half abs(sycl::half v) {
+    if (v < sycl::half(0))
         return -v;
     else
         return v;
@@ -142,8 +142,8 @@ uint8_t rand_scalar() {
 }
 
 template <>
-half rand_scalar() {
-    return half(std::rand() % 32000) / half(32000) - half(0.5);
+sycl::half rand_scalar() {
+    return sycl::half(std::rand() % 32000) / sycl::half(32000) - sycl::half(0.5);
 }
 
 template <typename fp>

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -164,33 +164,33 @@ TEST_P(GemmTests, Bfloat16Bfloat16FloatPrecision) {
 TEST_P(GemmTests, HalfHalfFloatPrecision) {
     float alpha(2.0);
     float beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }
 
 TEST_P(GemmTests, RealHalfPrecision) {
-    half alpha(2.0);
-    half beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, half>(
+    sycl::half alpha(2.0);
+    sycl::half beta(3.0);
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -166,33 +166,33 @@ TEST_P(GemmUsmTests, Bfloat16Bfloat16FloatPrecision) {
 TEST_P(GemmUsmTests, HalfHalfFloatPrecision) {
     float alpha(2.0);
     float beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, float>(
+    EXPECT_TRUEORSKIP((test<sycl::half, float>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }
 
 TEST_P(GemmUsmTests, RealHalfPrecision) {
-    half alpha(2.0);
-    half beta(3.0);
-    EXPECT_TRUEORSKIP((test<half, half>(
+    sycl::half alpha(2.0);
+    sycl::half beta(3.0);
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::nontrans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::nontrans, 79, 83, 91, 103, 105, 106, alpha, beta)));
-    EXPECT_TRUEORSKIP((test<half, half>(
+    EXPECT_TRUEORSKIP((test<sycl::half, sycl::half>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::transpose::trans,
         oneapi::mkl::transpose::trans, 79, 83, 91, 103, 105, 106, alpha, beta)));
 }

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -170,10 +170,4 @@ static inline void free_shared(void *p, cl::sycl::context ctx) {
 } // namespace mkl
 } // namespace oneapi
 
-// Workaround for supporting ::half for hipSYCL
-// TODO: This should be removed after the interface is SYCL2020 conformant
-#ifdef __HIPSYCL__
-using ::cl::sycl::half;
-#endif
-
 #endif // _TEST_HELPER_HPP_


### PR DESCRIPTION
# Description

Changes to SYCL standard mean we should use `sycl::half` instead of `half`. This PR implements this change.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New interfaces

Not applicable.

## New features

Not applicable.

## Bug fixes

Not applicable.

[test.txt](https://github.com/oneapi-src/oneMKL/files/7573317/test.txt)
