### PR TITLE
doc: add template to enable collection of analytics data

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,11 +5,13 @@
   var wapLocalCode = 'us-en'; // Dynamically set per localized site; see mapping table for values
   var wapSection = "oneapi-mkl"; // WAP team will give you a unique section for your site
   // Load TMS
-  (function () {
-    var url = 'https://www.intel.com/content/dam/www/global/wap/tms-loader.js'; // WAP file URL
-    var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = url;
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-  })();
+  if (document.location.href.contains("oneapi-src.github.io")) {
+    (function () {
+      var url = 'https://www.intel.com/content/dam/www/global/wap/tms-loader.js'; // WAP file URL
+      var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = url;
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+    })();
+  }
 </script>
 {% endblock %}
 <!-- any other content blocks -->

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,16 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+<script type="text/javascript">
+  // Configure TMS settings
+  var wapLocalCode = 'us-en'; // Dynamically set per localized site; see mapping table for values
+  var wapSection = "oneapi-mkl"; // WAP team will give you a unique section for your site
+  // Load TMS
+  (function () {
+    var url = 'https://www.intel.com/content/dam/www/global/wap/tms-loader.js'; // WAP file URL
+    var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = url;
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+  })();
+</script>
+{% endblock %}
+<!-- any other content blocks -->
+<!--...-->


### PR DESCRIPTION
Signed-off-by: Benjamin Fitch <benjamin.fitch@intel.com>
The template adds a script to the HTML on GitHub Pages to enable analytics. See the BKM [Collect analytics data from open-source Sphinx projects](https://intel-my.sharepoint.com/:w:/r/personal/ekaterina_mekhnetsova_intel_com/_layouts/15/Doc.aspx?sourcedoc=%7B1f65fa99-938d-4024-ad1e-e736e908a26f%7D&action=view&wdLOR=cF1AA0C4A-15B4-4B8E-B442-966435420026&wdAccPdf=0&wdparaid=43947FEE&cid=e9e0f74d-d92a-4348-9a15-48bf462a0b32).