### PR TITLE
Remove tautological constant compare warnings for isnan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,10 +137,9 @@ if(WIN32 AND ONEMKL_SYCL_IMPLEMENTATION STREQUAL "dpc++")
   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fsycl /nologo <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 endif()
 
+# Temporary disable sycl 2020 deprecations warnings
 if(ONEMKL_SYCL_IMPLEMENTATION STREQUAL "dpc++")
-  # Temporary disable sycl 2020 deprecations warnings
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSYCL2020_DISABLE_DEPRECATION_WARNINGS")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-constant-compare")
 endif()
 
 # Target domains

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,9 +137,10 @@ if(WIN32 AND ONEMKL_SYCL_IMPLEMENTATION STREQUAL "dpc++")
   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fsycl /nologo <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
 endif()
 
-# Temporary disable sycl 2020 deprecations warnings
 if(ONEMKL_SYCL_IMPLEMENTATION STREQUAL "dpc++")
+  # Temporary disable sycl 2020 deprecations warnings
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSYCL2020_DISABLE_DEPRECATION_WARNINGS")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-constant-compare")
 endif()
 
 # Target domains

--- a/src/blas/backends/netlib/netlib_level1.cpp
+++ b/src/blas/backends/netlib/netlib_level1.cpp
@@ -49,7 +49,10 @@ int cblas_isamin(int n, const float *x, int incx) {
     for (int logical_i = 0; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -68,7 +71,10 @@ int cblas_idamin(int n, const double *x, int incx) {
     for (int logical_i = 0; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -87,7 +93,10 @@ int cblas_icamin(int n, const std::complex<float> *x, int incx) {
     for (int logical_i = 0; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -106,7 +115,10 @@ int cblas_izamin(int n, const std::complex<double> *x, int incx) {
     for (int logical_i = 0; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1465,7 +1465,10 @@ int iamin(const int *n, const float *x, const int *incx) {
     for (int logical_i = 0; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -1485,7 +1488,10 @@ int iamin(const int *n, const double *x, const int *incx) {
     for (int logical_i = 0; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -1505,7 +1511,10 @@ int iamin(const int *n, const std::complex<float> *x, const int *incx) {
     for (int logical_i = 0; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -1525,7 +1534,10 @@ int iamin(const int *n, const std::complex<double> *x, const int *incx) {
     for (int logical_i = 0; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-compare"
         bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
+#pragma clang diagnostic pop
         if (is_first_nan || curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;


### PR DESCRIPTION
# Description

Remove thousands of warnings related to `isnan` that report `tautological constant compare` when using DPC++.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

[test.txt](https://github.com/oneapi-src/oneMKL/files/7748481/test.txt)

