### PR TITLE
tests: Fix CT-only build errors with hipSYCL

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -159,8 +159,10 @@ foreach(domain ${TARGET_DOMAINS})
     PROPERTIES TEST_PREFIX ${DOMAIN_PREFIX}/CT/
     DISCOVERY_TIMEOUT 30
   )
-  if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
-    add_sycl_to_target(TARGET test_main_${domain}_rt)
-  endif()
 
+  if(BUILD_SHARED_LIBS)
+    if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
+      add_sycl_to_target(TARGET test_main_${domain}_rt)
+    endif()
+  endif()
 endforeach()


### PR DESCRIPTION
During hipSYCL CI integration, we observed build errors when only CT is enabled. This PR is fixing this error. 

The tests passed locally on AMD GPU. 

## All Submissions

- [X] Do all unit tests pass locally? Attach a log.
- [X] Have you formatted the code using clang-format?

