### PR TITLE
[docs] [BLAS] make documentation consistent with oneAPI spec

### DIFF
--- a/docs/domains/blas/axpby.rst
+++ b/docs/domains/blas/axpby.rst
@@ -1,0 +1,180 @@
+.. _onemkl_blas_axpby:
+
+axpby
+=====
+
+Computes a vector-scalar product added to a scaled-vector.
+
+.. _onemkl_blas_axpby_description:
+
+.. rubric:: Description
+
+The ``axpby`` routines compute two scalar-vector product and add them:
+
+.. math::
+
+      y \leftarrow beta * y + alpha * x
+
+where ``x`` and ``y`` are vectors of ``n`` elements and ``alpha`` and ``beta`` are scalars.
+
+``axpby`` supports the following precisions.
+
+   .. list-table::
+      :header-rows: 1
+
+      * -  T
+      * -  ``float``
+      * -  ``double``
+      * -  ``std::complex<float>``
+      * -  ``std::complex<double>``
+
+.. _onemkl_blas_axpby_buffer:
+
+axpby (Buffer Version)
+----------------------
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       void axpby(sycl::queue &queue,
+                 std::int64_t n,
+                 T alpha,
+                 sycl::buffer<T,1> &x, std::int64_t incx,
+                 T beta,
+                 sycl::buffer<T,1> &y, std::int64_t incy)
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       void axpby(sycl::queue &queue,
+                 std::int64_t n,
+                 T alpha,
+                 sycl::buffer<T,1> &x, std::int64_t incx,
+                 T beta,
+                 sycl::buffer<T,1> &y, std::int64_t incy)
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   n
+      Number of elements in vector ``x`` and ``y``.
+
+   alpha
+      Specifies the scalar ``alpha``.
+
+   x
+      Buffer holding input vector ``x``. The buffer must be of size at least
+      (1 + (``n`` – 1)*abs(``incx``)). See :ref:`matrix-storage` for
+      more details.
+
+   incx
+      Stride between two consecutive elements of the ``x`` vector.
+
+   beta
+      Specifies the scalar ``beta``.
+
+   y
+      Buffer holding input vector ``y``. The buffer must be of size at least
+      (1 + (``n`` – 1)*abs(``incy``)). See :ref:`matrix-storage` for
+      more details.
+
+   incy
+      Stride between two consecutive elements of the ``y`` vector.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   y
+      Buffer holding the updated vector ``y``.
+
+
+.. _onemkl_blas_axpby_usm:
+
+axpby (USM Version)
+-------------------
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event axpby(sycl::queue &queue,
+                        std::int64_t n,
+                        T alpha,
+                        const T *x, std::int64_t incx,
+                        const T beta,
+                        T *y, std::int64_t incy,
+                        const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event axpby(sycl::queue &queue,
+                        std::int64_t n,
+                        T alpha,
+                        const T *x, std::int64_t incx,
+                        const T beta,
+                        T *y, std::int64_t incy,
+                        const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   n
+      Number of elements in vector ``x`` and ``y``.
+
+   alpha
+      Specifies the scalar alpha.
+
+   beta
+      Specifies the scalar beta.
+
+   x
+      Pointer to the input vector ``x``. The allocated memory must be
+      of size at least (1 + (``n`` – 1)*abs(``incx``)). See
+      :ref:`matrix-storage` for more details.
+
+   incx
+      Stride between consecutive elements of the ``x`` vector.
+
+   y
+      Pointer to the input vector ``y``. The allocated memory must be
+      of size at least (1 + (``n`` – 1)*abs(``incy``)). See
+      :ref:`matrix-storage` for more details.
+
+   incy
+      Stride between consecutive elements of the ``y`` vector.
+
+   dependencies
+      List of events to wait for before starting computation, if any.
+      If omitted, defaults to no dependencies.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   y
+      Array holding the updated vector ``y``.
+
+.. container:: section
+
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+
+   **Parent topic:** :ref:`blas-like-extensions`
+

--- a/docs/domains/blas/blas-like-extensions.rst
+++ b/docs/domains/blas/blas-like-extensions.rst
@@ -42,7 +42,12 @@ BLAS-like Extensions
     :hidden:
 
     axpy_batch
+    axpby
+    copy_batch
+    dgmm_batch
     gemm_batch
+    gemv_batch
+    syrk_batch
     trsm_batch
     gemmt
     gemm_bias

--- a/docs/domains/blas/blas.rst
+++ b/docs/domains/blas/blas.rst
@@ -13,3 +13,5 @@ oneMKL provides DPC++ interfaces to the Basic Linear Algebra Subprograms (BLAS) 
     blas-level-3-routines.rst
     blas-like-extensions.rst
 
+
+**Parent topic:** :ref:`onemkl_dense_linear_algebra`

--- a/docs/domains/blas/copy_batch.rst
+++ b/docs/domains/blas/copy_batch.rst
@@ -1,19 +1,19 @@
-.. _onemkl_blas_axpy_batch:
+.. _onemkl_blas_copy_batch:
 
-axpy_batch
+copy_batch
 ==========
 
-Computes a group of ``axpy`` operations.
+Computes a group of ``copy`` operations.
 
-.. _onemkl_blas_axpy_batch_description:
+.. _onemkl_blas_copy_batch_description:
 
 .. rubric:: Description
 
-The ``axpy_batch`` routines are batched versions of :ref:`onemkl_blas_axpy`, performing
-multiple ``axpy`` operations in a single call. Each ``axpy`` 
-operation adds a scalar-vector product to a vector.
+The ``copy_batch`` routines are batched versions of :ref:`onemkl_blas_copy`, performing
+multiple ``copy`` operations in a single call. Each ``copy`` 
+operation copies one vector to another.
    
-``axpy_batch`` supports the following precisions for data.
+``copy_batch`` supports the following precisions for data.
 
    .. list-table:: 
       :header-rows: 1
@@ -24,26 +24,24 @@ operation adds a scalar-vector product to a vector.
       * -  ``std::complex<float>`` 
       * -  ``std::complex<double>`` 
 
-.. _onemkl_blas_axpy_batch_buffer:
+.. _onemkl_blas_copy_batch_buffer:
 
-axpy_batch (Buffer Version)
+copy_batch (Buffer Version)
 ---------------------------
 
 .. rubric:: Description
 
-The buffer version of ``axpy_batch`` supports only the strided API. 
+The buffer version of ``copy_batch`` supports only the strided API. 
 
 The strided API operation is defined as:
 ::
   
    for i = 0 … batch_size – 1
       X and Y are vectors at offset i * stridex, i * stridey in x and y
-      Y := alpha * X + Y
+      Y := X
    end for
 
 where:
-
-``alpha`` is scalar,
 
 ``X`` and ``Y`` are vectors.
    
@@ -54,9 +52,8 @@ where:
 .. code-block:: cpp
 
    namespace oneapi::mkl::blas::column_major {
-       void axpy_batch(sycl::queue &queue,
+       void copy_batch(sycl::queue &queue,
                        std::int64_t n,
-                       T alpha,
                        sycl::buffer<T,
                        1> &x,
                        std::int64_t incx,
@@ -70,9 +67,8 @@ where:
 .. code-block:: cpp
 
    namespace oneapi::mkl::blas::row_major {
-       void axpy_batch(sycl::queue &queue,
+       void copy_batch(sycl::queue &queue,
                        std::int64_t n,
-                       T alpha,
                        sycl::buffer<T,
                        1> &x,
                        std::int64_t incx,
@@ -94,9 +90,6 @@ where:
    n
       Number of elements in ``X`` and ``Y``.
 
-   alpha
-       Specifies the scalar ``alpha``.
-
    x
       Buffer holding input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
@@ -116,25 +109,24 @@ where:
       Stride between different ``Y`` vectors.
 
    batch_size 
-      Specifies the number of ``axpy`` operations to perform.
+      Specifies the number of ``copy`` operations to perform.
 
 .. container:: section
 
    .. rubric:: Output Parameters
 
    y
-      Output buffer, overwritten by ``batch_size`` ``axpy`` operations of the form 
-      ``alpha`` * ``X`` + ``Y``.
+      Output buffer, overwritten by ``batch_size`` ``copy`` operations.
 
 
-.. _onemkl_blas_axpy_batch_usm:
+.. _onemkl_blas_copy_batch_usm:
 
-axpy_batch (USM Version)
+copy_batch (USM Version)
 ------------------------
 
 .. rubric:: Description
 
-The USM version of ``axpy_batch`` supports the group API and strided API. 
+The USM version of ``copy_batch`` supports the group API and strided API. 
 
 The group API operation is defined as
 ::
@@ -143,7 +135,7 @@ The group API operation is defined as
    for i = 0 … group_count – 1
        for j = 0 … group_size – 1
            X and Y are vectors in x[idx] and y[idx]
-           Y := alpha[i] * X + Y
+           Y := X
            idx := idx + 1
        end for
    end for
@@ -153,12 +145,10 @@ The strided API operation is defined as
    
    for i = 0 … batch_size – 1
       X and Y are vectors at offset i * stridex, i * stridey in x and y
-      Y := alpha * X + Y
+      Y := X
    end for
 
 where:
-
-``alpha`` is scalar,
 
 ``X`` and ``Y`` are vectors.
 
@@ -179,9 +169,8 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
 .. code-block:: cpp
 
    namespace oneapi::mkl::blas::column_major {
-       sycl::event axpy_batch(sycl::queue &queue,
+       sycl::event copy_batch(sycl::queue &queue,
                               std::int64_t *n,
-                              T *alpha,
                               const T **x,
                               std::int64_t *incx,
                               T **y,
@@ -193,9 +182,8 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
 .. code-block:: cpp
 
    namespace oneapi::mkl::blas::row_major {
-       sycl::event axpy_batch(sycl::queue &queue,
+       sycl::event copy_batch(sycl::queue &queue,
                               std::int64_t *n,
-                              T *alpha,
                               const T **x,
                               std::int64_t *incx,
                               T **y,
@@ -214,9 +202,6 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
 
    n
       Array of ``group_count`` integers. ``n[i]`` specifies the number of elements in vectors ``X`` and ``Y`` for every vector in group ``i``.
-
-   alpha
-       Array of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor for vector ``X`` in group ``i``.
 
    x
       Array of pointers to input vectors ``X`` with size ``total_batch_count``.
@@ -238,7 +223,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       Number of groups. Must be at least 0.
 
    group_size
-      Array of ``group_count`` integers. ``group_size[i]`` specifies the number of ``axpy`` operations in group ``i``. 
+      Array of ``group_count`` integers. ``group_size[i]`` specifies the number of ``copy`` operations in group ``i``. 
       Each element in ``group_size`` must be at least 0.
 
    dependencies
@@ -250,8 +235,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
    .. rubric:: Output Parameters
 
    y
-      Array of pointers holding the ``Y`` vectors, overwritten by ``total_batch_count`` ``axpy`` operations of the form 
-      ``alpha`` * ``X`` + ``Y``.
+      Array of pointers holding the ``Y`` vectors, overwritten by ``total_batch_count`` ``copy`` operations.
 
 .. container:: section
 
@@ -266,9 +250,8 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
 .. code-block:: cpp
 
    namespace oneapi::mkl::blas::column_major {
-       sycl::event axpy_batch(sycl::queue &queue,
+       sycl::event copy_batch(sycl::queue &queue,
                               std::int64_t n,
-                              T alpha,
                               const T *x,
                               std::int64_t incx,
                               std::int64_t stridex,
@@ -281,9 +264,8 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
 .. code-block:: cpp
 
    namespace oneapi::mkl::blas::row_major {
-       sycl::event axpy_batch(sycl::queue &queue,
+       sycl::event copy_batch(sycl::queue &queue,
                               std::int64_t n,
-                              T alpha,
                               const T *x,
                               std::int64_t incx,
                               std::int64_t stridex,
@@ -304,9 +286,6 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
    n
       Number of elements in ``X`` and ``Y``.
 
-   alpha
-       Specifies the scalar ``alpha``.
-
    x
       Pointer to input vectors ``X`` with size ``stridex`` * ``batch_size``.
 
@@ -326,7 +305,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
       Stride between different ``Y`` vectors.
 
    batch_size 
-      Specifies the number of ``axpy`` operations to perform.
+      Specifies the number of ``copy`` operations to perform.
   
    dependencies
       List of events to wait for before starting computation, if any.
@@ -337,8 +316,7 @@ The total number of vectors in ``x`` and ``y`` are given by the ``batch_size`` p
    .. rubric:: Output Parameters
 
    y
-      Output vectors, overwritten by ``batch_size`` ``axpy`` operations of the form 
-      ``alpha`` * ``X`` + ``Y``.
+      Output vectors, overwritten by ``batch_size`` ``copy`` operations
 
 .. container:: section
 

--- a/docs/domains/blas/dgmm_batch.rst
+++ b/docs/domains/blas/dgmm_batch.rst
@@ -1,0 +1,462 @@
+.. _onemkl_blas_dgmm_batch:
+
+dgmm_batch
+==========
+
+Computes a group of ``dgmm`` operations.
+
+.. _onemkl_blas_dgmm_batch_description:
+
+.. rubric:: Description
+
+The ``dgmm_batch`` routines perform
+multiple diagonal matrix-matrix product operations in a single call.
+   
+``dgmm_batch`` supports the following precisions.
+
+   .. list-table:: 
+      :header-rows: 1
+
+      * -  T 
+      * -  ``float`` 
+      * -  ``double`` 
+      * -  ``std::complex<float>`` 
+      * -  ``std::complex<double>`` 
+
+.. _onemkl_blas_dgmm_batch_buffer:
+
+dgmm_batch (Buffer Version)
+---------------------------
+
+.. rubric:: Description
+
+The buffer version of ``dgmm_batch`` supports only the strided API. 
+
+The strided API operation is defined as:
+::
+
+   for i = 0 … batch_size – 1
+       A and C are matrices at offset i * stridea in a, i * stridec in c.
+       X is a vector at offset i * stridex in x
+       C := diag(X) * A or  C = A * diag(X)
+   end for
+
+where:
+
+``A`` is a matrix,
+
+``X`` is a diagonal matrix stored as a vector
+
+The ``a`` and ``x`` buffers contain all the input matrices. The stride 
+between matrices is given by the stride parameter. The total number
+of matrices in ``a`` and ``x`` buffers is given by the ``batch_size`` parameter.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       void dgmm_batch(sycl::queue &queue,
+                       onemkl::mkl::side left_right,
+                       std::int64_t m,
+                       std::int64_t n,
+                       sycl::buffer<T,1> &a,
+                       std::int64_t lda,
+                       std::int64_t stridea,
+                       sycl::buffer<T,1> &x,
+                       std::int64_t incx,
+                       std::int64_t stridex,
+                       sycl::buffer<T,1> &c,
+                       std::int64_t ldc,
+                       std::int64_t stridec,
+                       std::int64_t batch_size)
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       void dgmm_batch(sycl::queue &queue,
+                       onemkl::mkl::side left_right,
+                       std::int64_t m,
+                       std::int64_t n,
+                       sycl::buffer<T,1> &a,
+                       std::int64_t lda,
+                       std::int64_t stridea,
+                       sycl::buffer<T,1> &x,
+                       std::int64_t incx,
+                       std::int64_t stridex,
+                       sycl::buffer<T,1> &c,
+                       std::int64_t ldc,
+                       std::int64_t stridec,
+                       std::int64_t batch_size)
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   left_right
+      Specifies the position of the diagonal matrix in the product.
+      See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Number of rows of matrices ``A`` and ``C``. Must be at least zero.
+
+   n
+      Number of columns of matrices ``A`` and ``C``. Must be at least zero.
+
+   a
+
+      Buffer holding the input matrices ``A`` with size ``stridea`` *
+      ``batch_size``.  Must be of at least ``lda`` * ``j`` +
+      ``stridea`` * (``batch_size`` - 1) where j is n if column major
+      layout is used or m if major layout is used.
+
+   lda
+      The leading dimension of the matrices ``A``. It must be positive
+      and at least ``m`` if column major layout is used or at least
+      ``n`` if row major layout is used.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   x
+      Buffer holding the input matrices ``X`` with size ``stridex`` *
+      ``batch_size``.  Must be of size at least 
+      (1 + (``len`` - 1)*abs(``incx``)) + ``stridex`` * (``batch_size`` - 1) 
+      where ``len`` is ``n`` if the diagonal matrix is on the right 
+      of the product or ``m`` otherwise.
+
+   incx
+      Stride between two consecutive elements of the ``x`` vectors.
+
+   stridex
+      Stride between different ``X`` vectors, must be at least 0.
+
+   c
+      Buffer holding input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
+
+   ldc
+      The leading dimension of the matrices ``C``. It must be positive and at least
+      ``m`` if column major layout is used to store matrices or at
+      least ``n`` if column major layout is used to store matrices.
+
+   stridec
+      Stride between different ``C`` matrices. Must be at least
+      ``ldc`` * ``n`` if column major layout is used or ``ldc`` * ``m`` if row
+      major layout is used.
+
+   batch_size
+      Specifies the number of diagonal matrix-matrix product operations to perform.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   c
+      Output overwritten by ``batch_size`` diagonal matrix-matrix product
+      operations.
+
+
+.. _onemkl_blas_dgmm_batch_usm:
+
+dgmm_batch (USM Version)
+---------------------------
+
+.. rubric:: Description
+
+The USM version of ``dgmm_batch`` supports the group API and strided API. 
+
+The group API operation is defined as:
+::
+
+   idx = 0
+   for i = 0 … group_count – 1
+       for j = 0 … group_size – 1
+           a and c are matrices of size mxn at position idx in a_array and c_array
+           x is a vector of size m or n depending on left_right, at position idx in x_array
+           if (left_right == oneapi::mkl::side::left)
+               c := diag(x) * a
+           else
+               c := a * diag(x)
+           idx := idx + 1
+       end for
+   end for
+
+The strided API operation is defined as
+::
+
+   for i = 0 … batch_size – 1
+       A and C are matrices at offset i * stridea in a, i * stridec in c.
+       X is a vector at offset i * stridex in x
+       C := diag(X) * A or  C = A * diag(X)
+   end for
+
+where:
+
+``A`` is a matrix,
+
+``X`` is a diagonal matrix stored as a vector
+
+The ``a`` and ``x`` buffers contain all the input matrices. The stride 
+between matrices is given by the stride parameter. The total number
+of matrices in ``a`` and ``x`` buffers is given by the ``batch_size`` parameter.
+ 
+For group API, ``a`` and ``x`` arrays contain the pointers for all the input matrices. 
+The total number of matrices in ``a`` and ``x`` are given by: 
+
+.. math::
+
+      total\_batch\_count = \sum_{i=0}^{group\_count-1}group\_size[i]    
+ 
+For strided API, ``a`` and ``x`` arrays contain all the input matrices. The total number of matrices 
+in ``a`` and ``x`` are given by the ``batch_size`` parameter.  
+   
+**Group API**
+
+.. rubric:: Syntax
+   
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event dgmm_batch(sycl::queue &queue,
+                              onemkl::mkl::side *left_right,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              const T **a,
+                              std::int64_t *lda,
+                              const T **x,
+                              std::int64_t *incx,
+                              T **c,
+                              std::int64_t *ldc,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event dgmm_batch(sycl::queue &queue,
+                              onemkl::mkl::side *left_right,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              const T **a,
+                              std::int64_t *lda,
+                              const T **x,
+                              std::int64_t *incx,
+                              T **c,
+                              std::int64_t *ldc,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   left_right
+      Specifies the position of the diagonal matrix in the product.
+      See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Array of ``group_count`` integers. ``m[i]`` specifies the
+      number of rows of ``A`` for every matrix in group ``i``. All entries must be at least zero.
+
+   n
+      Array of ``group_count`` integers. ``n[i]`` specifies the
+      number of columns of ``A`` for every matrix in group ``i``. All entries must be at least zero.
+
+   a
+      Array of pointers to input matrices ``A`` with size
+      ``total_batch_count``.  Must be of size at least ``lda[i]`` * ``n[i]`` if
+      column major layout is used or at least ``lda[i]`` * ``m[i]`` if row major
+      layout is used.
+      See :ref:`matrix-storage` for more details.
+
+   lda
+      Array of ``group_count`` integers. ``lda[i]`` specifies the
+      leading dimension of ``A`` for every matrix in group ``i``. All
+      entries must be positive and at least ``m[i]`` if column major
+      layout is used or at least ``n[i]`` if row major layout is used.
+
+   x
+      Array of pointers to input vectors ``X`` with size
+      ``total_batch_count``.  Must be of size at least (1 + ``len[i]`` –
+      1)*abs(``incx[i]``)) where ``len[i]`` is ``n[i]`` if the diagonal matrix is on the
+      right of the product or ``m[i]`` otherwise.
+      See :ref:`matrix-storage` for more details.
+
+   incx
+      Array of ``group_count`` integers. ``incx[i]`` specifies the
+      stride of ``x`` for every vector in group ``i``. All entries
+      must be positive.
+   c
+      Array of pointers to input/output matrices ``C`` with size ``total_batch_count``. 
+      Must be of size at least
+      ``ldc[i]`` * ``n[i]``
+      if column major layout is used or at least
+      ``ldc[i]`` * ``m[i]``
+      if row major layout is used.
+      See :ref:`matrix-storage` for more details.
+
+   ldc
+      Array of ``group_count`` integers. ``ldc[i]`` specifies the
+      leading dimension of ``C`` for every matrix in group ``i``.  All
+      entries must be positive and ``ldc[i]`` must be at least
+      ``m[i]`` if column major layout is used to store matrices or at
+      least ``n[i]`` if row major layout is used to store matrices.
+
+   group_count
+      Specifies the number of groups. Must be at least 0.
+
+   group_size
+      Array of ``group_count`` integers. ``group_size[i]`` specifies the
+      number of diagonal matrix-matrix product operations in group ``i``.
+      All entries must be at least 0.
+
+   dependencies
+         List of events to wait for before starting computation, if any.
+         If omitted, defaults to no dependencies.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   c
+      Output overwritten by ``batch_size`` diagonal matrix-matrix product
+      operations.
+
+.. container:: section
+
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event dgmm_batch(sycl::queue &queue,
+                              onemkl::mkl::side left_right,
+                              std::int64_t m,
+                              std::int64_t n,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              const T *b,
+                              std::int64_t incx,
+                              std::int64_t stridex,
+                              T *c,
+                              std::int64_t ldc,
+                              std::int64_t stridec,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event dgmm_batch(sycl::queue &queue,
+                              onemkl::mkl::side left_right,
+                              std::int64_t m,
+                              std::int64_t n,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              const T *b,
+                              std::int64_t incx,
+                              std::int64_t stridex,
+                              T *c,
+                              std::int64_t ldc,
+                              std::int64_t stridec,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   left_right
+      Specifies the position of the diagonal matrix in the product.
+      See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Number of rows of ``A``. Must be at least zero.
+
+   n
+      Number of columns of ``A``. Must be at least zero.
+
+   a
+      Pointer to input matrices ``A`` with size ``stridea`` *
+      ``batch_size``.  Must be of size at least
+      ``lda`` * ``k`` + ``stridea`` * (``batch_size`` - 1) 
+      where ``k`` is ``n`` if column major layout is used 
+      or ``m`` if row major layout is used.
+
+   lda
+      The leading dimension of the matrices ``A``. It must be positive
+      and at least ``m``.  Must be positive and at least ``m`` if column
+      major layout is used or at least ``n`` if row major layout is used.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   x
+      Pointer to input matrices ``X`` with size ``stridex`` * ``batch_size``.
+      Must be of size at least
+      (1 + (``len`` - 1)*abs(``incx``)) + ``stridex`` * (``batch_size`` - 1)
+      where ``len`` is ``n`` if the diagonal matrix is on the right
+      of the product or ``m`` otherwise.
+
+   incx
+      Stride between two consecutive elements of the ``x`` vector.
+
+   stridex
+      Stride between different ``X`` vectors, must be at least 0.
+
+   c
+      Pointer to input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
+
+   ldc
+      The leading dimension of the matrices ``C``. It must be positive and at least
+      ``ldc`` * ``m`` if column major layout is used to store matrices or at
+      least ``ldc`` * ``n`` if column major layout is used to store matrices.
+
+   stridec
+      Stride between different ``C`` matrices. Must be at least
+      ``ldc`` * ``n`` if column major layout is used or 
+      ``ldc`` * ``m`` if row major layout is used.
+
+   batch_size
+      Specifies the number of diagonal matrix-matrix product operations to perform.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   c
+      Output overwritten by ``batch_size`` diagonal matrix-matrix product
+      operations.
+
+.. container:: section
+      
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+
+   **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/gemm.rst
+++ b/docs/domains/blas/gemm.rst
@@ -49,6 +49,10 @@ op(``X``) = ``X``\ :sup:`H`,
        -  ``half`` 
        -  ``half`` 
        -  ``half`` 
+     * -  ``float``
+       -  ``bfloat16``
+       -  ``bfloat16``
+       -  ``float``
      * -  ``float`` 
        -  ``float`` 
        -  ``float`` 

--- a/docs/domains/blas/gemm_batch.rst
+++ b/docs/domains/blas/gemm_batch.rst
@@ -19,6 +19,7 @@ operation perform a matrix-matrix product with general matrices.
       :header-rows: 1
 
       * -  T 
+      * -  ``half``
       * -  ``float`` 
       * -  ``double`` 
       * -  ``std::complex<float>`` 
@@ -186,7 +187,7 @@ of matrices in ``a``, ``b`` and ``c`` buffers is given by the ``batch_size`` par
       Buffer holding input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
 
    ldc
-      The leading dimension of the mattrices ``C``. It must be positive and at least
+      The leading dimension of the matrices ``C``. It must be positive and at least
       ``m`` if column major layout is used to store matrices or at
       least ``n`` if column major layout is used to store matrices.
 
@@ -212,7 +213,6 @@ of matrices in ``a``, ``b`` and ``c`` buffers is given by the ``batch_size`` par
    If ``beta`` = 0, matrix ``C`` does not need to be initialized before
    calling ``gemm_batch``.
 
-      
 
 .. _onemkl_blas_gemm_batch_usm:
 
@@ -221,7 +221,8 @@ gemm_batch (USM Version)
 
 .. rubric:: Description
 
-The USM version of ``gemm_batch`` supports the group API and strided API. 
+The USM version of ``gemm_batch`` supports the group API and the strided API.
+The group API supports pointer and span inputs.
 
 The group API operation is defined as:
 ::
@@ -234,6 +235,25 @@ The group API operation is defined as:
            idx = idx + 1
        end for
    end for
+
+The advantage of using span instead of pointer is that the sizes of
+the array can vary and the size of the span can be queried at
+runtime. For each GEMM parameter, except the output matrices, the span
+can be of size 1, the number of groups or the total batch size. For
+the output matrices, to ensure all computation are independent, the size
+of the span must be the total batch size.
+
+Depending on the size of the spans, each parameter for the GEMM computation is used as follows:
+
+  - If the span has size 1, the parameter is reused for all GEMM
+    computation.
+
+  - If the span has size group_count, the parameter is reused for all
+    GEMM within a group, but each group will have a different value
+    for this parameter.  This is like the gemm_batch group API with pointers.
+
+  - If the span has size equal to the total batch size, each GEMM
+    computation will use a different value for this parameter.
 
 The strided API operation is defined as
 ::
@@ -288,6 +308,24 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t group_count,
                               std::int64_t *group_size,
                               const std::vector<sycl::event> &dependencies = {})
+
+       sycl::event gemm_batch(sycl::queue &queue,
+                              const sycl::span<onemkl::transpose> &transa,
+                              const sycl::span<onemkl::transpose> &transb,
+                              const sycl::span<std::int64_t> &m,
+                              const sycl::span<std::int64_t> &n,
+                              const sycl::span<std::int64_t> &k,
+                              const sycl::span<std::int64_t> &alpha,
+                              const sycl::span<const T*> &a,
+                              const sycl::span<std::int64_t> &lda,
+                              const sycl::span<const T*> &b,
+                              const sycl::span<std::int64_t> &ldb,
+                              const sycl::span<T> &beta,
+                              sycl::span<T*> &c,
+                              const sycl::span<std::int64_t> &ldc,
+                              size_t group_count,
+                              const sycl::span<size_t> &group_sizes,
+                              const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -309,6 +347,24 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t group_count,
                               std::int64_t *group_size,
                               const std::vector<sycl::event> &dependencies = {})
+
+       sycl::event gemm_batch(sycl::queue &queue,
+                              const sycl::span<onemkl::transpose> &transa,
+                              const sycl::span<onemkl::transpose> &transb,
+                              const sycl::span<std::int64_t> &m,
+                              const sycl::span<std::int64_t> &n,
+                              const sycl::span<std::int64_t> &k,
+                              const sycl::span<std::int64_t> &alpha,
+                              const sycl::span<const T*> &a,
+                              const sycl::span<std::int64_t> &lda,
+                              const sycl::span<const T*> &b,
+                              const sycl::span<std::int64_t> &ldb,
+                              const sycl::span<T> &beta,
+                              sycl::span<T*> &c,
+                              const sycl::span<std::int64_t> &ldc,
+                              size_t group_count,
+                              const sycl::span<size_t> &group_sizes,
+                              const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section
@@ -319,37 +375,37 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       The queue where the routine should be executed.
 
    transa
-      Array of ``group_count`` ``onemkl::transpose`` values. ``transa[i]`` specifies the form of op(``A``) used in
+      Array or span of ``group_count`` ``onemkl::transpose`` values. ``transa[i]`` specifies the form of op(``A``) used in
       the matrix multiplication in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    transb
-      Array of ``group_count`` ``onemkl::transpose`` values. ``transb[i]`` specifies the form of op(``B``) used in
+      Array or span of ``group_count`` ``onemkl::transpose`` values. ``transb[i]`` specifies the form of op(``B``) used in
       the matrix multiplication in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    m
-      Array of ``group_count`` integers. ``m[i]`` specifies the
+      Array or span of ``group_count`` integers. ``m[i]`` specifies the
       number of rows of op(``A``) and ``C`` for every matrix in group ``i``. All entries must be at least zero.
 
    n
-      Array of ``group_count`` integers. ``n[i]`` specifies the
+      Array or span of ``group_count`` integers. ``n[i]`` specifies the
       number of columns of op(``B``) and ``C`` for every matrix in group ``i``. All entries must be at least zero.
 
    k
-      Array of ``group_count`` integers. ``k[i]`` specifies the
+      Array or span of ``group_count`` integers. ``k[i]`` specifies the
       number of columns of op(``A``) and rows of op(``B``) for every matrix in group ``i``. All entries must be at
       least zero.
 
    alpha
-      Array of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor for every matrix-matrix
+      Array or span of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor for every matrix-matrix
       product in group ``i``.
 
    a
-      Array of pointers to input matrices ``A`` with size ``total_batch_count``. 
+      Array of pointers or span of input matrices ``A`` with size ``total_batch_count``. 
       
       See :ref:`matrix-storage` for more details.
 
    lda
-      Array of ``group_count`` integers. ``lda[i]`` specifies the
+      Array or span of ``group_count`` integers. ``lda[i]`` specifies the
       leading dimension of ``A`` for every matrix in group ``i``. All
       entries must be positive.
 
@@ -367,13 +423,12 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
            - ``lda[i]`` must be at least ``m[i]``.
              
    b
-      Array of pointers to input matrices ``B`` with size ``total_batch_count``. 
+      Array of pointers or span of input matrices ``B`` with size ``total_batch_count``. 
       
       See :ref:`matrix-storage` for more details.
 
    ldb
-   
-      Array of ``group_count`` integers. ``ldb[i]`` specifies the
+      Array or span of ``group_count`` integers. ``ldb[i]`` specifies the
       leading dimension of ``B`` for every matrix in group ``i``. All
       entries must be positive.
 
@@ -391,16 +446,16 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
            - ``ldb[i]`` must be at least ``k[i]``.
              
    beta
-      Array of ``group_count`` scalar elements. ``beta[i]`` specifies the scaling factor for matrix ``C`` 
+      Array or span of ``group_count`` scalar elements. ``beta[i]`` specifies the scaling factor for matrix ``C`` 
       for every matrix in group ``i``.
 
    c
-      Array of pointers to input/output matrices ``C`` with size ``total_batch_count``. 
+      Array of pointers or span of input/output matrices ``C`` with size ``total_batch_count``. 
       
       See :ref:`matrix-storage` for more details.
 
    ldc
-      Array of ``group_count`` integers. ``ldc[i]`` specifies the
+      Array or span of ``group_count`` integers. ``ldc[i]`` specifies the
       leading dimension of ``C`` for every matrix in group ``i``.  All
       entries must be positive and ``ldc[i]`` must be at least
       ``m[i]`` if column major layout is used to store matrices or at
@@ -410,7 +465,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       Specifies the number of groups. Must be at least 0.
 
    group_size
-      Array of ``group_count`` integers. ``group_size[i]`` specifies the
+      Array or span of ``group_count`` integers. ``group_size[i]`` specifies the
       number of matrix multiply products in group ``i``. All entries must be at least 0.
 
    dependencies
@@ -423,6 +478,27 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
 
    c
       Overwritten by the ``m[i]``-by-``n[i]`` matrix calculated by 
+      (``alpha[i]`` * op(``A``)*op(``B``) + ``beta[i]`` * ``C``) for group ``i``.
+
+.. container:: section
+
+   .. rubric:: Notes
+
+   If ``beta`` = 0, matrix ``C`` does not need to be initialized
+   before calling ``gemm_batch``.
+
+.. container:: section
+
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   c
+      Overwritten by the ``m[i]``-by-``n[i]`` matrix calculated by
       (``alpha[i]`` * op(``A``)*op(``B``) + ``beta[i]`` * ``C``) for group ``i``.
 
 .. container:: section
@@ -568,7 +644,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       Pointer to input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
 
    ldc
-      The leading dimension of the mattrices ``C``. It must be positive and at least
+      The leading dimension of the matrices ``C``. It must be positive and at least
       ``m`` if column major layout is used to store matrices or at
       least ``n`` if column major layout is used to store matrices.
 

--- a/docs/domains/blas/gemm_batch.rst
+++ b/docs/domains/blas/gemm_batch.rst
@@ -221,8 +221,7 @@ gemm_batch (USM Version)
 
 .. rubric:: Description
 
-The USM version of ``gemm_batch`` supports the group API and the strided API.
-The group API supports pointer and span inputs.
+The USM version of ``gemm_batch`` supports the group API and strided API.
 
 The group API operation is defined as:
 ::
@@ -235,25 +234,6 @@ The group API operation is defined as:
            idx = idx + 1
        end for
    end for
-
-The advantage of using span instead of pointer is that the sizes of
-the array can vary and the size of the span can be queried at
-runtime. For each GEMM parameter, except the output matrices, the span
-can be of size 1, the number of groups or the total batch size. For
-the output matrices, to ensure all computation are independent, the size
-of the span must be the total batch size.
-
-Depending on the size of the spans, each parameter for the GEMM computation is used as follows:
-
-  - If the span has size 1, the parameter is reused for all GEMM
-    computation.
-
-  - If the span has size group_count, the parameter is reused for all
-    GEMM within a group, but each group will have a different value
-    for this parameter.  This is like the gemm_batch group API with pointers.
-
-  - If the span has size equal to the total batch size, each GEMM
-    computation will use a different value for this parameter.
 
 The strided API operation is defined as
 ::
@@ -308,24 +288,6 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t group_count,
                               std::int64_t *group_size,
                               const std::vector<sycl::event> &dependencies = {})
-
-       sycl::event gemm_batch(sycl::queue &queue,
-                              const sycl::span<onemkl::transpose> &transa,
-                              const sycl::span<onemkl::transpose> &transb,
-                              const sycl::span<std::int64_t> &m,
-                              const sycl::span<std::int64_t> &n,
-                              const sycl::span<std::int64_t> &k,
-                              const sycl::span<std::int64_t> &alpha,
-                              const sycl::span<const T*> &a,
-                              const sycl::span<std::int64_t> &lda,
-                              const sycl::span<const T*> &b,
-                              const sycl::span<std::int64_t> &ldb,
-                              const sycl::span<T> &beta,
-                              sycl::span<T*> &c,
-                              const sycl::span<std::int64_t> &ldc,
-                              size_t group_count,
-                              const sycl::span<size_t> &group_sizes,
-                              const std::vector<sycl::event> &dependencies = {})
    }
 .. code-block:: cpp
 
@@ -347,24 +309,6 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
                               std::int64_t group_count,
                               std::int64_t *group_size,
                               const std::vector<sycl::event> &dependencies = {})
-
-       sycl::event gemm_batch(sycl::queue &queue,
-                              const sycl::span<onemkl::transpose> &transa,
-                              const sycl::span<onemkl::transpose> &transb,
-                              const sycl::span<std::int64_t> &m,
-                              const sycl::span<std::int64_t> &n,
-                              const sycl::span<std::int64_t> &k,
-                              const sycl::span<std::int64_t> &alpha,
-                              const sycl::span<const T*> &a,
-                              const sycl::span<std::int64_t> &lda,
-                              const sycl::span<const T*> &b,
-                              const sycl::span<std::int64_t> &ldb,
-                              const sycl::span<T> &beta,
-                              sycl::span<T*> &c,
-                              const sycl::span<std::int64_t> &ldc,
-                              size_t group_count,
-                              const sycl::span<size_t> &group_sizes,
-                              const std::vector<sycl::event> &dependencies = {})
    }
 
 .. container:: section
@@ -375,37 +319,37 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       The queue where the routine should be executed.
 
    transa
-      Array or span of ``group_count`` ``onemkl::transpose`` values. ``transa[i]`` specifies the form of op(``A``) used in
+      Array of ``group_count`` ``onemkl::transpose`` values. ``transa[i]`` specifies the form of op(``A``) used in
       the matrix multiplication in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    transb
-      Array or span of ``group_count`` ``onemkl::transpose`` values. ``transb[i]`` specifies the form of op(``B``) used in
+      Array of ``group_count`` ``onemkl::transpose`` values. ``transb[i]`` specifies the form of op(``B``) used in
       the matrix multiplication in group ``i``. See :ref:`onemkl_datatypes` for more details.
 
    m
-      Array or span of ``group_count`` integers. ``m[i]`` specifies the
+      Array of ``group_count`` integers. ``m[i]`` specifies the
       number of rows of op(``A``) and ``C`` for every matrix in group ``i``. All entries must be at least zero.
 
    n
-      Array or span of ``group_count`` integers. ``n[i]`` specifies the
+      Array of ``group_count`` integers. ``n[i]`` specifies the
       number of columns of op(``B``) and ``C`` for every matrix in group ``i``. All entries must be at least zero.
 
    k
-      Array or span of ``group_count`` integers. ``k[i]`` specifies the
+      Array of ``group_count`` integers. ``k[i]`` specifies the
       number of columns of op(``A``) and rows of op(``B``) for every matrix in group ``i``. All entries must be at
       least zero.
 
    alpha
-      Array or span of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor for every matrix-matrix
+      Array of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor for every matrix-matrix
       product in group ``i``.
 
    a
-      Array of pointers or span of input matrices ``A`` with size ``total_batch_count``. 
+      Array of pointers to input matrices ``A`` with size ``total_batch_count``. 
       
       See :ref:`matrix-storage` for more details.
 
    lda
-      Array or span of ``group_count`` integers. ``lda[i]`` specifies the
+      Array of ``group_count`` integers. ``lda[i]`` specifies the
       leading dimension of ``A`` for every matrix in group ``i``. All
       entries must be positive.
 
@@ -423,12 +367,12 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
            - ``lda[i]`` must be at least ``m[i]``.
              
    b
-      Array of pointers or span of input matrices ``B`` with size ``total_batch_count``. 
+      Array of pointers to input matrices ``B`` with size ``total_batch_count``. 
       
       See :ref:`matrix-storage` for more details.
 
    ldb
-      Array or span of ``group_count`` integers. ``ldb[i]`` specifies the
+      Array of ``group_count`` integers. ``ldb[i]`` specifies the
       leading dimension of ``B`` for every matrix in group ``i``. All
       entries must be positive.
 
@@ -446,16 +390,16 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
            - ``ldb[i]`` must be at least ``k[i]``.
              
    beta
-      Array or span of ``group_count`` scalar elements. ``beta[i]`` specifies the scaling factor for matrix ``C`` 
+      Array of ``group_count`` scalar elements. ``beta[i]`` specifies the scaling factor for matrix ``C`` 
       for every matrix in group ``i``.
 
    c
-      Array of pointers or span of input/output matrices ``C`` with size ``total_batch_count``. 
+      Array of pointers to input/output matrices ``C`` with size ``total_batch_count``. 
       
       See :ref:`matrix-storage` for more details.
 
    ldc
-      Array or span of ``group_count`` integers. ``ldc[i]`` specifies the
+      Array of ``group_count`` integers. ``ldc[i]`` specifies the
       leading dimension of ``C`` for every matrix in group ``i``.  All
       entries must be positive and ``ldc[i]`` must be at least
       ``m[i]`` if column major layout is used to store matrices or at
@@ -465,7 +409,7 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
       Specifies the number of groups. Must be at least 0.
 
    group_size
-      Array or span of ``group_count`` integers. ``group_size[i]`` specifies the
+      Array of ``group_count`` integers. ``group_size[i]`` specifies the
       number of matrix multiply products in group ``i``. All entries must be at least 0.
 
    dependencies
@@ -478,27 +422,6 @@ in ``a``, ``b`` and ``c`` are given by the ``batch_size`` parameter.
 
    c
       Overwritten by the ``m[i]``-by-``n[i]`` matrix calculated by 
-      (``alpha[i]`` * op(``A``)*op(``B``) + ``beta[i]`` * ``C``) for group ``i``.
-
-.. container:: section
-
-   .. rubric:: Notes
-
-   If ``beta`` = 0, matrix ``C`` does not need to be initialized
-   before calling ``gemm_batch``.
-
-.. container:: section
-
-   .. rubric:: Return Values
-
-   Output event to wait on to ensure computation is complete.
-
-.. container:: section
-
-   .. rubric:: Output Parameters
-
-   c
-      Overwritten by the ``m[i]``-by-``n[i]`` matrix calculated by
       (``alpha[i]`` * op(``A``)*op(``B``) + ``beta[i]`` * ``C``) for group ``i``.
 
 .. container:: section

--- a/docs/domains/blas/gemm_bias.rst
+++ b/docs/domains/blas/gemm_bias.rst
@@ -46,8 +46,20 @@ op(``A``) is ``m`` x ``k``, op(``B``) is ``k`` x ``n``, and
        -  Tb 
        -  Tc 
      * -  ``float`` 
+       -  ``std::uint8_t`` 
+       -  ``std::uint8_t`` 
+       -  ``std::int32_t`` 
+     * -  ``float`` 
        -  ``std::int8_t`` 
        -  ``std::uint8_t`` 
+       -  ``std::int32_t`` 
+     * -  ``float`` 
+       -  ``std::uint8_t`` 
+       -  ``std::int8_t`` 
+       -  ``std::int32_t`` 
+     * -  ``float`` 
+       -  ``std::int8_t`` 
+       -  ``std::int8_t`` 
        -  ``std::int32_t`` 
 
 .. _onemkl_blas_gemm_bias_buffer:
@@ -266,6 +278,236 @@ gemm_bias (Buffer Version)
  
    If ``beta`` = 0, matrix ``C`` does not need to be initialized
    before calling ``gemm_bias``.
+
+
+.. _onemkl_blas_gemm_bias_usm:
+
+gemm_bias (USM Version)
+-----------------------
+
+.. rubric:: Syntax
+      
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event gemm_bias(sycl::queue &queue,
+                             onemkl::transpose transa,
+                             onemkl::transpose transb,
+                             onemkl::offset offset_type,
+                             std::int64_t m,
+                             std::int64_t n,
+                             std::int64_t k,
+                             Ts alpha,
+                             const Ta *a,
+                             std::int64_t lda,
+                             Ta ao,
+                             const Tb *b,
+                             std::int64_t ldb,
+                             Tb bo,
+                             Ts beta,
+                             Tc *c,
+                             std::int64_t ldc,
+                             const Tc *co,
+                             const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event gemm_bias(sycl::queue &queue,
+                             onemkl::transpose transa,
+                             onemkl::transpose transb,
+                             onemkl::offset offset_type,
+                             std::int64_t m,
+                             std::int64_t n,
+                             std::int64_t k,
+                             Ts alpha,
+                             const Ta *a,
+                             std::int64_t lda,
+                             Ta ao,
+                             const Tb *b,
+                             std::int64_t ldb,
+                             Tb bo,
+                             Ts beta,
+                             Tc *c,
+                             std::int64_t ldc,
+                             const Tc *co,
+                             const std::vector<sycl::event> &dependencies = {})
+   }
+      
+.. container:: section
+   
+   .. rubric:: Input Parameters
+ 
+   queue
+      The queue where the routine should be executed.
+ 
+   transa
+      Specifies op(``A``), the transposition operation applied to
+      ``A``. See
+      :ref:`onemkl_datatypes` for
+      more details.
+ 
+   transb
+      Specifies op(``B``), the transposition operation applied to
+      ``B``. See
+      :ref:`onemkl_datatypes` for
+      more details.
+ 
+   offset_type
+      Specifies the form of ``C_offset`` used in the matrix
+      multiplication. See
+      :ref:`onemkl_datatypes` for
+      more details.
+ 
+   m
+      Number of rows of op(``A``) and ``C``. Must be at least zero.
+ 
+   n
+      Number of columns of op(``B``) and ``C``. Must be at least
+      zero.
+ 
+   k
+      Number of columns of op(``A``) and rows of op(``B``). Must be
+      at least zero.
+ 
+   alpha
+      Scaling factor for the matrix-matrix product.
+ 
+   a
+      Pointer to input matrix ``A``.
+ 
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``A`` not transposed
+           - ``A`` transposed
+         * - Column major
+           - ``A`` is an ``m``-by-``k`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``k``.
+           - ``A`` is an ``k``-by-``m`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``m``
+         * - Row major
+           - ``A`` is an ``m``-by-``k`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``m``.
+           - ``A`` is an ``k``-by-``m`` matrix so the array ``a``
+             must have size at least ``lda``\ \*\ ``k``
+ 
+      See :ref:`matrix-storage` for more details.
+ 
+   lda
+      The leading dimension of ``A``. It must be positive.
+
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``A`` not transposed
+           - ``A`` transposed
+         * - Column major
+           - ``lda`` must be at least ``m``.
+           - ``lda`` must be at least ``k``.
+         * - Row major
+           - ``lda`` must be at least ``k``.
+           - ``lda`` must be at least ``m``.
+ 
+   ao
+      Specifies the scalar offset value for matrix ``A``.
+ 
+   b
+      Pointer to input matrix ``B``.
+ 
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``B`` not transposed
+           - ``B`` transposed
+         * - Column major
+           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``.
+           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``k``
+         * - Row major
+           - ``B`` is an ``k``-by-``n`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``k``.
+           - ``B`` is an ``n``-by-``k`` matrix so the array ``b``
+             must have size at least ``ldb``\ \*\ ``n``
+ 
+      See :ref:`matrix-storage` for more details.
+ 
+   ldb
+      The leading dimension of ``B``. It must be positive.
+
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``B`` not transposed
+           - ``B`` transposed
+         * - Column major
+           - ``ldb`` must be at least ``k``.
+           - ``ldb`` must be at least ``n``.
+         * - Row major
+           - ``ldb`` must be at least ``n``.
+           - ``ldb`` must be at least ``k``.
+ 
+   bo 
+      Specifies the scalar offset value for matrix ``B``.
+ 
+   beta
+      Scaling factor for matrix ``C``.
+ 
+   c
+      Pointer to input/output matrix ``C``. It must have a
+      size of at least ``ldc``\ \*\ ``n`` if column major layout is
+      used to store matrices or at least ``ldc``\ \*\ ``m`` if row
+      major layout is used to store matrices . See :ref:`matrix-storage` for more details.
+ 
+   ldc
+      The leading dimension of ``C``. It must be positive and at least
+      ``m`` if column major layout is used to store matrices or at
+      least ``n`` if column major layout is used to store matrices.
+
+   co
+      Pointer to offset values for matrix ``C``.
+ 
+ 
+      If ``offset_type`` = ``offset::fix``, the ``co`` array must have
+      size at least 1.
+ 
+ 
+      If ``offset_type`` = ``offset::col``, the ``co`` array must have
+      size at least ``max(1,m)``.
+ 
+ 
+      If ``offset_type`` = ``offset::row``, the ``co`` array must have
+      size at least ``max(1,n)``.
+
+   dependencies
+      List of events to wait for before starting computation, if any.
+      If omitted, defaults to no dependencies.
+ 
+.. container:: section
+ 
+   .. rubric:: Output Parameters
+ 
+   c
+      Pointer to the output matrix, overwritten by ``alpha`` * (op(``A``) -
+      ``A_offset``)*(op(``B``) - ``B_offset``) + ``beta`` * ``C`` + ``C_offset``.
+ 
+.. container:: section
+ 
+   .. rubric:: Notes
+ 
+   If ``beta`` = 0, matrix ``C`` does not need to be initialized
+   before calling ``gemm_bias``.
+
+.. container:: section
+
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
 
 
    **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/gemv.rst
+++ b/docs/domains/blas/gemv.rst
@@ -206,7 +206,7 @@ gemv (USM Version)
       Scaling factor for the matrix-vector product.
 
    a
-      The pointer to the input matrix ``A``. Must have a size of at
+      Pointer to the input matrix ``A``. Must have a size of at
       least ``lda``\ \*\ ``n`` if column major layout is used or at
       least ``lda``\ \*\ ``m`` if row major layout is used. See
       :ref:`matrix-storage` for more details.

--- a/docs/domains/blas/gemv_batch.rst
+++ b/docs/domains/blas/gemv_batch.rst
@@ -1,0 +1,472 @@
+.. _onemkl_blas_gemv_batch:
+
+gemv_batch
+==========
+
+Computes a group of ``gemv`` operations.
+
+.. _onemkl_blas_gemv_batch_description:
+
+.. rubric:: Description
+
+The ``gemv_batch`` routines are batched versions of
+:ref:`onemkl_blas_gemv`, performing multiple ``gemv`` operations in a
+single call. Each ``gemv`` operations perform a scalar-matrix-vector
+product and add the result to a scalar-vector product.
+   
+``gemv_batch`` supports the following precisions.
+
+   .. list-table:: 
+      :header-rows: 1
+
+      * -  T 
+      * -  ``float`` 
+      * -  ``double`` 
+      * -  ``std::complex<float>`` 
+      * -  ``std::complex<double>`` 
+
+.. _onemkl_blas_gemv_batch_buffer:
+
+gemv_batch (Buffer Version)
+---------------------------
+
+.. rubric:: Description
+
+The buffer version of ``gemv_batch`` supports only the strided API. 
+
+The strided API operation is defined as:
+::
+
+   for i = 0 … batch_size – 1
+       A is a matrix at offset i * stridea in a.
+       X and Y are matrices at offset i * stridex, i * stridey, in x and y.
+       Y := alpha * op(A) * X + beta * Y
+   end for
+
+where:
+
+op(A) is one of op(A) = A, or op(A) = A\ :sup:`T`, or op(A) = A\ :sup:`H`,
+
+``alpha`` and ``beta`` are scalars,
+
+``A`` is a matrix and ``X`` and ``Y`` are vectors,
+
+The ``x`` and ``y`` buffers contain all the input matrices. The stride
+between vectors is given by the stride parameter. The total number of
+vectors in ``x`` and ``y`` buffers is given by the ``batch_size``
+parameter.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       void gemv_batch(sycl::queue &queue,
+                       onemkl::transpose trans,
+                       std::int64_t m,
+                       std::int64_t n,
+                       T alpha,
+                       sycl::buffer<T,1> &a,
+                       std::int64_t lda,
+                       std::int64_t stridea,
+                       sycl::buffer<T,1> &x,
+                       std::int64_t incx,
+                       std::int64_t stridex,
+                       T beta,
+                       sycl::buffer<T,1> &y,
+                       std::int64_t incy,
+                       std::int64_t stridey,
+                       std::int64_t batch_size)
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       void gemv_batch(sycl::queue &queue,
+                       onemkl::transpose trans,
+                       std::int64_t m,
+                       std::int64_t n,
+                       T alpha,
+                       sycl::buffer<T,1> &a,
+                       std::int64_t lda,
+                       std::int64_t stridea,
+                       sycl::buffer<T,1> &x,
+                       std::int64_t incx,
+                       std::int64_t stridex,
+                       T beta,
+                       sycl::buffer<T,1> &y,
+                       std::int64_t incy,
+                       std::int64_t stridey,
+                       std::int64_t batch_size)
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   trans
+      Specifies op(``A``) the transposition operation applied to the
+      matrices ``A``. See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Number of rows of op(``A``). Must be at least zero.
+
+   n
+      Number of columns of op(``A``). Must be at least zero.
+
+   alpha
+      Scaling factor for the matrix-vector products.
+
+   a
+      Buffer holding the input matrices ``A`` with size ``stridea`` * ``batch_size``.
+
+   lda
+      The leading dimension of the matrices ``A``. It must be positive
+      and at least ``m`` if column major layout is used or at least
+      ``n`` if row major layout is used.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   x
+      Buffer holding the input vectors ``X`` with size ``stridex`` * ``batch_size``.
+
+   incx
+      The stride of the vector ``X``. It must be positive.
+
+   stridex
+      Stride between different consecutive ``X`` vectors, must be at least 0.
+
+   beta
+      Scaling factor for the vector ``Y``.
+
+   y
+      Buffer holding input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
+
+   incy
+      Stride between two consecutive elements of the ``y`` vectors.
+
+   stridey
+      Stride between two consecutive ``Y`` vectors. Must be at least
+      (1 + (len-1)*abs(incy)) where ``len`` is ``m`` if the matrix ``A``
+      is non transpose or ``n`` otherwise.
+
+   batch_size
+      Specifies the number of matrix-vector operations to perform.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   y
+      Output overwritten by ``batch_size`` matrix-vector product
+      operations of the form ``alpha`` * op(``A``) * ``X`` + ``beta`` * ``Y``.
+
+
+.. _onemkl_blas_gemv_batch_usm:
+
+gemv_batch (USM Version)
+---------------------------
+
+.. rubric:: Description
+
+The USM version of ``gemv_batch`` supports the group API and strided API. 
+
+The group API operation is defined as:
+::
+
+   idx = 0
+   for i = 0 … group_count – 1
+       for j = 0 … group_size – 1
+           A is an m x n matrix in a[idx]
+           X and Y are vectors in x[idx] and y[idx]
+           Y := alpha[i] * op(A) * X + beta[i] * Y
+           idx = idx + 1
+       end for
+   end for
+
+The strided API operation is defined as
+::
+
+   for i = 0 … batch_size – 1
+       A is a matrix at offset i * stridea in a.
+       X and Y are vectors at offset i * stridex, i * stridey in x and y.
+       Y := alpha * op(A) * X + beta * Y
+   end for
+
+where:
+
+op(A) is one of op(A) = A, or op(A) = A\ :sup:`T`, or op(A) = A\ :sup:`H`,
+
+``alpha`` and ``beta`` are scalars,
+
+``A`` is a matrix and ``X`` and ``Y`` are vectors,
+
+For group API, ``x`` and ``y`` arrays contain the pointers for all the input vectors. 
+``A`` array contains the pointers to all input matrices.
+The total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by: 
+
+.. math::
+
+      total\_batch\_count = \sum_{i=0}^{group\_count-1}group\_size[i]    
+ 
+For strided API, ``x`` and ``y`` arrays contain all the input
+vectors. ``A`` array contains the pointers to all input matrices.  The
+total number of vectors in ``x`` and ``y`` and matrices in ``A`` are given by the
+``batch_size`` parameter.
+   
+**Group API**
+
+.. rubric:: Syntax
+   
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event gemv_batch(sycl::queue &queue,
+                              onemkl::transpose *trans,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              const T **x,
+                              std::int64_t *incx,
+                              T *beta,
+                              T **y,
+                              std::int64_t *incy,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event gemv_batch(sycl::queue &queue,
+                              onemkl::transpose *trans,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              const T **x,
+                              std::int64_t *incx,
+                              T *beta,
+                              T **y,
+                              std::int64_t *incy,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   trans
+      Array of ``group_count`` ``onemkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used in
+      the matrix-vector product in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Array of ``group_count`` integers. ``m[i]`` specifies the
+      number of rows of op(``A``) for every matrix in group ``i``. All entries must be at least zero.
+
+   n
+      Array of ``group_count`` integers. ``n[i]`` specifies the
+      number of columns of op(``A``) for every matrix in group ``i``. All entries must be at least zero.
+
+   alpha
+      Array of ``group_count`` scalar elements. ``alpha[i]`` specifies
+      the scaling factor for every matrix-vector product in group
+      ``i``.
+
+   a
+      Array of pointers to input matrices ``A`` with size ``total_batch_count``. 
+      
+      See :ref:`matrix-storage` for more details.
+
+   lda
+      Array of ``group_count`` integers. ``lda[i]`` specifies the
+      leading dimension of ``A`` for every matrix in group ``i``. All
+      entries must be positive and at least ``m`` if column major
+      layout is used or at least ``n`` if row major layout is used.
+             
+   x
+      Array of pointers to input vectors ``X`` with size ``total_batch_count``. 
+      
+      See :ref:`matrix-storage` for more details.
+
+   incx
+      Array of ``group_count`` integers. ``incx[i]`` specifies the
+      stride of ``X`` for every vector in group ``i``. All
+      entries must be positive.
+             
+   beta
+      Array of ``group_count`` scalar elements. ``beta[i]`` specifies
+      the scaling factor for vector ``Y`` for every vector in group
+      ``i``.
+
+   y
+      Array of pointers to input/output vectors ``Y`` with size ``total_batch_count``. 
+      
+      See :ref:`matrix-storage` for more details.
+
+   incy
+      Array of ``group_count`` integers. ``incy[i]`` specifies the
+      leading dimension of ``Y`` for every vector in group ``i``.  All
+      entries must be positive and ``incy[i]`` must be at least
+      ``m[i]`` if column major layout is used or at
+      least ``n[i]`` if row major layout is used.
+
+   group_count
+      Specifies the number of groups. Must be at least 0.
+
+   group_size
+      Array of ``group_count`` integers. ``group_size[i]`` specifies the
+      number of matrix-vector products in group ``i``. All entries must be at least 0.
+
+   dependencies
+         List of events to wait for before starting computation, if any.
+         If omitted, defaults to no dependencies.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   y
+      Overwritten by vector calculated by 
+      (``alpha[i]`` * op(``A``) * ``X`` + ``beta[i]`` * ``Y``) for group ``i``.
+
+.. container:: section
+
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event gemv_batch(sycl::queue &queue,
+                              onemkl::transpose trans,
+                              std::int64_t m,
+                              std::int64_t n,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              const T *x,
+                              std::int64_t incx,
+                              std::int64_t stridex,
+                              T beta,
+                              T *y,
+                              std::int64_t incy,
+                              std::int64_t stridey,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event gemv_batch(sycl::queue &queue,
+                              onemkl::transpose trans,
+                              std::int64_t m,
+                              std::int64_t n,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              const T *x,
+                              std::int64_t incx,
+                              std::int64_t stridex,
+                              T beta,
+                              T *y,
+                              std::int64_t incy,
+                              std::int64_t stridey,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   trans
+      Specifies op(``A``) the transposition operation applied to the
+      matrices ``A``. See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Number of rows of op(``A``). Must be at least zero.
+
+   n
+      Number of columns of op(``A``). Must be at least zero.
+
+   alpha
+      Scaling factor for the matrix-vector products.
+
+   a
+      Pointer to the input matrices ``A`` with size ``stridea`` * ``batch_size``.
+
+   lda
+      The leading dimension of the matrices ``A``. It must be positive
+      and at least ``m`` if column major layout is used or at least
+      ``n`` if row major layout is used.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   x
+      Pointer to the input vectors ``X`` with size ``stridex`` * ``batch_size``.
+
+   incx
+      Stride of the vector ``X``. It must be positive.
+
+   stridex
+      Stride between different consecutive ``X`` vectors, must be at least 0.
+
+   beta
+      Scaling factor for the vector ``Y``.
+
+   y
+      Pointer to the input/output vectors ``Y`` with size ``stridey`` * ``batch_size``.
+
+   incy
+      Stride between two consecutive elements of the ``y`` vectors.
+
+   stridey
+      Stride between two consecutive ``Y`` vectors. Must be at least
+      (1 + (len-1)*abs(incy)) where ``len`` is ``m`` if the matrix ``A``
+      is non transpose or ``n`` otherwise.
+
+   batch_size
+      Specifies the number of matrix-vector operations to perform.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   y
+      Output overwritten by ``batch_size`` matrix-vector product
+      operations of the form ``alpha`` * op(``A``) * ``X`` + ``beta`` * ``Y``.
+
+.. container:: section
+      
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+
+   **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/syrk_batch.rst
+++ b/docs/domains/blas/syrk_batch.rst
@@ -1,0 +1,484 @@
+.. _onemkl_blas_syrk_batch:
+
+syrk_batch
+==========
+
+Computes a group of ``syrk`` operations.
+
+.. _onemkl_blas_syrk_batch_description:
+
+.. rubric:: Description
+
+The ``syrk_batch`` routines are batched versions of :ref:`onemkl_blas_syrk`, performing
+multiple ``syrk`` operations in a single call. Each ``syrk`` 
+operation perform a rank-k update with general matrices.
+   
+``syrk_batch`` supports the following precisions.
+
+   .. list-table:: 
+      :header-rows: 1
+
+      * -  T 
+      * -  ``float`` 
+      * -  ``double`` 
+      * -  ``std::complex<float>`` 
+      * -  ``std::complex<double>`` 
+
+.. _onemkl_blas_syrk_batch_buffer:
+
+syrk_batch (Buffer Version)
+---------------------------
+
+.. rubric:: Description
+
+The buffer version of ``syrk_batch`` supports only the strided API. 
+
+The strided API operation is defined as:
+::
+
+   for i = 0 … batch_size – 1
+       A and C are matrices at offset i * stridea, i * stridec in a and c.
+       C := alpha * op(A) * op(A)^T + beta * C
+   end for
+
+where:
+
+op(X) is one of op(X) = X, or op(X) = X\ :sup:`T`, or op(X) = X\ :sup:`H`,
+
+``alpha`` and ``beta`` are scalars,
+
+``A`` and ``C`` are matrices,
+
+op(``A``) is ``n`` x ``k`` and ``C`` is ``n`` x ``n``.
+
+The ``a`` and ``c`` buffers contain all the input matrices. The stride 
+between matrices is given by the stride parameter. The total number
+of matrices in ``a`` and ``c`` buffers is given by the ``batch_size`` parameter.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       void syrk_batch(sycl::queue &queue,
+                       onemkl::uplo upper_lower,
+                       onemkl::transpose trans,
+                       std::int64_t n,
+                       std::int64_t k,
+                       T alpha,
+                       sycl::buffer<T,1> &a,
+                       std::int64_t lda,
+                       std::int64_t stridea,
+                       T beta,
+                       sycl::buffer<T,1> &c,
+                       std::int64_t ldc,
+                       std::int64_t stridec,
+                       std::int64_t batch_size)
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       void syrk_batch(sycl::queue &queue,
+                       onemkl::uplo upper_lower,
+                       onemkl::transpose trans,
+                       std::int64_t n,
+                       std::int64_t k,
+                       T alpha,
+                       sycl::buffer<T,1> &a,
+                       std::int64_t lda,
+                       std::int64_t stridea,
+                       T beta,
+                       sycl::buffer<T,1> &c,
+                       std::int64_t ldc,
+                       std::int64_t stridec,
+                       std::int64_t batch_size)
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   upper_lower
+      Specifies whether data in ``C`` is stored in its upper or lower triangle.
+      For more details, see :ref:`onemkl_datatypes`.
+
+   trans
+      Specifies op(``A``) the transposition operation applied to the
+      matrix ``A``. Conjugation is never performed, even if trans =
+      transpose::conjtrans. See :ref:`onemkl_datatypes` for more
+      details.
+
+   n
+      Number of rows and columns of ``C``.
+      Must be at least zero.
+
+   k
+      Number of columns of op(``A``).
+      Must be at least zero.
+
+   alpha
+      Scaling factor for the rank-k update.
+
+   a
+      Buffer holding the input matrices ``A`` with size ``stridea`` * ``batch_size``.
+
+   lda
+      The leading dimension of the matrices ``A``. It must be positive.
+
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``A`` not transposed
+           - ``A`` transposed
+         * - Column major
+           - ``lda`` must be at least ``n``.
+           - ``lda`` must be at least ``k``.
+         * - Row major
+           - ``lda`` must be at least ``k``.
+           - ``lda`` must be at least ``n``.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   beta
+      Scaling factor for the matrices ``C``.
+
+   c
+      Buffer holding input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
+
+   ldc
+      The leading dimension of the matrices ``C``. It must be positive
+      and at least ``n``.
+
+   stridec
+      Stride between different ``C`` matrices. Must be at least
+      ``ldc`` * ``n``.
+
+   batch_size
+      Specifies the number of rank-k update operations to perform.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   c
+      Output buffer, overwritten by ``batch_size`` rank-k update
+      operations of the form ``alpha`` * op(``A``)*op(``A``)^T + ``beta`` * ``C``.
+
+
+.. _onemkl_blas_syrk_batch_usm:
+
+syrk_batch (USM Version)
+---------------------------
+
+.. rubric:: Description
+
+The USM version of ``syrk_batch`` supports the group API and strided API. 
+
+The group API operation is defined as:
+::
+
+   idx = 0
+   for i = 0 … group_count – 1
+       for j = 0 … group_size – 1
+           A, B, and C are matrices in a[idx] and c[idx]
+           C := alpha[i] * op(A) * op(A)^T + beta[i] * C
+           idx = idx + 1
+       end for
+   end for
+
+The strided API operation is defined as
+::
+
+   for i = 0 … batch_size – 1
+       A, B and C are matrices at offset i * stridea, i * stridec in a and c.
+       C := alpha * op(A) * op(A)^T + beta * C
+   end for
+
+where:
+
+op(X) is one of op(X) = X, or op(X) = X\ :sup:`T`, or op(X) = X\ :sup:`H`,
+
+``alpha`` and ``beta`` are scalars,
+
+``A`` and ``C`` are matrices,
+
+op(``A``) is ``n`` x ``k`` and ``C`` is ``n`` x ``n``.
+
+ 
+For group API, ``a`` and ``c`` arrays contain the pointers for all the input matrices. 
+The total number of matrices in ``a`` and ``c`` are given by: 
+
+.. math::
+
+      total\_batch\_count = \sum_{i=0}^{group\_count-1}group\_size[i]    
+ 
+For strided API, ``a`` and ``c`` arrays contain all the input matrices. The total number of matrices 
+in ``a`` and ``c`` are given by the ``batch_size`` parameter.  
+   
+**Group API**
+
+.. rubric:: Syntax
+   
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event syrk_batch(sycl::queue &queue,
+                              uplo *upper_lower,
+                              transpose *trans,
+                              std::int64_t *n,
+                              std::int64_t *k,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              T *beta,
+                              T **c,
+                              std::int64_t *ldc,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event syrk_batch(sycl::queue &queue,
+                              uplo *upper_lower,
+                              transpose *trans,
+                              std::int64_t *n,
+                              std::int64_t *k,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              T *beta,
+                              T **c,
+                              std::int64_t *ldc,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   upper_lower
+      Array of ``group_count`` ``onemkl::upper_lower``
+      values. ``upper_lower[i]`` specifies whether data in C for every
+      matrix in group ``i`` is in upper or lower triangle.
+
+   trans
+      Array of ``group_count`` ``onemkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used in
+      the rank-k update in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   n
+      Array of ``group_count`` integers. ``n[i]`` specifies the
+      number of rows and columns of ``C`` for every matrix in group ``i``. All entries must be at least zero.
+
+   k
+      Array of ``group_count`` integers. ``k[i]`` specifies the
+      number of columns of op(``A``) for every matrix in group ``i``. All entries must be at
+      least zero.
+
+   alpha
+      Array of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor for every rank-k update in group ``i``.
+
+   a
+      Array of pointers to input matrices ``A`` with size ``total_batch_count``. 
+      
+      See :ref:`matrix-storage` for more details.
+
+   lda
+      Array of ``group_count`` integers. ``lda[i]`` specifies the
+      leading dimension of ``A`` for every matrix in group ``i``. All
+      entries must be positive.
+
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``A`` not transposed
+           - ``A`` transposed
+         * - Column major
+           - ``lda[i]`` must be at least ``n[i]``.
+           - ``lda[i]`` must be at least ``k[i]``.
+         * - Row major
+           - ``lda[i]`` must be at least ``k[i]``.
+           - ``lda[i]`` must be at least ``n[i]``.
+             
+   beta
+      Array of ``group_count`` scalar elements. ``beta[i]`` specifies the scaling factor for matrix ``C`` 
+      for every matrix in group ``i``.
+
+   c
+      Array of pointers to input/output matrices ``C`` with size ``total_batch_count``. 
+      
+      See :ref:`matrix-storage` for more details.
+
+   ldc
+      Array of ``group_count`` integers. ``ldc[i]`` specifies the
+      leading dimension of ``C`` for every matrix in group ``i``.  All
+      entries must be positive and ``ldc[i]`` must be at least ``n[i]``.
+
+   group_count
+      Specifies the number of groups. Must be at least 0.
+
+   group_size
+      Array of ``group_count`` integers. ``group_size[i]`` specifies the
+      number of rank-k update products in group ``i``. All entries must be at least 0.
+
+   dependencies
+         List of events to wait for before starting computation, if any.
+         If omitted, defaults to no dependencies.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   c
+      Overwritten by the ``n[i]``-by-``n[i]`` matrix calculated by 
+      (``alpha[i]`` * op(``A``)*op(``A``)^T + ``beta[i]`` * ``C``) for group ``i``.
+
+.. container:: section
+
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event syrk_batch(sycl::queue &queue,
+                              uplo upper_lower,
+                              transpose trans,
+                              std::int64_t n,
+                              std::int64_t k,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stride_a,
+                              T beta,
+                              T *c,
+                              std::int64_t ldc,
+                              std::int64_t stride_c,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event syrk_batch(sycl::queue &queue,
+                              uplo upper_lower,
+                              transpose trans,
+                              std::int64_t n,
+                              std::int64_t k,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stride_a,
+                              T beta,
+                              T *c,
+                              std::int64_t ldc,
+                              std::int64_t stride_c,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   upper_lower
+      Specifies whether data in ``C`` is stored in its upper or lower triangle.
+      For more details, see :ref:`onemkl_datatypes`.
+
+   trans
+      Specifies op(``A``) the transposition operation applied to the
+      matrices ``A``. Conjugation is never performed, even if trans =
+      transpose::conjtrans. See :ref:`onemkl_datatypes` for more
+      details.
+
+   n
+      Number of rows and columns of ``C``.
+      Must be at least zero.
+
+   k
+      Number of columns of op(``A``).
+      Must be at least zero.
+
+   alpha
+      Scaling factor for the rank-k updates.
+
+   a
+      Pointer to input matrices ``A`` with size ``stridea`` * ``batch_size``.
+
+   lda
+      The leading dimension of the matrices ``A``. It must be positive.
+
+      .. list-table::
+         :header-rows: 1
+
+         * -
+           - ``A`` not transposed
+           - ``A`` transposed
+         * - Column major
+           - ``lda`` must be at least ``n``.
+           - ``lda`` must be at least ``k``.
+         * - Row major
+           - ``lda`` must be at least ``k``.
+           - ``lda`` must be at least ``n``.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   beta
+      Scaling factor for the matrices ``C``.
+
+   c
+      Pointer to input/output matrices ``C`` with size ``stridec`` * ``batch_size``.
+
+   ldc
+      The leading dimension of the matrices ``C``. It must be positive
+      and at least ``n``.
+
+   stridec
+      Stride between different ``C`` matrices.
+
+   batch_size
+      Specifies the number of rank-k update operations to perform.
+
+   dependencies
+         List of events to wait for before starting computation, if any.
+         If omitted, defaults to no dependencies.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   c
+      Output matrices, overwritten by ``batch_size`` rank-k update
+      operations of the form ``alpha`` * op(``A``)*op(``A``)^T + ``beta`` * ``C``.
+
+.. container:: section
+      
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+
+   **Parent topic:** :ref:`blas-like-extensions`

--- a/docs/domains/blas/trsm_batch.rst
+++ b/docs/domains/blas/trsm_batch.rst
@@ -180,4 +180,318 @@ of matrices in ``a`` and ``b`` buffers are given by the ``batch_size`` parameter
    If ``alpha`` = 0, matrix ``B`` is set to zero and the matrices ``A``
    and ``B`` do not need to be initialized before calling ``trsm_batch``.
 
+
+.. rubric:: Description
+
+The USM version of ``trsm_batch`` supports the group API and strided API. 
+
+The group API operation is defined as:
+::
+
+   idx = 0
+   for i = 0 … group_count – 1
+       for j = 0 … group_size – 1
+           A and B are matrices in a[idx] and b[idx]
+           if (left_right == onemkl::side::left) then
+               compute X such that op(A) * X = alpha[i] * B
+           else
+               compute X such that X * op(A) = alpha[i] * B
+           end if
+           B := X
+           idx = idx + 1
+       end for
+   end for     
+
+
+The strided API operation is defined as:
+::
+
+   for i = 0 … batch_size – 1
+       A and B are matrices at offset i * stridea and i * strideb in a and b.
+       if (left_right == onemkl::side::left) then
+           compute X such that op(A) * X = alpha * B
+       else
+           compute X such that X * op(A) = alpha * B
+       end if
+       B := X
+   end for
+
+   where:
+
+op(``A``) is one of op(``A``) = ``A``, or op(A) = ``A``\ :sup:`T`,
+or op(``A``) = ``A``\ :sup:`H`,
+
+``alpha`` is a scalar,
+
+``A`` is a triangular matrix,
+
+``B`` and ``X`` are ``m`` x ``n`` general matrices,
+
+``A`` is either ``m`` x ``m`` or ``n`` x ``n``,depending on whether
+it multiplies ``X`` on the left or right. On return, the matrix ``B``
+is overwritten by the solution matrix ``X``.
+
+For group API, ``a`` and ``b`` arrays contain the pointers for all the input matrices. 
+The total number of matrices in ``a`` and ``b`` are given by: 
+ 
+.. math::
+      
+      total\_batch\_count = \sum_{i=0}^{group\_count-1}group\_size[i]
+
+For strided API, ``a`` and ``b`` arrays contain all the input matrices. The total number of matrices 
+in ``a`` and ``b`` are given by the ``batch_size`` parameter.  
+
+**Group API**
+
+.. rubric:: Syntax
+      
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side *left_right,
+                              onemkl::uplo *upper_lower,
+                              onemkl::transpose *trans,
+                              onemkl::diag *unit_diag,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              T **b,
+                              std::int64_t *ldb,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side *left_right,
+                              onemkl::uplo *upper_lower,
+                              onemkl::transpose *trans,
+                              onemkl::diag *unit_diag,
+                              std::int64_t *m,
+                              std::int64_t *n,
+                              T *alpha,
+                              const T **a,
+                              std::int64_t *lda,
+                              T **b,
+                              std::int64_t *ldb,
+                              std::int64_t group_count,
+                              std::int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   left_right
+      Array of ``group_count`` ``onemkl::side`` values. ``left_right[i]`` specifies whether ``A`` multiplies
+      ``X`` on the left (``side::left``) or on the right
+      (``side::right``) for every ``trsm`` operation in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   upper_lower
+      Array of ``group_count`` ``onemkl::uplo`` values. ``upper_lower[i]`` specifies whether ``A`` is upper or lower
+      triangular for every matrix in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   trans
+      Array of ``group_count`` ``onemkl::transpose`` values. ``trans[i]`` specifies the form of op(``A``) used
+      for every ``trsm`` operation in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   unit_diag
+      Array of ``group_count`` ``onemkl::diag`` values. ``unit_diag[i]`` specifies whether ``A`` is assumed to
+      be unit triangular (all diagonal elements are 1) for every matrix in group ``i``. See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Array of ``group_count`` integers. ``m[i]`` specifies the
+      number of rows of ``B`` for every matrix in group ``i``. All entries must be at least zero.
+
+   n
+      Array of ``group_count`` integers. ``n[i]`` specifies the
+      number of columns of ``B`` for every matrix in group ``i``. All entries must be at least zero.
+
+   alpha
+      Array of ``group_count`` scalar elements. ``alpha[i]`` specifies the scaling factor in group ``i``.
+
+   a
+      Array of pointers to input matrices ``A`` with size ``total_batch_count``. See :ref:`matrix-storage` for more details.
+
+   lda
+      Array of ``group_count`` integers. ``lda[i]`` specifies the leading dimension of ``A`` for every matrix in group ``i``. 
+      All entries must be at least ``m``
+      if ``left_right`` is ``side::left``, and at least 
+      ``n`` if ``left_right`` is ``side::right``. All entries must be positive.
+
+   b
+      Array of pointers to input matrices ``B`` with size ``total_batch_count``. See :ref:`matrix-storage` for more details.
+
+   ldb
+      Array of ``group_count`` integers. ``ldb[i]`` specifies the
+      leading dimension of ``B`` for every matrix in group ``i``.  All
+      entries must be positive and at least ``m`` and positive if
+      column major layout is used to store matrices or at least ``n``
+      if row major layout is used to store matrices.
+
+   group_count
+      Specifies the number of groups. Must be at least 0.
+
+   group_size
+      Array of ``group_count`` integers. ``group_size[i]`` specifies the
+      number of ``trsm`` operations in group ``i``. All entries must be at least 0.
+
+   dependencies
+         List of events to wait for before starting computation, if any.
+         If omitted, defaults to no dependencies.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   b
+      Output buffer, overwritten by the ``total_batch_count`` solution
+      matrices ``X``.
+
+.. container:: section
+
+   .. rubric:: Notes
+
+   If ``alpha`` = 0, matrix ``B`` is set to zero and the matrices ``A``
+   and ``B`` do not need to be initialized before calling ``trsm_batch``.
+
+.. container:: section
+   
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+**Strided API**
+
+.. rubric:: Syntax
+
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::column_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side left_right,
+                              onemkl::uplo upper_lower,
+                              onemkl::transpose trans,
+                              onemkl::diag unit_diag,
+                              std::int64_t m,
+                              std::int64_t n,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              T *b,
+                              std::int64_t ldb,
+                              std::int64_t strideb,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+.. code-block:: cpp
+
+   namespace oneapi::mkl::blas::row_major {
+       sycl::event trsm_batch(sycl::queue &queue,
+                              onemkl::side left_right,
+                              onemkl::uplo upper_lower,
+                              onemkl::transpose trans,
+                              onemkl::diag unit_diag,
+                              std::int64_t m,
+                              std::int64_t n,
+                              T alpha,
+                              const T *a,
+                              std::int64_t lda,
+                              std::int64_t stridea,
+                              T *b,
+                              std::int64_t ldb,
+                              std::int64_t strideb,
+                              std::int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies = {})
+   }
+
+.. container:: section
+
+   .. rubric:: Input Parameters
+
+   queue
+      The queue where the routine should be executed.
+
+   left_right
+      Specifies whether the matrices ``A`` multiply ``X`` on the left
+      (``side::left``) or on the right (``side::right``). See :ref:`onemkl_datatypes` for more details.
+
+   upper_lower
+      Specifies whether the matrices ``A`` are upper or lower
+      triangular. See :ref:`onemkl_datatypes` for more details.
+
+   trans
+      Specifies op(``A``), the transposition operation applied to the
+      matrices ``A``. See :ref:`onemkl_datatypes` for more details.
+
+   unit_diag
+      Specifies whether the matrices ``A`` are assumed to be unit
+      triangular (all diagonal elements are 1). See :ref:`onemkl_datatypes` for more details.
+
+   m
+      Number of rows of the ``B`` matrices. Must be at least zero.
+
+   n
+      Number of columns of the ``B`` matrices. Must be at least zero.
+
+   alpha
+      Scaling factor for the solutions.
+
+   a
+      Pointer to input matrices ``A`` with size ``stridea`` * ``batch_size``.
+
+   lda
+      Leading dimension of the matrices ``A``. Must be at least ``m`` if
+      ``left_right`` = ``side::left``, and at least ``n`` if ``left_right`` =
+      ``side::right``. Must be positive.
+
+   stridea
+      Stride between different ``A`` matrices.
+
+   b
+      Pointer to input matrices ``B`` with size ``strideb`` * ``batch_size``.
+
+   ldb
+      Leading dimension of the matrices ``B``. It must be positive and at least
+      ``m`` if column major layout is used to store matrices or at
+      least ``n`` if row major layout is used to store matrices.
+
+   strideb
+      Stride between different ``B`` matrices. 
+
+   batch_size
+      Specifies the number of triangular linear systems to solve.
+
+.. container:: section
+
+   .. rubric:: Output Parameters
+
+   b
+      Output matrices, overwritten by ``batch_size`` solution matrices
+      ``X``.
+
+.. container:: section
+
+   .. rubric:: Notes
+
+   If ``alpha`` = 0, matrix ``B`` is set to zero and the matrices ``A``
+   and ``B`` do not need to be initialized before calling ``trsm_batch``.
+
+.. container:: section
+   
+   .. rubric:: Return Values
+
+   Output event to wait on to ensure computation is complete.
+
+
    **Parent topic:** :ref:`blas-like-extensions`


### PR DESCRIPTION
# Description

Update documentation of BLAS interfaces to be consistent with the [oneAPI spec](https://github.com/oneapi-src/oneAPI-spec).

# Checklist

All changes are to `.rst` files. No code changes, no new interface, no new feature, no bug fixes.

Log from `make Documentation`:
```
Scanning dependencies of target Documentation
Building HTML documentation with Sphinx
Built target Documentation
```
