### PR TITLE
[BLAS] change reference iamin to avoid nan comparison issues/warnings

### DIFF
--- a/src/blas/backends/netlib/netlib_level1.cpp
+++ b/src/blas/backends/netlib/netlib_level1.cpp
@@ -45,12 +45,14 @@ int cblas_isamin(int n, const float *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -65,12 +67,14 @@ int cblas_idamin(int n, const double *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -85,12 +89,14 @@ int cblas_icamin(int n, const std::complex<float> *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -105,12 +111,14 @@ int cblas_izamin(int n, const std::complex<double> *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;

--- a/src/blas/backends/netlib/netlib_level1.cpp
+++ b/src/blas/backends/netlib/netlib_level1.cpp
@@ -45,12 +45,13 @@ int cblas_isamin(int n, const float *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < n; ++logical_i) {
+    for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }
@@ -64,12 +65,13 @@ int cblas_idamin(int n, const double *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < n; ++logical_i) {
+    for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }
@@ -83,12 +85,13 @@ int cblas_icamin(int n, const std::complex<float> *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < n; ++logical_i) {
+    for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }
@@ -102,12 +105,13 @@ int cblas_izamin(int n, const std::complex<double> *x, int incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < n; ++logical_i) {
+    for (int logical_i = 1; logical_i < n; ++logical_i) {
         int i = logical_i * std::abs(incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1461,12 +1461,14 @@ int iamin(const int *n, const float *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -1482,12 +1484,14 @@ int iamin(const int *n, const double *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -1503,12 +1507,14 @@ int iamin(const int *n, const std::complex<float> *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
@@ -1524,12 +1530,14 @@ int iamin(const int *n, const std::complex<double> *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
-    if (sycl::isnan(min_val)) return 0;
+    if (sycl::isnan(min_val))
+        return 0;
 
     for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        if (sycl::isnan(curr_val)) return logical_i;
+        if (sycl::isnan(curr_val))
+            return logical_i;
         if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1461,12 +1461,13 @@ int iamin(const int *n, const float *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < *n; ++logical_i) {
+    for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }
@@ -1481,12 +1482,13 @@ int iamin(const int *n, const double *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < *n; ++logical_i) {
+    for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }
@@ -1501,12 +1503,13 @@ int iamin(const int *n, const std::complex<float> *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < *n; ++logical_i) {
+    for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }
@@ -1521,12 +1524,13 @@ int iamin(const int *n, const std::complex<double> *x, const int *incx) {
     }
     int min_idx = 0;
     auto min_val = abs_val(x[0]);
+    if (sycl::isnan(min_val)) return 0;
 
-    for (int logical_i = 0; logical_i < *n; ++logical_i) {
+    for (int logical_i = 1; logical_i < *n; ++logical_i) {
         int i = logical_i * std::abs(*incx);
         auto curr_val = abs_val(x[i]);
-        bool is_first_nan = std::isnan(curr_val) && !std::isnan(min_val);
-        if (is_first_nan || curr_val < min_val) {
+        if (sycl::isnan(curr_val)) return logical_i;
+        if (curr_val < min_val) {
             min_idx = logical_i;
             min_val = curr_val;
         }


### PR DESCRIPTION
# Description

Change `iamin` reference implementations to avoid "tautological constant compare" warnings and also correctly/consistently handle NaN in input.

Fixes #157 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?

It would be possible and probably desirable to add tests with NaN input, but currently the comparisons would give spurious failures on GPU because of similar issues in oneMKL.

[test.txt](https://github.com/oneapi-src/oneMKL/files/7962219/test.txt)
