### PR TITLE
[BLAS][MKLCPU][hipSYCL] Add missing include 

### DIFF
--- a/include/oneapi/mkl/exceptions.hpp
+++ b/include/oneapi/mkl/exceptions.hpp
@@ -24,6 +24,8 @@
 #include <exception>
 #include <string>
 
+#include "oneapi/mkl/types.hpp"
+
 // These are oneAPI oneMKL Specification exceptions
 
 namespace oneapi {


### PR DESCRIPTION
# Description

in PR #167 the hipSYCL BLAS domain was broken due to an unintentional, presumably search and replace, error. This PR fixes that error. Due to the global switch from `cl::sycl` to `sycl::` namespace it became necessary to also include the `types.hpp` in the `exceptions.hpp` since we need to propagate the aliased `sycl::` namespace there as well from the `types.hpp` file 



## All Submissions


- [x] Have you formatted the code using clang-format?
- [x] Do all unit tests pass locally? Attach a log.

[~~2022-04-25-fix-hipsycl-cublas-test.txt~~](https://github.com/oneapi-src/oneMKL/files/8558410/2022-04-25-fix-hipsycl-cublas-test.txt)

I had some issues with ctest with the rocBLAS platform, however with gtest directly everything passes:
[2022-04-25-hipsycl-rocblas-rt-test.txt](https://github.com/oneapi-src/oneMKL/files/8558451/2022-04-25-hipsycl-rocblas-rt-test.txt)
[2022-04-25-hipsycl-rocblas-ct-test.txt](https://github.com/oneapi-src/oneMKL/files/8558452/2022-04-25-hipsycl-rocblas-ct-test.txt)


