### PR TITLE
Fix empty kernel name issue for old and new compilers.

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -31,7 +31,8 @@ namespace cublas {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-thread_local cublas_handle<pi_context> CublasScopedContextHandler::handle_helper = cublas_handle<pi_context>{};
+thread_local cublas_handle<pi_context> CublasScopedContextHandler::handle_helper =
+    cublas_handle<pi_context>{};
 
 CublasScopedContextHandler::CublasScopedContextHandler(cl::sycl::queue queue,
                                                        cl::sycl::interop_handler &ih)

--- a/src/blas/backends/mklgpu/mklgpu_batch.cpp
+++ b/src/blas/backends/mklgpu/mklgpu_batch.cpp
@@ -30,16 +30,20 @@ namespace blas {
 namespace mklgpu {
 namespace column_major {
 
-#define MAJOR MKL_COL_MAJOR
+#define MAJOR             MKL_COL_MAJOR
+#define EMPTY_KERNEL_NAME ColMajorEmptyKernel
 #include "mklgpu_batch.cxx"
 #undef MAJOR
+#undef EMPTY_KERNEL_NAME
 
 } // namespace column_major
 namespace row_major {
 
-#define MAJOR MKL_ROW_MAJOR
+#define MAJOR             MKL_ROW_MAJOR
+#define EMPTY_KERNEL_NAME RowMajorEmptyKernel
 #include "mklgpu_batch.cxx"
 #undef MAJOR
+#undef EMPTY_KERNEL_NAME
 
 } // namespace row_major
 } // namespace mklgpu

--- a/src/blas/backends/mklgpu/mklgpu_batch.cxx
+++ b/src/blas/backends/mklgpu/mklgpu_batch.cxx
@@ -296,7 +296,7 @@ cl::sycl::event *coalesce_events(cl::sycl::queue &queue, std::vector<cl::sycl::e
         return new cl::sycl::event(queue.submit([&](cl::sycl::handler &cgh) {
             for (int64_t i = 0; i < prereqs.size(); i++)
                 cgh.depends_on(*prereqs[i]);
-            cgh.single_task<class MAJOR>([]() {});
+            cgh.single_task<class EMPTY_KERNEL_NAME>([]() {});
         }));
     }
     else


### PR DESCRIPTION
# Description

Change kernel name parameter in `mklgpu_batch.cxx` to work with newer SYCL compilers.

The behavior changes for SYCL 2020, this workaround is intended to work with the compilers currently in our CI as well as upcoming DPC++.

Fixes #147 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests? (*not applicable for build failure*)
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
