### PR TITLE
doc: javascript fix (contains --> includes)

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,7 +5,7 @@
   var wapLocalCode = 'us-en'; // Dynamically set per localized site; see mapping table for values
   var wapSection = "oneapi-mkl"; // WAP team will give you a unique section for your site
   // Load TMS
-  if (document.location.href.contains("oneapi-src.github.io")) {
+  if (document.location.href.includes("oneapi-src.github.io")) {
     (function () {
       var url = 'https://www.intel.com/content/dam/www/global/wap/tms-loader.js'; // WAP file URL
       var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = url;


### PR DESCRIPTION
Signed-off-by: Benjamin Fitch <benjamin.fitch@intel.com>

Small fix. JavaScript strings don't have a `contains` method. (D'oh!)