### PR TITLE
[cublas] Fix exception message

### DIFF
--- a/src/blas/backends/cublas/cublas_helper.hpp
+++ b/src/blas/backends/cublas/cublas_helper.hpp
@@ -176,6 +176,12 @@ public:
         throw cublas_error(std::string(#name) + std::string(" : "), err); \
     }
 
+#define CUBLAS_ERROR_FUNC_T(name, func, err, ...)                        \
+    err = func(__VA_ARGS__);                                             \
+    if (err != CUBLAS_STATUS_SUCCESS) {                                  \
+        throw cublas_error(std::string(name) + std::string(" : "), err); \
+    }
+
 inline cublasOperation_t get_cublas_operation(oneapi::mkl::transpose trn) {
     switch (trn) {
         case oneapi::mkl::transpose::nontrans: return CUBLAS_OP_N;


### PR DESCRIPTION
This patch fixes the cublas exception message displaying
the cublas function name instead of ``func``.

# Description

E.g., this fix turns 
```
terminate called after throwing an instance of 'oneapi::mkl::blas::cublas::cublas_error'
  what():  func : CUBLAS_STATUS_INVALID_VALUE
Aborted
```
into 
```
terminate called after throwing an instance of 'oneapi::mkl::blas::cublas::cublas_error'
  what():  cublasSgemv : CUBLAS_STATUS_INVALID_VALUE
Aborted
```
*Note: this exception can be thrown by setting ``n,m <0`` in ``gemv``.* 

Consider,
https://github.com/oneapi-src/oneMKL/blob/9d238c9c55aedd765dc4b47312b5136143ef79cc/src/blas/backends/cublas/cublas_helper.hpp#L173-L177
when ``CUBLAS_ERROR_FUNC(func, ...)`` is invoked within a function where``func``
is template parameter, e.g.,
https://github.com/oneapi-src/oneMKL/blob/9d238c9c55aedd765dc4b47312b5136143ef79cc/src/blas/backends/cublas/cublas_level2.cpp#L33-L61 
resolves ``#func`` as ``func``.

The proposed fix introduces a [macro](https://github.com/pgorlani/oneMKL/blob/84088bfd7104e2736276d4bd3b3de20b22ea7c14/src/blas/backends/cublas/cublas_helper.hpp#L179-L183) that takes the actual cublas function name
as an argument passed by the invoking template function.
This introduces the same modification for each wrapper function.

```diff
 template <typename Func, typename T>
-inline void gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void gemv(const char *func_name, Func func, cl::sycl::queue &queue, transpose trans,
+                 int64_t m, int64_t n, T alpha, cl::sycl::buffer<T, 1> &a, int64_t lda,
+                 cl::sycl::buffer<T, 1> &x, int64_t incx, T beta, cl::sycl::buffer<T, 1> &y,
+                 int64_t incy) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, m, lda, incx, incy);
     queue.submit([&](cl::sycl::handler &cgh) {
@@ -46,18 +47,19 @@ inline void gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
             auto x_ = sc.get_mem<cuDataType *>(x_acc);
             auto y_ = sc.get_mem<cuDataType *>(y_acc);
             cublasStatus_t err;
-            CUBLAS_ERROR_FUNC(func, err, handle, get_cublas_operation(trans), m, n,
-                              (cuDataType *)&alpha, a_, lda, x_, incx, (cuDataType *)&beta, y_,
-                              incy);
+            CUBLAS_ERROR_FUNC_T(func_name, func, err, handle, get_cublas_operation(trans), m, n,
+                                (cuDataType *)&alpha, a_, lda, x_, incx, (cuDataType *)&beta, y_,
+                                incy);
         });
     });
 }
 
-#define GEMV_LAUNCHER(TYPE, CUBLAS_ROUTINE)                                              \
-    void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha, \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,   \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {     \
-        gemv(CUBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy); \
+#define GEMV_LAUNCHER(TYPE, CUBLAS_ROUTINE)                                                        \
+    void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha,           \
+              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,             \
+              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {               \
+        gemv(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, \
+             incy);                                                                                \
     }
```


# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Yes, -> [ctest-j64-output.txt](https://github.com/oneapi-src/oneMKL/files/7993999/ctest-j64-output.txt)
- [x] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?


