### PR TITLE
[BLAS] Fix syrk test bug

### DIFF
--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -63,14 +63,13 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 
     upper_lower = (oneapi::mkl::uplo)(std::rand() % 2);
     if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-        trans = (oneapi::mkl::transpose)(std::rand() % 2);
+        trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
+                                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                                                : oneapi::mkl::transpose::conjtrans;
     }
     else {
-        tmp = std::rand() % 3;
-        if (tmp == 2)
-            trans = oneapi::mkl::transpose::conjtrans;
-        else
-            trans = (oneapi::mkl::transpose)tmp;
+        trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
+                                       : oneapi::mkl::transpose::trans;
     }
 
     int64_t stride_a, stride_c;

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -28,6 +28,8 @@
 
 #include <CL/sycl.hpp>
 
+#define MAX_NUM_PRINT 20
+
 namespace std {
 static sycl::half abs(sycl::half v) {
     if (v < sycl::half(0))
@@ -466,7 +468,7 @@ bool check_equal(fp x, fp x_ref, int error_mag, std::ostream &out) {
 
 template <typename fp>
 bool check_equal_vector(fp *v, fp *v_ref, int n, int inc, int error_mag, std::ostream &out) {
-    int abs_inc = std::abs(inc);
+    int abs_inc = std::abs(inc), count = 0;
     bool good = true;
 
     for (int i = 0; i < n; i++) {
@@ -475,6 +477,9 @@ bool check_equal_vector(fp *v, fp *v_ref, int n, int inc, int error_mag, std::os
             std::cout << "Difference in entry " << i_actual << ": DPC++ " << v[i * abs_inc]
                       << " vs. Reference " << v_ref[i * abs_inc] << std::endl;
             good = false;
+            count++;
+            if (count > MAX_NUM_PRINT)
+                return good;
         }
     }
 
@@ -483,7 +488,7 @@ bool check_equal_vector(fp *v, fp *v_ref, int n, int inc, int error_mag, std::os
 
 template <typename vec1, typename vec2>
 bool check_equal_vector(vec1 &v, vec2 &v_ref, int n, int inc, int error_mag, std::ostream &out) {
-    int abs_inc = std::abs(inc);
+    int abs_inc = std::abs(inc), count = 0;
     bool good = true;
 
     for (int i = 0; i < n; i++) {
@@ -492,6 +497,9 @@ bool check_equal_vector(vec1 &v, vec2 &v_ref, int n, int inc, int error_mag, std
             std::cout << "Difference in entry " << i_actual << ": DPC++ " << v[i * abs_inc]
                       << " vs. Reference " << v_ref[i * abs_inc] << std::endl;
             good = false;
+            count++;
+            if (count > MAX_NUM_PRINT)
+                return good;
         }
     }
 
@@ -501,7 +509,7 @@ bool check_equal_vector(vec1 &v, vec2 &v_ref, int n, int inc, int error_mag, std
 template <typename vec1, typename vec2>
 bool check_equal_trsv_vector(vec1 &v, vec2 &v_ref, int n, int inc, int error_mag,
                              std::ostream &out) {
-    int abs_inc = std::abs(inc);
+    int abs_inc = std::abs(inc), count = 0;
     bool good = true;
 
     for (int i = 0; i < n; i++) {
@@ -510,6 +518,9 @@ bool check_equal_trsv_vector(vec1 &v, vec2 &v_ref, int n, int inc, int error_mag
             std::cout << "Difference in entry " << i_actual << ": DPC++ " << v[i * abs_inc]
                       << " vs. Reference " << v_ref[i * abs_inc] << std::endl;
             good = false;
+            count++;
+            if (count > MAX_NUM_PRINT)
+                return good;
         }
     }
 
@@ -520,7 +531,7 @@ template <typename acc1, typename acc2>
 bool check_equal_matrix(acc1 &M, acc2 &M_ref, oneapi::mkl::layout layout, int m, int n, int ld,
                         int error_mag, std::ostream &out) {
     bool good = true;
-    int idx;
+    int idx, count = 0;
     for (int j = 0; j < n; j++) {
         for (int i = 0; i < m; i++) {
             idx = (layout == oneapi::mkl::layout::column_major) ? i + j * ld : j + i * ld;
@@ -528,6 +539,9 @@ bool check_equal_matrix(acc1 &M, acc2 &M_ref, oneapi::mkl::layout layout, int m,
                 out << "Difference in entry (" << i << ',' << j << "): DPC++ " << M[idx]
                     << " vs. Reference " << M_ref[idx] << std::endl;
                 good = false;
+                count++;
+                if (count > MAX_NUM_PRINT)
+                    return good;
             }
         }
     }
@@ -539,7 +553,7 @@ template <typename fp>
 bool check_equal_matrix(fp *M, fp *M_ref, oneapi::mkl::layout layout, int m, int n, int ld,
                         int error_mag, std::ostream &out) {
     bool good = true;
-    int idx;
+    int idx, count = 0;
     for (int j = 0; j < n; j++) {
         for (int i = 0; i < m; i++) {
             idx = (layout == oneapi::mkl::layout::column_major) ? i + j * ld : j + i * ld;
@@ -547,6 +561,9 @@ bool check_equal_matrix(fp *M, fp *M_ref, oneapi::mkl::layout layout, int m, int
                 out << "Difference in entry (" << i << ',' << j << "): DPC++ " << M[idx]
                     << " vs. Reference " << M_ref[idx] << std::endl;
                 good = false;
+                count++;
+                if (count > MAX_NUM_PRINT)
+                    return good;
             }
         }
     }
@@ -559,7 +576,7 @@ bool check_equal_matrix(acc1 &M, acc2 &M_ref, oneapi::mkl::layout layout,
                         oneapi::mkl::uplo upper_lower, int m, int n, int ld, int error_mag,
                         std::ostream &out) {
     bool good = true;
-    int idx;
+    int idx, count = 0;
     for (int j = 0; j < n; j++) {
         for (int i = 0; i < m; i++) {
             idx = (layout == oneapi::mkl::layout::column_major) ? i + j * ld : j + i * ld;
@@ -569,6 +586,9 @@ bool check_equal_matrix(acc1 &M, acc2 &M_ref, oneapi::mkl::layout layout,
                     out << "Difference in entry (" << i << ',' << j << "): DPC++ " << M[idx]
                         << " vs. Reference " << M_ref[idx] << std::endl;
                     good = false;
+                    count++;
+                    if (count > MAX_NUM_PRINT)
+                        return good;
                 }
             }
         }
@@ -581,7 +601,7 @@ template <typename acc1, typename acc2>
 bool check_equal_trsm_matrix(acc1 &M, acc2 &M_ref, oneapi::mkl::layout layout, int m, int n, int ld,
                              int error_mag, std::ostream &out) {
     bool good = true;
-    int idx;
+    int idx, count = 0;
     for (int j = 0; j < n; j++) {
         for (int i = 0; i < m; i++) {
             idx = (layout == oneapi::mkl::layout::column_major) ? i + j * ld : j + i * ld;
@@ -589,6 +609,9 @@ bool check_equal_trsm_matrix(acc1 &M, acc2 &M_ref, oneapi::mkl::layout layout, i
                 out << "Difference in entry (" << i << ',' << j << "): DPC++ " << M[idx]
                     << " vs. Reference " << M_ref[idx] << std::endl;
                 good = false;
+                count++;
+                if (count > MAX_NUM_PRINT)
+                    return good;
             }
         }
     }


### PR DESCRIPTION
This PR is fixing a test bug found during hipSYCL testing. Removed unsupported conjugate_transpose test conditions from SYRK. 

Also capped max error printing to 20 to avoid large log files when there are errors. 

- [X] Do all unit tests pass locally?
- [X] Have you formatted the code using clang-format?

