### PR TITLE
enable tests gpu backend

### DIFF
--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -90,26 +90,26 @@ int main(int argc, char** argv) {
     std::vector<cl::sycl::device> local_devices;
 
     auto platforms = cl::sycl::platform::get_platforms();
-    
+
     bool level_zero_enabled = false;
-    
+
     for (auto plat : platforms) {
-        if(plat.get_info<cl::sycl::info::platform::name>().find(
-                "Level-Zero") != std::string::npos) {
+        if (plat.get_info<cl::sycl::info::platform::name>().find("Level-Zero") !=
+            std::string::npos) {
             level_zero_enabled = true;
             break;
         }
     }
-    
+
     for (auto plat : platforms) {
         if (!plat.is_host()) {
             auto plat_devs = plat.get_devices();
             for (auto dev : plat_devs) {
                 try {
                     /* Do not test for OpenCL backend on GPU when Level-Zero is available */
-                    if (dev.is_gpu() && level_zero_enabled && 
-                            plat.get_info<cl::sycl::info::platform::name>().find(
-                            "OpenCL") != std::string::npos) {
+                    if (dev.is_gpu() && level_zero_enabled &&
+                        plat.get_info<cl::sycl::info::platform::name>().find("OpenCL") !=
+                            std::string::npos) {
                         continue;
                     }
                     if (unique_devices.find(dev.get_info<cl::sycl::info::device::name>()) ==

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -96,6 +96,7 @@ int main(int argc, char** argv) {
         if(plat.get_info<cl::sycl::info::platform::name>().find(
                                 "Level-Zero") != std::string::npos){
             level_zero_enabled = true;
+            break;
         }
     }
     
@@ -104,8 +105,9 @@ int main(int argc, char** argv) {
             auto plat_devs = plat.get_devices();
             for (auto dev : plat_devs) {
                 try {
-                    /* Do not test for OpenCL backend on GPU */
-                    if (dev.is_gpu() && level_zero_enabled && plat.get_info<cl::sycl::info::platform::name>().find(
+                    /* Do not test for OpenCL backend on GPU when Level-Zero is available */
+                    if (dev.is_gpu() && level_zero_enabled && 
+                                            plat.get_info<cl::sycl::info::platform::name>().find(
                                             "OpenCL") != std::string::npos)
                         continue;
                     if (unique_devices.find(dev.get_info<cl::sycl::info::device::name>()) ==

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -91,10 +91,11 @@ int main(int argc, char** argv) {
 
     auto platforms = cl::sycl::platform::get_platforms();
     
-    bool level_zero_enabled=false;
+    bool level_zero_enabled = false;
+    
     for (auto plat : platforms) {
         if(plat.get_info<cl::sycl::info::platform::name>().find(
-                                "Level-Zero") != std::string::npos){
+                "Level-Zero") != std::string::npos) {
             level_zero_enabled = true;
             break;
         }
@@ -107,9 +108,10 @@ int main(int argc, char** argv) {
                 try {
                     /* Do not test for OpenCL backend on GPU when Level-Zero is available */
                     if (dev.is_gpu() && level_zero_enabled && 
-                                            plat.get_info<cl::sycl::info::platform::name>().find(
-                                            "OpenCL") != std::string::npos)
+                            plat.get_info<cl::sycl::info::platform::name>().find(
+                            "OpenCL") != std::string::npos) {
                         continue;
+                    }
                     if (unique_devices.find(dev.get_info<cl::sycl::info::device::name>()) ==
                         unique_devices.end()) {
                         unique_devices.insert(dev.get_info<cl::sycl::info::device::name>());

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -90,13 +90,22 @@ int main(int argc, char** argv) {
     std::vector<cl::sycl::device> local_devices;
 
     auto platforms = cl::sycl::platform::get_platforms();
+    
+    bool level_zero_enabled=false;
+    for (auto plat : platforms) {
+        if(plat.get_info<cl::sycl::info::platform::name>().find(
+                                "Level-Zero") != std::string::npos){
+            level_zero_enabled = true;
+        }
+    }
+    
     for (auto plat : platforms) {
         if (!plat.is_host()) {
             auto plat_devs = plat.get_devices();
             for (auto dev : plat_devs) {
                 try {
                     /* Do not test for OpenCL backend on GPU */
-                    if (dev.is_gpu() && plat.get_info<cl::sycl::info::platform::name>().find(
+                    if (dev.is_gpu() && level_zero_enabled && plat.get_info<cl::sycl::info::platform::name>().find(
                                             "OpenCL") != std::string::npos)
                         continue;
                     if (unique_devices.find(dev.get_info<cl::sycl::info::device::name>()) ==


### PR DESCRIPTION
# Description

Originally, we always chose to skip OpenCL backend testing on GPU's. However, if L0 was not enabled, we needed to allow for using OpenCL backend to test GPUs on Linux. 

These changes still prioritize running L0 backend on GPUs, it only ensures that if L0 is unavailable, OpenCL backend is used.