### PR TITLE
[BLAS][rocBLAS] Switch to using sycl:: insteald of cl::sycl::

### DIFF
--- a/include/oneapi/mkl/blas/detail/rocblas/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/rocblas/blas_ct.hxx
@@ -20,8 +20,8 @@
 **************************************************************************/
 
 void herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          float beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+          int64_t k, float alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda, float beta,
+          sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::herk(selector.get_queue(), upper_lower, trans, n, k, alpha,
                                             a, lda, beta, c, ldc);
@@ -29,8 +29,8 @@ void herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans, int64_t n,
-          int64_t k, double alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          double beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+          int64_t k, double alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          double beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::herk(selector.get_queue(), upper_lower, trans, n, k, alpha,
                                             a, lda, beta, c, ldc);
@@ -38,50 +38,50 @@ void herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void scal(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &x, int64_t incx) {
+          sycl::buffer<float, 1> &x, int64_t incx) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
     scal_postcondition(selector.get_queue(), n, alpha, x, incx);
 }
 
 void scal(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &x, int64_t incx) {
+          sycl::buffer<double, 1> &x, int64_t incx) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
     scal_postcondition(selector.get_queue(), n, alpha, x, incx);
 }
 
 void scal(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
     scal_postcondition(selector.get_queue(), n, alpha, x, incx);
 }
 
 void scal(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
     scal_postcondition(selector.get_queue(), n, alpha, x, incx);
 }
 
 void scal(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
     scal_postcondition(selector.get_queue(), n, alpha, x, incx);
 }
 
 void scal(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
     scal_postcondition(selector.get_queue(), n, alpha, x, incx);
 }
 
 void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &x, int64_t incx) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
@@ -89,8 +89,8 @@ void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<double, 1> &a, int64_t lda,
-          cl::sycl::buffer<double, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &x, int64_t incx) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
@@ -98,8 +98,8 @@ void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
@@ -107,8 +107,8 @@ void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
@@ -116,7 +116,7 @@ void trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<float, 1> &a, cl::sycl::buffer<float, 1> &x,
+          diag unit_diag, int64_t n, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x,
           int64_t incx) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
@@ -125,7 +125,7 @@ void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<double, 1> &a, cl::sycl::buffer<double, 1> &x,
+          diag unit_diag, int64_t n, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x,
           int64_t incx) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
@@ -134,8 +134,8 @@ void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &a,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, x, incx);
@@ -143,8 +143,8 @@ void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, x, incx);
@@ -152,23 +152,23 @@ void tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void spr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &a) {
+         sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &a) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     oneapi::mkl::blas::rocblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     spr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
 }
 
 void spr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &a) {
+         sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &a) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     oneapi::mkl::blas::rocblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     spr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
 }
 
 void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-                int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<float, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<float, 1> &b, int64_t ldb,
-                int64_t stride_b, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc,
+                int64_t m, int64_t n, int64_t k, float alpha, sycl::buffer<float, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &b, int64_t ldb,
+                int64_t stride_b, float beta, sycl::buffer<float, 1> &c, int64_t ldc,
                 int64_t stride_c, int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
@@ -180,9 +180,9 @@ void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, t
 }
 
 void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-                int64_t m, int64_t n, int64_t k, double alpha, cl::sycl::buffer<double, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<double, 1> &b, int64_t ldb,
-                int64_t stride_b, double beta, cl::sycl::buffer<double, 1> &c, int64_t ldc,
+                int64_t m, int64_t n, int64_t k, double alpha, sycl::buffer<double, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<double, 1> &b, int64_t ldb,
+                int64_t stride_b, double beta, sycl::buffer<double, 1> &c, int64_t ldc,
                 int64_t stride_c, int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
@@ -195,9 +195,9 @@ void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, t
 
 void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
                 int64_t m, int64_t n, int64_t k, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
-                std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
+                std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc,
                 int64_t stride_c, int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
@@ -210,10 +210,10 @@ void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, t
 
 void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
                 int64_t m, int64_t n, int64_t k, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
-                std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c,
-                int64_t ldc, int64_t stride_c, int64_t batch_size) {
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
+                std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc,
+                int64_t stride_c, int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
@@ -224,11 +224,10 @@ void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, t
 }
 
 void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-                int64_t m, int64_t n, int64_t k, sycl::half alpha,
-                cl::sycl::buffer<sycl::half, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b, sycl::half beta,
-                cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
+                int64_t m, int64_t n, int64_t k, sycl::half alpha, sycl::buffer<sycl::half, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<sycl::half, 1> &b, int64_t ldb,
+                int64_t stride_b, sycl::half beta, sycl::buffer<sycl::half, 1> &c, int64_t ldc,
+                int64_t stride_c, int64_t batch_size) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
@@ -239,8 +238,8 @@ void gemm_batch(backend_selector<backend::rocblas> selector, transpose transa, t
 }
 
 void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, float beta,
-          cl::sycl::buffer<float, 1> &c, int64_t ldc) {
+          int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda, float beta,
+          sycl::buffer<float, 1> &c, int64_t ldc) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
                                             a, lda, beta, c, ldc);
@@ -248,8 +247,8 @@ void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans, int64_t n,
-          int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, double beta,
-          cl::sycl::buffer<double, 1> &c, int64_t ldc) {
+          int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda, double beta,
+          sycl::buffer<double, 1> &c, int64_t ldc) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
                                             a, lda, beta, c, ldc);
@@ -257,8 +256,8 @@ void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans, int64_t n,
-          int64_t k, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-          int64_t lda, std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c,
+          int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c,
           int64_t ldc) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
@@ -267,8 +266,8 @@ void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans, int64_t n,
-          int64_t k, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-          int64_t lda, std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c,
+          int64_t k, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          int64_t lda, std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c,
           int64_t ldc) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
@@ -277,8 +276,8 @@ void syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                int64_t n, int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-                int64_t stride_a, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc,
+                int64_t n, int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+                int64_t stride_a, float beta, sycl::buffer<float, 1> &c, int64_t ldc,
                 int64_t stride_c, int64_t batch_size) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size);
@@ -290,8 +289,8 @@ void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, t
 }
 
 void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                int64_t n, int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-                int64_t stride_a, double beta, cl::sycl::buffer<double, 1> &c, int64_t ldc,
+                int64_t n, int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+                int64_t stride_a, double beta, sycl::buffer<double, 1> &c, int64_t ldc,
                 int64_t stride_c, int64_t batch_size) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size);
@@ -304,8 +303,8 @@ void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, t
 
 void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
                 int64_t n, int64_t k, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc,
                 int64_t stride_c, int64_t batch_size) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size);
@@ -318,9 +317,9 @@ void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, t
 
 void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
                 int64_t n, int64_t k, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c,
-                int64_t ldc, int64_t stride_c, int64_t batch_size) {
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc,
+                int64_t stride_c, int64_t batch_size) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(selector.get_queue(), upper_lower, trans, n, k,
@@ -331,9 +330,9 @@ void syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower, t
 }
 
 void her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a, lda);
@@ -341,9 +340,9 @@ void her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a, lda);
@@ -351,9 +350,9 @@ void her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, int64_t k,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy);
     oneapi::mkl::blas::rocblas::MAJOR::hbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
@@ -363,9 +362,9 @@ void hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, int64_t k,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy);
     oneapi::mkl::blas::rocblas::MAJOR::hbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
@@ -375,70 +374,68 @@ void hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void rot(backend_selector<backend::rocblas> selector, int64_t n,
-         cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, float c, float s) {
+         sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &y, int64_t incy, float c, float s) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
     rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
 }
 
 void rot(backend_selector<backend::rocblas> selector, int64_t n,
-         cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, double c, double s) {
+         sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &y, int64_t incy, double c, double s) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
     rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
 }
 
-void rot(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-         int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy, float c, float s) {
+void rot(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, float c, float s) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
     rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
 }
 
-void rot(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-         int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy, double c, double s) {
+void rot(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+         int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, double c, double s) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
     rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
 }
 
 void axpy(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &y,
-          int64_t incy) {
+          sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &y, int64_t incy) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
     axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
 }
 
 void axpy(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &y,
-          int64_t incy) {
+          sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &y, int64_t incy) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
     axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
 }
 
 void axpy(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
     axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
 }
 
 void axpy(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
     axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
 }
 
 void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
+                sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex, sycl::buffer<float, 1> &y,
+                int64_t incy, int64_t stridey, int64_t batch_size) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x, incx, stridex,
@@ -448,8 +445,8 @@ void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, float al
 }
 
 void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x, incx, stridex,
@@ -459,8 +456,8 @@ void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, double a
 }
 
 void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size);
@@ -471,8 +468,8 @@ void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, std::com
 }
 
 void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size);
@@ -483,7 +480,7 @@ void axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, std::com
 }
 
 void axpby(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-           cl::sycl::buffer<float, 1> &x, int64_t incx, float beta, cl::sycl::buffer<float, 1> &y,
+           sycl::buffer<float, 1> &x, int64_t incx, float beta, sycl::buffer<float, 1> &y,
            int64_t incy) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
@@ -492,8 +489,8 @@ void axpby(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
 }
 
 void axpby(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-           cl::sycl::buffer<double, 1> &x, int64_t incx, double beta,
-           cl::sycl::buffer<double, 1> &y, int64_t incy) {
+           sycl::buffer<double, 1> &x, int64_t incx, double beta, sycl::buffer<double, 1> &y,
+           int64_t incy) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
                                              incy);
@@ -501,8 +498,8 @@ void axpby(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
 }
 
 void axpby(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> alpha,
-           cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-           cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+           sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
                                              incy);
@@ -510,8 +507,8 @@ void axpby(backend_selector<backend::rocblas> selector, int64_t n, std::complex<
 }
 
 void axpby(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> alpha,
-           cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-           cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+           sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
                                              incy);
@@ -519,8 +516,8 @@ void axpby(backend_selector<backend::rocblas> selector, int64_t n, std::complex<
 }
 
 void sdsdot(backend_selector<backend::rocblas> selector, int64_t n, float sb,
-            cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &y,
-            int64_t incy, cl::sycl::buffer<float, 1> &result) {
+            sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &y, int64_t incy,
+            sycl::buffer<float, 1> &result) {
     sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y, incy,
                                               result);
@@ -528,9 +525,9 @@ void sdsdot(backend_selector<backend::rocblas> selector, int64_t n, float sb,
 }
 
 void gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
                                             lda);
@@ -538,9 +535,9 @@ void gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
 }
 
 void gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
                                             lda);
@@ -548,8 +545,8 @@ void gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
 }
 
 void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-           int64_t n, int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-           cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+           int64_t n, int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+           sycl::buffer<float, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
            int64_t ldc) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
@@ -560,8 +557,8 @@ void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 }
 
 void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-           int64_t n, int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-           cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c,
+           int64_t n, int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+           sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
            int64_t ldc) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
@@ -572,10 +569,9 @@ void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 }
 
 void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-           int64_t n, int64_t k, std::complex<float> alpha,
-           cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
-           cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+           int64_t n, int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
+           std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
@@ -586,9 +582,9 @@ void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 
 void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
            int64_t n, int64_t k, std::complex<double> alpha,
-           cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
-           cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+           sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
@@ -598,8 +594,8 @@ void syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 }
 
 void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-          float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, float beta, cl::sycl::buffer<float, 1> &y, int64_t incy) {
+          float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x,
+          int64_t incx, float beta, sycl::buffer<float, 1> &y, int64_t incy) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -607,8 +603,8 @@ void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 }
 
 void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-          double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, double beta, cl::sycl::buffer<double, 1> &y, int64_t incy) {
+          double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x,
+          int64_t incx, double beta, sycl::buffer<double, 1> &y, int64_t incy) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -616,9 +612,9 @@ void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 }
 
 void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -626,9 +622,9 @@ void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 }
 
 void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -636,9 +632,9 @@ void gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 }
 
 void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-                float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex, float beta,
-                cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
+                float alpha, sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex, float beta,
+                sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
@@ -649,9 +645,9 @@ void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, in
 }
 
 void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-                double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex, double beta,
-                cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
+                double alpha, sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex, double beta,
+                sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
@@ -662,10 +658,24 @@ void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, in
 }
 
 void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-                std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-                int64_t stridea, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-                int64_t stridex, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+                int64_t stridea, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+                int64_t stridex, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &y,
+                int64_t incy, int64_t stridey, int64_t batch_size) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size);
+    oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
+                                                  stridea, x, incx, stridex, beta, y, incy, stridey,
+                                                  batch_size);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size);
+}
+
+void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+                int64_t stridea, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+                int64_t stridex, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size);
@@ -676,25 +686,10 @@ void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, in
                              stridex, beta, y, incy, stridey, batch_size);
 }
 
-void gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-                std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stridea, cl::sycl::buffer<std::complex<double>, 1> &x,
-                int64_t incx, int64_t stridex, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
-                int64_t batch_size) {
-    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
-                            stridex, beta, y, incy, stridey, batch_size);
-    oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
-                                                  stridea, x, incx, stridex, beta, y, incy, stridey,
-                                                  batch_size);
-    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
-                             stridex, beta, y, incy, stridey, batch_size);
-}
-
 void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stridec, int64_t batch_size) {
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<float, 1> &c, int64_t ldc,
+                int64_t stridec, int64_t batch_size) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n, a, lda,
@@ -705,9 +700,9 @@ void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, in
 }
 
 void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stridec, int64_t batch_size) {
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<double, 1> &c, int64_t ldc, int64_t stridec, int64_t batch_size) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n, a, lda,
@@ -718,9 +713,9 @@ void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, in
 }
 
 void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stridec,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stridec,
                 int64_t batch_size) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size);
@@ -732,9 +727,9 @@ void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, in
 }
 
 void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stridec,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stridec,
                 int64_t batch_size) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size);
@@ -746,8 +741,8 @@ void dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, in
 }
 
 void her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
+         sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
                                            lda);
@@ -755,8 +750,8 @@ void her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t 
 }
 
 void her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
+         sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
                                            lda);
@@ -764,55 +759,55 @@ void her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t 
 }
 
 void hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<float>, 1> &a) {
+         sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     oneapi::mkl::blas::rocblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     hpr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
 }
 
 void hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<double>, 1> &a) {
+         sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     oneapi::mkl::blas::rocblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
     hpr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
 }
 
-void iamin(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
+void iamin(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+           int64_t incx, sycl::buffer<int64_t, 1> &result) {
     iamin_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
     iamin_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
-void iamin(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
-    iamin_precondition(selector.get_queue(), n, x, incx, result);
-    oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
-    iamin_postcondition(selector.get_queue(), n, x, incx, result);
-}
-
-void iamin(backend_selector<backend::rocblas> selector, int64_t n,
-           cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result) {
+void iamin(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+           int64_t incx, sycl::buffer<int64_t, 1> &result) {
     iamin_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
     iamin_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
 void iamin(backend_selector<backend::rocblas> selector, int64_t n,
-           cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result) {
+           sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void iamin(backend_selector<backend::rocblas> selector, int64_t n,
+           sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
     iamin_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
     iamin_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
 void hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha, a, x, incx,
                                             beta, y, incy);
@@ -820,9 +815,9 @@ void hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha, a, x, incx,
                                             beta, y, incy);
@@ -830,8 +825,8 @@ void hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &a, cl::sycl::buffer<float, 1> &x, int64_t incx, float beta,
-          cl::sycl::buffer<float, 1> &y, int64_t incy) {
+          sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x, int64_t incx, float beta,
+          sycl::buffer<float, 1> &y, int64_t incy) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha, a, x, incx,
                                             beta, y, incy);
@@ -839,8 +834,8 @@ void spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &a, cl::sycl::buffer<double, 1> &x, int64_t incx, double beta,
-          cl::sycl::buffer<double, 1> &y, int64_t incy) {
+          sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x, int64_t incx, double beta,
+          sycl::buffer<double, 1> &y, int64_t incy) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha, a, x, incx,
                                             beta, y, incy);
@@ -849,9 +844,9 @@ void spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 
 void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
                offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-               cl::sycl::buffer<int8_t, 1> &a, int64_t lda, int8_t ao,
-               cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
-               cl::sycl::buffer<int32_t, 1> &c, int64_t ldc, cl::sycl::buffer<int32_t, 1> &co) {
+               sycl::buffer<int8_t, 1> &a, int64_t lda, int8_t ao, sycl::buffer<uint8_t, 1> &b,
+               int64_t ldb, uint8_t bo, float beta, sycl::buffer<int32_t, 1> &c, int64_t ldc,
+               sycl::buffer<int32_t, 1> &co) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co);
     oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
@@ -863,9 +858,9 @@ void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, tr
 
 void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
                offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-               cl::sycl::buffer<int8_t, 1> &a, int64_t lda, int8_t ao,
-               cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
-               cl::sycl::buffer<int32_t, 1> &c, int64_t ldc, cl::sycl::buffer<int32_t, 1> &co) {
+               sycl::buffer<int8_t, 1> &a, int64_t lda, int8_t ao, sycl::buffer<int8_t, 1> &b,
+               int64_t ldb, int8_t bo, float beta, sycl::buffer<int32_t, 1> &c, int64_t ldc,
+               sycl::buffer<int32_t, 1> &co) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co);
     oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
@@ -877,9 +872,9 @@ void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, tr
 
 void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
                offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-               cl::sycl::buffer<uint8_t, 1> &a, int64_t lda, uint8_t ao,
-               cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
-               cl::sycl::buffer<int32_t, 1> &c, int64_t ldc, cl::sycl::buffer<int32_t, 1> &co) {
+               sycl::buffer<uint8_t, 1> &a, int64_t lda, uint8_t ao, sycl::buffer<int8_t, 1> &b,
+               int64_t ldb, int8_t bo, float beta, sycl::buffer<int32_t, 1> &c, int64_t ldc,
+               sycl::buffer<int32_t, 1> &co) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co);
     oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
@@ -891,9 +886,9 @@ void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, tr
 
 void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
                offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-               cl::sycl::buffer<uint8_t, 1> &a, int64_t lda, uint8_t ao,
-               cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
-               cl::sycl::buffer<int32_t, 1> &c, int64_t ldc, cl::sycl::buffer<int32_t, 1> &co) {
+               sycl::buffer<uint8_t, 1> &a, int64_t lda, uint8_t ao, sycl::buffer<uint8_t, 1> &b,
+               int64_t ldb, uint8_t bo, float beta, sycl::buffer<int32_t, 1> &c, int64_t ldc,
+               sycl::buffer<int32_t, 1> &co) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co);
     oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
@@ -903,40 +898,40 @@ void gemm_bias(backend_selector<backend::rocblas> selector, transpose transa, tr
                             ao, b, ldb, bo, beta, c, ldc, co);
 }
 
-void swap(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy) {
+void swap(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
     swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
 }
 
-void swap(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy) {
-    swap_precondition(selector.get_queue(), n, x, incx, y, incy);
-    oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
-    swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
-}
-
-void swap(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+void swap(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
     swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
 }
 
 void swap(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void swap(backend_selector<backend::rocblas> selector, int64_t n,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
     swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
 }
 
 void geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
                                             lda);
@@ -944,9 +939,9 @@ void geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
 }
 
 void geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
                                             lda);
@@ -954,38 +949,36 @@ void geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
 }
 
 void nrm2(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<float, 1> &result) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, sycl::buffer<float, 1> &result) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
     nrm2_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
 void nrm2(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<double, 1> &result) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, sycl::buffer<double, 1> &result) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
     nrm2_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
-void nrm2(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &result) {
+void nrm2(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &result) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
     nrm2_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
-void nrm2(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &result) {
+void nrm2(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &result) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
     nrm2_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
 void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-          int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+          int64_t m, int64_t n, int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
           int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
@@ -996,9 +989,9 @@ void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpo
 }
 
 void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-          int64_t m, int64_t n, int64_t k, double alpha, cl::sycl::buffer<double, 1> &a,
-          int64_t lda, cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta,
-          cl::sycl::buffer<double, 1> &c, int64_t ldc) {
+          int64_t m, int64_t n, int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
+          int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1009,9 +1002,9 @@ void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpo
 
 void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
           int64_t m, int64_t n, int64_t k, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1022,9 +1015,9 @@ void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpo
 
 void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
           int64_t m, int64_t n, int64_t k, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1034,9 +1027,9 @@ void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpo
 }
 
 void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-          int64_t m, int64_t n, int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a,
-          int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
-          cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc) {
+          int64_t m, int64_t n, int64_t k, sycl::half alpha, sycl::buffer<sycl::half, 1> &a,
+          int64_t lda, sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
+          sycl::buffer<sycl::half, 1> &c, int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1046,9 +1039,9 @@ void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpo
 }
 
 void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-          int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a,
-          int64_t lda, cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, int64_t ldc) {
+          int64_t m, int64_t n, int64_t k, float alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda,
+          sycl::buffer<sycl::half, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
+          int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1058,9 +1051,9 @@ void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpo
 }
 
 void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
-          int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<bfloat16, 1> &a,
-          int64_t lda, cl::sycl::buffer<bfloat16, 1> &b, int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, int64_t ldc) {
+          int64_t m, int64_t n, int64_t k, float alpha, sycl::buffer<bfloat16, 1> &a, int64_t lda,
+          sycl::buffer<bfloat16, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
+          int64_t ldc) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha, a,
@@ -1070,8 +1063,8 @@ void gemm(backend_selector<backend::rocblas> selector, transpose transa, transpo
 }
 
 void syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-          cl::sycl::buffer<float, 1> &a, int64_t lda) {
+          sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &y, int64_t incy,
+          sycl::buffer<float, 1> &a, int64_t lda) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a, lda);
@@ -1079,8 +1072,8 @@ void syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &y,
-          int64_t incy, cl::sycl::buffer<double, 1> &a, int64_t lda) {
+          sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &y, int64_t incy,
+          sycl::buffer<double, 1> &a, int64_t lda) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a, lda);
@@ -1088,8 +1081,8 @@ void syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, float alpha,
-         cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-         cl::sycl::buffer<float, 1> &a, int64_t lda) {
+         sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &y, int64_t incy,
+         sycl::buffer<float, 1> &a, int64_t lda) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
                                            lda);
@@ -1097,8 +1090,8 @@ void ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, floa
 }
 
 void ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, double alpha,
-         cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy,
-         cl::sycl::buffer<double, 1> &a, int64_t lda) {
+         sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &y, int64_t incy,
+         sycl::buffer<double, 1> &a, int64_t lda) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
                                            lda);
@@ -1107,7 +1100,7 @@ void ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, doub
 
 void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &b, int64_t ldb) {
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1118,8 +1111,7 @@ void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 
 void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &b,
-          int64_t ldb) {
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b, int64_t ldb) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1130,8 +1122,8 @@ void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 
 void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1142,8 +1134,8 @@ void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 
 void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb) {
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1153,27 +1145,27 @@ void trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 }
 
 void dotu(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &result) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy, result);
     dotu_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
 }
 
 void dotu(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &result) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy, result);
     dotu_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
 }
 
 void hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower, int64_t m,
-          int64_t n, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
-          std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+          int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
+          std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::hemm(selector.get_queue(), left_right, upper_lower, m, n,
@@ -1183,9 +1175,9 @@ void hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 }
 
 void hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower, int64_t m,
-          int64_t n, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
-          std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+          int64_t n, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
+          std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::hemm(selector.get_queue(), left_right, upper_lower, m, n,
@@ -1195,9 +1187,9 @@ void hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 }
 
 void hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
     oneapi::mkl::blas::rocblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a);
@@ -1205,9 +1197,9 @@ void hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
     oneapi::mkl::blas::rocblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a);
@@ -1215,8 +1207,8 @@ void hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-          int64_t kl, int64_t ku, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &x, int64_t incx, float beta, cl::sycl::buffer<float, 1> &y,
+          int64_t kl, int64_t ku, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &x, int64_t incx, float beta, sycl::buffer<float, 1> &y,
           int64_t incy) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy);
@@ -1227,8 +1219,8 @@ void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 }
 
 void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
-          int64_t kl, int64_t ku, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-          cl::sycl::buffer<double, 1> &x, int64_t incx, double beta, cl::sycl::buffer<double, 1> &y,
+          int64_t kl, int64_t ku, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &x, int64_t incx, double beta, sycl::buffer<double, 1> &y,
           int64_t incy) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy);
@@ -1240,9 +1232,9 @@ void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 
 void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
           int64_t kl, int64_t ku, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy);
     oneapi::mkl::blas::rocblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha, a,
@@ -1253,9 +1245,9 @@ void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 
 void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
           int64_t kl, int64_t ku, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy);
     oneapi::mkl::blas::rocblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha, a,
@@ -1265,8 +1257,8 @@ void gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t 
 }
 
 void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &x, int64_t incx) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1274,8 +1266,8 @@ void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<double, 1> &a, int64_t lda,
-          cl::sycl::buffer<double, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &x, int64_t incx) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1283,8 +1275,8 @@ void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<std::complex<float>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1292,8 +1284,8 @@ void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<std::complex<double>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<std::complex<double>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1301,8 +1293,19 @@ void tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower, int64_t m,
-          int64_t n, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+          int64_t n, float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b,
+          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc);
+    oneapi::mkl::blas::rocblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
+                                            alpha, a, lda, b, ldb, beta, c, ldc);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc);
+}
+
+void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower, int64_t m,
+          int64_t n, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
           int64_t ldc) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc);
@@ -1313,9 +1316,9 @@ void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 }
 
 void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower, int64_t m,
-          int64_t n, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-          cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c,
-          int64_t ldc) {
+          int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
+          std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
@@ -1325,21 +1328,9 @@ void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 }
 
 void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower, int64_t m,
-          int64_t n, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
-          std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
-    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
-                      beta, c, ldc);
-    oneapi::mkl::blas::rocblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
-                                            alpha, a, lda, b, ldb, beta, c, ldc);
-    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
-                       beta, c, ldc);
-}
-
-void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower, int64_t m,
-          int64_t n, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
-          std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+          int64_t n, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
+          std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
@@ -1349,25 +1340,25 @@ void symm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 }
 
 void dotc(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &result) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy, result);
     dotc_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
 }
 
 void dotc(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &result) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy, result);
     dotc_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
 }
 
 void syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &a, int64_t lda) {
+         sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &a, int64_t lda) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
                                            lda);
@@ -1375,8 +1366,7 @@ void syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t 
 }
 
 void syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &a,
-         int64_t lda) {
+         sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &a, int64_t lda) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
     oneapi::mkl::blas::rocblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
                                            lda);
@@ -1385,7 +1375,7 @@ void syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t 
 
 void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &b, int64_t ldb) {
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1396,8 +1386,7 @@ void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 
 void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &b,
-          int64_t ldb) {
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b, int64_t ldb) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1408,8 +1397,8 @@ void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 
 void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1420,8 +1409,8 @@ void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
 
 void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
           transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb) {
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb);
     oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
@@ -1430,24 +1419,24 @@ void trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upp
                        a, lda, b, ldb);
 }
 
-void rotmg(backend_selector<backend::rocblas> selector, cl::sycl::buffer<float, 1> &d1,
-           cl::sycl::buffer<float, 1> &d2, cl::sycl::buffer<float, 1> &x1, float y1,
-           cl::sycl::buffer<float, 1> &param) {
+void rotmg(backend_selector<backend::rocblas> selector, sycl::buffer<float, 1> &d1,
+           sycl::buffer<float, 1> &d2, sycl::buffer<float, 1> &x1, float y1,
+           sycl::buffer<float, 1> &param) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param);
     oneapi::mkl::blas::rocblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param);
     rotmg_postcondition(selector.get_queue(), d1, d2, x1, y1, param);
 }
 
-void rotmg(backend_selector<backend::rocblas> selector, cl::sycl::buffer<double, 1> &d1,
-           cl::sycl::buffer<double, 1> &d2, cl::sycl::buffer<double, 1> &x1, double y1,
-           cl::sycl::buffer<double, 1> &param) {
+void rotmg(backend_selector<backend::rocblas> selector, sycl::buffer<double, 1> &d1,
+           sycl::buffer<double, 1> &d2, sycl::buffer<double, 1> &x1, double y1,
+           sycl::buffer<double, 1> &param) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param);
     oneapi::mkl::blas::rocblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param);
     rotmg_postcondition(selector.get_queue(), d1, d2, x1, y1, param);
 }
 
 void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<float, 1> &a, cl::sycl::buffer<float, 1> &x,
+          diag unit_diag, int64_t n, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x,
           int64_t incx) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
@@ -1456,7 +1445,7 @@ void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<double, 1> &a, cl::sycl::buffer<double, 1> &x,
+          diag unit_diag, int64_t n, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x,
           int64_t incx) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
@@ -1465,8 +1454,8 @@ void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &a,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, x, incx);
@@ -1474,8 +1463,8 @@ void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, x, incx);
@@ -1483,8 +1472,8 @@ void tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &x, int64_t incx) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
@@ -1492,8 +1481,8 @@ void trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<double, 1> &a, int64_t lda,
-          cl::sycl::buffer<double, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &x, int64_t incx) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
@@ -1501,8 +1490,8 @@ void trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
@@ -1510,47 +1499,58 @@ void trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             a, lda, x, incx);
     trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
 }
 
-void copy(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy) {
+void copy(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
     copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
 }
 
-void copy(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy) {
+void copy(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
     copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
 }
 
 void copy(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
     copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
 }
 
 void copy(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
     copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
 }
 
-void copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
+void copy_batch(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<float, 1> &y, int64_t incy,
+                int64_t stridey, int64_t batch_size) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::rocblas::MAJOR::copy_batch(selector.get_queue(), n, x, incx, stridex, y,
+                                                  incy, stridey, batch_size);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void copy_batch(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<double, 1> &y, int64_t incy,
+                int64_t stridey, int64_t batch_size) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
                             batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::copy_batch(selector.get_queue(), n, x, incx, stridex, y,
@@ -1560,19 +1560,8 @@ void copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
 }
 
 void copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size) {
-    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
-                            batch_size);
-    oneapi::mkl::blas::rocblas::MAJOR::copy_batch(selector.get_queue(), n, x, incx, stridex, y,
-                                                  incy, stridey, batch_size);
-    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
-                             batch_size);
-}
-
-void copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
                             batch_size);
@@ -1583,8 +1572,8 @@ void copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
 }
 
 void copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
                             batch_size);
@@ -1595,9 +1584,9 @@ void copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
 }
 
 void hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::hemv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -1605,9 +1594,9 @@ void hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::hemv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -1615,9 +1604,9 @@ void hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
-           transpose transb, int64_t n, int64_t k, float alpha, cl::sycl::buffer<float, 1> &a,
-           int64_t lda, cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta,
-           cl::sycl::buffer<float, 1> &c, int64_t ldc) {
+           transpose transb, int64_t n, int64_t k, float alpha, sycl::buffer<float, 1> &a,
+           int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb, float beta,
+           sycl::buffer<float, 1> &c, int64_t ldc) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
@@ -1627,9 +1616,9 @@ void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 }
 
 void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
-           transpose transb, int64_t n, int64_t k, double alpha, cl::sycl::buffer<double, 1> &a,
-           int64_t lda, cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta,
-           cl::sycl::buffer<double, 1> &c, int64_t ldc) {
+           transpose transb, int64_t n, int64_t k, double alpha, sycl::buffer<double, 1> &a,
+           int64_t lda, sycl::buffer<double, 1> &b, int64_t ldb, double beta,
+           sycl::buffer<double, 1> &c, int64_t ldc) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
@@ -1640,9 +1629,9 @@ void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 
 void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
            transpose transb, int64_t n, int64_t k, std::complex<float> alpha,
-           cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
-           cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+           sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
@@ -1653,9 +1642,9 @@ void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 
 void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
            transpose transb, int64_t n, int64_t k, std::complex<double> alpha,
-           cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
-           cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+           sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
@@ -1665,38 +1654,36 @@ void gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 }
 
 void asum(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<float, 1> &result) {
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, sycl::buffer<float, 1> &result) {
     asum_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
     asum_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
 void asum(backend_selector<backend::rocblas> selector, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<double, 1> &result) {
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, sycl::buffer<double, 1> &result) {
     asum_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
     asum_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
-void asum(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &result) {
+void asum(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &result) {
     asum_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
     asum_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
-void asum(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &result) {
+void asum(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &result) {
     asum_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
     asum_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
 void sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, int64_t k,
-          float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, float beta, cl::sycl::buffer<float, 1> &y, int64_t incy) {
+          float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x,
+          int64_t incx, float beta, sycl::buffer<float, 1> &y, int64_t incy) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy);
     oneapi::mkl::blas::rocblas::MAJOR::sbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
@@ -1706,8 +1693,8 @@ void sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, int64_t k,
-          double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, double beta, cl::sycl::buffer<double, 1> &y, int64_t incy) {
+          double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x,
+          int64_t incx, double beta, sycl::buffer<double, 1> &y, int64_t incy) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy);
     oneapi::mkl::blas::rocblas::MAJOR::sbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
@@ -1717,8 +1704,8 @@ void sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &x, int64_t incx) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1726,8 +1713,8 @@ void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<double, 1> &a, int64_t lda,
-          cl::sycl::buffer<double, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &x, int64_t incx) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1735,8 +1722,8 @@ void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<std::complex<float>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1744,8 +1731,8 @@ void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<std::complex<double>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          diag unit_diag, int64_t n, int64_t k, sycl::buffer<std::complex<double>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
     oneapi::mkl::blas::rocblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
                                             k, a, lda, x, incx);
@@ -1753,8 +1740,8 @@ void tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpo
 }
 
 void spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-          cl::sycl::buffer<float, 1> &a) {
+          sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &y, int64_t incy,
+          sycl::buffer<float, 1> &a) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
     oneapi::mkl::blas::rocblas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a);
@@ -1762,79 +1749,74 @@ void spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &y,
-          int64_t incy, cl::sycl::buffer<double, 1> &a) {
+          sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &y, int64_t incy,
+          sycl::buffer<double, 1> &a) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
     oneapi::mkl::blas::rocblas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha, x, incx, y,
                                             incy, a);
     spr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
 }
 
-void iamax(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
+void iamax(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+           int64_t incx, sycl::buffer<int64_t, 1> &result) {
     iamax_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
     iamax_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
-void iamax(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
-    iamax_precondition(selector.get_queue(), n, x, incx, result);
-    oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
-    iamax_postcondition(selector.get_queue(), n, x, incx, result);
-}
-
-void iamax(backend_selector<backend::rocblas> selector, int64_t n,
-           cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result) {
+void iamax(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+           int64_t incx, sycl::buffer<int64_t, 1> &result) {
     iamax_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
     iamax_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
 void iamax(backend_selector<backend::rocblas> selector, int64_t n,
-           cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result) {
+           sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
     iamax_precondition(selector.get_queue(), n, x, incx, result);
     oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
     iamax_postcondition(selector.get_queue(), n, x, incx, result);
 }
 
-void rotm(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-          cl::sycl::buffer<float, 1> &param) {
+void iamax(backend_selector<backend::rocblas> selector, int64_t n,
+           sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void rotm(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &param) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param);
     oneapi::mkl::blas::rocblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy, param);
     rotm_postcondition(selector.get_queue(), n, x, incx, y, incy, param);
 }
 
-void rotm(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy,
-          cl::sycl::buffer<double, 1> &param) {
+void rotm(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &param) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param);
     oneapi::mkl::blas::rocblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy, param);
     rotm_postcondition(selector.get_queue(), n, x, incx, y, incy, param);
 }
 
-void dot(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-         int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-         cl::sycl::buffer<float, 1> &result) {
+void dot(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &result) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy, result);
     dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
 }
 
-void dot(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<double, 1> &x,
-         int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy,
-         cl::sycl::buffer<double, 1> &result) {
+void dot(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1> &x,
+         int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &result) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy, result);
     dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
 }
 
-void dot(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffer<float, 1> &x,
-         int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-         cl::sycl::buffer<double, 1> &result) {
+void dot(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<double, 1> &result) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result);
     oneapi::mkl::blas::rocblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy, result);
     dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
@@ -1842,8 +1824,8 @@ void dot(backend_selector<backend::rocblas> selector, int64_t n, cl::sycl::buffe
 
 void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
                 transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<float, 1> &b, int64_t ldb, int64_t stride_b, int64_t batch_size) {
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &b,
+                int64_t ldb, int64_t stride_b, int64_t batch_size) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(selector.get_queue(), left_right, upper_lower,
@@ -1855,8 +1837,8 @@ void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, up
 
 void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
                 transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<double, 1> &b, int64_t ldb, int64_t stride_b, int64_t batch_size) {
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<double, 1> &b, int64_t ldb, int64_t stride_b, int64_t batch_size) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
     oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(selector.get_queue(), left_right, upper_lower,
@@ -1868,8 +1850,8 @@ void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, up
 
 void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
                 transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
@@ -1882,8 +1864,8 @@ void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, up
 
 void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
                 transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
@@ -1895,10 +1877,9 @@ void trsm_batch(backend_selector<backend::rocblas> selector, side left_right, up
 }
 
 void her2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-           int64_t n, int64_t k, std::complex<float> alpha,
-           cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, float beta,
-           cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+           int64_t n, int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, float beta,
+           sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::her2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
@@ -1909,9 +1890,9 @@ void her2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
 
 void her2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
            int64_t n, int64_t k, std::complex<double> alpha,
-           cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, double beta,
-           cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+           sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, double beta,
+           sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc);
     oneapi::mkl::blas::rocblas::MAJOR::her2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
@@ -1920,41 +1901,39 @@ void her2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transp
                         c, ldc);
 }
 
-void rotg(backend_selector<backend::rocblas> selector, cl::sycl::buffer<float, 1> &a,
-          cl::sycl::buffer<float, 1> &b, cl::sycl::buffer<float, 1> &c,
-          cl::sycl::buffer<float, 1> &s) {
+void rotg(backend_selector<backend::rocblas> selector, sycl::buffer<float, 1> &a,
+          sycl::buffer<float, 1> &b, sycl::buffer<float, 1> &c, sycl::buffer<float, 1> &s) {
     rotg_precondition(selector.get_queue(), a, b, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
     rotg_postcondition(selector.get_queue(), a, b, c, s);
 }
 
-void rotg(backend_selector<backend::rocblas> selector, cl::sycl::buffer<double, 1> &a,
-          cl::sycl::buffer<double, 1> &b, cl::sycl::buffer<double, 1> &c,
-          cl::sycl::buffer<double, 1> &s) {
+void rotg(backend_selector<backend::rocblas> selector, sycl::buffer<double, 1> &a,
+          sycl::buffer<double, 1> &b, sycl::buffer<double, 1> &c, sycl::buffer<double, 1> &s) {
     rotg_precondition(selector.get_queue(), a, b, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
     rotg_postcondition(selector.get_queue(), a, b, c, s);
 }
 
-void rotg(backend_selector<backend::rocblas> selector, cl::sycl::buffer<std::complex<float>, 1> &a,
-          cl::sycl::buffer<std::complex<float>, 1> &b, cl::sycl::buffer<float, 1> &c,
-          cl::sycl::buffer<std::complex<float>, 1> &s) {
+void rotg(backend_selector<backend::rocblas> selector, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &b, sycl::buffer<float, 1> &c,
+          sycl::buffer<std::complex<float>, 1> &s) {
     rotg_precondition(selector.get_queue(), a, b, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
     rotg_postcondition(selector.get_queue(), a, b, c, s);
 }
 
-void rotg(backend_selector<backend::rocblas> selector, cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &b, cl::sycl::buffer<double, 1> &c,
-          cl::sycl::buffer<std::complex<double>, 1> &s) {
+void rotg(backend_selector<backend::rocblas> selector, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &b, sycl::buffer<double, 1> &c,
+          sycl::buffer<std::complex<double>, 1> &s) {
     rotg_precondition(selector.get_queue(), a, b, c, s);
     oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
     rotg_postcondition(selector.get_queue(), a, b, c, s);
 }
 
 void symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          float beta, cl::sycl::buffer<float, 1> &y, int64_t incy) {
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x, int64_t incx,
+          float beta, sycl::buffer<float, 1> &y, int64_t incy) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::symv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -1962,8 +1941,8 @@ void symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          double beta, cl::sycl::buffer<double, 1> &y, int64_t incy) {
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x, int64_t incx,
+          double beta, sycl::buffer<double, 1> &y, int64_t incy) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
     oneapi::mkl::blas::rocblas::MAJOR::symv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
                                             incx, beta, y, incy);
@@ -1972,9 +1951,9 @@ void symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 
 // USM APIs
 
-cl::sycl::event syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     float alpha, const float *x, int64_t incx, const float *y, int64_t incy,
-                     float *a, int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 float alpha, const float *x, int64_t incx, const float *y, int64_t incy, float *a,
+                 int64_t lda, const std::vector<sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -1984,9 +1963,9 @@ cl::sycl::event syr2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     double alpha, const double *x, int64_t incx, const double *y, int64_t incy,
-                     double *a, int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 double alpha, const double *x, int64_t incx, const double *y, int64_t incy,
+                 double *a, int64_t lda, const std::vector<sycl::event> &dependencies) {
     syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha,
@@ -1996,8 +1975,8 @@ cl::sycl::event syr2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, float alpha, float *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, float alpha, float *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                         dependencies);
@@ -2005,8 +1984,8 @@ cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, flo
     return done;
 }
 
-cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-                     double *x, int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, double alpha, double *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                         dependencies);
@@ -2014,9 +1993,9 @@ cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, dou
     return done;
 }
 
-cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n,
-                     std::complex<float> alpha, std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> alpha,
+                 std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                         dependencies);
@@ -2024,9 +2003,9 @@ cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n,
-                     std::complex<double> alpha, std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> alpha,
+                 std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                         dependencies);
@@ -2034,9 +2013,9 @@ cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
+                 std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                         dependencies);
@@ -2044,9 +2023,9 @@ cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, flo
     return done;
 }
 
-cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
+                 std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
                                                         dependencies);
@@ -2054,9 +2033,9 @@ cl::sycl::event scal(backend_selector<backend::rocblas> selector, int64_t n, dou
     return done;
 }
 
-cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmv(
@@ -2066,9 +2045,9 @@ cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const double *a, int64_t lda, double *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmv(
@@ -2078,10 +2057,10 @@ cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<float> *a, int64_t lda,
+                 std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmv(
@@ -2091,10 +2070,10 @@ cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<double> *a, int64_t lda,
+                 std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmv(
@@ -2104,9 +2083,9 @@ cl::sycl::event trmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const float *a, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const float *a, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2116,9 +2095,9 @@ cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const double *a, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const double *a, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2128,10 +2107,9 @@ cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<float> *a,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<float> *a, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2141,10 +2119,9 @@ cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<double> *a,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<double> *a, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
@@ -2154,9 +2131,9 @@ cl::sycl::event tpmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event spr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    float alpha, const float *x, int64_t incx, float *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event spr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                float alpha, const float *x, int64_t incx, float *a,
+                const std::vector<sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, dependencies);
@@ -2164,9 +2141,9 @@ cl::sycl::event spr(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event spr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    double alpha, const double *x, int64_t incx, double *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event spr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                double alpha, const double *x, int64_t incx, double *a,
+                const std::vector<sycl::event> &dependencies) {
     spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, dependencies);
@@ -2174,11 +2151,11 @@ cl::sycl::event spr(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *a,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2188,11 +2165,11 @@ cl::sycl::event hpmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha,
@@ -2202,9 +2179,9 @@ cl::sycl::event hpmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     int64_t n, int64_t k, float alpha, const float *a, int64_t lda, float beta,
-                     float *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 int64_t n, int64_t k, float alpha, const float *a, int64_t lda, float beta,
+                 float *c, int64_t ldc, const std::vector<sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk(
@@ -2214,9 +2191,9 @@ cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     int64_t n, int64_t k, double alpha, const double *a, int64_t lda, double beta,
-                     double *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 int64_t n, int64_t k, double alpha, const double *a, int64_t lda, double beta,
+                 double *c, int64_t ldc, const std::vector<sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk(
@@ -2226,10 +2203,10 @@ cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                 int64_t lda, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk(
@@ -2239,11 +2216,10 @@ cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     int64_t n, int64_t k, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, std::complex<double> beta,
-                     std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 int64_t n, int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                 int64_t lda, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk(
@@ -2253,10 +2229,10 @@ cl::sycl::event syrk(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
-                           transpose *trans, int64_t *n, int64_t *k, float *alpha, const float **a,
-                           int64_t *lda, float *beta, float **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
+                       transpose *trans, int64_t *n, int64_t *k, float *alpha, const float **a,
+                       int64_t *lda, float *beta, float **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2267,11 +2243,10 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *up
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
-                           transpose *trans, int64_t *n, int64_t *k, double *alpha,
-                           const double **a, int64_t *lda, double *beta, double **c, int64_t *ldc,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
+                       transpose *trans, int64_t *n, int64_t *k, double *alpha, const double **a,
+                       int64_t *lda, double *beta, double **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2282,11 +2257,11 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *up
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
-                           transpose *trans, int64_t *n, int64_t *k, std::complex<float> *alpha,
-                           const std::complex<float> **a, int64_t *lda, std::complex<float> *beta,
-                           std::complex<float> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
+                       transpose *trans, int64_t *n, int64_t *k, std::complex<float> *alpha,
+                       const std::complex<float> **a, int64_t *lda, std::complex<float> *beta,
+                       std::complex<float> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2297,11 +2272,11 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *up
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
-                           transpose *trans, int64_t *n, int64_t *k, std::complex<double> *alpha,
-                           const std::complex<double> **a, int64_t *lda, std::complex<double> *beta,
-                           std::complex<double> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *upper_lower,
+                       transpose *trans, int64_t *n, int64_t *k, std::complex<double> *alpha,
+                       const std::complex<double> **a, int64_t *lda, std::complex<double> *beta,
+                       std::complex<double> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
                             ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2312,11 +2287,11 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo *up
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                           transpose trans, int64_t n, int64_t k, float alpha, const float *a,
-                           int64_t lda, int64_t stride_a, float beta, float *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
+                       transpose trans, int64_t n, int64_t k, float alpha, const float *a,
+                       int64_t lda, int64_t stride_a, float beta, float *c, int64_t ldc,
+                       int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2327,11 +2302,11 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upp
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                           transpose trans, int64_t n, int64_t k, double alpha, const double *a,
-                           int64_t lda, int64_t stride_a, double beta, double *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
+                       transpose trans, int64_t n, int64_t k, double alpha, const double *a,
+                       int64_t lda, int64_t stride_a, double beta, double *c, int64_t ldc,
+                       int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2342,12 +2317,12 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upp
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                           transpose trans, int64_t n, int64_t k, std::complex<float> alpha,
-                           const std::complex<float> *a, int64_t lda, int64_t stride_a,
-                           std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
+                       transpose trans, int64_t n, int64_t k, std::complex<float> alpha,
+                       const std::complex<float> *a, int64_t lda, int64_t stride_a,
+                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
+                       int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2358,12 +2333,12 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upp
     return done;
 }
 
-cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                           transpose trans, int64_t n, int64_t k, std::complex<double> alpha,
-                           const std::complex<double> *a, int64_t lda, int64_t stride_a,
-                           std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upper_lower,
+                       transpose trans, int64_t n, int64_t k, std::complex<double> alpha,
+                       const std::complex<double> *a, int64_t lda, int64_t stride_a,
+                       std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                       int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
                             beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syrk_batch(
@@ -2374,10 +2349,10 @@ cl::sycl::event syrk_batch(backend_selector<backend::rocblas> selector, uplo upp
     return done;
 }
 
-cl::sycl::event her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2387,10 +2362,10 @@ cl::sycl::event her2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event her2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha,
@@ -2400,11 +2375,11 @@ cl::sycl::event her2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 int64_t k, std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2415,11 +2390,11 @@ cl::sycl::event hbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *x, int64_t incx,
-                     std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 int64_t k, std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -2430,9 +2405,9 @@ cl::sycl::event hbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> *x,
-                    int64_t incx, std::complex<float> *y, int64_t incy, float c, float s,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> *x,
+                int64_t incx, std::complex<float> *y, int64_t incy, float c, float s,
+                const std::vector<sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                        s, dependencies);
@@ -2440,9 +2415,9 @@ cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, std:
     return done;
 }
 
-cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> *x,
-                    int64_t incx, std::complex<double> *y, int64_t incy, double c, double s,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> *x,
+                int64_t incx, std::complex<double> *y, int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                        s, dependencies);
@@ -2450,9 +2425,9 @@ cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, std:
     return done;
 }
 
-cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, float *x, int64_t incx,
-                    float *y, int64_t incy, float c, float s,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, float *x, int64_t incx,
+                float *y, int64_t incy, float c, float s,
+                const std::vector<sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                        s, dependencies);
@@ -2460,9 +2435,9 @@ cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, floa
     return done;
 }
 
-cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, double *x, int64_t incx,
-                    double *y, int64_t incy, double c, double s,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, double *x, int64_t incx,
+                double *y, int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies) {
     rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c,
                                                        s, dependencies);
@@ -2470,9 +2445,9 @@ cl::sycl::event rot(backend_selector<backend::rocblas> selector, int64_t n, doub
     return done;
 }
 
-cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-                     const float *x, int64_t incx, float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
+                 const float *x, int64_t incx, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                         incy, dependencies);
@@ -2480,9 +2455,9 @@ cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, flo
     return done;
 }
 
-cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-                     const double *x, int64_t incx, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
+                 const double *x, int64_t incx, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                         incy, dependencies);
@@ -2490,10 +2465,9 @@ cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, dou
     return done;
 }
 
-cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                         incy, dependencies);
@@ -2501,10 +2475,9 @@ cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
                                                         incy, dependencies);
@@ -2512,10 +2485,10 @@ cl::sycl::event axpy(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n, float *alpha,
-                           const float **x, int64_t *incx, float **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n, float *alpha,
+                       const float **x, int64_t *incx, float **y, int64_t *incy,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(
@@ -2525,10 +2498,10 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n, double *alpha,
-                           const double **x, int64_t *incx, double **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n, double *alpha,
+                       const double **x, int64_t *incx, double **y, int64_t *incy,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(
@@ -2538,10 +2511,10 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
-                           std::complex<float> *alpha, const std::complex<float> **x, int64_t *incx,
-                           std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
+                       std::complex<float> *alpha, const std::complex<float> **x, int64_t *incx,
+                       std::complex<float> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(
@@ -2551,11 +2524,10 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
-                           std::complex<double> *alpha, const std::complex<double> **x,
-                           int64_t *incx, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
+                       std::complex<double> *alpha, const std::complex<double> **x, int64_t *incx,
+                       std::complex<double> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
                             group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(
@@ -2565,10 +2537,10 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-                           const float *x, int64_t incx, int64_t stridex, float *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
+                       const float *x, int64_t incx, int64_t stridex, float *y, int64_t incy,
+                       int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2579,10 +2551,10 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-                           const double *x, int64_t incx, int64_t stridex, double *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
+                       const double *x, int64_t incx, int64_t stridex, double *y, int64_t incy,
+                       int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2593,10 +2565,10 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
-                           int64_t stridex, std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n,
+                       std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
+                       int64_t stridex, std::complex<float> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2607,10 +2579,10 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                           int64_t stridex, std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t n,
+                       std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
+                       int64_t stridex, std::complex<double> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
                             batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
@@ -2621,9 +2593,9 @@ cl::sycl::event axpy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
-                      const float *x, int64_t incx, const float beta, float *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n, float alpha,
+                  const float *x, int64_t incx, const float beta, float *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                          beta, y, incy, dependencies);
@@ -2631,9 +2603,9 @@ cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n, fl
     return done;
 }
 
-cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
-                      const double *x, int64_t incx, const double beta, double *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n, double alpha,
+                  const double *x, int64_t incx, const double beta, double *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                          beta, y, incy, dependencies);
@@ -2641,10 +2613,10 @@ cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n, do
     return done;
 }
 
-cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n,
-                      std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
-                      const std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> alpha,
+                  const std::complex<float> *x, int64_t incx, const std::complex<float> beta,
+                  std::complex<float> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                          beta, y, incy, dependencies);
@@ -2652,10 +2624,10 @@ cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n,
-                      std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                      const std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n,
+                  std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
+                  const std::complex<double> beta, std::complex<double> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
                                                          beta, y, incy, dependencies);
@@ -2663,10 +2635,10 @@ cl::sycl::event axpby(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                         y, incy, a, lda, dependencies);
@@ -2674,10 +2646,10 @@ cl::sycl::event gerc(backend_selector<backend::rocblas> selector, int64_t m, int
     return done;
 }
 
-cl::sycl::event gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gerc(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
                                                         y, incy, a, lda, dependencies);
@@ -2685,10 +2657,10 @@ cl::sycl::event gerc(backend_selector<backend::rocblas> selector, int64_t m, int
     return done;
 }
 
-cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose trans, int64_t n, int64_t k, float alpha, const float *a,
-                      int64_t lda, const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                  int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
+                  int64_t ldb, float beta, float *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2699,10 +2671,10 @@ cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose trans, int64_t n, int64_t k, double alpha, const double *a,
-                      int64_t lda, const double *b, int64_t ldb, double beta, double *c,
-                      int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                  int64_t n, int64_t k, double alpha, const double *a, int64_t lda, const double *b,
+                  int64_t ldb, double beta, double *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2713,11 +2685,11 @@ cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose trans, int64_t n, int64_t k, std::complex<float> alpha,
-                      const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
-                      int64_t ldb, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                  int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                  int64_t lda, const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                  std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2728,11 +2700,11 @@ cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose trans, int64_t n, int64_t k, std::complex<double> alpha,
-                      const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                      int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                  int64_t n, int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                  int64_t lda, const std::complex<double> *b, int64_t ldb,
+                  std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -2743,10 +2715,9 @@ cl::sycl::event syr2k(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, float alpha, const float *a, int64_t lda, const float *x,
-                     int64_t incx, float beta, float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 float alpha, const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                 float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2756,10 +2727,10 @@ cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, double alpha, const double *a, int64_t lda, const double *x,
-                     int64_t incx, double beta, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 double alpha, const double *a, int64_t lda, const double *x, int64_t incx,
+                 double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2769,11 +2740,11 @@ cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2783,11 +2754,11 @@ cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *x, int64_t incx,
-                     std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a,
@@ -2797,11 +2768,11 @@ cl::sycl::event gemv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                           int64_t n, float alpha, const float *a, int64_t lda, int64_t stridea,
-                           const float *x, int64_t incx, int64_t stridex, float beta, float *y,
-                           int64_t incy, int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
+                       int64_t n, float alpha, const float *a, int64_t lda, int64_t stridea,
+                       const float *x, int64_t incx, int64_t stridex, float beta, float *y,
+                       int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2812,11 +2783,11 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                           int64_t n, double alpha, const double *a, int64_t lda, int64_t stridea,
-                           const double *x, int64_t incx, int64_t stridex, double beta, double *y,
-                           int64_t incy, int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
+                       int64_t n, double alpha, const double *a, int64_t lda, int64_t stridea,
+                       const double *x, int64_t incx, int64_t stridex, double beta, double *y,
+                       int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2827,12 +2798,12 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                           int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                           int64_t lda, int64_t stridea, const std::complex<float> *x, int64_t incx,
-                           int64_t stridex, std::complex<float> beta, std::complex<float> *y,
-                           int64_t incy, int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
+                       int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                       int64_t lda, int64_t stridea, const std::complex<float> *x, int64_t incx,
+                       int64_t stridex, std::complex<float> beta, std::complex<float> *y,
+                       int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2843,12 +2814,12 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                           int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-                           int64_t lda, int64_t stridea, const std::complex<double> *x,
-                           int64_t incx, int64_t stridex, std::complex<double> beta,
-                           std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
+                       int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                       int64_t lda, int64_t stridea, const std::complex<double> *x, int64_t incx,
+                       int64_t stridex, std::complex<double> beta, std::complex<double> *y,
+                       int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
                             stridex, beta, y, incy, stridey, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2859,11 +2830,10 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans,
-                           int64_t *m, int64_t *n, float *alpha, const float **a, int64_t *lda,
-                           const float **x, int64_t *incx, float *beta, float **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans, int64_t *m,
+                       int64_t *n, float *alpha, const float **a, int64_t *lda, const float **x,
+                       int64_t *incx, float *beta, float **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2874,11 +2844,10 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans,
-                           int64_t *m, int64_t *n, double *alpha, const double **a, int64_t *lda,
-                           const double **x, int64_t *incx, double *beta, double **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans, int64_t *m,
+                       int64_t *n, double *alpha, const double **a, int64_t *lda, const double **x,
+                       int64_t *incx, double *beta, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2889,12 +2858,12 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans,
-                           int64_t *m, int64_t *n, std::complex<float> *alpha,
-                           const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
-                           std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans, int64_t *m,
+                       int64_t *n, std::complex<float> *alpha, const std::complex<float> **a,
+                       int64_t *lda, const std::complex<float> **x, int64_t *incx,
+                       std::complex<float> *beta, std::complex<float> **y, int64_t *incy,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2905,13 +2874,12 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans,
-                           int64_t *m, int64_t *n, std::complex<double> *alpha,
-                           const std::complex<double> **a, int64_t *lda,
-                           const std::complex<double> **x, int64_t *incx,
-                           std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpose *trans, int64_t *m,
+                       int64_t *n, std::complex<double> *alpha, const std::complex<double> **a,
+                       int64_t *lda, const std::complex<double> **x, int64_t *incx,
+                       std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
                             incy, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemv_batch(
@@ -2922,10 +2890,10 @@ cl::sycl::event gemv_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
-                           int64_t n, const float *a, int64_t lda, int64_t stridea, const float *x,
-                           int64_t incx, int64_t stridex, float *c, int64_t ldc, int64_t stridec,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
+                       int64_t n, const float *a, int64_t lda, int64_t stridea, const float *x,
+                       int64_t incx, int64_t stridex, float *c, int64_t ldc, int64_t stridec,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -2936,11 +2904,10 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
-                           int64_t n, const double *a, int64_t lda, int64_t stridea,
-                           const double *x, int64_t incx, int64_t stridex, double *c, int64_t ldc,
-                           int64_t stridec, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
+                       int64_t n, const double *a, int64_t lda, int64_t stridea, const double *x,
+                       int64_t incx, int64_t stridex, double *c, int64_t ldc, int64_t stridec,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -2951,11 +2918,11 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
-                           int64_t n, const std::complex<float> *a, int64_t lda, int64_t stridea,
-                           const std::complex<float> *x, int64_t incx, int64_t stridex,
-                           std::complex<float> *c, int64_t ldc, int64_t stridec, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
+                       int64_t n, const std::complex<float> *a, int64_t lda, int64_t stridea,
+                       const std::complex<float> *x, int64_t incx, int64_t stridex,
+                       std::complex<float> *c, int64_t ldc, int64_t stridec, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -2966,11 +2933,11 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
-                           int64_t n, const std::complex<double> *a, int64_t lda, int64_t stridea,
-                           const std::complex<double> *x, int64_t incx, int64_t stridex,
-                           std::complex<double> *c, int64_t ldc, int64_t stridec,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side left_right, int64_t m,
+                       int64_t n, const std::complex<double> *a, int64_t lda, int64_t stridea,
+                       const std::complex<double> *x, int64_t incx, int64_t stridex,
+                       std::complex<double> *c, int64_t ldc, int64_t stridec, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
                             stridex, c, ldc, stridec, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -2981,10 +2948,10 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           int64_t *m, int64_t *n, const float **a, int64_t *lda, const float **x,
-                           int64_t *incx, float **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right, int64_t *m,
+                       int64_t *n, const float **a, int64_t *lda, const float **x, int64_t *incx,
+                       float **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -2995,10 +2962,10 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           int64_t *m, int64_t *n, const double **a, int64_t *lda, const double **x,
-                           int64_t *incx, double **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right, int64_t *m,
+                       int64_t *n, const double **a, int64_t *lda, const double **x, int64_t *incx,
+                       double **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -3009,11 +2976,11 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           int64_t *m, int64_t *n, const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right, int64_t *m,
+                       int64_t *n, const std::complex<float> **a, int64_t *lda,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -3024,11 +2991,11 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           int64_t *m, int64_t *n, const std::complex<double> **a, int64_t *lda,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *left_right, int64_t *m,
+                       int64_t *n, const std::complex<double> **a, int64_t *lda,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
                             group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dgmm_batch(
@@ -3039,9 +3006,9 @@ cl::sycl::event dgmm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    float alpha, const std::complex<float> *x, int64_t incx, std::complex<float> *a,
-                    int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                float alpha, const std::complex<float> *x, int64_t incx, std::complex<float> *a,
+                int64_t lda, const std::vector<sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, lda, dependencies);
@@ -3049,10 +3016,9 @@ cl::sycl::event her(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    double alpha, const std::complex<double> *x, int64_t incx,
-                    std::complex<double> *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event her(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                double alpha, const std::complex<double> *x, int64_t incx, std::complex<double> *a,
+                int64_t lda, const std::vector<sycl::event> &dependencies) {
     her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, lda, dependencies);
@@ -3060,9 +3026,9 @@ cl::sycl::event her(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    float alpha, const std::complex<float> *x, int64_t incx, std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                float alpha, const std::complex<float> *x, int64_t incx, std::complex<float> *a,
+                const std::vector<sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, dependencies);
@@ -3070,9 +3036,9 @@ cl::sycl::event hpr(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    double alpha, const std::complex<double> *x, int64_t incx,
-                    std::complex<double> *a, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                double alpha, const std::complex<double> *x, int64_t incx, std::complex<double> *a,
+                const std::vector<sycl::event> &dependencies) {
     hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, dependencies);
@@ -3080,9 +3046,8 @@ cl::sycl::event hpr(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                  int64_t incx, int64_t *result, const std::vector<sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -3090,9 +3055,8 @@ cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, co
     return done;
 }
 
-cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
+                  int64_t incx, int64_t *result, const std::vector<sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -3100,9 +3064,9 @@ cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, co
     return done;
 }
 
-cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
-                      const std::complex<float> *x, int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
+                  const std::complex<float> *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -3110,9 +3074,9 @@ cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
-                      const std::complex<double> *x, int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
+                  const std::complex<double> *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -3120,11 +3084,11 @@ cl::sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
-                           transpose *transb, int64_t *m, int64_t *n, int64_t *k, float *alpha,
-                           const float **a, int64_t *lda, const float **b, int64_t *ldb,
-                           float *beta, float **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
+                       transpose *transb, int64_t *m, int64_t *n, int64_t *k, float *alpha,
+                       const float **a, int64_t *lda, const float **b, int64_t *ldb, float *beta,
+                       float **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3135,11 +3099,11 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
-                           transpose *transb, int64_t *m, int64_t *n, int64_t *k, double *alpha,
-                           const double **a, int64_t *lda, const double **b, int64_t *ldb,
-                           double *beta, double **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
+                       transpose *transb, int64_t *m, int64_t *n, int64_t *k, double *alpha,
+                       const double **a, int64_t *lda, const double **b, int64_t *ldb, double *beta,
+                       double **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3150,12 +3114,12 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
-                           transpose *transb, int64_t *m, int64_t *n, int64_t *k,
-                           std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
-                           std::complex<float> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
+                       transpose *transb, int64_t *m, int64_t *n, int64_t *k,
+                       std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
+                       const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
+                       std::complex<float> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3166,13 +3130,12 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
-                           transpose *transb, int64_t *m, int64_t *n, int64_t *k,
-                           std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, const std::complex<double> **b, int64_t *ldb,
-                           std::complex<double> *beta, std::complex<double> **c, int64_t *ldc,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
+                       transpose *transb, int64_t *m, int64_t *n, int64_t *k,
+                       std::complex<double> *alpha, const std::complex<double> **a, int64_t *lda,
+                       const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
+                       std::complex<double> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3183,11 +3146,11 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
-                           transpose *transb, int64_t *m, int64_t *n, int64_t *k, sycl::half *alpha,
-                           const sycl::half **a, int64_t *lda, const sycl::half **b, int64_t *ldb,
-                           sycl::half *beta, sycl::half **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose *transa,
+                       transpose *transb, int64_t *m, int64_t *n, int64_t *k, sycl::half *alpha,
+                       const sycl::half **a, int64_t *lda, const sycl::half **b, int64_t *ldb,
+                       sycl::half *beta, sycl::half **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
                             beta, c, ldc, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3198,12 +3161,11 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
-                           transpose transb, int64_t m, int64_t n, int64_t k, float alpha,
-                           const float *a, int64_t lda, int64_t stride_a, const float *b,
-                           int64_t ldb, int64_t stride_b, float beta, float *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
+                       transpose transb, int64_t m, int64_t n, int64_t k, float alpha,
+                       const float *a, int64_t lda, int64_t stride_a, const float *b, int64_t ldb,
+                       int64_t stride_b, float beta, float *c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3214,12 +3176,11 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
-                           transpose transb, int64_t m, int64_t n, int64_t k, double alpha,
-                           const double *a, int64_t lda, int64_t stride_a, const double *b,
-                           int64_t ldb, int64_t stride_b, double beta, double *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
+                       transpose transb, int64_t m, int64_t n, int64_t k, double alpha,
+                       const double *a, int64_t lda, int64_t stride_a, const double *b, int64_t ldb,
+                       int64_t stride_b, double beta, double *c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3230,13 +3191,13 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
-                           transpose transb, int64_t m, int64_t n, int64_t k,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stride_a, const std::complex<float> *b, int64_t ldb,
-                           int64_t stride_b, std::complex<float> beta, std::complex<float> *c,
-                           int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
+                       transpose transb, int64_t m, int64_t n, int64_t k, std::complex<float> alpha,
+                       const std::complex<float> *a, int64_t lda, int64_t stride_a,
+                       const std::complex<float> *b, int64_t ldb, int64_t stride_b,
+                       std::complex<float> beta, std::complex<float> *c, int64_t ldc,
+                       int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3247,13 +3208,13 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
-                           transpose transb, int64_t m, int64_t n, int64_t k,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stride_a, const std::complex<double> *b, int64_t ldb,
-                           int64_t stride_b, std::complex<double> beta, std::complex<double> *c,
-                           int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
+                       transpose transb, int64_t m, int64_t n, int64_t k,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stride_a, const std::complex<double> *b, int64_t ldb,
+                       int64_t stride_b, std::complex<double> beta, std::complex<double> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3264,12 +3225,12 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
-                           transpose transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
-                           const sycl::half *a, int64_t lda, int64_t stride_a, const sycl::half *b,
-                           int64_t ldb, int64_t stride_b, sycl::half beta, sycl::half *c,
-                           int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpose transa,
+                       transpose transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
+                       const sycl::half *a, int64_t lda, int64_t stride_a, const sycl::half *b,
+                       int64_t ldb, int64_t stride_b, sycl::half beta, sycl::half *c, int64_t ldc,
+                       int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_batch(
@@ -3280,9 +3241,9 @@ cl::sycl::event gemm_batch(backend_selector<backend::rocblas> selector, transpos
     return done;
 }
 
-cl::sycl::event spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     float alpha, const float *a, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 float alpha, const float *a, const float *x, int64_t incx, float beta, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3292,9 +3253,9 @@ cl::sycl::event spmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     double alpha, const double *a, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event spmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 double alpha, const double *a, const double *x, int64_t incx, double beta,
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha,
@@ -3304,8 +3265,8 @@ cl::sycl::event spmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, float *x, int64_t incx,
-                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, float *x, int64_t incx,
+                 float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -3313,9 +3274,8 @@ cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, flo
     return done;
 }
 
-cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, double *x,
-                     int64_t incx, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, double *x, int64_t incx,
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -3323,9 +3283,9 @@ cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, dou
     return done;
 }
 
-cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> *x,
-                     int64_t incx, std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, std::complex<float> *x,
+                 int64_t incx, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -3333,9 +3293,9 @@ cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, std
     return done;
 }
 
-cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n,
-                     std::complex<double> *x, int64_t incx, std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n, std::complex<double> *x,
+                 int64_t incx, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -3343,10 +3303,10 @@ cl::sycl::event swap(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                         y, incy, a, lda, dependencies);
@@ -3354,10 +3314,10 @@ cl::sycl::event geru(backend_selector<backend::rocblas> selector, int64_t m, int
     return done;
 }
 
-cl::sycl::event geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event geru(backend_selector<backend::rocblas> selector, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
                                                         y, incy, a, lda, dependencies);
@@ -3365,9 +3325,9 @@ cl::sycl::event geru(backend_selector<backend::rocblas> selector, int64_t m, int
     return done;
 }
 
-cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<float> *x, int64_t incx, float *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<float> *x, int64_t incx, float *result,
+                 const std::vector<sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3375,9 +3335,9 @@ cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<double> *x, int64_t incx, double *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<double> *x, int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3385,9 +3345,8 @@ cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                     int64_t incx, float *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                 int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3395,9 +3354,8 @@ cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n, con
     return done;
 }
 
-cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
-                     int64_t incx, double *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
+                 int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
     nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -3405,10 +3363,10 @@ cl::sycl::event nrm2(backend_selector<backend::rocblas> selector, int64_t n, con
     return done;
 }
 
-cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa,
-                     transpose transb, int64_t m, int64_t n, int64_t k, float alpha, const float *a,
-                     int64_t lda, const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
+                 int64_t m, int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
+                 const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3419,10 +3377,10 @@ cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa,
-                     transpose transb, int64_t m, int64_t n, int64_t k, double alpha,
-                     const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
-                     double *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
+                 int64_t m, int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
+                 const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3433,11 +3391,11 @@ cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa,
-                     transpose transb, int64_t m, int64_t n, int64_t k, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
-                     int64_t ldb, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
+                 int64_t m, int64_t n, int64_t k, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
+                 int64_t ldb, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3448,11 +3406,11 @@ cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa,
-                     transpose transb, int64_t m, int64_t n, int64_t k, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                     int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
+                 int64_t m, int64_t n, int64_t k, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
+                 int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3463,11 +3421,10 @@ cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa,
-                     transpose transb, int64_t m, int64_t n, int64_t k, sycl::half alpha,
-                     const sycl::half *a, int64_t lda, const sycl::half *b, int64_t ldb,
-                     sycl::half beta, sycl::half *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
+                 int64_t m, int64_t n, int64_t k, sycl::half alpha, const sycl::half *a,
+                 int64_t lda, const sycl::half *b, int64_t ldb, sycl::half beta, sycl::half *c,
+                 int64_t ldc, const std::vector<sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3478,10 +3435,10 @@ cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa,
-                     transpose transb, int64_t m, int64_t n, int64_t k, float alpha,
-                     const sycl::half *a, int64_t lda, const sycl::half *b, int64_t ldb, float beta,
-                     float *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
+                 int64_t m, int64_t n, int64_t k, float alpha, const sycl::half *a, int64_t lda,
+                 const sycl::half *b, int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3492,10 +3449,10 @@ cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa,
-                     transpose transb, int64_t m, int64_t n, int64_t k, float alpha,
-                     const bfloat16 *a, int64_t lda, const bfloat16 *b, int64_t ldb, float beta,
-                     float *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm(backend_selector<backend::rocblas> selector, transpose transa, transpose transb,
+                 int64_t m, int64_t n, int64_t k, float alpha, const bfloat16 *a, int64_t lda,
+                 const bfloat16 *b, int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
                       ldc, dependencies);
     auto done =
@@ -3506,12 +3463,12 @@ cl::sycl::event gemm(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
-                          transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
-                          float alpha, const std::int8_t *a, int64_t lda, std::int8_t ao,
-                          const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
-                          std::int32_t *c, int64_t ldc, const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
+                      transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
+                      float alpha, const std::int8_t *a, int64_t lda, std::int8_t ao,
+                      const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
+                      std::int32_t *c, int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(
@@ -3522,12 +3479,12 @@ cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose
     return done;
 }
 
-cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
-                          transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
-                          float alpha, const std::int8_t *a, int64_t lda, std::int8_t ao,
-                          const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta,
-                          std::int32_t *c, int64_t ldc, const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
+                      transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
+                      float alpha, const std::int8_t *a, int64_t lda, std::int8_t ao,
+                      const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta,
+                      std::int32_t *c, int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(
@@ -3538,12 +3495,12 @@ cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose
     return done;
 }
 
-cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
-                          transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
-                          float alpha, const std::uint8_t *a, int64_t lda, std::uint8_t ao,
-                          const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta,
-                          std::int32_t *c, int64_t ldc, const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
+                      transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
+                      float alpha, const std::uint8_t *a, int64_t lda, std::uint8_t ao,
+                      const std::int8_t *b, int64_t ldb, std::int8_t bo, float beta,
+                      std::int32_t *c, int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(
@@ -3554,12 +3511,12 @@ cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose
     return done;
 }
 
-cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
-                          transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
-                          float alpha, const std::uint8_t *a, int64_t lda, std::uint8_t ao,
-                          const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
-                          std::int32_t *c, int64_t ldc, const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose transa,
+                      transpose transb, offset offsetc, int64_t m, int64_t n, int64_t k,
+                      float alpha, const std::uint8_t *a, int64_t lda, std::uint8_t ao,
+                      const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
+                      std::int32_t *c, int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemm_bias(
@@ -3570,10 +3527,10 @@ cl::sycl::event gemm_bias(backend_selector<backend::rocblas> selector, transpose
     return done;
 }
 
-cl::sycl::event herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     int64_t n, int64_t k, float alpha, const std::complex<float> *a, int64_t lda,
-                     float beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 int64_t n, int64_t k, float alpha, const std::complex<float> *a, int64_t lda,
+                 float beta, std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::herk(
@@ -3583,10 +3540,10 @@ cl::sycl::event herk(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     int64_t n, int64_t k, double alpha, const std::complex<double> *a, int64_t lda,
-                     double beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event herk(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 int64_t n, int64_t k, double alpha, const std::complex<double> *a, int64_t lda,
+                 double beta, std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::herk(
@@ -3596,9 +3553,9 @@ cl::sycl::event herk(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, float alpha,
-                    const float *x, int64_t incx, const float *y, int64_t incy, float *a,
-                    int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, float alpha,
+                const float *x, int64_t incx, const float *y, int64_t incy, float *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3606,9 +3563,9 @@ cl::sycl::event ger(backend_selector<backend::rocblas> selector, int64_t m, int6
     return done;
 }
 
-cl::sycl::event ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, double alpha,
-                    const double *x, int64_t incx, const double *y, int64_t incy, double *a,
-                    int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event ger(backend_selector<backend::rocblas> selector, int64_t m, int64_t n, double alpha,
+                const double *x, int64_t incx, const double *y, int64_t incy, double *a,
+                int64_t lda, const std::vector<sycl::event> &dependencies) {
     ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx,
                                                        y, incy, a, lda, dependencies);
@@ -3616,10 +3573,9 @@ cl::sycl::event ger(backend_selector<backend::rocblas> selector, int64_t m, int6
     return done;
 }
 
-cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-                     const float *a, int64_t lda, float *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha, const float *a,
+                 int64_t lda, float *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3630,10 +3586,10 @@ cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-                     const double *a, int64_t lda, double *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
+                 const double *a, int64_t lda, double *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3644,11 +3600,10 @@ cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3659,11 +3614,10 @@ cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm(selector.get_queue(), left_right,
@@ -3674,11 +3628,11 @@ cl::sycl::event trsm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
-                           uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           float alpha, const float *a, int64_t lda, int64_t stride_a, float *b,
-                           int64_t ldb, int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
+                       float alpha, const float *a, int64_t lda, int64_t stride_a, float *b,
+                       int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3689,11 +3643,11 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
-                           uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           double alpha, const double *a, int64_t lda, int64_t stride_a, double *b,
-                           int64_t ldb, int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
+                       double alpha, const double *a, int64_t lda, int64_t stride_a, double *b,
+                       int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3704,11 +3658,11 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
-                           uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
+                       std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                       int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3719,11 +3673,11 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
-                           uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, int64_t m, int64_t n,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3734,11 +3688,11 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side lef
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
-                           int64_t *n, float *alpha, const float **a, int64_t *lda, float **b,
-                           int64_t *ldb, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
+                       float *alpha, const float **a, int64_t *lda, float **b, int64_t *ldb,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3749,11 +3703,11 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
-                           int64_t *n, double *alpha, const double **a, int64_t *lda, double **b,
-                           int64_t *ldb, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
+                       double *alpha, const double **a, int64_t *lda, double **b, int64_t *ldb,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3764,11 +3718,11 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
-                           int64_t *n, std::complex<float> *alpha, const std::complex<float> **a,
-                           int64_t *lda, std::complex<float> **b, int64_t *ldb, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
+                       std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
+                       std::complex<float> **b, int64_t *ldb, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3779,12 +3733,11 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
-                           uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
-                           int64_t *n, std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, std::complex<double> **b, int64_t *ldb,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
+                       std::complex<double> *alpha, const std::complex<double> **a, int64_t *lda,
+                       std::complex<double> **b, int64_t *ldb, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsm_batch(
@@ -3795,10 +3748,10 @@ cl::sycl::event trsm_batch(backend_selector<backend::rocblas> selector, side *le
     return done;
 }
 
-cl::sycl::event dotu(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dotu(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                         result, dependencies);
@@ -3806,10 +3759,10 @@ cl::sycl::event dotu(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event dotu(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
-                     int64_t incy, std::complex<double> *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dotu(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies) {
     dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
                                                         result, dependencies);
@@ -3817,11 +3770,11 @@ cl::sycl::event dotu(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     int64_t m, int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 int64_t m, int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                 int64_t lda, const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3832,11 +3785,11 @@ cl::sycl::event hemm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                     int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hemm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 int64_t m, int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                 int64_t lda, const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3847,10 +3800,10 @@ cl::sycl::event hemm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *a,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, int64_t incx,
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *a,
+                 const std::vector<sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -3860,10 +3813,10 @@ cl::sycl::event hpr2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hpr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *a,
+                 const std::vector<sycl::event> &dependencies) {
     hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha,
@@ -3873,10 +3826,10 @@ cl::sycl::event hpr2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, int64_t kl, int64_t ku, float alpha, const float *a, int64_t lda,
-                     const float *x, int64_t incx, float beta, float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 int64_t kl, int64_t ku, float alpha, const float *a, int64_t lda, const float *x,
+                 int64_t incx, float beta, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -3887,10 +3840,10 @@ cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, int64_t kl, int64_t ku, double alpha, const double *a, int64_t lda,
-                     const double *x, int64_t incx, double beta, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 int64_t kl, int64_t ku, double alpha, const double *a, int64_t lda,
+                 const double *x, int64_t incx, double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -3901,11 +3854,11 @@ cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, int64_t kl, int64_t ku, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
-                     int64_t incx, std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 int64_t kl, int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
+                 int64_t lda, const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -3916,11 +3869,11 @@ cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m,
-                     int64_t n, int64_t kl, int64_t ku, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, const std::complex<double> *x,
-                     int64_t incx, std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose trans, int64_t m, int64_t n,
+                 int64_t kl, int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
+                 int64_t lda, const std::complex<double> *x, int64_t incx,
+                 std::complex<double> beta, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -3931,9 +3884,9 @@ cl::sycl::event gbmv(backend_selector<backend::rocblas> selector, transpose tran
     return done;
 }
 
-cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const float *a, int64_t lda, float *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const float *a, int64_t lda, float *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbmv(
@@ -3943,9 +3896,9 @@ cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const double *a, int64_t lda, double *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const double *a, int64_t lda, double *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbmv(
@@ -3955,10 +3908,10 @@ cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const std::complex<float> *a,
-                     int64_t lda, std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
+                 std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbmv(
@@ -3968,10 +3921,10 @@ cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const std::complex<double> *a,
-                     int64_t lda, std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
+                 std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbmv(
@@ -3981,10 +3934,10 @@ cl::sycl::event tbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     int64_t m, int64_t n, float alpha, const float *a, int64_t lda, const float *b,
-                     int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 int64_t m, int64_t n, float alpha, const float *a, int64_t lda, const float *b,
+                 int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -3995,10 +3948,10 @@ cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
-                     const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 int64_t m, int64_t n, double alpha, const double *a, int64_t lda, const double *b,
+                 int64_t ldb, double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4009,11 +3962,11 @@ cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     int64_t m, int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 int64_t m, int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                 int64_t lda, const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4024,11 +3977,11 @@ cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                     int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event symm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 int64_t m, int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                 int64_t lda, const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
                       beta, c, ldc, dependencies);
     auto done =
@@ -4039,10 +3992,10 @@ cl::sycl::event symm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event dotc(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dotc(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                         result, dependencies);
@@ -4050,10 +4003,10 @@ cl::sycl::event dotc(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event dotc(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
-                     int64_t incy, std::complex<double> *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dotc(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies) {
     dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
                                                         result, dependencies);
@@ -4061,9 +4014,9 @@ cl::sycl::event dotc(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    float alpha, const float *x, int64_t incx, float *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                float alpha, const float *x, int64_t incx, float *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, lda, dependencies);
@@ -4071,9 +4024,9 @@ cl::sycl::event syr(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                    double alpha, const double *x, int64_t incx, double *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                double alpha, const double *x, int64_t incx, double *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
                                                        x, incx, a, lda, dependencies);
@@ -4081,10 +4034,9 @@ cl::sycl::event syr(backend_selector<backend::rocblas> selector, uplo upper_lowe
     return done;
 }
 
-cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-                     const float *a, int64_t lda, float *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha, const float *a,
+                 int64_t lda, float *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4095,10 +4047,10 @@ cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-                     const double *a, int64_t lda, double *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
+                 const double *a, int64_t lda, double *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4109,11 +4061,10 @@ cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4124,11 +4075,10 @@ cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
-                     transpose trans, diag unit_diag, int64_t m, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trmm(backend_selector<backend::rocblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
                       a, lda, b, ldb, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trmm(selector.get_queue(), left_right,
@@ -4139,8 +4089,8 @@ cl::sycl::event trmm(backend_selector<backend::rocblas> selector, side left_righ
     return done;
 }
 
-cl::sycl::event rotmg(backend_selector<backend::rocblas> selector, float *d1, float *d2, float *x1,
-                      float y1, float *param, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotmg(backend_selector<backend::rocblas> selector, float *d1, float *d2, float *x1,
+                  float y1, float *param, const std::vector<sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1,
                                                          param, dependencies);
@@ -4148,9 +4098,8 @@ cl::sycl::event rotmg(backend_selector<backend::rocblas> selector, float *d1, fl
     return done;
 }
 
-cl::sycl::event rotmg(backend_selector<backend::rocblas> selector, double *d1, double *d2,
-                      double *x1, double y1, double *param,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotmg(backend_selector<backend::rocblas> selector, double *d1, double *d2, double *x1,
+                  double y1, double *param, const std::vector<sycl::event> &dependencies) {
     rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1,
                                                          param, dependencies);
@@ -4158,9 +4107,9 @@ cl::sycl::event rotmg(backend_selector<backend::rocblas> selector, double *d1, d
     return done;
 }
 
-cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const float *a, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const float *a, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4170,9 +4119,9 @@ cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const double *a, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const double *a, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4182,10 +4131,9 @@ cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<float> *a,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<float> *a, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4195,10 +4143,9 @@ cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<double> *a,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<double> *a, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
@@ -4208,9 +4155,9 @@ cl::sycl::event tpsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsv(
@@ -4220,9 +4167,9 @@ cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const double *a, int64_t lda, double *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsv(
@@ -4232,10 +4179,10 @@ cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<float> *a, int64_t lda,
+                 std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsv(
@@ -4245,10 +4192,10 @@ cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, const std::complex<double> *a, int64_t lda,
+                 std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::trsv(
@@ -4258,9 +4205,9 @@ cl::sycl::event trsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                     int64_t incx, float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                 int64_t incx, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -4268,9 +4215,9 @@ cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n, con
     return done;
 }
 
-cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
-                     int64_t incx, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
+                 int64_t incx, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -4278,9 +4225,9 @@ cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n, con
     return done;
 }
 
-cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -4288,9 +4235,9 @@ cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
                                                         dependencies);
@@ -4298,9 +4245,9 @@ cl::sycl::event copy(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n, const float **x,
-                           int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n, const float **x,
+                       int64_t *incx, float **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4310,10 +4257,9 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
-                           const double **x, int64_t *incx, double **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n, const double **x,
+                       int64_t *incx, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4323,10 +4269,10 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4336,10 +4282,10 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t *n,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4349,9 +4295,9 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                           int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                       int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4361,9 +4307,9 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
-                           int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
+                       int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4373,10 +4319,10 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                           const std::complex<float> *x, int64_t incx, int64_t stridex,
-                           std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
+                       const std::complex<float> *x, int64_t incx, int64_t stridex,
+                       std::complex<float> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4386,10 +4332,10 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
-                           const std::complex<double> *x, int64_t incx, int64_t stridex,
-                           std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t n,
+                       const std::complex<double> *x, int64_t incx, int64_t stridex,
+                       std::complex<double> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
                             dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::copy_batch(
@@ -4399,11 +4345,11 @@ cl::sycl::event copy_batch(backend_selector<backend::rocblas> selector, int64_t 
     return done;
 }
 
-cl::sycl::event hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hemv(
@@ -4413,11 +4359,11 @@ cl::sycl::event hemv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event hemv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::hemv(
@@ -4427,10 +4373,10 @@ cl::sycl::event hemv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose transa, transpose transb, int64_t n, int64_t k, float alpha,
-                      const float *a, int64_t lda, const float *b, int64_t ldb, float beta,
-                      float *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
+                  const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4441,10 +4387,10 @@ cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose transa, transpose transb, int64_t n, int64_t k, double alpha,
-                      const double *a, int64_t lda, const double *b, int64_t ldb, double beta,
-                      double *c, int64_t ldc, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, int64_t n, int64_t k, double alpha, const double *a,
+                  int64_t lda, const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4455,12 +4401,11 @@ cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose transa, transpose transb, int64_t n, int64_t k,
-                      std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                      const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
-                      std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, int64_t n, int64_t k, std::complex<float> alpha,
+                  const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
+                  int64_t ldb, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4471,12 +4416,11 @@ cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose transa, transpose transb, int64_t n, int64_t k,
-                      std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                      const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
-                      std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, int64_t n, int64_t k, std::complex<double> alpha,
+                  const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
+                  int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
                        ldb, beta, c, ldc, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
@@ -4487,10 +4431,9 @@ cl::sycl::event gemmt(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     int64_t k, float alpha, const float *a, int64_t lda, const float *x,
-                     int64_t incx, float beta, float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 int64_t k, float alpha, const float *a, int64_t lda, const float *x, int64_t incx,
+                 float beta, float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4501,10 +4444,10 @@ cl::sycl::event sbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     int64_t k, double alpha, const double *a, int64_t lda, const double *x,
-                     int64_t incx, double beta, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event sbmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 int64_t k, double alpha, const double *a, int64_t lda, const double *x,
+                 int64_t incx, double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
                       incy, dependencies);
     auto done =
@@ -4515,9 +4458,9 @@ cl::sycl::event sbmv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<float> *x, int64_t incx, float *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<float> *x, int64_t incx, float *result,
+                 const std::vector<sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4525,9 +4468,9 @@ cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n,
-                     const std::complex<double> *x, int64_t incx, double *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n,
+                 const std::complex<double> *x, int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4535,9 +4478,8 @@ cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                     int64_t incx, float *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                 int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4545,9 +4487,8 @@ cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n, con
     return done;
 }
 
-cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
-                     int64_t incx, double *result,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
+                 int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
     asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
                                                         dependencies);
@@ -4555,9 +4496,9 @@ cl::sycl::event asum(backend_selector<backend::rocblas> selector, int64_t n, con
     return done;
 }
 
-cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const float *a, int64_t lda, float *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const float *a, int64_t lda, float *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbsv(
@@ -4567,9 +4508,9 @@ cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const double *a, int64_t lda, double *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const double *a, int64_t lda, double *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbsv(
@@ -4579,10 +4520,10 @@ cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const std::complex<float> *a,
-                     int64_t lda, std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
+                 std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbsv(
@@ -4592,10 +4533,10 @@ cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t n, int64_t k, const std::complex<double> *a,
-                     int64_t lda, std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
+                 std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::tbsv(
@@ -4605,9 +4546,9 @@ cl::sycl::event tbsv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     float alpha, const float *x, int64_t incx, const float *y, int64_t incy,
-                     float *a, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 float alpha, const float *x, int64_t incx, const float *y, int64_t incy, float *a,
+                 const std::vector<sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4617,9 +4558,9 @@ cl::sycl::event spr2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     double alpha, const double *x, int64_t incx, const double *y, int64_t incy,
-                     double *a, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 double alpha, const double *x, int64_t incx, const double *y, int64_t incy,
+                 double *a, const std::vector<sycl::event> &dependencies) {
     spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha,
@@ -4629,9 +4570,8 @@ cl::sycl::event spr2(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                  int64_t incx, int64_t *result, const std::vector<sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -4639,9 +4579,8 @@ cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, co
     return done;
 }
 
-cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
+                  int64_t incx, int64_t *result, const std::vector<sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -4649,9 +4588,9 @@ cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, co
     return done;
 }
 
-cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
-                      const std::complex<float> *x, int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
+                  const std::complex<float> *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -4659,9 +4598,9 @@ cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
-                      const std::complex<double> *x, int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
+                  const std::complex<double> *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          dependencies);
@@ -4669,9 +4608,9 @@ cl::sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
     return done;
 }
 
-cl::sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, float *x, int64_t incx,
-                     float *y, int64_t incy, float *param,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, float *x, int64_t incx,
+                 float *y, int64_t incy, float *param,
+                 const std::vector<sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);
@@ -4679,9 +4618,9 @@ cl::sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, flo
     return done;
 }
 
-cl::sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, double *x,
-                     int64_t incx, double *y, int64_t incy, double *param,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, double *x, int64_t incx,
+                 double *y, int64_t incy, double *param,
+                 const std::vector<sycl::event> &dependencies) {
     rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
                                                         param, dependencies);
@@ -4689,8 +4628,8 @@ cl::sycl::event rotm(backend_selector<backend::rocblas> selector, int64_t n, dou
     return done;
 }
 
-cl::sycl::event rotg(backend_selector<backend::rocblas> selector, float *a, float *b, float *c,
-                     float *s, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotg(backend_selector<backend::rocblas> selector, float *a, float *b, float *c,
+                 float *s, const std::vector<sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4698,8 +4637,8 @@ cl::sycl::event rotg(backend_selector<backend::rocblas> selector, float *a, floa
     return done;
 }
 
-cl::sycl::event rotg(backend_selector<backend::rocblas> selector, double *a, double *b, double *c,
-                     double *s, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotg(backend_selector<backend::rocblas> selector, double *a, double *b, double *c,
+                 double *s, const std::vector<sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4707,9 +4646,9 @@ cl::sycl::event rotg(backend_selector<backend::rocblas> selector, double *a, dou
     return done;
 }
 
-cl::sycl::event rotg(backend_selector<backend::rocblas> selector, std::complex<float> *a,
-                     std::complex<float> *b, float *c, std::complex<float> *s,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotg(backend_selector<backend::rocblas> selector, std::complex<float> *a,
+                 std::complex<float> *b, float *c, std::complex<float> *s,
+                 const std::vector<sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4717,9 +4656,9 @@ cl::sycl::event rotg(backend_selector<backend::rocblas> selector, std::complex<f
     return done;
 }
 
-cl::sycl::event rotg(backend_selector<backend::rocblas> selector, std::complex<double> *a,
-                     std::complex<double> *b, double *c, std::complex<double> *s,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event rotg(backend_selector<backend::rocblas> selector, std::complex<double> *a,
+                 std::complex<double> *b, double *c, std::complex<double> *s,
+                 const std::vector<sycl::event> &dependencies) {
     rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
     auto done =
         oneapi::mkl::blas::rocblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
@@ -4727,9 +4666,9 @@ cl::sycl::event rotg(backend_selector<backend::rocblas> selector, std::complex<d
     return done;
 }
 
-cl::sycl::event sdsdot(backend_selector<backend::rocblas> selector, int64_t n, float sb,
-                       const float *x, int64_t incx, const float *y, int64_t incy, float *result,
-                       const std::vector<cl::sycl::event> &dependencies) {
+sycl::event sdsdot(backend_selector<backend::rocblas> selector, int64_t n, float sb, const float *x,
+                   int64_t incx, const float *y, int64_t incy, float *result,
+                   const std::vector<sycl::event> &dependencies) {
     sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y,
                                                           incy, result, dependencies);
@@ -4737,11 +4676,11 @@ cl::sycl::event sdsdot(backend_selector<backend::rocblas> selector, int64_t n, f
     return done;
 }
 
-cl::sycl::event her2k(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose trans, int64_t n, int64_t k, std::complex<float> alpha,
-                      const std::complex<float> *a, int64_t lda, const std::complex<float> *b,
-                      int64_t ldb, float beta, std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event her2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                  int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                  int64_t lda, const std::complex<float> *b, int64_t ldb, float beta,
+                  std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4752,11 +4691,11 @@ cl::sycl::event her2k(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event her2k(backend_selector<backend::rocblas> selector, uplo upper_lower,
-                      transpose trans, int64_t n, int64_t k, std::complex<double> alpha,
-                      const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                      int64_t ldb, double beta, std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event her2k(backend_selector<backend::rocblas> selector, uplo upper_lower, transpose trans,
+                  int64_t n, int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                  int64_t lda, const std::complex<double> *b, int64_t ldb, double beta,
+                  std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
                        c, ldc, dependencies);
     auto done =
@@ -4767,9 +4706,9 @@ cl::sycl::event her2k(backend_selector<backend::rocblas> selector, uplo upper_lo
     return done;
 }
 
-cl::sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                    int64_t incx, const float *y, int64_t incy, float *result,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                int64_t incx, const float *y, int64_t incy, float *result,
+                const std::vector<sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4777,9 +4716,9 @@ cl::sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, cons
     return done;
 }
 
-cl::sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
-                    int64_t incx, const double *y, int64_t incy, double *result,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, const double *x,
+                int64_t incx, const double *y, int64_t incy, double *result,
+                const std::vector<sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4787,9 +4726,9 @@ cl::sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, cons
     return done;
 }
 
-cl::sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
-                    int64_t incx, const float *y, int64_t incy, double *result,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, const float *x,
+                int64_t incx, const float *y, int64_t incy, double *result,
+                const std::vector<sycl::event> &dependencies) {
     dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
                                                        result, dependencies);
@@ -4797,10 +4736,9 @@ cl::sycl::event dot(backend_selector<backend::rocblas> selector, int64_t n, cons
     return done;
 }
 
-cl::sycl::event symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     float alpha, const float *a, int64_t lda, const float *x, int64_t incx,
-                     float beta, float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 float alpha, const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                 float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::symv(
@@ -4810,10 +4748,10 @@ cl::sycl::event symv(backend_selector<backend::rocblas> selector, uplo upper_low
     return done;
 }
 
-cl::sycl::event symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
-                     double alpha, const double *a, int64_t lda, const double *x, int64_t incx,
-                     double beta, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies) {
+sycl::event symv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
+                 double alpha, const double *a, int64_t lda, const double *x, int64_t incx,
+                 double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
                       dependencies);
     auto done = oneapi::mkl::blas::rocblas::MAJOR::symv(

--- a/include/oneapi/mkl/blas/detail/rocblas/onemkl_blas_rocblas.hxx
+++ b/include/oneapi/mkl/blas/detail/rocblas/onemkl_blas_rocblas.hxx
@@ -21,1889 +21,1788 @@
 
 // Buffer APIs
 
-void asum(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &result);
+void asum(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &result);
 
-void asum(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &result);
+void asum(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &result);
 
-void asum(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          cl::sycl::buffer<float, 1> &result);
+void asum(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &result);
 
-void asum(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          cl::sycl::buffer<double, 1> &result);
+void asum(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &result);
 
-void axpy(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy);
+void axpy(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &y, int64_t incy);
 
-void axpy(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy);
+void axpy(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &y, int64_t incy);
 
-void axpy(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+void axpy(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
 
-void axpy(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+void axpy(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<float, 1> &y, int64_t incy,
+void axpy_batch(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
+                int64_t batch_size);
+
+void axpy_batch(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<double, 1> &y, int64_t incy,
                 int64_t stridey, int64_t batch_size);
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<double, 1> &y, int64_t incy,
+void axpy_batch(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
+                int64_t batch_size);
+
+void axpy_batch(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
+                int64_t batch_size);
+
+void axpby(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+           float beta, sycl::buffer<float, 1> &y, int64_t incy);
+
+void axpby(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx,
+           double beta, sycl::buffer<double, 1> &y, int64_t incy);
+
+void axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+
+void axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+
+void copy(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &y, int64_t incy);
+
+void copy(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &y, int64_t incy);
+
+void copy(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+
+void copy(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
+                int64_t batch_size);
+
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey,
+                int64_t batch_size);
+
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<std::complex<float>, 1> &y,
+                int64_t incy, int64_t stridey, int64_t batch_size);
+
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<std::complex<double>, 1> &y,
+                int64_t incy, int64_t stridey, int64_t batch_size);
+
+void dot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+         sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &result);
+
+void dot(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+         sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &result);
+
+void dot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+         sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<double, 1> &result);
+
+void dotc(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result);
+
+void dotc(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result);
+
+void dotu(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result);
+
+void dotu(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result);
+
+void iamin(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void iamin(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void iamin(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void iamin(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void iamax(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void iamax(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void iamax(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void iamax(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result);
+
+void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &result);
+
+void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &result);
+
+void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &result);
+
+void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &result);
+
+void rot(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &y, int64_t incy, float c, float s);
+
+void rot(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &y, int64_t incy, double c, double s);
+
+void rot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+         sycl::buffer<float, 1> &y, int64_t incy, float c, float s);
+
+void rot(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+         sycl::buffer<double, 1> &y, int64_t incy, double c, double s);
+
+void rotg(sycl::queue &queue, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &b,
+          sycl::buffer<float, 1> &c, sycl::buffer<float, 1> &s);
+
+void rotg(sycl::queue &queue, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &b,
+          sycl::buffer<double, 1> &c, sycl::buffer<double, 1> &s);
+
+void rotg(sycl::queue &queue, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &b, sycl::buffer<float, 1> &c,
+          sycl::buffer<std::complex<float>, 1> &s);
+
+void rotg(sycl::queue &queue, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &b, sycl::buffer<double, 1> &c,
+          sycl::buffer<std::complex<double>, 1> &s);
+
+void rotm(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &param);
+
+void rotm(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &param);
+
+void rotmg(sycl::queue &queue, sycl::buffer<float, 1> &d1, sycl::buffer<float, 1> &d2,
+           sycl::buffer<float, 1> &x1, float y1, sycl::buffer<float, 1> &param);
+
+void rotmg(sycl::queue &queue, sycl::buffer<double, 1> &d1, sycl::buffer<double, 1> &d2,
+           sycl::buffer<double, 1> &x1, double y1, sycl::buffer<double, 1> &param);
+
+void scal(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx);
+
+void scal(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx);
+
+void scal(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
+
+void scal(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
+
+void scal(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<std::complex<float>, 1> &x,
+          int64_t incx);
+
+void scal(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<std::complex<double>, 1> &x,
+          int64_t incx);
+
+void sdsdot(sycl::queue &queue, int64_t n, float sb, sycl::buffer<float, 1> &x, int64_t incx,
+            sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &result);
+
+void swap(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &y, int64_t incy);
+
+void swap(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &y, int64_t incy);
+
+void swap(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+
+void swap(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+
+void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+          float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x,
+          int64_t incx, float beta, sycl::buffer<float, 1> &y, int64_t incy);
+
+void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+          double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x,
+          int64_t incx, double beta, sycl::buffer<double, 1> &y, int64_t incy);
+
+void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+
+void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+
+void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x, int64_t incx,
+          float beta, sycl::buffer<float, 1> &y, int64_t incy);
+
+void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x, int64_t incx,
+          double beta, sycl::buffer<double, 1> &y, int64_t incy);
+
+void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+
+void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+
+void gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stridex, float beta, sycl::buffer<float, 1> &y, int64_t incy,
                 int64_t stridey, int64_t batch_size);
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
-                int64_t batch_size);
+void gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex, double beta,
+                sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size);
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
-                int64_t batch_size);
-
-void axpby(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-           int64_t incx, float beta, cl::sycl::buffer<float, 1> &y, int64_t incy);
-
-void axpby(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-           int64_t incx, double beta, cl::sycl::buffer<double, 1> &y, int64_t incy);
-
-void axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-           cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-           cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
-
-void axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-           cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-           cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
-
-void copy(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          cl::sycl::buffer<float, 1> &y, int64_t incy);
-
-void copy(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          cl::sycl::buffer<double, 1> &y, int64_t incy);
-
-void copy(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
-
-void copy(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
-
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-                int64_t stridex, cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
-                int64_t batch_size);
-
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-                int64_t stridex, cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey,
-                int64_t batch_size);
-
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<std::complex<float>, 1> &y,
+void gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+                int64_t stridea, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+                int64_t stridex, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &y,
                 int64_t incy, int64_t stridey, int64_t batch_size);
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<std::complex<double>, 1> &y,
-                int64_t incy, int64_t stridey, int64_t batch_size);
-
-void dot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-         cl::sycl::buffer<float, 1> &y, int64_t incy, cl::sycl::buffer<float, 1> &result);
-
-void dot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-         cl::sycl::buffer<double, 1> &y, int64_t incy, cl::sycl::buffer<double, 1> &result);
-
-void dot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-         cl::sycl::buffer<float, 1> &y, int64_t incy, cl::sycl::buffer<double, 1> &result);
-
-void dotc(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &result);
-
-void dotc(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &result);
-
-void dotu(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &result);
-
-void dotu(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &result);
-
-void iamin(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result);
-
-void iamin(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result);
-
-void iamin(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result);
-
-void iamin(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result);
-
-void iamax(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result);
-
-void iamax(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-           cl::sycl::buffer<int64_t, 1> &result);
-
-void iamax(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result);
-
-void iamax(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-           int64_t incx, cl::sycl::buffer<int64_t, 1> &result);
-
-void nrm2(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, cl::sycl::buffer<float, 1> &result);
-
-void nrm2(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, cl::sycl::buffer<double, 1> &result);
-
-void nrm2(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          cl::sycl::buffer<float, 1> &result);
-
-void nrm2(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          cl::sycl::buffer<double, 1> &result);
-
-void rot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-         int64_t incx, cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, float c, float s);
-
-void rot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-         int64_t incx, cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, double c,
-         double s);
-
-void rot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-         cl::sycl::buffer<float, 1> &y, int64_t incy, float c, float s);
-
-void rot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-         cl::sycl::buffer<double, 1> &y, int64_t incy, double c, double s);
-
-void rotg(cl::sycl::queue &queue, cl::sycl::buffer<float, 1> &a, cl::sycl::buffer<float, 1> &b,
-          cl::sycl::buffer<float, 1> &c, cl::sycl::buffer<float, 1> &s);
-
-void rotg(cl::sycl::queue &queue, cl::sycl::buffer<double, 1> &a, cl::sycl::buffer<double, 1> &b,
-          cl::sycl::buffer<double, 1> &c, cl::sycl::buffer<double, 1> &s);
-
-void rotg(cl::sycl::queue &queue, cl::sycl::buffer<std::complex<float>, 1> &a,
-          cl::sycl::buffer<std::complex<float>, 1> &b, cl::sycl::buffer<float, 1> &c,
-          cl::sycl::buffer<std::complex<float>, 1> &s);
-
-void rotg(cl::sycl::queue &queue, cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &b, cl::sycl::buffer<double, 1> &c,
-          cl::sycl::buffer<std::complex<double>, 1> &s);
-
-void rotm(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          cl::sycl::buffer<float, 1> &y, int64_t incy, cl::sycl::buffer<float, 1> &param);
-
-void rotm(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          cl::sycl::buffer<double, 1> &y, int64_t incy, cl::sycl::buffer<double, 1> &param);
-
-void rotmg(cl::sycl::queue &queue, cl::sycl::buffer<float, 1> &d1, cl::sycl::buffer<float, 1> &d2,
-           cl::sycl::buffer<float, 1> &x1, float y1, cl::sycl::buffer<float, 1> &param);
-
-void rotmg(cl::sycl::queue &queue, cl::sycl::buffer<double, 1> &d1, cl::sycl::buffer<double, 1> &d2,
-           cl::sycl::buffer<double, 1> &x1, double y1, cl::sycl::buffer<double, 1> &param);
-
-void scal(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-          int64_t incx);
-
-void scal(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-          int64_t incx);
-
-void scal(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
-
-void scal(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
-
-void scal(cl::sycl::queue &queue, int64_t n, float alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
-
-void scal(cl::sycl::queue &queue, int64_t n, double alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
-
-void sdsdot(cl::sycl::queue &queue, int64_t n, float sb, cl::sycl::buffer<float, 1> &x,
-            int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-            cl::sycl::buffer<float, 1> &result);
-
-void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          cl::sycl::buffer<float, 1> &y, int64_t incy);
-
-void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          cl::sycl::buffer<double, 1> &y, int64_t incy);
-
-void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
-
-void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
-
-void gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
-          float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x,
-          int64_t incx, float beta, cl::sycl::buffer<float, 1> &y, int64_t incy);
-
-void gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
-          double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x,
-          int64_t incx, double beta, cl::sycl::buffer<double, 1> &y, int64_t incy);
-
-void gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
-
-void gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
-
-void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          float beta, cl::sycl::buffer<float, 1> &y, int64_t incy);
-
-void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          double beta, cl::sycl::buffer<double, 1> &y, int64_t incy);
-
-void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
-
-void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
-
-void gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex, float beta,
-                cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size);
-
-void gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex, double beta,
-                cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey, int64_t batch_size);
-
-void gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-                int64_t stridea, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-                int64_t stridex, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
+void gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+                int64_t stridea, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+                int64_t stridex, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size);
 
-void gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stridea, cl::sycl::buffer<std::complex<double>, 1> &x,
-                int64_t incx, int64_t stridex, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<float, 1> &c, int64_t ldc,
+                int64_t stridec, int64_t batch_size);
+
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<double, 1> &c, int64_t ldc, int64_t stridec, int64_t batch_size);
+
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stridec,
                 int64_t batch_size);
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stridec, int64_t batch_size);
-
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stridec, int64_t batch_size);
-
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stridec,
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stridea,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stridec,
                 int64_t batch_size);
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stridea,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stridec,
-                int64_t batch_size);
-
-void ger(cl::sycl::queue &queue, int64_t m, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-         int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy, cl::sycl::buffer<float, 1> &a,
+void ger(sycl::queue &queue, int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &a,
          int64_t lda);
 
-void ger(cl::sycl::queue &queue, int64_t m, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-         int64_t incx, cl::sycl::buffer<double, 1> &y, int64_t incy, cl::sycl::buffer<double, 1> &a,
+void ger(sycl::queue &queue, int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+         int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &a,
          int64_t lda);
 
-void gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
+void gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
 
-void gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
+void gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
 
-void geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
+void geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
 
-void geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
+void geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
 
-void hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
 
-void hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
 
-void hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
+void hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy);
 
-void hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+void hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
 
-void her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
+void her(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
+         sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
 
-void her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
+void her(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
+         sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
 
-void her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
+void her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda);
 
-void her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
+void her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda);
 
-void hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, cl::sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &y,
+void hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, sycl::buffer<std::complex<float>, 1> &x,
+          int64_t incx, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &y,
           int64_t incy);
 
-void hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy);
+void hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, sycl::buffer<std::complex<double>, 1> &x,
+          int64_t incx, std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &y,
+          int64_t incy);
 
-void hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<float>, 1> &a);
+void hpr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
+         sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a);
 
-void hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-         cl::sycl::buffer<std::complex<double>, 1> &a);
+void hpr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
+         sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a);
 
-void hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<float>, 1> &a);
+void hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a);
 
-void hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
-          cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
-          cl::sycl::buffer<std::complex<double>, 1> &a);
+void hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a);
 
-void sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          float beta, cl::sycl::buffer<float, 1> &y, int64_t incy);
+void sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x, int64_t incx,
+          float beta, sycl::buffer<float, 1> &y, int64_t incy);
 
-void sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          double beta, cl::sycl::buffer<double, 1> &y, int64_t incy);
+void sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x, int64_t incx,
+          double beta, sycl::buffer<double, 1> &y, int64_t incy);
 
-void spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &a, cl::sycl::buffer<float, 1> &x, int64_t incx, float beta,
-          cl::sycl::buffer<float, 1> &y, int64_t incy);
+void spmv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &a,
+          sycl::buffer<float, 1> &x, int64_t incx, float beta, sycl::buffer<float, 1> &y,
+          int64_t incy);
 
-void spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &a, cl::sycl::buffer<double, 1> &x, int64_t incx, double beta,
-          cl::sycl::buffer<double, 1> &y, int64_t incy);
+void spmv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &a,
+          sycl::buffer<double, 1> &x, int64_t incx, double beta, sycl::buffer<double, 1> &y,
+          int64_t incy);
 
-void spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &a);
+void spr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &a);
 
-void spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &a);
+void spr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+         int64_t incx, sycl::buffer<double, 1> &a);
 
-void spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-          cl::sycl::buffer<float, 1> &a);
+void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &a);
 
-void spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &y,
-          int64_t incy, cl::sycl::buffer<double, 1> &a);
+void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &a);
 
-void symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x, int64_t incx,
-          float beta, cl::sycl::buffer<float, 1> &y, int64_t incy);
+void symv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &a,
+          int64_t lda, sycl::buffer<float, 1> &x, int64_t incx, float beta,
+          sycl::buffer<float, 1> &y, int64_t incy);
 
-void symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x, int64_t incx,
-          double beta, cl::sycl::buffer<double, 1> &y, int64_t incy);
+void symv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &a,
+          int64_t lda, sycl::buffer<double, 1> &x, int64_t incx, double beta,
+          sycl::buffer<double, 1> &y, int64_t incy);
 
-void syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-         cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &a, int64_t lda);
+void syr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &a, int64_t lda);
 
-void syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-         cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &a, int64_t lda);
+void syr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+         int64_t incx, sycl::buffer<double, 1> &a, int64_t lda);
 
-void syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          cl::sycl::buffer<float, 1> &x, int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-          cl::sycl::buffer<float, 1> &a, int64_t lda);
+void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &a,
+          int64_t lda);
 
-void syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          cl::sycl::buffer<double, 1> &x, int64_t incx, cl::sycl::buffer<double, 1> &y,
-          int64_t incy, cl::sycl::buffer<double, 1> &a, int64_t lda);
+void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &a,
+          int64_t lda);
 
-void tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x,
+void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x,
           int64_t incx);
 
-void tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x,
+void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x,
           int64_t incx);
 
-void tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
+void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
 
-void tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
+void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
 
-void tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x,
+void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x,
           int64_t incx);
 
-void tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x,
+void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x,
           int64_t incx);
 
-void tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
+void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
 
-void tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          int64_t k, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
+void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          int64_t k, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
 
-void tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<float, 1> &a, cl::sycl::buffer<float, 1> &x, int64_t incx);
+void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x, int64_t incx);
 
-void tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<double, 1> &a, cl::sycl::buffer<double, 1> &x, int64_t incx);
+void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x, int64_t incx);
 
-void tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &a, cl::sycl::buffer<std::complex<float>, 1> &x,
+void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<float>, 1> &a, sycl::buffer<std::complex<float>, 1> &x,
           int64_t incx);
 
-void tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
-
-void tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<float, 1> &a, cl::sycl::buffer<float, 1> &x, int64_t incx);
-
-void tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<double, 1> &a, cl::sycl::buffer<double, 1> &x, int64_t incx);
-
-void tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &a, cl::sycl::buffer<std::complex<float>, 1> &x,
+void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<double>, 1> &a, sycl::buffer<std::complex<double>, 1> &x,
           int64_t incx);
 
-void tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &a,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
+void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x, int64_t incx);
 
-void trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x, int64_t incx);
+void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x, int64_t incx);
 
-void trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x,
+void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<float>, 1> &a, sycl::buffer<std::complex<float>, 1> &x,
           int64_t incx);
 
-void trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
-
-void trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
-
-void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &x, int64_t incx);
-
-void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &x,
+void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<double>, 1> &a, sycl::buffer<std::complex<double>, 1> &x,
           int64_t incx);
 
-void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
+void trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x, int64_t incx);
 
-void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
+void trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x, int64_t incx);
 
-void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-          cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+void trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
+
+void trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
+
+void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x, int64_t incx);
+
+void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x, int64_t incx);
+
+void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, int64_t incx);
+
+void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, int64_t incx);
+
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b,
+          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc);
+
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b,
+          int64_t ldb, double beta, sycl::buffer<double, 1> &c, int64_t ldc);
+
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          sycl::half alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda,
+          sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
+          sycl::buffer<sycl::half, 1> &c, int64_t ldc);
+
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          float alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda, sycl::buffer<sycl::half, 1> &b,
+          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc);
+
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          float alpha, sycl::buffer<bfloat16, 1> &a, int64_t lda, sycl::buffer<bfloat16, 1> &b,
+          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc);
+
+void hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+
+void hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+
+void herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, float alpha,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda, float beta,
+          sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+
+void herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, double alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda, double beta,
+          sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+
+void her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, float beta,
+           sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+
+void her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, double beta,
+           sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+
+void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n, float alpha,
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb,
+          float beta, sycl::buffer<float, 1> &c, int64_t ldc);
+
+void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n, double alpha,
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b, int64_t ldb,
+          double beta, sycl::buffer<double, 1> &c, int64_t ldc);
+
+void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+
+void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+
+void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, float alpha,
+          sycl::buffer<float, 1> &a, int64_t lda, float beta, sycl::buffer<float, 1> &c,
           int64_t ldc);
 
-void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-          cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c,
+void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, double alpha,
+          sycl::buffer<double, 1> &a, int64_t lda, double beta, sycl::buffer<double, 1> &c,
           int64_t ldc);
 
-void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
-          std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
 
-void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-          int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
-          std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
 
-void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
-          cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
-          cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc);
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                float alpha, sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, float beta,
+                sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size);
 
-void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
-          cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, float beta,
-          cl::sycl::buffer<float, 1> &c, int64_t ldc);
-
-void gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, cl::sycl::buffer<bfloat16, 1> &a, int64_t lda,
-          cl::sycl::buffer<bfloat16, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
-          int64_t ldc);
-
-void hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
-
-void hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
-
-void herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          float alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, float beta,
-          cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
-
-void herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          double alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, double beta,
-          cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
-
-void her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, float beta,
-           cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
-
-void her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, double beta,
-           cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
-
-void symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &b,
-          int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
-
-void symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, cl::sycl::buffer<double, 1> &b,
-          int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c, int64_t ldc);
-
-void symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
-          cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
-
-void symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
-          cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
-
-void syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, float beta,
-          cl::sycl::buffer<float, 1> &c, int64_t ldc);
-
-void syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, double beta,
-          cl::sycl::buffer<double, 1> &c, int64_t ldc);
-
-void syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
-
-void syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
-
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c,
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                double alpha, sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                double beta, sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size);
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                double beta, cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c,
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+                int64_t stride_a, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c,
+                int64_t ldc, int64_t stride_c, int64_t batch_size);
+
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+                int64_t stride_a, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size);
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-                int64_t stride_a, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size);
+void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, float alpha,
+           sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb,
+           float beta, sycl::buffer<float, 1> &c, int64_t ldc);
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stride_a, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size);
+void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+           double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b,
+           int64_t ldb, double beta, sycl::buffer<double, 1> &c, int64_t ldc);
 
-void syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, cl::sycl::buffer<float, 1> &b,
-           int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc);
+void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
 
-void syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-           cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c,
-           int64_t ldc);
+void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
 
-void syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
-           cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &b, int64_t ldb);
 
-void syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-           cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
-           cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &b, int64_t ldb);
 
-void trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, float alpha, cl::sycl::buffer<float, 1> &a,
-          int64_t lda, cl::sycl::buffer<float, 1> &b, int64_t ldb);
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb);
 
-void trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, double alpha, cl::sycl::buffer<double, 1> &a,
-          int64_t lda, cl::sycl::buffer<double, 1> &b, int64_t ldb);
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb);
 
-void trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb);
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &b, int64_t ldb);
 
-void trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb);
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &b, int64_t ldb);
 
-void trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, float alpha, cl::sycl::buffer<float, 1> &a,
-          int64_t lda, cl::sycl::buffer<float, 1> &b, int64_t ldb);
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb);
 
-void trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, double alpha, cl::sycl::buffer<double, 1> &a,
-          int64_t lda, cl::sycl::buffer<double, 1> &b, int64_t ldb);
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans, diag unit_diag,
+          int64_t m, int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb);
 
-void trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-          cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb);
+void gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<float, 1> &b, int64_t ldb, int64_t stride_b, float beta,
+                sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size);
 
-void trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-          diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-          cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
-          cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb);
+void gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<double, 1> &b, int64_t ldb, int64_t stride_b, double beta,
+                sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size);
 
-void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-                int64_t stride_a, cl::sycl::buffer<float, 1> &b, int64_t ldb, int64_t stride_b,
-                float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size);
+void gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
+                int64_t stride_b, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c,
+                int64_t ldc, int64_t stride_c, int64_t batch_size);
 
-void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-                int64_t stride_a, cl::sycl::buffer<double, 1> &b, int64_t ldb, int64_t stride_b,
-                double beta, cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size);
-
-void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<std::complex<float>, 1> &b,
-                int64_t ldb, int64_t stride_b, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size);
-
-void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<std::complex<double>, 1> &b,
+void gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                int64_t k, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<std::complex<double>, 1> &b,
                 int64_t ldb, int64_t stride_b, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size);
 
-void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-                int64_t k, sycl::half alpha, cl::sycl::buffer<sycl::half, 1> &a, int64_t lda,
-                int64_t stride_a, cl::sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b,
-                sycl::half beta, cl::sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c,
+void gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                int64_t k, sycl::half alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda,
+                int64_t stride_a, sycl::buffer<sycl::half, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::half beta, sycl::buffer<sycl::half, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size);
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                diag unit_diag, int64_t m, int64_t n, float alpha, cl::sycl::buffer<float, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<float, 1> &b, int64_t ldb,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                diag unit_diag, int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &b, int64_t ldb,
                 int64_t stride_b, int64_t batch_size);
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                diag unit_diag, int64_t m, int64_t n, double alpha, cl::sycl::buffer<double, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<double, 1> &b, int64_t ldb,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                diag unit_diag, int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<double, 1> &b, int64_t ldb,
                 int64_t stride_b, int64_t batch_size);
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                 diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size);
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                 diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size);
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-           cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+           sycl::buffer<float, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
            int64_t ldc);
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-           cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c,
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+           sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
            int64_t ldc);
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-           int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
-           std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
+           std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc);
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-           int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
-           std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
+           std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc);
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<int8_t, 1> &a,
-               int64_t lda, int8_t ao, cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co);
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<int8_t, 1> &a, int64_t lda,
+               int8_t ao, sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co);
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<int8_t, 1> &a,
-               int64_t lda, int8_t ao, cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co);
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<int8_t, 1> &a, int64_t lda,
+               int8_t ao, sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co);
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<uint8_t, 1> &a,
-               int64_t lda, uint8_t ao, cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co);
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<uint8_t, 1> &a, int64_t lda,
+               uint8_t ao, sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co);
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<uint8_t, 1> &a,
-               int64_t lda, uint8_t ao, cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co);
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<uint8_t, 1> &a, int64_t lda,
+               uint8_t ao, sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co);
 
 // USM APIs
 
-cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
-                           int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
-                           int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
-                           int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
-                           int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                           const std::complex<float> *x, int64_t incx, int64_t stridex,
-                           std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                           const std::complex<double> *x, int64_t incx, int64_t stridex,
-                           std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                      const float beta, float *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
-                      int64_t incx, const double beta, double *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                      const std::complex<float> *x, int64_t incx, const std::complex<float> beta,
-                      std::complex<float> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                      const std::complex<double> *x, int64_t incx, const std::complex<double> beta,
-                      std::complex<double> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
-                           float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event asum(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                 float *result, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
-                           double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event asum(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                 double *result, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event asum(sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
-                           int64_t *incx, std::complex<float> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event asum(sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
-                           int64_t *incx, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                           int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event axpy(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event axpy(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, float *alpha, const float **x, int64_t *incx,
+                       float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                           int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, double *alpha, const double **x,
+                       int64_t *incx, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
-                           int64_t incx, int64_t stridex, std::complex<float> *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
-                           int64_t incx, int64_t stridex, std::complex<double> *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, float *result,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
+                       int64_t stridex, float *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                    const double *y, int64_t incy, double *result,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                       int64_t stridex, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, double *result,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *x, int64_t incx, int64_t stridex,
+                       std::complex<float> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *x, int64_t incx, int64_t stridex,
+                       std::complex<double> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event dotc(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpby(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
+                  const float beta, float *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpby(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                  const double beta, double *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event dotu(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                  const std::complex<float> *x, int64_t incx, const std::complex<float> beta,
+                  std::complex<float> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                  const std::complex<double> *x, int64_t incx, const std::complex<double> beta,
+                  std::complex<double> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy(sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy(sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const float **x, int64_t *incx, float **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const double **x, int64_t *incx, double **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const std::complex<float> **x, int64_t *incx,
+                       std::complex<float> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const std::complex<double> **x,
+                       int64_t *incx, std::complex<double> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const float *x, int64_t incx, int64_t stridex,
+                       float *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
+                       int64_t stridex, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                       int64_t stridex, std::complex<float> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
-                    std::complex<float> *y, int64_t incy, float c, float s,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                       int64_t stridex, std::complex<double> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
-                    std::complex<double> *y, int64_t incy, double c, double s,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
+                int64_t incy, float *result, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                    int64_t incy, float c, float s,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event dot(sycl::queue &queue, int64_t n, const double *x, int64_t incx, const double *y,
+                int64_t incy, double *result, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                    int64_t incy, double c, double s,
-                    const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
+                int64_t incy, double *result, const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rotg(cl::sycl::queue &queue, float *a, float *b, float *c, float *s,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event dotc(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rotg(cl::sycl::queue &queue, double *a, double *b, double *c, double *s,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event dotc(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<float> *a, std::complex<float> *b,
-                     float *c, std::complex<float> *s,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event dotu(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rotg(cl::sycl::queue &queue, std::complex<double> *a, std::complex<double> *b,
-                     double *c, std::complex<double> *s,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event dotu(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, float *param,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event iamin(sycl::queue &queue, int64_t n, const float *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                     int64_t incy, double *param,
-                     const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event iamin(sycl::queue &queue, int64_t n, const double *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies = {});
 
-cl::sycl::event rotmg(cl::sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                      float *param, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event rotmg(cl::sycl::queue &queue, double *d1, double *d2, double *x1, double y1,
-                      double *param, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, float alpha, std::complex<float> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, double alpha, std::complex<double> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
-                       const float *y, int64_t incy, float *result,
-                       const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, float alpha, const float *a, int64_t lda, const float *x,
-                     int64_t incx, float beta, float *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, double alpha, const double *a, int64_t lda, const double *x,
-                     int64_t incx, double beta, double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *x, int64_t incx,
-                     std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
-                     const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
-                     const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                           float alpha, const float *a, int64_t lda, int64_t stridea,
-                           const float *x, int64_t incx, int64_t stridex, float beta, float *y,
-                           int64_t incy, int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                           double alpha, const double *a, int64_t lda, int64_t stridea,
-                           const double *x, int64_t incx, int64_t stridex, double beta, double *y,
-                           int64_t incy, int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stridea, const std::complex<float> *x, int64_t incx,
-                           int64_t stridex, std::complex<float> beta, std::complex<float> *y,
-                           int64_t incy, int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stridea, const std::complex<double> *x, int64_t incx,
-                           int64_t stridex, std::complex<double> beta, std::complex<double> *y,
-                           int64_t incy, int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n,
-                           float *alpha, const float **a, int64_t *lda, const float **x,
-                           int64_t *incx, float *beta, float **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n,
-                           double *alpha, const double **a, int64_t *lda, const double **x,
-                           int64_t *incx, double *beta, double **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n,
-                           std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
-                           std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n,
-                           std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, const std::complex<double> **x, int64_t *incx,
-                           std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const float *a, int64_t lda, int64_t stridea, const float *x,
-                           int64_t incx, int64_t stridex, float *c, int64_t ldc, int64_t stridec,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const double *a, int64_t lda, int64_t stridea, const double *x,
-                           int64_t incx, int64_t stridex, double *c, int64_t ldc, int64_t stridec,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const std::complex<float> *a, int64_t lda, int64_t stridea,
-                           const std::complex<float> *x, int64_t incx, int64_t stridex,
-                           std::complex<float> *c, int64_t ldc, int64_t stridec, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const std::complex<double> *a, int64_t lda, int64_t stridea,
-                           const std::complex<double> *x, int64_t incx, int64_t stridex,
-                           std::complex<double> *c, int64_t ldc, int64_t stridec,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
-                           int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const double **a, int64_t *lda, const double **x, int64_t *incx,
-                           double **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const std::complex<double> **a, int64_t *lda,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, float alpha, const float *x,
-                    int64_t incx, const float *y, int64_t incy, float *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event ger(cl::sycl::queue &queue, int64_t m, int64_t n, double alpha, const double *x,
-                    int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *a, int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gerc(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
-                     int64_t incy, std::complex<double> *a, int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *a, int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event geru(cl::sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
-                     int64_t incy, std::complex<double> *a, int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
-                     std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
-                     int64_t incx, std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const std::complex<float> *x, int64_t incx, std::complex<float> *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const std::complex<double> *x, int64_t incx, std::complex<double> *a,
-                    int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *a, int64_t lda,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *a, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const std::complex<float> *x, int64_t incx, std::complex<float> *a,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const std::complex<double> *x, int64_t incx, std::complex<double> *a,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *a,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
-                     const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
-                     const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *a, const float *x, int64_t incx, float beta, float *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *a, const double *x, int64_t incx, double beta, double *y,
-                     int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const float *x, int64_t incx, float *a,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const double *x, int64_t incx, double *a,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *x, int64_t incx, const float *y, int64_t incy, float *a,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *x, int64_t incx, const double *y, int64_t incy, double *a,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const float *x, int64_t incx, float *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const double *x, int64_t incx, double *a, int64_t lda,
-                    const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *x, int64_t incx, const float *y, int64_t incy, float *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *x, int64_t incx, const double *y, int64_t incy, double *a,
-                     int64_t lda, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const float *a, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const double *a, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<float> *a, std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<double> *a, std::complex<double> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const float *a, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const double *a, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<float> *a, std::complex<float> *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<double> *a, std::complex<double> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const double *a, int64_t lda, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const double *a, int64_t lda, double *x, int64_t incx,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                     int64_t incx, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
-                     int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
-                     const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                     int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
-                     const sycl::half *b, int64_t ldb, sycl::half beta, sycl::half *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const sycl::half *a, int64_t lda,
-                     const sycl::half *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const bfloat16 *a, int64_t lda,
-                     const bfloat16 *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event hemm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *b, int64_t ldb,
-                     std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, float alpha, const std::complex<float> *a, int64_t lda, float beta,
-                     std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event herk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, double alpha, const std::complex<double> *a, int64_t lda,
-                     double beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                      int64_t lda, const std::complex<float> *b, int64_t ldb, float beta,
-                      std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event her2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                      int64_t lda, const std::complex<double> *b, int64_t ldb, double beta,
-                      std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, float alpha, const float *a, int64_t lda, const float *b,
-                     int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, double alpha, const double *a, int64_t lda, const double *b,
-                     int64_t ldb, double beta, double *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event symm(cl::sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *b, int64_t ldb,
-                     std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, float alpha, const float *a, int64_t lda, float beta, float *c,
-                     int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, double alpha, const double *a, int64_t lda, double beta, double *c,
-                     int64_t ldc, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
-                           float **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
-                           double **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
-                           int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
-                           float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
-                           double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                           int64_t lda, int64_t stride_a, std::complex<float> beta,
-                           std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                           int64_t lda, int64_t stride_a, std::complex<double> beta,
-                           std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, float alpha, const float *a, int64_t lda, const float *b,
-                      int64_t ldb, float beta, float *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, double alpha, const double *a, int64_t lda, const double *b,
-                      int64_t ldb, double beta, double *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                      int64_t lda, const std::complex<float> *b, int64_t ldb,
-                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event syr2k(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                      int64_t lda, const std::complex<double> *b, int64_t ldb,
-                      std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
-                     int64_t lda, double *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trmm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
-                     int64_t lda, double *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-                           const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
-                           int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-                           const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
-                           int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-                           transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, float *alpha,
-                           const float **a, int64_t *lda, float **b, int64_t *ldb,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-                           transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, double *alpha,
-                           const double **a, int64_t *lda, double **b, int64_t *ldb,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-                           transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
-                           std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
-                           std::complex<float> **b, int64_t *ldb, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,
-                           transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,
-                           std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, std::complex<double> **b, int64_t *ldb,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, float *alpha, const float **a, int64_t *lda,
-                           const float **b, int64_t *ldb, float *beta, float **c, int64_t *ldc,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, double *alpha, const double **a, int64_t *lda,
-                           const double **b, int64_t *ldb, double *beta, double **c, int64_t *ldc,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, std::complex<float> *alpha,
-                           const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **b, int64_t *ldb, std::complex<float> *beta,
-                           std::complex<float> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, std::complex<double> *alpha,
-                           const std::complex<double> **a, int64_t *lda,
-                           const std::complex<double> **b, int64_t *ldb, std::complex<double> *beta,
-                           std::complex<double> **c, int64_t *ldc, int64_t group_count,
-                           int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
-                           int64_t *n, int64_t *k, sycl::half *alpha, const sycl::half **a,
-                           int64_t *lda, const sycl::half **b, int64_t *ldb, sycl::half *beta,
-                           sycl::half **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
-                           int64_t stride_a, const float *b, int64_t ldb, int64_t stride_b,
-                           float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
-                           int64_t stride_a, const double *b, int64_t ldb, int64_t stride_b,
-                           double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, std::complex<float> alpha,
-                           const std::complex<float> *a, int64_t lda, int64_t stride_a,
-                           const std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, std::complex<double> alpha,
-                           const std::complex<double> *a, int64_t lda, int64_t stride_a,
-                           const std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                           int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                           int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
-                           int64_t stride_a, const sycl::half *b, int64_t ldb, int64_t stride_b,
-                           sycl::half beta, sycl::half *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
-                      const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
-                      const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                      int64_t lda, const std::complex<float> *b, int64_t ldb,
-                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, std::complex<double> alpha,
-                      const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                      int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const std::int8_t *a, int64_t lda, std::int8_t ao, const std::uint8_t *b,
-                          int64_t ldb, std::uint8_t bo, float beta, std::int32_t *c, int64_t ldc,
-                          const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const std::int8_t *a, int64_t lda, std::int8_t ao, const std::int8_t *b,
-                          int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, int64_t ldc,
-                          const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const std::uint8_t *a, int64_t lda, std::uint8_t ao, const std::int8_t *b,
-                          int64_t ldb, std::int8_t bo, float beta, std::int32_t *c, int64_t ldc,
-                          const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies = {});
-
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const std::uint8_t *a, int64_t lda, std::uint8_t ao,
-                          const std::uint8_t *b, int64_t ldb, std::uint8_t bo, float beta,
-                          std::int32_t *c, int64_t ldc, const std::int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies = {});
+sycl::event iamin(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                  int64_t *result, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event iamin(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                  int64_t *result, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event iamax(sycl::queue &queue, int64_t n, const float *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event iamax(sycl::queue &queue, int64_t n, const double *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event iamax(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                  int64_t *result, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event iamax(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                  int64_t *result, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event nrm2(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                 float *result, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event nrm2(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                 double *result, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event nrm2(sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event nrm2(sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rot(sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
+                std::complex<float> *y, int64_t incy, float c, float s,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rot(sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
+                std::complex<double> *y, int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rot(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y, int64_t incy,
+                float c, float s, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rot(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y, int64_t incy,
+                double c, double s, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotg(sycl::queue &queue, float *a, float *b, float *c, float *s,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotg(sycl::queue &queue, double *a, double *b, double *c, double *s,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotg(sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
+                 std::complex<float> *s, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotg(sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
+                 std::complex<double> *s, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotm(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y, int64_t incy,
+                 float *param, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotm(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y, int64_t incy,
+                 double *param, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotmg(sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotmg(sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event scal(sycl::queue &queue, int64_t n, float alpha, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event scal(sycl::queue &queue, int64_t n, double alpha, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event scal(sycl::queue &queue, int64_t n, std::complex<float> alpha, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event scal(sycl::queue &queue, int64_t n, std::complex<double> alpha, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event scal(sycl::queue &queue, int64_t n, float alpha, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event scal(sycl::queue &queue, int64_t n, double alpha, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event sdsdot(sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
+                   const float *y, int64_t incy, float *result,
+                   const std::vector<sycl::event> &dependencies = {});
+
+sycl::event swap(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event swap(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event swap(sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event swap(sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 float alpha, const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                 float *y, int64_t incy, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 double alpha, const double *a, int64_t lda, const double *x, int64_t incx,
+                 double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
+                 const float *a, int64_t lda, const float *x, int64_t incx, float beta, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
+                 const double *a, int64_t lda, const double *x, int64_t incx, double beta,
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
+                       const float *a, int64_t lda, int64_t stridea, const float *x, int64_t incx,
+                       int64_t stridex, float beta, float *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
+                       const double *a, int64_t lda, int64_t stridea, const double *x, int64_t incx,
+                       int64_t stridex, double beta, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                       std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                       int64_t stridea, const std::complex<float> *x, int64_t incx, int64_t stridex,
+                       std::complex<float> beta, std::complex<float> *y, int64_t incy,
+                       int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stridea, const std::complex<double> *x, int64_t incx,
+                       int64_t stridex, std::complex<double> beta, std::complex<double> *y,
+                       int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n, float *alpha,
+                       const float **a, int64_t *lda, const float **x, int64_t *incx, float *beta,
+                       float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n, double *alpha,
+                       const double **a, int64_t *lda, const double **x, int64_t *incx,
+                       double *beta, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n,
+                       std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
+                       std::complex<float> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemv_batch(sycl::queue &queue, transpose *trans, int64_t *m, int64_t *n,
+                       std::complex<double> *alpha, const std::complex<double> **a, int64_t *lda,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> *beta,
+                       std::complex<double> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n, const float *a,
+                       int64_t lda, int64_t stridea, const float *x, int64_t incx, int64_t stridex,
+                       float *c, int64_t ldc, int64_t stridec, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n, const double *a,
+                       int64_t lda, int64_t stridea, const double *x, int64_t incx, int64_t stridex,
+                       double *c, int64_t ldc, int64_t stridec, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                       const std::complex<float> *a, int64_t lda, int64_t stridea,
+                       const std::complex<float> *x, int64_t incx, int64_t stridex,
+                       std::complex<float> *c, int64_t ldc, int64_t stridec, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                       const std::complex<double> *a, int64_t lda, int64_t stridea,
+                       const std::complex<double> *x, int64_t incx, int64_t stridex,
+                       std::complex<double> *c, int64_t ldc, int64_t stridec, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const double **a, int64_t *lda, const double **x, int64_t *incx, double **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const std::complex<float> **a, int64_t *lda, const std::complex<float> **x,
+                       int64_t *incx, std::complex<float> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const std::complex<double> **a, int64_t *lda, const std::complex<double> **x,
+                       int64_t *incx, std::complex<double> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event ger(sycl::queue &queue, int64_t m, int64_t n, float alpha, const float *x, int64_t incx,
+                const float *y, int64_t incy, float *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event ger(sycl::queue &queue, int64_t m, int64_t n, double alpha, const double *x,
+                int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
+                 int64_t incx, std::complex<float> beta, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, const std::complex<double> *x,
+                 int64_t incx, std::complex<double> beta, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
+                const std::complex<float> *x, int64_t incx, std::complex<float> *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
+                const std::complex<double> *x, int64_t incx, std::complex<double> *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, const std::complex<float> *x, int64_t incx,
+                 std::complex<float> beta, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, const std::complex<double> *x, int64_t incx,
+                 std::complex<double> beta, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
+                const std::complex<float> *x, int64_t incx, std::complex<float> *a,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
+                const std::complex<double> *x, int64_t incx, std::complex<double> *a,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *a,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *a,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
+                 const float *a, int64_t lda, const float *x, int64_t incx, float beta, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
+                 const double *a, int64_t lda, const double *x, int64_t incx, double beta,
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *a,
+                 const float *x, int64_t incx, float beta, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *a,
+                 const double *x, int64_t incx, double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                int64_t incx, float *a, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                int64_t incx, double *a, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                 int64_t incx, const float *y, int64_t incy, float *a,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                 int64_t incx, const double *y, int64_t incy, double *a,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *a,
+                 int64_t lda, const float *x, int64_t incx, float beta, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *a,
+                 int64_t lda, const double *x, int64_t incx, double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                int64_t incx, float *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                int64_t incx, double *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                 int64_t incx, const float *y, int64_t incy, float *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                 int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const float *a, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const double *a, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<float> *a, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<double> *a, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const float *a, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const double *a, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<float> *a, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<double> *a, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, float alpha, const float *a, int64_t lda, const float *b, int64_t ldb,
+                 float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, double alpha, const double *a, int64_t lda, const double *b,
+                 int64_t ldb, double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda, const sycl::half *b,
+                 int64_t ldb, sycl::half beta, sycl::half *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, float alpha, const sycl::half *a, int64_t lda, const sycl::half *b,
+                 int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, float alpha, const bfloat16 *a, int64_t lda, const bfloat16 *b,
+                 int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 float alpha, const std::complex<float> *a, int64_t lda, float beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 double alpha, const std::complex<double> *a, int64_t lda, double beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                  const std::complex<float> *b, int64_t ldb, float beta, std::complex<float> *c,
+                  int64_t ldc, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                  const std::complex<double> *b, int64_t ldb, double beta, std::complex<double> *c,
+                  int64_t ldc, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 float alpha, const float *a, int64_t lda, const float *b, int64_t ldb, float beta,
+                 float *c, int64_t ldc, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 double alpha, const double *a, int64_t lda, const double *b, int64_t ldb,
+                 double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 float alpha, const float *a, int64_t lda, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 double alpha, const double *a, int64_t lda, double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 std::complex<float> beta, std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
+                       float **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
+                       double **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
+                       int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
+                       int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       float alpha, const float *a, int64_t lda, int64_t stride_a, float beta,
+                       float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       double alpha, const double *a, int64_t lda, int64_t stride_a, double beta,
+                       double *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                       int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  float alpha, const float *a, int64_t lda, const float *b, int64_t ldb, float beta,
+                  float *c, int64_t ldc, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  double alpha, const double *a, int64_t lda, const double *b, int64_t ldb,
+                  double beta, double *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                  const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                  std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                  const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                  std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
+                 float *b, int64_t ldb, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
+                 double *b, int64_t ldb, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
+                 float *b, int64_t ldb, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
+                 double *b, int64_t ldb, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                 diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, float alpha, const float *a,
+                       int64_t lda, int64_t stride_a, float *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
+                       int64_t lda, int64_t stride_a, double *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *a, int64_t lda, int64_t stride_a,
+                       std::complex<float> *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *a, int64_t lda, int64_t stride_a,
+                       std::complex<double> *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans,
+                       diag *unit_diag, int64_t *m, int64_t *n, float *alpha, const float **a,
+                       int64_t *lda, float **b, int64_t *ldb, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans,
+                       diag *unit_diag, int64_t *m, int64_t *n, double *alpha, const double **a,
+                       int64_t *lda, double **b, int64_t *ldb, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans,
+                       diag *unit_diag, int64_t *m, int64_t *n, std::complex<float> *alpha,
+                       const std::complex<float> **a, int64_t *lda, std::complex<float> **b,
+                       int64_t *ldb, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event trsm_batch(sycl::queue &queue, side *left_right, uplo *upper_lower, transpose *trans,
+                       diag *unit_diag, int64_t *m, int64_t *n, std::complex<double> *alpha,
+                       const std::complex<double> **a, int64_t *lda, std::complex<double> **b,
+                       int64_t *ldb, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
+                       int64_t *n, int64_t *k, float *alpha, const float **a, int64_t *lda,
+                       const float **b, int64_t *ldb, float *beta, float **c, int64_t *ldc,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
+                       int64_t *n, int64_t *k, double *alpha, const double **a, int64_t *lda,
+                       const double **b, int64_t *ldb, double *beta, double **c, int64_t *ldc,
+                       int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
+                       int64_t *n, int64_t *k, std::complex<float> *alpha,
+                       const std::complex<float> **a, int64_t *lda, const std::complex<float> **b,
+                       int64_t *ldb, std::complex<float> *beta, std::complex<float> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
+                       int64_t *n, int64_t *k, std::complex<double> *alpha,
+                       const std::complex<double> **a, int64_t *lda, const std::complex<double> **b,
+                       int64_t *ldb, std::complex<double> *beta, std::complex<double> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,
+                       int64_t *n, int64_t *k, sycl::half *alpha, const sycl::half **a,
+                       int64_t *lda, const sycl::half **b, int64_t *ldb, sycl::half *beta,
+                       sycl::half **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                       int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
+                       const float *b, int64_t ldb, int64_t stride_b, float beta, float *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                       int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
+                       const double *b, int64_t ldb, int64_t stride_b, double beta, double *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                       int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                       int64_t lda, int64_t stride_a, const std::complex<float> *b, int64_t ldb,
+                       int64_t stride_b, std::complex<float> beta, std::complex<float> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                       int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                       int64_t lda, int64_t stride_a, const std::complex<double> *b, int64_t ldb,
+                       int64_t stride_b, std::complex<double> beta, std::complex<double> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                       int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
+                       int64_t stride_a, const sycl::half *b, int64_t ldb, int64_t stride_b,
+                       sycl::half beta, sycl::half *c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
+                  int64_t ldb, float beta, float *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, double alpha, const double *a, int64_t lda, const double *b,
+                  int64_t ldb, double beta, double *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                  int64_t lda, const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                  std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                  int64_t lda, const std::complex<double> *b, int64_t ldb,
+                  std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a,
+                      int64_t lda, std::int8_t ao, const std::uint8_t *b, int64_t ldb,
+                      std::uint8_t bo, float beta, std::int32_t *c, int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const std::int8_t *a,
+                      int64_t lda, std::int8_t ao, const std::int8_t *b, int64_t ldb,
+                      std::int8_t bo, float beta, std::int32_t *c, int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a,
+                      int64_t lda, std::uint8_t ao, const std::int8_t *b, int64_t ldb,
+                      std::int8_t bo, float beta, std::int32_t *c, int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies = {});
+
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const std::uint8_t *a,
+                      int64_t lda, std::uint8_t ao, const std::uint8_t *b, int64_t ldb,
+                      std::uint8_t bo, float beta, std::int32_t *c, int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies = {});

--- a/src/blas/backends/rocblas/rocblas_batch.cpp
+++ b/src/blas/backends/rocblas/rocblas_batch.cpp
@@ -32,131 +32,129 @@ namespace column_major {
 
 // Buffer APIs
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-                int64_t stridex, cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-                int64_t stridex, cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<std::complex<float>, 1> &y,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<std::complex<float>, 1> &y,
                 int64_t incy, int64_t stridey, int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<std::complex<double>, 1> &y,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<std::complex<double>, 1> &y,
                 int64_t incy, int64_t stridey, int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<float, 1> &y, int64_t incy,
+void axpy_batch(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
+                int64_t batch_size) {
+    throw unimplemented("blas", "axpy_batch", "for column_major layout");
+}
+
+void axpy_batch(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<double, 1> &y, int64_t incy,
                 int64_t stridey, int64_t batch_size) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<double, 1> &y, int64_t incy,
-                int64_t stridey, int64_t batch_size) {
-    throw unimplemented("blas", "axpy_batch", "for column_major layout");
-}
-
-void axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
+void axpy_batch(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
+void axpy_batch(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n, float alpha,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stride_x, float beta,
-                cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stride_y, int64_t batch_size) {
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, float alpha,
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stride_x, float beta, sycl::buffer<float, 1> &y, int64_t incy,
+                int64_t stride_y, int64_t batch_size) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n, double alpha,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x, double beta,
-                cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stride_y,
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, double alpha,
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x, double beta,
+                sycl::buffer<double, 1> &y, int64_t incy, int64_t stride_y, int64_t batch_size) {
+    throw unimplemented("blas", "gemv_batch", "for column_major layout");
+}
+
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+                int64_t stride_a, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+                int64_t stride_x, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &y,
+                int64_t incy, int64_t stride_y, int64_t batch_size) {
+    throw unimplemented("blas", "gemv_batch", "for column_major layout");
+}
+
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+                int64_t stride_a, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+                int64_t stride_x, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stride_y,
                 int64_t batch_size) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-                int64_t stride_a, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-                int64_t stride_x, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stride_y,
-                int64_t batch_size) {
-    throw unimplemented("blas", "gemv_batch", "for column_major layout");
-}
-
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<std::complex<double>, 1> &x,
-                int64_t incx, int64_t stride_x, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stride_y,
-                int64_t batch_size) {
-    throw unimplemented("blas", "gemv_batch", "for column_major layout");
-}
-
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stride_x, sycl::buffer<float, 1> &c, int64_t ldc,
+                int64_t stride_c, int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x,
+                sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stride_x,
+                sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stride_x,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
 template <typename Func, typename T>
-inline void gemm_batch(Func func, cl::sycl::queue &queue, transpose transa, transpose transb,
-                       int64_t m, int64_t n, int64_t k, T alpha, cl::sycl::buffer<T, 1> &a,
-                       int64_t lda, int64_t stride_a, cl::sycl::buffer<T, 1> &b, int64_t ldb,
-                       int64_t stride_b, T beta, cl::sycl::buffer<T, 1> &c, int64_t ldc,
-                       int64_t stride_c, int64_t batch_size) {
+inline void gemm_batch(Func func, sycl::queue &queue, transpose transa, transpose transb, int64_t m,
+                       int64_t n, int64_t k, T alpha, sycl::buffer<T, 1> &a, int64_t lda,
+                       int64_t stride_a, sycl::buffer<T, 1> &b, int64_t ldb, int64_t stride_b,
+                       T beta, sycl::buffer<T, 1> &c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(m, n, k, lda, ldb, ldc, stride_a, stride_b, stride_c, batch_size);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto b_acc = b.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto c_acc = c.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
+        auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -172,14 +170,14 @@ inline void gemm_batch(Func func, cl::sycl::queue &queue, transpose transa, tran
     });
 }
 
-#define GEMM_STRIDED_BATCH_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
-    void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,         \
-                    int64_t n, int64_t k, TYPE alpha, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,   \
-                    int64_t stride_a, cl::sycl::buffer<TYPE, 1> &b, int64_t ldb, int64_t stride_b, \
-                    TYPE beta, cl::sycl::buffer<TYPE, 1> &c, int64_t ldc, int64_t stride_c,        \
-                    int64_t batch_size) {                                                          \
-        gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b,    \
-                   ldb, stride_b, beta, c, ldc, stride_c, batch_size);                             \
+#define GEMM_STRIDED_BATCH_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                        \
+    void gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, \
+                    int64_t k, TYPE alpha, sycl::buffer<TYPE, 1> &a, int64_t lda,                 \
+                    int64_t stride_a, sycl::buffer<TYPE, 1> &b, int64_t ldb, int64_t stride_b,    \
+                    TYPE beta, sycl::buffer<TYPE, 1> &c, int64_t ldc, int64_t stride_c,           \
+                    int64_t batch_size) {                                                         \
+        gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b,   \
+                   ldb, stride_b, beta, c, ldc, stride_c, batch_size);                            \
     }
 
 GEMM_STRIDED_BATCH_LAUNCHER(sycl::half, rocblas_hgemm_strided_batched)
@@ -190,307 +188,294 @@ GEMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, rocblas_zgemm_strided_batched)
 
 #undef GEMM_STRIDED_BATCH_LAUNCHER
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                diag unit_diag, int64_t m, int64_t n, float alpha, cl::sycl::buffer<float, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<float, 1> &b, int64_t ldb,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                diag unit_diag, int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &b, int64_t ldb,
                 int64_t stride_b, int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                diag unit_diag, int64_t m, int64_t n, double alpha, cl::sycl::buffer<double, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<double, 1> &b, int64_t ldb,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                diag unit_diag, int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<double, 1> &b, int64_t ldb,
                 int64_t stride_b, int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                 diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                 diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c,
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                float alpha, sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, float beta,
+                sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+    throw unimplemented("blas", "syrk_batch", "for column_major layout");
+}
+
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                double alpha, sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                double beta, sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                double beta, cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+                int64_t stride_a, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c,
+                int64_t ldc, int64_t stride_c, int64_t batch_size) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-                int64_t stride_a, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
-    throw unimplemented("blas", "syrk_batch", "for column_major layout");
-}
-
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stride_a, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+                int64_t stride_a, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 // USM APIs
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
-                           float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const float **x, int64_t *incx, float **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
-                           double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const double **x, int64_t *incx, double **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
-                           int64_t *incx, std::complex<float> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const std::complex<float> **x, int64_t *incx,
+                       std::complex<float> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
-                           int64_t *incx, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const std::complex<double> **x,
+                       int64_t *incx, std::complex<double> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                           int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const float *x, int64_t incx, int64_t stridex,
+                       float *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                           int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
+                       int64_t stridex, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
-                           int64_t incx, int64_t stridex, std::complex<float> *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                       int64_t stridex, std::complex<float> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
-                           int64_t incx, int64_t stridex, std::complex<double> *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                       int64_t stridex, std::complex<double> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
-                           int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, float *alpha, const float **x, int64_t *incx,
+                       float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
-                           int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, double *alpha, const double **x,
+                       int64_t *incx, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
-                           int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
+                       int64_t stridex, float *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
-                           int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                       int64_t stridex, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                           const std::complex<float> *x, int64_t incx, int64_t stridex,
-                           std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *x, int64_t incx, int64_t stridex,
+                       std::complex<float> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                           const std::complex<double> *x, int64_t incx, int64_t stridex,
-                           std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *x, int64_t incx, int64_t stridex,
+                       std::complex<double> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           float alpha, const float *a, int64_t lda, int64_t stride_a,
-                           const float *x, int64_t incx, int64_t stride_x, float beta, float *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, float alpha,
+                       const float *a, int64_t lda, int64_t stride_a, const float *x, int64_t incx,
+                       int64_t stride_x, float beta, float *y, int64_t incy, int64_t stride_y,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           double alpha, const double *a, int64_t lda, int64_t stride_a,
-                           const double *x, int64_t incx, int64_t stride_x, double beta, double *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, double alpha,
+                       const double *a, int64_t lda, int64_t stride_a, const double *x,
+                       int64_t incx, int64_t stride_x, double beta, double *y, int64_t incy,
+                       int64_t stride_y, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stride_a, const std::complex<float> *x, int64_t incx,
-                           int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                       std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                       int64_t stride_a, const std::complex<float> *x, int64_t incx,
+                       int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
+                       int64_t incy, int64_t stride_y, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stride_a, const std::complex<double> *x, int64_t incx,
-                           int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stride_a, const std::complex<double> *x, int64_t incx,
+                       int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
+                       int64_t incy, int64_t stride_y, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           float *alpha, const float **a, int64_t *lda, const float **x,
-                           int64_t *incx, float *beta, float **y, int64_t *incy,
-                           int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n, float *alpha,
+                       const float **a, int64_t *lda, const float **x, int64_t *incx, float *beta,
+                       float **y, int64_t *incy, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           double *alpha, const double **a, int64_t *lda, const double **x,
-                           int64_t *incx, double *beta, double **y, int64_t *incy,
-                           int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n, double *alpha,
+                       const double **a, int64_t *lda, const double **x, int64_t *incx,
+                       double *beta, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
-                           std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
+                       std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
+                       std::complex<float> **y, int64_t *incy, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, const std::complex<double> **x, int64_t *incx,
-                           std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
+                       std::complex<double> *alpha, const std::complex<double> **a, int64_t *lda,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> *beta,
+                       std::complex<double> **y, int64_t *incy, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const float *a, int64_t lda, int64_t stride_a, const float *x,
-                           int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n, const float *a,
+                       int64_t lda, int64_t stride_a, const float *x, int64_t incx,
+                       int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const double *a, int64_t lda, int64_t stride_a, const double *x,
-                           int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n, const double *a,
+                       int64_t lda, int64_t stride_a, const double *x, int64_t incx,
+                       int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const std::complex<float> *a, int64_t lda, int64_t stride_a,
-                           const std::complex<float> *x, int64_t incx, int64_t stride_x,
-                           std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                       const std::complex<float> *a, int64_t lda, int64_t stride_a,
+                       const std::complex<float> *x, int64_t incx, int64_t stride_x,
+                       std::complex<float> *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const std::complex<double> *a, int64_t lda, int64_t stride_a,
-                           const std::complex<double> *x, int64_t incx, int64_t stride_x,
-                           std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                       const std::complex<double> *a, int64_t lda, int64_t stride_a,
+                       const std::complex<double> *x, int64_t incx, int64_t stride_x,
+                       std::complex<double> *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const double **a, int64_t *lda, const double **x, int64_t *incx,
-                           double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const double **a, int64_t *lda, const double **x, int64_t *incx, double **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const std::complex<float> **a, int64_t *lda, const std::complex<float> **x,
+                       int64_t *incx, std::complex<float> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const std::complex<double> **a, int64_t *lda,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const std::complex<double> **a, int64_t *lda, const std::complex<double> **x,
+                       int64_t *incx, std::complex<double> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for column_major layout");
 }
 
 template <typename Func, typename T>
-inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose transa,
-                                  transpose transb, int64_t m, int64_t n, int64_t k, T alpha,
-                                  const T *a, int64_t lda, int64_t stride_a, const T *b,
-                                  int64_t ldb, int64_t stride_b, T beta, T *c, int64_t ldc,
-                                  int64_t stride_c, int64_t batch_size,
-                                  const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gemm_batch(Func func, sycl::queue &queue, transpose transa, transpose transb,
+                              int64_t m, int64_t n, int64_t k, T alpha, const T *a, int64_t lda,
+                              int64_t stride_a, const T *b, int64_t ldb, int64_t stride_b, T beta,
+                              T *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(m, n, k, lda, ldb, ldc, stride_a, stride_b, stride_c, batch_size);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -511,15 +496,15 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose t
     return done;
 }
 
-#define GEMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                              \
-    cl::sycl::event gemm_batch(                                                             \
-        cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,   \
-        int64_t k, TYPE alpha, const TYPE *a, int64_t lda, int64_t stride_a, const TYPE *b, \
-        int64_t ldb, int64_t stride_b, TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c,   \
-        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {             \
-        return gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda,   \
-                          stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size,   \
-                          dependencies);                                                    \
+#define GEMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                    \
+    sycl::event gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m,     \
+                           int64_t n, int64_t k, TYPE alpha, const TYPE *a, int64_t lda,          \
+                           int64_t stride_a, const TYPE *b, int64_t ldb, int64_t stride_b,        \
+                           TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c, int64_t batch_size, \
+                           const std::vector<sycl::event> &dependencies) {                        \
+        return gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda,         \
+                          stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size,         \
+                          dependencies);                                                          \
     }
 
 GEMM_STRIDED_BATCH_LAUNCHER_USM(sycl::half, rocblas_hgemm_strided_batched)
@@ -531,16 +516,16 @@ GEMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zgemm_strided_batc
 #undef GEMM_STRIDED_BATCH_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *transa,
-                                  transpose *transb, int64_t *m, int64_t *n, int64_t *k, T *alpha,
-                                  const T **a, int64_t *lda, const T **b, int64_t *ldb, T *beta,
-                                  T **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                                  const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gemm_batch(Func func, sycl::queue &queue, transpose *transa, transpose *transb,
+                              int64_t *m, int64_t *n, int64_t *k, T *alpha, const T **a,
+                              int64_t *lda, const T **b, int64_t *ldb, T *beta, T **c, int64_t *ldc,
+                              int64_t group_count, int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     for (int64_t i = 0; i < group_count; i++) {
         overflow_check(m[i], n[i], k[i], lda[i], ldb[i], ldc[i], group_size[i]);
     }
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -567,11 +552,11 @@ inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *
 }
 
 #define GEMM_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,      \
-                               int64_t *m, int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a,   \
-                               int64_t *lda, const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c,  \
-                               int64_t *ldc, int64_t group_count, int64_t *group_size,            \
-                               const std::vector<cl::sycl::event> &dependencies) {                \
+    sycl::event gemm_batch(sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,  \
+                           int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a, int64_t *lda,     \
+                           const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c, int64_t *ldc,      \
+                           int64_t group_count, int64_t *group_size,                              \
+                           const std::vector<sycl::event> &dependencies) {                        \
         return gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, \
                           beta, c, ldc, group_count, group_size, dependencies);                   \
     }
@@ -584,49 +569,46 @@ GEMM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zgemm_batched)
 
 #undef GEMM_BATCH_LAUNCHER_USM
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-                           const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
-                           int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, float alpha, const float *a,
+                       int64_t lda, int64_t stride_a, float *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-                           const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
-                           int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
+                       int64_t lda, int64_t stride_a, double *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *a, int64_t lda, int64_t stride_a,
+                       std::complex<float> *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *a, int64_t lda, int64_t stride_a,
+                       std::complex<double> *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for column_major layout");
 }
 
 template <typename Func, typename T>
-inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_right,
-                                  uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
-                                  int64_t *n, T *alpha, const T **a, int64_t *lda, T **b,
-                                  int64_t *ldb, int64_t group_count, int64_t *group_size,
-                                  const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event trsm_batch(Func func, sycl::queue &queue, side *left_right, uplo *upper_lower,
+                              transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, T *alpha,
+                              const T **a, int64_t *lda, T **b, int64_t *ldb, int64_t group_count,
+                              int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     for (int64_t i = 0; i < group_count; i++) {
         overflow_check(m[i], n[i], lda[i], ldb[i], group_size[i]);
     }
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -652,11 +634,11 @@ inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_
 }
 
 #define TRSM_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,        \
-                               transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,          \
-                               TYPE *alpha, const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb,  \
-                               int64_t group_count, int64_t *group_size,                           \
-                               const std::vector<cl::sycl::event> &dependencies) {                 \
+    sycl::event trsm_batch(sycl::queue &queue, side *left_right, uplo *upper_lower,                \
+                           transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, TYPE *alpha, \
+                           const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb,                   \
+                           int64_t group_count, int64_t *group_size,                               \
+                           const std::vector<sycl::event> &dependencies) {                         \
         return trsm_batch(ROCBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, \
                           alpha, a, lda, b, ldb, group_count, group_size, dependencies);           \
     }
@@ -668,63 +650,63 @@ TRSM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_ztrsm_batched)
 
 #undef TRSM_BATCH_LAUNCHER_USM
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
-                           float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
+                       float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
-                           double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
+                       double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
-                           int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
+                       int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
+                       int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
-                           float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       float alpha, const float *a, int64_t lda, int64_t stride_a, float beta,
+                       float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
-                           double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       double alpha, const double *a, int64_t lda, int64_t stride_a, double beta,
+                       double *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                           int64_t lda, int64_t stride_a, std::complex<float> beta,
-                           std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                       int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                           int64_t lda, int64_t stride_a, std::complex<double> beta,
-                           std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for column_major layout");
 }
 
@@ -732,136 +714,134 @@ cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose t
 namespace row_major {
 
 // Buffer APIs
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-                int64_t stridex, cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<double, 1> &x, int64_t incx,
-                int64_t stridex, cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<double, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<float>, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<std::complex<float>, 1> &y,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<std::complex<float>, 1> &y,
                 int64_t incy, int64_t stridey, int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-void copy_batch(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<std::complex<double>, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<std::complex<double>, 1> &y,
+void copy_batch(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<std::complex<double>, 1> &y,
                 int64_t incy, int64_t stridey, int64_t batch_size) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<float, 1> &y, int64_t incy,
+void axpy_batch(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+                int64_t stridex, sycl::buffer<float, 1> &y, int64_t incy, int64_t stridey,
+                int64_t batch_size) {
+    throw unimplemented("blas", "axpy_batch", "for row_major layout");
+}
+
+void axpy_batch(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+                int64_t incx, int64_t stridex, sycl::buffer<double, 1> &y, int64_t incy,
                 int64_t stridey, int64_t batch_size) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-                int64_t incx, int64_t stridex, cl::sycl::buffer<double, 1> &y, int64_t incy,
-                int64_t stridey, int64_t batch_size) {
-    throw unimplemented("blas", "axpy_batch", "for row_major layout");
-}
-
-void axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
+void axpy_batch(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-void axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
+void axpy_batch(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stridey,
                 int64_t batch_size) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n, float alpha,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stride_x, float beta,
-                cl::sycl::buffer<float, 1> &y, int64_t incy, int64_t stride_y, int64_t batch_size) {
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, float alpha,
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stride_x, float beta, sycl::buffer<float, 1> &y, int64_t incy,
+                int64_t stride_y, int64_t batch_size) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n, double alpha,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x, double beta,
-                cl::sycl::buffer<double, 1> &y, int64_t incy, int64_t stride_y,
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, double alpha,
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x, double beta,
+                sycl::buffer<double, 1> &y, int64_t incy, int64_t stride_y, int64_t batch_size) {
+    throw unimplemented("blas", "gemv_batch", "for row_major layout");
+}
+
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+                int64_t stride_a, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+                int64_t stride_x, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &y,
+                int64_t incy, int64_t stride_y, int64_t batch_size) {
+    throw unimplemented("blas", "gemv_batch", "for row_major layout");
+}
+
+void gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+                int64_t stride_a, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+                int64_t stride_x, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stride_y,
                 int64_t batch_size) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-                int64_t stride_a, cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
-                int64_t stride_x, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy, int64_t stride_y,
-                int64_t batch_size) {
-    throw unimplemented("blas", "gemv_batch", "for row_major layout");
-}
-
-void gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<std::complex<double>, 1> &x,
-                int64_t incx, int64_t stride_x, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy, int64_t stride_y,
-                int64_t batch_size) {
-    throw unimplemented("blas", "gemv_batch", "for row_major layout");
-}
-
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<float, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &x,
+                int64_t incx, int64_t stride_x, sycl::buffer<float, 1> &c, int64_t ldc,
+                int64_t stride_c, int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<double, 1> &x, int64_t incx, int64_t stride_x,
+                sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &x, int64_t incx, int64_t stride_x,
+                sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-void dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stride_x,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
+void dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &x, int64_t incx, int64_t stride_x,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
 template <typename Func, typename T>
-inline void gemm_batch(Func func, cl::sycl::queue &queue, transpose transa, transpose transb,
-                       int64_t m, int64_t n, int64_t k, T alpha, cl::sycl::buffer<T, 1> &a,
-                       int64_t lda, int64_t stride_a, cl::sycl::buffer<T, 1> &b, int64_t ldb,
-                       int64_t stride_b, T beta, cl::sycl::buffer<T, 1> &c, int64_t ldc,
-                       int64_t stride_c, int64_t batch_size) {
+inline void gemm_batch(Func func, sycl::queue &queue, transpose transa, transpose transb, int64_t m,
+                       int64_t n, int64_t k, T alpha, sycl::buffer<T, 1> &a, int64_t lda,
+                       int64_t stride_a, sycl::buffer<T, 1> &b, int64_t ldb, int64_t stride_b,
+                       T beta, sycl::buffer<T, 1> &c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size) {
     throw unimplemented("blas", "gemm_batch", "for row_major layout");
 }
 
-#define GEMM_STRIDED_BATCH_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
-    void gemm_batch(cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m,         \
-                    int64_t n, int64_t k, TYPE alpha, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,   \
-                    int64_t stride_a, cl::sycl::buffer<TYPE, 1> &b, int64_t ldb, int64_t stride_b, \
-                    TYPE beta, cl::sycl::buffer<TYPE, 1> &c, int64_t ldc, int64_t stride_c,        \
-                    int64_t batch_size) {                                                          \
-        gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b,    \
-                   ldb, stride_b, beta, c, ldc, stride_c, batch_size);                             \
+#define GEMM_STRIDED_BATCH_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                        \
+    void gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, \
+                    int64_t k, TYPE alpha, sycl::buffer<TYPE, 1> &a, int64_t lda,                 \
+                    int64_t stride_a, sycl::buffer<TYPE, 1> &b, int64_t ldb, int64_t stride_b,    \
+                    TYPE beta, sycl::buffer<TYPE, 1> &c, int64_t ldc, int64_t stride_c,           \
+                    int64_t batch_size) {                                                         \
+        gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, stride_a, b,   \
+                   ldb, stride_b, beta, c, ldc, stride_c, batch_size);                            \
     }
 GEMM_STRIDED_BATCH_LAUNCHER(sycl::half, rocblas_hgemm_strided_batched)
 GEMM_STRIDED_BATCH_LAUNCHER(float, rocblas_sgemm_strided_batched)
@@ -871,317 +851,304 @@ GEMM_STRIDED_BATCH_LAUNCHER(std::complex<double>, rocblas_zgemm_strided_batched)
 
 #undef GEMM_STRIDED_BATCH_LAUNCHER
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                diag unit_diag, int64_t m, int64_t n, float alpha, cl::sycl::buffer<float, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<float, 1> &b, int64_t ldb,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                diag unit_diag, int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<float, 1> &b, int64_t ldb,
                 int64_t stride_b, int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
-                diag unit_diag, int64_t m, int64_t n, double alpha, cl::sycl::buffer<double, 1> &a,
-                int64_t lda, int64_t stride_a, cl::sycl::buffer<double, 1> &b, int64_t ldb,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                diag unit_diag, int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a,
+                int64_t lda, int64_t stride_a, sycl::buffer<double, 1> &b, int64_t ldb,
                 int64_t stride_b, int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                 diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<float>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
-void trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+void trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
                 diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                cl::sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
-                cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
+                sycl::buffer<std::complex<double>, 1> &a, int64_t lda, int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, int64_t stride_b,
                 int64_t batch_size) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a,
-                float beta, cl::sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c,
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                float alpha, sycl::buffer<float, 1> &a, int64_t lda, int64_t stride_a, float beta,
+                sycl::buffer<float, 1> &c, int64_t ldc, int64_t stride_c, int64_t batch_size) {
+    throw unimplemented("blas", "syrk_batch", "for row_major layout");
+}
+
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                double alpha, sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
+                double beta, sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda, int64_t stride_a,
-                double beta, cl::sycl::buffer<double, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+                int64_t stride_a, std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c,
+                int64_t ldc, int64_t stride_c, int64_t batch_size) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-                int64_t stride_a, std::complex<float> beta,
-                cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc, int64_t stride_c,
-                int64_t batch_size) {
-    throw unimplemented("blas", "syrk_batch", "for row_major layout");
-}
-
-void syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-                std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-                int64_t lda, int64_t stride_a, std::complex<double> beta,
-                cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
+void syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+                int64_t stride_a, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &c, int64_t ldc, int64_t stride_c,
                 int64_t batch_size) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
 // USM APIs
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const float **x, int64_t *incx,
-                           float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const float **x, int64_t *incx, float **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const double **x, int64_t *incx,
-                           double **y, int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const double **x, int64_t *incx, double **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<float> **x,
-                           int64_t *incx, std::complex<float> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const std::complex<float> **x, int64_t *incx,
+                       std::complex<float> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t *n, const std::complex<double> **x,
-                           int64_t *incx, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t *n, const std::complex<double> **x,
+                       int64_t *incx, std::complex<double> **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                           int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const float *x, int64_t incx, int64_t stridex,
+                       float *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                           int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
+                       int64_t stridex, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<float> *x,
-                           int64_t incx, int64_t stridex, std::complex<float> *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
+                       int64_t stridex, std::complex<float> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event copy_batch(cl::sycl::queue &queue, int64_t n, const std::complex<double> *x,
-                           int64_t incx, int64_t stridex, std::complex<double> *y, int64_t incy,
-                           int64_t stridey, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event copy_batch(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                       int64_t stridex, std::complex<double> *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, float *alpha, const float **x,
-                           int64_t *incx, float **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, float *alpha, const float **x, int64_t *incx,
+                       float **y, int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, double *alpha, const double **x,
-                           int64_t *incx, double **y, int64_t *incy, int64_t group_count,
-                           int64_t *group_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, double *alpha, const double **x,
+                       int64_t *incx, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, std::complex<float> *alpha,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
-                           int64_t *incy, int64_t group_count, int64_t *group_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t *n, std::complex<double> *alpha,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> **y,
+                       int64_t *incy, int64_t group_count, int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, float alpha, const float *x,
-                           int64_t incx, int64_t stridex, float *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
+                       int64_t stridex, float *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
-                           int64_t incx, int64_t stridex, double *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                       int64_t stridex, double *y, int64_t incy, int64_t stridey,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                           const std::complex<float> *x, int64_t incx, int64_t stridex,
-                           std::complex<float> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *x, int64_t incx, int64_t stridex,
+                       std::complex<float> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event axpy_batch(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                           const std::complex<double> *x, int64_t incx, int64_t stridex,
-                           std::complex<double> *y, int64_t incy, int64_t stridey,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpy_batch(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *x, int64_t incx, int64_t stridex,
+                       std::complex<double> *y, int64_t incy, int64_t stridey, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           float alpha, const float *a, int64_t lda, int64_t stride_a,
-                           const float *x, int64_t incx, int64_t stride_x, float beta, float *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, float alpha,
+                       const float *a, int64_t lda, int64_t stride_a, const float *x, int64_t incx,
+                       int64_t stride_x, float beta, float *y, int64_t incy, int64_t stride_y,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           double alpha, const double *a, int64_t lda, int64_t stride_a,
-                           const double *x, int64_t incx, int64_t stride_x, double beta, double *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n, double alpha,
+                       const double *a, int64_t lda, int64_t stride_a, const double *x,
+                       int64_t incx, int64_t stride_x, double beta, double *y, int64_t incy,
+                       int64_t stride_y, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stride_a, const std::complex<float> *x, int64_t incx,
-                           int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                       std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                       int64_t stride_a, const std::complex<float> *x, int64_t incx,
+                       int64_t stride_x, std::complex<float> beta, std::complex<float> *y,
+                       int64_t incy, int64_t stride_y, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose transa, int64_t m, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stride_a, const std::complex<double> *x, int64_t incx,
-                           int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
-                           int64_t incy, int64_t stride_y, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose transa, int64_t m, int64_t n,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stride_a, const std::complex<double> *x, int64_t incx,
+                       int64_t stride_x, std::complex<double> beta, std::complex<double> *y,
+                       int64_t incy, int64_t stride_y, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           float *alpha, const float **a, int64_t *lda, const float **x,
-                           int64_t *incx, float *beta, float **y, int64_t *incy,
-                           int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n, float *alpha,
+                       const float **a, int64_t *lda, const float **x, int64_t *incx, float *beta,
+                       float **y, int64_t *incy, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           double *alpha, const double **a, int64_t *lda, const double **x,
-                           int64_t *incx, double *beta, double **y, int64_t *incy,
-                           int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n, double *alpha,
+                       const double **a, int64_t *lda, const double **x, int64_t *incx,
+                       double *beta, double **y, int64_t *incy, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
-                           std::complex<float> **y, int64_t *incy, int64_t group_count,
-                           int64_t *groupsize, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
+                       std::complex<float> *alpha, const std::complex<float> **a, int64_t *lda,
+                       const std::complex<float> **x, int64_t *incx, std::complex<float> *beta,
+                       std::complex<float> **y, int64_t *incy, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event gemv_batch(cl::sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
-                           std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, const std::complex<double> **x, int64_t *incx,
-                           std::complex<double> *beta, std::complex<double> **y, int64_t *incy,
-                           int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemv_batch(sycl::queue &queue, transpose *transa, int64_t *m, int64_t *n,
+                       std::complex<double> *alpha, const std::complex<double> **a, int64_t *lda,
+                       const std::complex<double> **x, int64_t *incx, std::complex<double> *beta,
+                       std::complex<double> **y, int64_t *incy, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const float *a, int64_t lda, int64_t stride_a, const float *x,
-                           int64_t incx, int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n, const float *a,
+                       int64_t lda, int64_t stride_a, const float *x, int64_t incx,
+                       int64_t stride_x, float *c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const double *a, int64_t lda, int64_t stride_a, const double *x,
-                           int64_t incx, int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n, const double *a,
+                       int64_t lda, int64_t stride_a, const double *x, int64_t incx,
+                       int64_t stride_x, double *c, int64_t ldc, int64_t stride_c,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const std::complex<float> *a, int64_t lda, int64_t stride_a,
-                           const std::complex<float> *x, int64_t incx, int64_t stride_x,
-                           std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                       const std::complex<float> *a, int64_t lda, int64_t stride_a,
+                       const std::complex<float> *x, int64_t incx, int64_t stride_x,
+                       std::complex<float> *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side left_right, int64_t m, int64_t n,
-                           const std::complex<double> *a, int64_t lda, int64_t stride_a,
-                           const std::complex<double> *x, int64_t incx, int64_t stride_x,
-                           std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side left_right, int64_t m, int64_t n,
+                       const std::complex<double> *a, int64_t lda, int64_t stride_a,
+                       const std::complex<double> *x, int64_t incx, int64_t stride_x,
+                       std::complex<double> *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const float **a, int64_t *lda, const float **x, int64_t *incx, float **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const double **a, int64_t *lda, const double **x, int64_t *incx,
-                           double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const double **a, int64_t *lda, const double **x, int64_t *incx, double **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const std::complex<float> **a, int64_t *lda,
-                           const std::complex<float> **x, int64_t *incx, std::complex<float> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const std::complex<float> **a, int64_t *lda, const std::complex<float> **x,
+                       int64_t *incx, std::complex<float> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
-cl::sycl::event dgmm_batch(cl::sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
-                           const std::complex<double> **a, int64_t *lda,
-                           const std::complex<double> **x, int64_t *incx, std::complex<double> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dgmm_batch(sycl::queue &queue, side *left_right, int64_t *m, int64_t *n,
+                       const std::complex<double> **a, int64_t *lda, const std::complex<double> **x,
+                       int64_t *incx, std::complex<double> **c, int64_t *ldc, int64_t group_count,
+                       int64_t *groupsize, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dgmm_batch", "for row_major layout");
 }
 
 template <typename Func, typename T>
-inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose transa,
-                                  transpose transb, int64_t m, int64_t n, int64_t k, T alpha,
-                                  const T *a, int64_t lda, int64_t stride_a, const T *b,
-                                  int64_t ldb, int64_t stride_b, T beta, T *c, int64_t ldc,
-                                  int64_t stride_c, int64_t batch_size,
-                                  const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gemm_batch(Func func, sycl::queue &queue, transpose transa, transpose transb,
+                              int64_t m, int64_t n, int64_t k, T alpha, const T *a, int64_t lda,
+                              int64_t stride_a, const T *b, int64_t ldb, int64_t stride_b, T beta,
+                              T *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                              const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_batch", "for row_major layout");
 }
 
-#define GEMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                              \
-    cl::sycl::event gemm_batch(                                                             \
-        cl::sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,   \
-        int64_t k, TYPE alpha, const TYPE *a, int64_t lda, int64_t stride_a, const TYPE *b, \
-        int64_t ldb, int64_t stride_b, TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c,   \
-        int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {             \
-        return gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda,   \
-                          stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size,   \
-                          dependencies);                                                    \
+#define GEMM_STRIDED_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                    \
+    sycl::event gemm_batch(sycl::queue &queue, transpose transa, transpose transb, int64_t m,     \
+                           int64_t n, int64_t k, TYPE alpha, const TYPE *a, int64_t lda,          \
+                           int64_t stride_a, const TYPE *b, int64_t ldb, int64_t stride_b,        \
+                           TYPE beta, TYPE *c, int64_t ldc, int64_t stride_c, int64_t batch_size, \
+                           const std::vector<sycl::event> &dependencies) {                        \
+        return gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda,         \
+                          stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size,         \
+                          dependencies);                                                          \
     }
 
 GEMM_STRIDED_BATCH_LAUNCHER_USM(sycl::half, rocblas_hgemm_strided_batched)
@@ -1193,20 +1160,20 @@ GEMM_STRIDED_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zgemm_strided_batc
 #undef GEMM_STRIDED_BATCH_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event gemm_batch(Func func, cl::sycl::queue &queue, transpose *transa,
-                                  transpose *transb, int64_t *m, int64_t *n, int64_t *k, T *alpha,
-                                  const T **a, int64_t *lda, const T **b, int64_t *ldb, T *beta,
-                                  T **c, int64_t *ldc, int64_t group_count, int64_t *group_size,
-                                  const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gemm_batch(Func func, sycl::queue &queue, transpose *transa, transpose *transb,
+                              int64_t *m, int64_t *n, int64_t *k, T *alpha, const T **a,
+                              int64_t *lda, const T **b, int64_t *ldb, T *beta, T **c, int64_t *ldc,
+                              int64_t group_count, int64_t *group_size,
+                              const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_batch", "for row_major layout");
 }
 
 #define GEMM_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event gemm_batch(cl::sycl::queue &queue, transpose *transa, transpose *transb,      \
-                               int64_t *m, int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a,   \
-                               int64_t *lda, const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c,  \
-                               int64_t *ldc, int64_t group_count, int64_t *group_size,            \
-                               const std::vector<cl::sycl::event> &dependencies) {                \
+    sycl::event gemm_batch(sycl::queue &queue, transpose *transa, transpose *transb, int64_t *m,  \
+                           int64_t *n, int64_t *k, TYPE *alpha, const TYPE **a, int64_t *lda,     \
+                           const TYPE **b, int64_t *ldb, TYPE *beta, TYPE **c, int64_t *ldc,      \
+                           int64_t group_count, int64_t *group_size,                              \
+                           const std::vector<sycl::event> &dependencies) {                        \
         return gemm_batch(ROCBLAS_ROUTINE, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, \
                           beta, c, ldc, group_count, group_size, dependencies);                   \
     }
@@ -1219,53 +1186,50 @@ GEMM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_zgemm_batched)
 
 #undef GEMM_BATCH_LAUNCHER_USM
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n, float alpha,
-                           const float *a, int64_t lda, int64_t stride_a, float *b, int64_t ldb,
-                           int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, float alpha, const float *a,
+                       int64_t lda, int64_t stride_a, float *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n, double alpha,
-                           const double *a, int64_t lda, int64_t stride_a, double *b, int64_t ldb,
-                           int64_t stride_b, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
+                       int64_t lda, int64_t stride_a, double *b, int64_t ldb, int64_t stride_b,
+                       int64_t batch_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                           int64_t stride_a, std::complex<float> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *a, int64_t lda, int64_t stride_a,
+                       std::complex<float> *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
-cl::sycl::event trsm_batch(cl::sycl::queue &queue, side left_right, uplo upper_lower,
-                           transpose trans, diag unit_diag, int64_t m, int64_t n,
-                           std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                           int64_t stride_a, std::complex<double> *b, int64_t ldb, int64_t stride_b,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event trsm_batch(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans,
+                       diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *a, int64_t lda, int64_t stride_a,
+                       std::complex<double> *b, int64_t ldb, int64_t stride_b, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
 template <typename Func, typename T>
-inline cl::sycl::event trsm_batch(Func func, cl::sycl::queue &queue, side *left_right,
-                                  uplo *upper_lower, transpose *trans, diag *unit_diag, int64_t *m,
-                                  int64_t *n, T *alpha, const T **a, int64_t *lda, T **b,
-                                  int64_t *ldb, int64_t group_count, int64_t *group_size,
-                                  const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event trsm_batch(Func func, sycl::queue &queue, side *left_right, uplo *upper_lower,
+                              transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, T *alpha,
+                              const T **a, int64_t *lda, T **b, int64_t *ldb, int64_t group_count,
+                              int64_t *group_size, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsm_batch", "for row_major layout");
 }
 
 #define TRSM_BATCH_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event trsm_batch(cl::sycl::queue &queue, side *left_right, uplo *upper_lower,        \
-                               transpose *trans, diag *unit_diag, int64_t *m, int64_t *n,          \
-                               TYPE *alpha, const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb,  \
-                               int64_t group_count, int64_t *group_size,                           \
-                               const std::vector<cl::sycl::event> &dependencies) {                 \
+    sycl::event trsm_batch(sycl::queue &queue, side *left_right, uplo *upper_lower,                \
+                           transpose *trans, diag *unit_diag, int64_t *m, int64_t *n, TYPE *alpha, \
+                           const TYPE **a, int64_t *lda, TYPE **b, int64_t *ldb,                   \
+                           int64_t group_count, int64_t *group_size,                               \
+                           const std::vector<sycl::event> &dependencies) {                         \
         return trsm_batch(ROCBLAS_ROUTINE, queue, left_right, upper_lower, trans, unit_diag, m, n, \
                           alpha, a, lda, b, ldb, group_count, group_size, dependencies);           \
     }
@@ -1277,63 +1241,63 @@ TRSM_BATCH_LAUNCHER_USM(std::complex<double>, rocblas_ztrsm_batched)
 
 #undef TRSM_BATCH_LAUNCHER_USM
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
-                           float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, float *alpha, const float **a, int64_t *lda, float *beta,
+                       float **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
-                           double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, double *alpha, const double **a, int64_t *lda, double *beta,
+                       double **c, int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
-                           int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
+                       int64_t *lda, std::complex<float> *beta, std::complex<float> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
-                           int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
-                           int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
-                           int64_t *ldc, int64_t group_count, int64_t *groupsize,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo *upper_lower, transpose *trans, int64_t *n,
+                       int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
+                       int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
+                       int64_t *ldc, int64_t group_count, int64_t *groupsize,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, float alpha, const float *a, int64_t lda, int64_t stride_a,
-                           float beta, float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
-                           const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       float alpha, const float *a, int64_t lda, int64_t stride_a, float beta,
+                       float *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, double alpha, const double *a, int64_t lda, int64_t stride_a,
-                           double beta, double *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       double alpha, const double *a, int64_t lda, int64_t stride_a, double beta,
+                       double *c, int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                           int64_t lda, int64_t stride_a, std::complex<float> beta,
-                           std::complex<float> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                       int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 
-cl::sycl::event syrk_batch(cl::sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                           int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                           int64_t lda, int64_t stride_a, std::complex<double> beta,
-                           std::complex<double> *c, int64_t ldc, int64_t stride_c,
-                           int64_t batch_size, const std::vector<cl::sycl::event> &dependencies) {
+sycl::event syrk_batch(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                       std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                       int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
+                       int64_t ldc, int64_t stride_c, int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syrk_batch", "for row_major layout");
 }
 

--- a/src/blas/backends/rocblas/rocblas_extensions.cpp
+++ b/src/blas/backends/rocblas/rocblas_extensions.cpp
@@ -32,127 +32,123 @@ namespace column_major {
 
 // Buffer APIs
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<int8_t, 1> &a,
-               int64_t lda, int8_t ao, cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<int8_t, 1> &a, int64_t lda,
+               int8_t ao, sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<int8_t, 1> &a,
-               int64_t lda, int8_t ao, cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<int8_t, 1> &a, int64_t lda,
+               int8_t ao, sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<uint8_t, 1> &a,
-               int64_t lda, uint8_t ao, cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<uint8_t, 1> &a, int64_t lda,
+               uint8_t ao, sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<uint8_t, 1> &a,
-               int64_t lda, uint8_t ao, cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<uint8_t, 1> &a, int64_t lda,
+               uint8_t ao, sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-           cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+           sycl::buffer<float, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
            int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-           cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c,
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+           sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
            int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-           int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
-           std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
+           std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-           int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
-           std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
+           std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
 // USM APIs
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const int8_t *a, int64_t lda, int8_t ao, const int8_t *b, int64_t ldb,
-                          int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const int8_t *a, int64_t lda,
+                      int8_t ao, const int8_t *b, int64_t ldb, int8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const int8_t *a, int64_t lda, int8_t ao, const uint8_t *b, int64_t ldb,
-                          uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const int8_t *a, int64_t lda,
+                      int8_t ao, const uint8_t *b, int64_t ldb, uint8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const uint8_t *a, int64_t lda, uint8_t ao, const int8_t *b, int64_t ldb,
-                          int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const uint8_t *a, int64_t lda,
+                      uint8_t ao, const int8_t *b, int64_t ldb, int8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const uint8_t *a, int64_t lda, uint8_t ao, const uint8_t *b, int64_t ldb,
-                          uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const uint8_t *a, int64_t lda,
+                      uint8_t ao, const uint8_t *b, int64_t ldb, uint8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for column_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
-                      const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
+                  int64_t ldb, float beta, float *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
-                      const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, double alpha, const double *a, int64_t lda, const double *b,
+                  int64_t ldb, double beta, double *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                      int64_t lda, const std::complex<float> *b, int64_t ldb,
-                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                  int64_t lda, const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                  std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, std::complex<double> alpha,
-                      const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                      int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                  int64_t lda, const std::complex<double> *b, int64_t ldb,
+                  std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for column_major layout");
 }
 
@@ -161,127 +157,123 @@ namespace row_major {
 
 // Buffer APIs
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<int8_t, 1> &a,
-               int64_t lda, int8_t ao, cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<int8_t, 1> &a, int64_t lda,
+               int8_t ao, sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<int8_t, 1> &a,
-               int64_t lda, int8_t ao, cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<int8_t, 1> &a, int64_t lda,
+               int8_t ao, sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<uint8_t, 1> &a,
-               int64_t lda, uint8_t ao, cl::sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<uint8_t, 1> &a, int64_t lda,
+               uint8_t ao, sycl::buffer<int8_t, 1> &b, int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-void gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
-               int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<uint8_t, 1> &a,
-               int64_t lda, uint8_t ao, cl::sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo,
-               float beta, cl::sycl::buffer<int32_t, 1> &c, int64_t ldc,
-               cl::sycl::buffer<int32_t, 1> &co) {
+void gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc, int64_t m,
+               int64_t n, int64_t k, float alpha, sycl::buffer<uint8_t, 1> &a, int64_t lda,
+               uint8_t ao, sycl::buffer<uint8_t, 1> &b, int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, int64_t ldc, sycl::buffer<int32_t, 1> &co) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, float alpha, cl::sycl::buffer<float, 1> &a, int64_t lda,
-           cl::sycl::buffer<float, 1> &b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> &c,
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+           sycl::buffer<float, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
            int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, double alpha, cl::sycl::buffer<double, 1> &a, int64_t lda,
-           cl::sycl::buffer<double, 1> &b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> &c,
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+           sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
            int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, std::complex<float> alpha, cl::sycl::buffer<std::complex<float>, 1> &a,
-           int64_t lda, cl::sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
-           std::complex<float> beta, cl::sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
+           std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
-void gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
-           int64_t k, std::complex<double> alpha, cl::sycl::buffer<std::complex<double>, 1> &a,
-           int64_t lda, cl::sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
-           std::complex<double> beta, cl::sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+void gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb, int64_t n,
+           int64_t k, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+           int64_t lda, sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
+           std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
 // USM APIs
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const int8_t *a, int64_t lda, int8_t ao, const int8_t *b, int64_t ldb,
-                          int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const int8_t *a, int64_t lda,
+                      int8_t ao, const int8_t *b, int64_t ldb, int8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const int8_t *a, int64_t lda, int8_t ao, const uint8_t *b, int64_t ldb,
-                          uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const int8_t *a, int64_t lda,
+                      int8_t ao, const uint8_t *b, int64_t ldb, uint8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const uint8_t *a, int64_t lda, uint8_t ao, const int8_t *b, int64_t ldb,
-                          int8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const uint8_t *a, int64_t lda,
+                      uint8_t ao, const int8_t *b, int64_t ldb, int8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-cl::sycl::event gemm_bias(cl::sycl::queue &queue, transpose transa, transpose transb,
-                          offset offsetc, int64_t m, int64_t n, int64_t k, float alpha,
-                          const uint8_t *a, int64_t lda, uint8_t ao, const uint8_t *b, int64_t ldb,
-                          uint8_t bo, float beta, int32_t *c, int64_t ldc, const int32_t *co,
-                          const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb, offset offsetc,
+                      int64_t m, int64_t n, int64_t k, float alpha, const uint8_t *a, int64_t lda,
+                      uint8_t ao, const uint8_t *b, int64_t ldb, uint8_t bo, float beta, int32_t *c,
+                      int64_t ldc, const int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemm_bias", "for row_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, float alpha, const float *a, int64_t lda,
-                      const float *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
+                  int64_t ldb, float beta, float *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
-                      const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, double alpha, const double *a, int64_t lda, const double *b,
+                  int64_t ldb, double beta, double *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                      int64_t lda, const std::complex<float> *b, int64_t ldb,
-                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                  int64_t lda, const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                  std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 
-cl::sycl::event gemmt(cl::sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
-                      int64_t n, int64_t k, std::complex<double> alpha,
-                      const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                      int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event gemmt(sycl::queue &queue, uplo upper_lower, transpose transa, transpose transb,
+                  int64_t n, int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                  int64_t lda, const std::complex<double> *b, int64_t ldb,
+                  std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemmt", "for row_major layout");
 }
 

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -34,15 +34,15 @@ namespace column_major {
 
 // Level 1
 template <typename Func, typename T1, typename T2>
-inline void asum(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T1, 1> &x,
-                 const int64_t incx, cl::sycl::buffer<T2, 1> &result) {
+inline void asum(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &x,
+                 const int64_t incx, sycl::buffer<T2, 1> &result) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     overflow_check(n, incx);
 
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto res_acc = result.template get_access<cl::sycl::access::mode::write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
             // By default the pointer mode is the rocblas_pointer_mode_host
@@ -64,10 +64,10 @@ inline void asum(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
     });
 }
 
-#define ASUM_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                            \
-    void asum(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE1, 1> &x, \
-              const int64_t incx, cl::sycl::buffer<TYPE2, 1> &result) {         \
-        asum(ROCBLAS_ROUTINE, queue, n, x, incx, result);                       \
+#define ASUM_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
+    void asum(sycl::queue &queue, int64_t n, sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
+              sycl::buffer<TYPE2, 1> &result) {                                             \
+        asum(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                   \
     }
 ASUM_LAUNCHER(float, float, rocblas_sasum)
 ASUM_LAUNCHER(double, double, rocblas_dasum)
@@ -76,13 +76,13 @@ ASUM_LAUNCHER(std::complex<double>, double, rocblas_dzasum)
 #undef ASUM_LAUNCHER
 
 template <typename Func, typename T1, typename T2>
-inline void scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, cl::sycl::buffer<T2, 1> &x,
+inline void scal(Func func, sycl::queue &queue, int64_t n, T1 a, sycl::buffer<T2, 1> &x,
                  int64_t incx) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     overflow_check(n, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
             auto x_ = sc.get_mem<rocDataType2 *>(x_acc);
@@ -93,10 +93,9 @@ inline void scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, cl::sycl::b
     });
 }
 
-#define SCAL_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                     \
-    void scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, cl::sycl::buffer<TYPE2, 1> &x, \
-              int64_t incx) {                                                            \
-        scal(ROCBLAS_ROUTINE, queue, n, a, x, incx);                                     \
+#define SCAL_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                             \
+    void scal(sycl::queue &queue, int64_t n, TYPE1 a, sycl::buffer<TYPE2, 1> &x, int64_t incx) { \
+        scal(ROCBLAS_ROUTINE, queue, n, a, x, incx);                                             \
     }
 SCAL_LAUNCHER(float, float, rocblas_sscal)
 SCAL_LAUNCHER(double, double, rocblas_dscal)
@@ -107,13 +106,13 @@ SCAL_LAUNCHER(double, std::complex<double>, rocblas_zdscal)
 #undef SCAL_LAUNCHER
 
 template <typename Func, typename T>
-inline void axpy(Func func, cl::sycl::queue &queue, int64_t n, T alpha, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void axpy(Func func, sycl::queue &queue, int64_t n, T alpha, sycl::buffer<T, 1> &x,
+                 int64_t incx, sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -125,10 +124,10 @@ inline void axpy(Func func, cl::sycl::queue &queue, int64_t n, T alpha, cl::sycl
     });
 }
 
-#define AXPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
-    void axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, cl::sycl::buffer<TYPE, 1> &x, \
-              int64_t incx, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                  \
-        axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy);                          \
+#define AXPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                     \
+    void axpy(sycl::queue &queue, int64_t n, TYPE alpha, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                                          \
+        axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy);                                \
     }
 
 AXPY_LAUNCHER(float, rocblas_saxpy)
@@ -137,39 +136,38 @@ AXPY_LAUNCHER(std::complex<float>, rocblas_caxpy)
 AXPY_LAUNCHER(std::complex<double>, rocblas_zaxpy)
 #undef AXPY_LAUNCHER
 
-void axpby(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-           int64_t incx, float beta, cl::sycl::buffer<float, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+           float beta, sycl::buffer<float, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 
-void axpby(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-           int64_t incx, double beta, cl::sycl::buffer<double, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx,
+           double beta, sycl::buffer<double, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 
-void axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-           cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-           cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 
-void axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-           cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-           cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 
 template <typename Func, typename T1, typename T2>
-inline void rotg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T1, 1> &a,
-                 cl::sycl::buffer<T1, 1> &b, cl::sycl::buffer<T2, 1> &c,
-                 cl::sycl::buffer<T1, 1> &s) {
+inline void rotg(Func func, sycl::queue &queue, sycl::buffer<T1, 1> &a, sycl::buffer<T1, 1> &b,
+                 sycl::buffer<T2, 1> &c, sycl::buffer<T1, 1> &s) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto b_acc = b.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto c_acc = c.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto s_acc = s.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto b_acc = b.template get_access<sycl::access::mode::read_write>(cgh);
+        auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
+        auto s_acc = s.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
             // By default the pointer mode is the rocblas_pointer_mode_host
@@ -192,11 +190,10 @@ inline void rotg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T1, 1> &a,
     });
 }
 
-#define ROTG_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                        \
-    void rotg(cl::sycl::queue &queue, cl::sycl::buffer<TYPE1, 1> &a,        \
-              cl::sycl::buffer<TYPE1, 1> &b, cl::sycl::buffer<TYPE2, 1> &c, \
-              cl::sycl::buffer<TYPE1, 1> &s) {                              \
-        rotg(ROCBLAS_ROUTINE, queue, a, b, c, s);                           \
+#define ROTG_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                    \
+    void rotg(sycl::queue &queue, sycl::buffer<TYPE1, 1> &a, sycl::buffer<TYPE1, 1> &b, \
+              sycl::buffer<TYPE2, 1> &c, sycl::buffer<TYPE1, 1> &s) {                   \
+        rotg(ROCBLAS_ROUTINE, queue, a, b, c, s);                                       \
     }
 
 ROTG_LAUNCHER(float, float, rocblas_srotg)
@@ -206,15 +203,14 @@ ROTG_LAUNCHER(std::complex<double>, double, rocblas_zrotg)
 #undef ROTG_LAUNCHER
 
 template <typename Func, typename T>
-inline void rotm(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &param) {
+inline void rotm(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, int64_t incx,
+                 sycl::buffer<T, 1> &y, int64_t incy, sycl::buffer<T, 1> &param) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto param_acc = param.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
+        auto param_acc = param.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -237,10 +233,10 @@ inline void rotm(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
     });
 }
 
-#define ROTM_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
-    void rotm(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, int64_t incx,  \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy, cl::sycl::buffer<TYPE, 1> &param) { \
-        rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param);                             \
+#define ROTM_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                          \
+    void rotm(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, int64_t incx,  \
+              sycl::buffer<TYPE, 1> &y, int64_t incy, sycl::buffer<TYPE, 1> &param) { \
+        rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param);                     \
     }
 
 ROTM_LAUNCHER(float, rocblas_srotm)
@@ -248,13 +244,13 @@ ROTM_LAUNCHER(double, rocblas_drotm)
 #undef ROTM_LAUNCHER
 
 template <typename Func, typename T>
-inline void copy(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void copy(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, int64_t incx,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -266,10 +262,10 @@ inline void copy(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
     });
 }
 
-#define COPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void copy(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                  \
-        copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                                   \
+#define COPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
+    void copy(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
+        copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                           \
     }
 
 COPY_LAUNCHER(float, rocblas_scopy)
@@ -279,15 +275,14 @@ COPY_LAUNCHER(std::complex<double>, rocblas_zcopy)
 #undef COPY_LAUNCHER
 
 template <typename Func, typename T>
-inline void dot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                const int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                cl::sycl::buffer<T, 1> &result) {
+inline void dot(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, const int64_t incx,
+                sycl::buffer<T, 1> &y, int64_t incy, sycl::buffer<T, 1> &result) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto res_acc = result.template get_access<cl::sycl::access::mode::write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -310,11 +305,10 @@ inline void dot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T
     });
 }
 
-#define DOT_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                        \
-    void dot##EXT(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x,      \
-                  const int64_t incx, cl::sycl::buffer<TYPE, 1> &y, const int64_t incy, \
-                  cl::sycl::buffer<TYPE, 1> &result) {                                  \
-        dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result);                       \
+#define DOT_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                                 \
+    void dot##EXT(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, const int64_t incx,   \
+                  sycl::buffer<TYPE, 1> &y, const int64_t incy, sycl::buffer<TYPE, 1> &result) { \
+        dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result);                                \
     }
 DOT_LAUNCHER(, float, rocblas_sdot)
 DOT_LAUNCHER(, double, rocblas_ddot)
@@ -325,15 +319,15 @@ DOT_LAUNCHER(u, std::complex<double>, rocblas_zdotu)
 #undef DOT_LAUNCHER
 
 template <typename Func, typename T1, typename T2, typename T3>
-inline void rot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T1, 1> &x,
-                const int64_t incx, cl::sycl::buffer<T1, 1> &y, int64_t incy, T2 c, T3 s) {
+inline void rot(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &x,
+                const int64_t incx, sycl::buffer<T1, 1> &y, int64_t incy, T2 c, T3 s) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     using rocDataType3 = typename RocEquivalentType<T3>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
             // By default the pointer mode is the rocblas_pointer_mode_host
@@ -351,10 +345,10 @@ inline void rot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T
     });
 }
 
-#define ROT_LAUNCHER(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                                         \
-    void rot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
-             cl::sycl::buffer<TYPE1, 1> &y, int64_t incy, TYPE2 c, TYPE3 s) {                      \
-        rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s);                                    \
+#define ROT_LAUNCHER(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                                 \
+    void rot(sycl::queue &queue, int64_t n, sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
+             sycl::buffer<TYPE1, 1> &y, int64_t incy, TYPE2 c, TYPE3 s) {                  \
+        rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s);                            \
     }
 
 ROT_LAUNCHER(float, float, float, rocblas_srot)
@@ -363,15 +357,14 @@ ROT_LAUNCHER(std::complex<float>, float, float, rocblas_csrot)
 ROT_LAUNCHER(std::complex<double>, double, double, rocblas_zdrot)
 #undef ROT_LAUNCHER
 
-void sdsdot(cl::sycl::queue &queue, int64_t n, float sb, cl::sycl::buffer<float, 1> &x,
-            int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-            cl::sycl::buffer<float, 1> &result) {
+void sdsdot(sycl::queue &queue, int64_t n, float sb, sycl::buffer<float, 1> &x, int64_t incx,
+            sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &result) {
     overflow_check(n, incx, incy);
     // rocBLAS does not support sdot so we need to mimic sdot.
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.get_access<cl::sycl::access::mode::read>(cgh);
-        auto res_acc = result.get_access<cl::sycl::access::mode::write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = result.get_access<sycl::access::mode::write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -394,26 +387,25 @@ void sdsdot(cl::sycl::queue &queue, int64_t n, float sb, cl::sycl::buffer<float,
     });
     // Since SB is a host pointer we need to bring the result back to the host and
     // add sb to it.
-    result.get_access<cl::sycl::access::mode::read_write>()[0] += sb;
+    result.get_access<sycl::access::mode::read_write>()[0] += sb;
 }
 
-void dot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-         cl::sycl::buffer<float, 1> &y, int64_t incy, cl::sycl::buffer<double, 1> &result) {
+void dot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+         sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<double, 1> &result) {
     throw unimplemented("blas", "dot", "for column_major layout");
 }
 
 template <typename Func, typename T>
-inline void rotmg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T, 1> &d1,
-                  cl::sycl::buffer<T, 1> &d2, cl::sycl::buffer<T, 1> &x1, T y1,
-                  cl::sycl::buffer<T, 1> &param) {
+inline void rotmg(Func func, sycl::queue &queue, sycl::buffer<T, 1> &d1, sycl::buffer<T, 1> &d2,
+                  sycl::buffer<T, 1> &x1, T y1, sycl::buffer<T, 1> &param) {
     using rocDataType = typename RocEquivalentType<T>::Type;
-    cl::sycl::buffer<T, 1> y1_buff(&y1, cl::sycl::range<1>(1));
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto d1_acc = d1.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto d2_acc = d2.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x1_acc = x1.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto y1_acc = y1_buff.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto param_acc = param.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    sycl::buffer<T, 1> y1_buff(&y1, sycl::range<1>(1));
+    queue.submit([&](sycl::handler &cgh) {
+        auto d1_acc = d1.template get_access<sycl::access::mode::read_write>(cgh);
+        auto d2_acc = d2.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x1_acc = x1.template get_access<sycl::access::mode::read_write>(cgh);
+        auto y1_acc = y1_buff.template get_access<sycl::access::mode::read>(cgh);
+        auto param_acc = param.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -438,11 +430,10 @@ inline void rotmg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T, 1> &d1,
     });
 }
 
-#define ROTMG_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
-    void rotmg(cl::sycl::queue &queue, cl::sycl::buffer<TYPE, 1> &d1,                 \
-               cl::sycl::buffer<TYPE, 1> &d2, cl::sycl::buffer<TYPE, 1> &x1, TYPE y1, \
-               cl::sycl::buffer<TYPE, 1> &param) {                                    \
-        rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param);                         \
+#define ROTMG_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
+    void rotmg(sycl::queue &queue, sycl::buffer<TYPE, 1> &d1, sycl::buffer<TYPE, 1> &d2, \
+               sycl::buffer<TYPE, 1> &x1, TYPE y1, sycl::buffer<TYPE, 1> &param) {       \
+        rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param);                            \
     }
 
 ROTMG_LAUNCHER(float, rocblas_srotmg)
@@ -450,8 +441,8 @@ ROTMG_LAUNCHER(double, rocblas_drotmg)
 #undef ROTMG_LAUNCHER
 
 template <typename Func, typename T>
-inline void iamax(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                  const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
+inline void iamax(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x,
+                  const int64_t incx, sycl::buffer<int64_t, 1> &result) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
     // rocBLAS does not support int64_t as return type for the data by default. So we need to
@@ -461,10 +452,10 @@ inline void iamax(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
     // based on the size. Alternatively either we need to write a sycl kernel
     // to elementwise copy the data between two buffer, or allow reinterpret cast
     // to convert to different type with different typesize size.
-    cl::sycl::buffer<int, 1> int_res_buff{ cl::sycl::range<1>(1) };
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto int_res_acc = int_res_buff.template get_access<cl::sycl::access::mode::write>(cgh);
+    sycl::buffer<int, 1> int_res_buff{ sycl::range<1>(1) };
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -488,15 +479,14 @@ inline void iamax(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
     });
     // This requires to bring the data to host, copy it, and return it back to
     // the device
-    result.template get_access<cl::sycl::access::mode::write>()[0] =
-        std::max((int64_t)int_res_buff.template get_access<cl::sycl::access::mode::read>()[0] - 1,
-                 int64_t{ 0 });
+    result.template get_access<sycl::access::mode::write>()[0] = std::max(
+        (int64_t)int_res_buff.template get_access<sycl::access::mode::read>()[0] - 1, int64_t{ 0 });
 }
 
-#define IAMAX_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                   \
-    void iamax(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, \
-               const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {      \
-        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result);                      \
+#define IAMAX_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void iamax(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, const int64_t incx, \
+               sycl::buffer<int64_t, 1> &result) {                                          \
+        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
     }
 IAMAX_LAUNCHER(float, rocblas_isamax)
 IAMAX_LAUNCHER(double, rocblas_idamax)
@@ -505,13 +495,13 @@ IAMAX_LAUNCHER(std::complex<double>, rocblas_izamax)
 #undef IAMAX_LAUNCHER
 
 template <typename Func, typename T>
-inline void swap(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void swap(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, int64_t incx,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -523,10 +513,10 @@ inline void swap(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
     });
 }
 
-#define SWAP_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                  \
-        swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                                   \
+#define SWAP_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
+    void swap(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
+        swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                           \
     }
 
 SWAP_LAUNCHER(float, rocblas_sswap)
@@ -536,8 +526,8 @@ SWAP_LAUNCHER(std::complex<double>, rocblas_zswap)
 #undef SWAP_LAUNCHER
 
 template <typename Func, typename T>
-inline void iamin(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                  const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
+inline void iamin(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x,
+                  const int64_t incx, sycl::buffer<int64_t, 1> &result) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
     // rocBLAS does not support int64_t as return type for the data by default. So we need to
@@ -547,10 +537,10 @@ inline void iamin(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
     // based on the size. Alternatively, either we need to write a sycl kernel
     // to elementwise copy the data between two buffer, or allow reinterpret cast
     // to convert to different type with different typesize size.
-    cl::sycl::buffer<int, 1> int_res_buff{ cl::sycl::range<1>(1) };
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto int_res_acc = int_res_buff.template get_access<cl::sycl::access::mode::write>(cgh);
+    sycl::buffer<int, 1> int_res_buff{ sycl::range<1>(1) };
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -572,15 +562,14 @@ inline void iamin(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer
             rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
-    result.template get_access<cl::sycl::access::mode::write>()[0] =
-        std::max((int64_t)int_res_buff.template get_access<cl::sycl::access::mode::read>()[0] - 1,
-                 int64_t{ 0 });
+    result.template get_access<sycl::access::mode::write>()[0] = std::max(
+        (int64_t)int_res_buff.template get_access<sycl::access::mode::read>()[0] - 1, int64_t{ 0 });
 }
 
-#define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                   \
-    void iamin(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, \
-               const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {      \
-        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result);                      \
+#define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void iamin(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, const int64_t incx, \
+               sycl::buffer<int64_t, 1> &result) {                                          \
+        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
     }
 IAMIN_LAUNCHER(float, rocblas_isamin)
 IAMIN_LAUNCHER(double, rocblas_idamin)
@@ -589,15 +578,15 @@ IAMIN_LAUNCHER(std::complex<double>, rocblas_izamin)
 #undef IAMIN_LAUNCHER
 
 template <typename Func, typename T1, typename T2>
-inline void nrm2(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T1, 1> &x,
-                 const int64_t incx, cl::sycl::buffer<T2, 1> &result) {
+inline void nrm2(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &x,
+                 const int64_t incx, sycl::buffer<T2, 1> &result) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     overflow_check(n, incx);
 
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto res_acc = result.template get_access<cl::sycl::access::mode::write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -620,10 +609,10 @@ inline void nrm2(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<
     });
 }
 
-#define NRM2_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                            \
-    void nrm2(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE1, 1> &x, \
-              const int64_t incx, cl::sycl::buffer<TYPE2, 1> &result) {         \
-        nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result);                       \
+#define NRM2_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
+    void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
+              sycl::buffer<TYPE2, 1> &result) {                                             \
+        nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                   \
     }
 NRM2_LAUNCHER(float, float, rocblas_snrm2)
 NRM2_LAUNCHER(double, double, rocblas_dnrm2)
@@ -635,14 +624,13 @@ NRM2_LAUNCHER(std::complex<double>, double, rocblas_dznrm2)
 
 // Level 1
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
-                            const int64_t incx, T2 *result,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event asum(Func func, sycl::queue &queue, int64_t n, const T1 *x, const int64_t incx,
+                        T2 *result, const std::vector<sycl::event> &dependencies) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     overflow_check(n, incx);
 
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -662,10 +650,10 @@ inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const 
     return done;
 }
 
-#define ASUM_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
-    cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
-        return asum(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
+#define ASUM_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                \
+    sycl::event asum(sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
+                     TYPE2 *result, const std::vector<sycl::event> &dependencies) {     \
+        return asum(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);          \
     }
 ASUM_LAUNCHER_USM(float, float, rocblas_sasum)
 ASUM_LAUNCHER_USM(double, double, rocblas_dasum)
@@ -674,12 +662,12 @@ ASUM_LAUNCHER_USM(std::complex<double>, double, rocblas_dzasum)
 #undef ASUM_LAUNCHER_USM
 
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, T2 *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event scal(Func func, sycl::queue &queue, int64_t n, T1 a, T2 *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     overflow_check(n, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -696,10 +684,10 @@ inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, 
     return done;
 }
 
-#define SCAL_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                     \
-    cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {                 \
-        return scal(ROCBLAS_ROUTINE, queue, n, a, x, incx, dependencies);                    \
+#define SCAL_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                             \
+    sycl::event scal(sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
+                     const std::vector<sycl::event> &dependencies) {                 \
+        return scal(ROCBLAS_ROUTINE, queue, n, a, x, incx, dependencies);            \
     }
 SCAL_LAUNCHER_USM(float, float, rocblas_sscal)
 SCAL_LAUNCHER_USM(double, double, rocblas_dscal)
@@ -710,12 +698,11 @@ SCAL_LAUNCHER_USM(double, std::complex<double>, rocblas_zdscal)
 #undef SCAL_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alpha, const T *x,
-                            int64_t incx, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event axpy(Func func, sycl::queue &queue, int64_t n, T alpha, const T *x, int64_t incx,
+                        T *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -732,11 +719,10 @@ inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alph
     return done;
 }
 
-#define AXPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
-    cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x, \
-                         int64_t incx, TYPE *y, int64_t incy,                          \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
-        return axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies); \
+#define AXPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
+    sycl::event axpy(sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x, int64_t incx, \
+                     TYPE *y, int64_t incy, const std::vector<sycl::event> &dependencies) {  \
+        return axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);       \
     }
 
 AXPY_LAUNCHER_USM(float, rocblas_saxpy)
@@ -745,35 +731,35 @@ AXPY_LAUNCHER_USM(std::complex<float>, rocblas_caxpy)
 AXPY_LAUNCHER_USM(std::complex<double>, rocblas_zaxpy)
 #undef AXPY_LAUNCHER_USM
 
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                      float beta, float *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
+                  float beta, float *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
-                      int64_t incx, double beta, double *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                  double beta, double *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                      const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                      std::complex<float> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                  const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                  std::complex<float> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                      std::complex<double> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                  const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                  std::complex<double> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for column_major layout");
 }
 
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 *c, T1 *s,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rotg(Func func, sycl::queue &queue, T1 *a, T1 *b, T2 *c, T1 *s,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -792,10 +778,10 @@ inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 
     return done;
 }
 
-#define ROTG_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                 \
-    cl::sycl::event rotg(cl::sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
-                         const std::vector<cl::sycl::event> &dependencies) {             \
-        return rotg(ROCBLAS_ROUTINE, queue, a, b, c, s, dependencies);                   \
+#define ROTG_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                         \
+    sycl::event rotg(sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
+                     const std::vector<sycl::event> &dependencies) {             \
+        return rotg(ROCBLAS_ROUTINE, queue, a, b, c, s, dependencies);           \
     }
 
 ROTG_LAUNCHER_USM(float, float, rocblas_srotg)
@@ -805,12 +791,11 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, rocblas_zrotg)
 #undef ROTG_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
-                            int64_t incy, T *param,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rotm(Func func, sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
+                        int64_t incy, T *param, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -828,11 +813,10 @@ inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, 
     return done;
 }
 
-#define ROTM_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy, TYPE *param,                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {                \
-        return rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);      \
+#define ROTM_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event rotm(sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, int64_t incy, \
+                     TYPE *param, const std::vector<sycl::event> &dependencies) {                 \
+        return rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);            \
     }
 
 ROTM_LAUNCHER_USM(float, rocblas_srotm)
@@ -840,11 +824,11 @@ ROTM_LAUNCHER_USM(double, rocblas_drotm)
 #undef ROTM_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const T *x, int64_t incx,
-                            T *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event copy(Func func, sycl::queue &queue, int64_t n, const T *x, int64_t incx, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -861,10 +845,10 @@ inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const 
     return done;
 }
 
-#define COPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {        \
-        return copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                   \
+#define COPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
+    sycl::event copy(sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {        \
+        return copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);           \
     }
 
 COPY_LAUNCHER_USM(float, rocblas_scopy)
@@ -874,12 +858,12 @@ COPY_LAUNCHER_USM(std::complex<double>, rocblas_zcopy)
 #undef COPY_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
-                           const int64_t incx, const T *y, int64_t incy, T *result,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event dot(Func func, sycl::queue &queue, int64_t n, const T *x, const int64_t incx,
+                       const T *y, int64_t incy, T *result,
+                       const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -897,11 +881,11 @@ inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T
     return done;
 }
 
-#define DOT_LAUNCHER_USM(EXT, TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event dot##EXT(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                             const TYPE *y, const int64_t incy, TYPE *result,                      \
-                             const std::vector<cl::sycl::event> &dependencies) {                   \
-        return dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);             \
+#define DOT_LAUNCHER_USM(EXT, TYPE, ROCBLAS_ROUTINE)                                       \
+    sycl::event dot##EXT(sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
+                         const TYPE *y, const int64_t incy, TYPE *result,                  \
+                         const std::vector<sycl::event> &dependencies) {                   \
+        return dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);     \
     }
 DOT_LAUNCHER_USM(, float, rocblas_sdot)
 DOT_LAUNCHER_USM(, double, rocblas_ddot)
@@ -912,14 +896,13 @@ DOT_LAUNCHER_USM(u, std::complex<double>, rocblas_zdotu)
 #undef DOT_LAUNCHER_USM
 
 template <typename Func, typename T1, typename T2, typename T3>
-inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, const int64_t incx,
-                           T1 *y, int64_t incy, T2 c, T3 s,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rot(Func func, sycl::queue &queue, int64_t n, T1 *x, const int64_t incx, T1 *y,
+                       int64_t incy, T2 c, T3 s, const std::vector<sycl::event> &dependencies) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     using rocDataType3 = typename RocEquivalentType<T3>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -937,11 +920,11 @@ inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, 
     return done;
 }
 
-#define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                                     \
-    cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
-                        int64_t incy, TYPE2 c, TYPE3 s,                                            \
-                        const std::vector<cl::sycl::event> &dependencies) {                        \
-        return rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);               \
+#define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                             \
+    sycl::event rot(sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
+                    int64_t incy, TYPE2 c, TYPE3 s,                                        \
+                    const std::vector<sycl::event> &dependencies) {                        \
+        return rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);       \
     }
 
 ROT_LAUNCHER_USM(float, float, float, rocblas_srot)
@@ -950,12 +933,12 @@ ROT_LAUNCHER_USM(std::complex<float>, float, float, rocblas_csrot)
 ROT_LAUNCHER_USM(std::complex<double>, double, double, rocblas_zdrot)
 #undef ROT_LAUNCHER_USM
 
-cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
-                       const float *y, int64_t incy, float *result,
-                       const std::vector<cl::sycl::event> &dependencies) {
+sycl::event sdsdot(sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
+                   const float *y, int64_t incy, float *result,
+                   const std::vector<sycl::event> &dependencies) {
     overflow_check(n, incx, incy);
     // rocBLAS does not support sdot so we need to mimic sdot.
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -975,17 +958,16 @@ cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float 
     return done;
 }
 
-cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, double *result,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
+                int64_t incy, double *result, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dot", "for column_major layout");
 }
 
 template <typename Func, typename T>
-inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T *x1, T y1, T *param,
-                             const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rotmg(Func func, sycl::queue &queue, T *d1, T *d2, T *x1, T y1, T *param,
+                         const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1005,10 +987,10 @@ inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T 
     return done;
 }
 
-#define ROTMG_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
-    cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1,   \
-                          TYPE *param, const std::vector<cl::sycl::event> &dependencies) { \
-        return rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);         \
+#define ROTMG_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
+    sycl::event rotmg(sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1, TYPE *param, \
+                      const std::vector<sycl::event> &dependencies) {                         \
+        return rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);            \
     }
 
 ROTMG_LAUNCHER_USM(float, rocblas_srotmg)
@@ -1016,9 +998,8 @@ ROTMG_LAUNCHER_USM(double, rocblas_drotmg)
 #undef ROTMG_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
-                             const int64_t incx, int64_t *result,
-                             const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event iamax(Func func, sycl::queue &queue, int64_t n, const T *x, const int64_t incx,
+                         int64_t *result, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
     // rocBLAS does not support int64_t as return type for the data by default. So we need to
@@ -1026,10 +1007,10 @@ inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const
     // it back to the actual data on the host.
     // This change may cause failure as the result of integer overflow
     // based on the size.
-    auto int_res_p = (int *)cl::sycl::aligned_alloc_shared(64, sizeof(rocblas_int),
-                                                           queue.get_device(), queue.get_context());
+    auto int_res_p = (int *)sycl::aligned_alloc_shared(64, sizeof(rocblas_int), queue.get_device(),
+                                                       queue.get_context());
     *int_res_p = 0;
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1051,10 +1032,10 @@ inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const
     return done;
 }
 
-#define IAMAX_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
-        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                 \
+#define IAMAX_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
+    sycl::event iamax(sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
+                      int64_t *result, const std::vector<sycl::event> &dependencies) {  \
+        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
     }
 IAMAX_LAUNCHER_USM(float, rocblas_isamax)
 IAMAX_LAUNCHER_USM(double, rocblas_idamax)
@@ -1063,11 +1044,11 @@ IAMAX_LAUNCHER_USM(std::complex<double>, rocblas_izamax)
 #undef IAMAX_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
-                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event swap(Func func, sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1084,10 +1065,10 @@ inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, 
     return done;
 }
 
-#define SWAP_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {  \
-        return swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);             \
+#define SWAP_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event swap(sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, int64_t incy, \
+                     const std::vector<sycl::event> &dependencies) {                              \
+        return swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                   \
     }
 
 SWAP_LAUNCHER_USM(float, rocblas_sswap)
@@ -1097,9 +1078,8 @@ SWAP_LAUNCHER_USM(std::complex<double>, rocblas_zswap)
 #undef SWAP_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
-                             const int64_t incx, int64_t *result,
-                             const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event iamin(Func func, sycl::queue &queue, int64_t n, const T *x, const int64_t incx,
+                         int64_t *result, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
     // rocBLAS does not support int64_t as return type for the data by default. So we need to
@@ -1107,10 +1087,10 @@ inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const
     // it back to the actual data on the host.
     // This change may cause failure as the result of integer overflow
     // based on the size.
-    auto int_res_p = (int *)cl::sycl::aligned_alloc_shared(64, sizeof(rocblas_int),
-                                                           queue.get_device(), queue.get_context());
+    auto int_res_p = (int *)sycl::aligned_alloc_shared(64, sizeof(rocblas_int), queue.get_device(),
+                                                       queue.get_context());
     *int_res_p = 0;
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1133,10 +1113,10 @@ inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const
     return done;
 }
 
-#define IAMIN_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
-        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                 \
+#define IAMIN_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
+    sycl::event iamin(sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
+                      int64_t *result, const std::vector<sycl::event> &dependencies) {  \
+        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
     }
 IAMIN_LAUNCHER_USM(float, rocblas_isamin)
 IAMIN_LAUNCHER_USM(double, rocblas_idamin)
@@ -1145,14 +1125,13 @@ IAMIN_LAUNCHER_USM(std::complex<double>, rocblas_izamin)
 #undef IAMIN_LAUNCHER_USM
 
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
-                            const int64_t incx, T2 *result,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event nrm2(Func func, sycl::queue &queue, int64_t n, const T1 *x, const int64_t incx,
+                        T2 *result, const std::vector<sycl::event> &dependencies) {
     using rocDataType1 = typename RocEquivalentType<T1>::Type;
     using rocDataType2 = typename RocEquivalentType<T2>::Type;
     overflow_check(n, incx);
 
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1172,10 +1151,10 @@ inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const 
     return done;
 }
 
-#define NRM2_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
-    cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
-        return nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
+#define NRM2_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                \
+    sycl::event nrm2(sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
+                     TYPE2 *result, const std::vector<sycl::event> &dependencies) {     \
+        return nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);          \
     }
 NRM2_LAUNCHER_USM(float, float, rocblas_snrm2)
 NRM2_LAUNCHER_USM(double, double, rocblas_dnrm2)
@@ -1190,15 +1169,15 @@ namespace row_major {
 
 // Level 1
 template <typename Func, typename T1, typename T2>
-inline void asum(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T1, 1> &x,
-                 const int64_t incx, cl::sycl::buffer<T2, 1> &result) {
+inline void asum(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &x,
+                 const int64_t incx, sycl::buffer<T2, 1> &result) {
     throw unimplemented("blas", "asum", "for row_major layout");
 }
 
-#define ASUM_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                            \
-    void asum(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE1, 1> &x, \
-              const int64_t incx, cl::sycl::buffer<TYPE2, 1> &result) {         \
-        asum(ROCBLAS_ROUTINE, queue, n, x, incx, result);                       \
+#define ASUM_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
+    void asum(sycl::queue &queue, int64_t n, sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
+              sycl::buffer<TYPE2, 1> &result) {                                             \
+        asum(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                   \
     }
 ASUM_LAUNCHER(float, float, rocblas_sasum)
 ASUM_LAUNCHER(double, double, rocblas_dasum)
@@ -1207,15 +1186,14 @@ ASUM_LAUNCHER(std::complex<double>, double, rocblas_dzasum)
 #undef ASUM_LAUNCHER
 
 template <typename Func, typename T1, typename T2>
-inline void scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, cl::sycl::buffer<T2, 1> &x,
+inline void scal(Func func, sycl::queue &queue, int64_t n, T1 a, sycl::buffer<T2, 1> &x,
                  int64_t incx) {
     throw unimplemented("blas", "scal", "for row_major layout");
 }
 
-#define SCAL_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                     \
-    void scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, cl::sycl::buffer<TYPE2, 1> &x, \
-              int64_t incx) {                                                            \
-        scal(ROCBLAS_ROUTINE, queue, n, a, x, incx);                                     \
+#define SCAL_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                             \
+    void scal(sycl::queue &queue, int64_t n, TYPE1 a, sycl::buffer<TYPE2, 1> &x, int64_t incx) { \
+        scal(ROCBLAS_ROUTINE, queue, n, a, x, incx);                                             \
     }
 SCAL_LAUNCHER(float, float, rocblas_sscal)
 SCAL_LAUNCHER(double, double, rocblas_dscal)
@@ -1226,15 +1204,15 @@ SCAL_LAUNCHER(double, std::complex<double>, rocblas_zdscal)
 #undef SCAL_LAUNCHER
 
 template <typename Func, typename T>
-inline void axpy(Func func, cl::sycl::queue &queue, int64_t n, T alpha, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void axpy(Func func, sycl::queue &queue, int64_t n, T alpha, sycl::buffer<T, 1> &x,
+                 int64_t incx, sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpy", "for row_major layout");
 }
 
-#define AXPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
-    void axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, cl::sycl::buffer<TYPE, 1> &x, \
-              int64_t incx, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                  \
-        axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy);                          \
+#define AXPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                     \
+    void axpy(sycl::queue &queue, int64_t n, TYPE alpha, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                                          \
+        axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy);                                \
     }
 
 AXPY_LAUNCHER(float, rocblas_saxpy)
@@ -1243,40 +1221,38 @@ AXPY_LAUNCHER(std::complex<float>, rocblas_caxpy)
 AXPY_LAUNCHER(std::complex<double>, rocblas_zaxpy)
 #undef AXPY_LAUNCHER
 
-void axpby(cl::sycl::queue &queue, int64_t n, float alpha, cl::sycl::buffer<float, 1> &x,
-           int64_t incx, float beta, cl::sycl::buffer<float, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+           float beta, sycl::buffer<float, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 
-void axpby(cl::sycl::queue &queue, int64_t n, double alpha, cl::sycl::buffer<double, 1> &x,
-           int64_t incx, double beta, cl::sycl::buffer<double, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx,
+           double beta, sycl::buffer<double, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 
-void axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-           cl::sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
-           cl::sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &x, int64_t incx, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 
-void axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-           cl::sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-           cl::sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 
 template <typename Func, typename T1, typename T2>
-inline void rotg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T1, 1> &a,
-                 cl::sycl::buffer<T1, 1> &b, cl::sycl::buffer<T2, 1> &c,
-                 cl::sycl::buffer<T1, 1> &s) {
+inline void rotg(Func func, sycl::queue &queue, sycl::buffer<T1, 1> &a, sycl::buffer<T1, 1> &b,
+                 sycl::buffer<T2, 1> &c, sycl::buffer<T1, 1> &s) {
     throw unimplemented("blas", "rotg", "for row_major layout");
 }
 
-#define ROTG_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                        \
-    void rotg(cl::sycl::queue &queue, cl::sycl::buffer<TYPE1, 1> &a,        \
-              cl::sycl::buffer<TYPE1, 1> &b, cl::sycl::buffer<TYPE2, 1> &c, \
-              cl::sycl::buffer<TYPE1, 1> &s) {                              \
-        rotg(ROCBLAS_ROUTINE, queue, a, b, c, s);                           \
+#define ROTG_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                    \
+    void rotg(sycl::queue &queue, sycl::buffer<TYPE1, 1> &a, sycl::buffer<TYPE1, 1> &b, \
+              sycl::buffer<TYPE2, 1> &c, sycl::buffer<TYPE1, 1> &s) {                   \
+        rotg(ROCBLAS_ROUTINE, queue, a, b, c, s);                                       \
     }
 
 ROTG_LAUNCHER(float, float, rocblas_srotg)
@@ -1286,16 +1262,15 @@ ROTG_LAUNCHER(std::complex<double>, double, rocblas_zrotg)
 #undef ROTG_LAUNCHER
 
 template <typename Func, typename T>
-inline void rotm(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &param) {
+inline void rotm(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, int64_t incx,
+                 sycl::buffer<T, 1> &y, int64_t incy, sycl::buffer<T, 1> &param) {
     throw unimplemented("blas", "rotm", "for row_major layout");
 }
 
-#define ROTM_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
-    void rotm(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, int64_t incx,  \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy, cl::sycl::buffer<TYPE, 1> &param) { \
-        rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param);                             \
+#define ROTM_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                          \
+    void rotm(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, int64_t incx,  \
+              sycl::buffer<TYPE, 1> &y, int64_t incy, sycl::buffer<TYPE, 1> &param) { \
+        rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param);                     \
     }
 
 ROTM_LAUNCHER(float, rocblas_srotm)
@@ -1303,15 +1278,15 @@ ROTM_LAUNCHER(double, rocblas_drotm)
 #undef ROTM_LAUNCHER
 
 template <typename Func, typename T>
-inline void copy(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void copy(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, int64_t incx,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "copy", "for row_major layout");
 }
 
-#define COPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void copy(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                  \
-        copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                                   \
+#define COPY_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
+    void copy(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
+        copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                           \
     }
 
 COPY_LAUNCHER(float, rocblas_scopy)
@@ -1321,17 +1296,15 @@ COPY_LAUNCHER(std::complex<double>, rocblas_zcopy)
 #undef COPY_LAUNCHER
 
 template <typename Func, typename T>
-inline void dot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                const int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                cl::sycl::buffer<T, 1> &result) {
+inline void dot(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, const int64_t incx,
+                sycl::buffer<T, 1> &y, int64_t incy, sycl::buffer<T, 1> &result) {
     throw unimplemented("blas", "dot", "for row_major layout");
 }
 
-#define DOT_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                        \
-    void dot##EXT(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x,      \
-                  const int64_t incx, cl::sycl::buffer<TYPE, 1> &y, const int64_t incy, \
-                  cl::sycl::buffer<TYPE, 1> &result) {                                  \
-        dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result);                       \
+#define DOT_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                                 \
+    void dot##EXT(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, const int64_t incx,   \
+                  sycl::buffer<TYPE, 1> &y, const int64_t incy, sycl::buffer<TYPE, 1> &result) { \
+        dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result);                                \
     }
 DOT_LAUNCHER(, float, rocblas_sdot)
 DOT_LAUNCHER(, double, rocblas_ddot)
@@ -1342,15 +1315,15 @@ DOT_LAUNCHER(u, std::complex<double>, rocblas_zdotu)
 #undef DOT_LAUNCHER
 
 template <typename Func, typename T1, typename T2, typename T3>
-inline void rot(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T1, 1> &x,
-                const int64_t incx, cl::sycl::buffer<T1, 1> &y, int64_t incy, T2 c, T3 s) {
+inline void rot(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &x,
+                const int64_t incx, sycl::buffer<T1, 1> &y, int64_t incy, T2 c, T3 s) {
     throw unimplemented("blas", "rot", "for row_major layout");
 }
 
-#define ROT_LAUNCHER(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                                         \
-    void rot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
-             cl::sycl::buffer<TYPE1, 1> &y, int64_t incy, TYPE2 c, TYPE3 s) {                      \
-        rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s);                                    \
+#define ROT_LAUNCHER(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                                 \
+    void rot(sycl::queue &queue, int64_t n, sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
+             sycl::buffer<TYPE1, 1> &y, int64_t incy, TYPE2 c, TYPE3 s) {                  \
+        rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s);                            \
     }
 
 ROT_LAUNCHER(float, float, float, rocblas_srot)
@@ -1359,29 +1332,26 @@ ROT_LAUNCHER(std::complex<float>, float, float, rocblas_csrot)
 ROT_LAUNCHER(std::complex<double>, double, double, rocblas_zdrot)
 #undef ROT_LAUNCHER
 
-void sdsdot(cl::sycl::queue &queue, int64_t n, float sb, cl::sycl::buffer<float, 1> &x,
-            int64_t incx, cl::sycl::buffer<float, 1> &y, int64_t incy,
-            cl::sycl::buffer<float, 1> &result) {
+void sdsdot(sycl::queue &queue, int64_t n, float sb, sycl::buffer<float, 1> &x, int64_t incx,
+            sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &result) {
     throw unimplemented("blas", "sdsdot", "for row_major layout");
 }
 
-void dot(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<float, 1> &x, int64_t incx,
-         cl::sycl::buffer<float, 1> &y, int64_t incy, cl::sycl::buffer<double, 1> &result) {
+void dot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
+         sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<double, 1> &result) {
     throw unimplemented("blas", "dot", "for row_major layout");
 }
 
 template <typename Func, typename T>
-inline void rotmg(Func func, cl::sycl::queue &queue, cl::sycl::buffer<T, 1> &d1,
-                  cl::sycl::buffer<T, 1> &d2, cl::sycl::buffer<T, 1> &x1, T y1,
-                  cl::sycl::buffer<T, 1> &param) {
+inline void rotmg(Func func, sycl::queue &queue, sycl::buffer<T, 1> &d1, sycl::buffer<T, 1> &d2,
+                  sycl::buffer<T, 1> &x1, T y1, sycl::buffer<T, 1> &param) {
     throw unimplemented("blas", "rotmg", "for row_major layout");
 }
 
-#define ROTMG_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
-    void rotmg(cl::sycl::queue &queue, cl::sycl::buffer<TYPE, 1> &d1,                 \
-               cl::sycl::buffer<TYPE, 1> &d2, cl::sycl::buffer<TYPE, 1> &x1, TYPE y1, \
-               cl::sycl::buffer<TYPE, 1> &param) {                                    \
-        rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param);                         \
+#define ROTMG_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
+    void rotmg(sycl::queue &queue, sycl::buffer<TYPE, 1> &d1, sycl::buffer<TYPE, 1> &d2, \
+               sycl::buffer<TYPE, 1> &x1, TYPE y1, sycl::buffer<TYPE, 1> &param) {       \
+        rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param);                            \
     }
 
 ROTMG_LAUNCHER(float, rocblas_srotmg)
@@ -1389,15 +1359,15 @@ ROTMG_LAUNCHER(double, rocblas_drotmg)
 #undef ROTMG_LAUNCHER
 
 template <typename Func, typename T>
-inline void iamax(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                  const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
+inline void iamax(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x,
+                  const int64_t incx, sycl::buffer<int64_t, 1> &result) {
     throw unimplemented("blas", "iamax", "for row_major layout");
 }
 
-#define IAMAX_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                   \
-    void iamax(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, \
-               const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {      \
-        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result);                      \
+#define IAMAX_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void iamax(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, const int64_t incx, \
+               sycl::buffer<int64_t, 1> &result) {                                          \
+        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
     }
 IAMAX_LAUNCHER(float, rocblas_isamax)
 IAMAX_LAUNCHER(double, rocblas_idamax)
@@ -1406,15 +1376,15 @@ IAMAX_LAUNCHER(std::complex<double>, rocblas_izamax)
 #undef IAMAX_LAUNCHER
 
 template <typename Func, typename T>
-inline void swap(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void swap(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x, int64_t incx,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "swap", "for row_major layout");
 }
 
-#define SWAP_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void swap(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                  \
-        swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                                   \
+#define SWAP_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                         \
+    void swap(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
+        swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy);                           \
     }
 
 SWAP_LAUNCHER(float, rocblas_sswap)
@@ -1424,15 +1394,15 @@ SWAP_LAUNCHER(std::complex<double>, rocblas_zswap)
 #undef SWAP_LAUNCHER
 
 template <typename Func, typename T>
-inline void iamin(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T, 1> &x,
-                  const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {
+inline void iamin(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x,
+                  const int64_t incx, sycl::buffer<int64_t, 1> &result) {
     throw unimplemented("blas", "iamin", "for row_major layout");
 }
 
-#define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                   \
-    void iamin(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE, 1> &x, \
-               const int64_t incx, cl::sycl::buffer<int64_t, 1> &result) {      \
-        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result);                      \
+#define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void iamin(sycl::queue &queue, int64_t n, sycl::buffer<TYPE, 1> &x, const int64_t incx, \
+               sycl::buffer<int64_t, 1> &result) {                                          \
+        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
     }
 IAMIN_LAUNCHER(float, rocblas_isamin)
 IAMIN_LAUNCHER(double, rocblas_idamin)
@@ -1441,15 +1411,15 @@ IAMIN_LAUNCHER(std::complex<double>, rocblas_izamin)
 #undef IAMIN_LAUNCHER
 
 template <typename Func, typename T1, typename T2>
-inline void nrm2(Func func, cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<T1, 1> &x,
-                 const int64_t incx, cl::sycl::buffer<T2, 1> &result) {
+inline void nrm2(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &x,
+                 const int64_t incx, sycl::buffer<T2, 1> &result) {
     throw unimplemented("blas", "nrm2", "for row_major layout");
 }
 
-#define NRM2_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                            \
-    void nrm2(cl::sycl::queue &queue, int64_t n, cl::sycl::buffer<TYPE1, 1> &x, \
-              const int64_t incx, cl::sycl::buffer<TYPE2, 1> &result) {         \
-        nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result);                       \
+#define NRM2_LAUNCHER(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
+    void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<TYPE1, 1> &x, const int64_t incx, \
+              sycl::buffer<TYPE2, 1> &result) {                                             \
+        nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                   \
     }
 NRM2_LAUNCHER(float, float, rocblas_snrm2)
 NRM2_LAUNCHER(double, double, rocblas_dnrm2)
@@ -1461,16 +1431,15 @@ NRM2_LAUNCHER(std::complex<double>, double, rocblas_dznrm2)
 
 // Level 1
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event asum(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
-                            const int64_t incx, T2 *result,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event asum(Func func, sycl::queue &queue, int64_t n, const T1 *x, const int64_t incx,
+                        T2 *result, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "asum", "for row_major layout");
 }
 
-#define ASUM_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
-    cl::sycl::event asum(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
-        return asum(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
+#define ASUM_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                \
+    sycl::event asum(sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
+                     TYPE2 *result, const std::vector<sycl::event> &dependencies) {     \
+        return asum(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);          \
     }
 ASUM_LAUNCHER_USM(float, float, rocblas_sasum)
 ASUM_LAUNCHER_USM(double, double, rocblas_dasum)
@@ -1479,15 +1448,15 @@ ASUM_LAUNCHER_USM(std::complex<double>, double, rocblas_dzasum)
 #undef ASUM_LAUNCHER_USM
 
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event scal(Func func, cl::sycl::queue &queue, int64_t n, T1 a, T2 *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event scal(Func func, sycl::queue &queue, int64_t n, T1 a, T2 *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "scal", "for row_major layout");
 }
 
-#define SCAL_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                     \
-    cl::sycl::event scal(cl::sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {                 \
-        return scal(ROCBLAS_ROUTINE, queue, n, a, x, incx, dependencies);                    \
+#define SCAL_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                             \
+    sycl::event scal(sycl::queue &queue, int64_t n, TYPE1 a, TYPE2 *x, int64_t incx, \
+                     const std::vector<sycl::event> &dependencies) {                 \
+        return scal(ROCBLAS_ROUTINE, queue, n, a, x, incx, dependencies);            \
     }
 SCAL_LAUNCHER_USM(float, float, rocblas_sscal)
 SCAL_LAUNCHER_USM(double, double, rocblas_dscal)
@@ -1498,17 +1467,15 @@ SCAL_LAUNCHER_USM(double, std::complex<double>, rocblas_zdscal)
 #undef SCAL_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event axpy(Func func, cl::sycl::queue &queue, int64_t n, T alpha, const T *x,
-                            int64_t incx, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event axpy(Func func, sycl::queue &queue, int64_t n, T alpha, const T *x, int64_t incx,
+                        T *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpy", "for row_major layout");
 }
 
-#define AXPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
-    cl::sycl::event axpy(cl::sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x, \
-                         int64_t incx, TYPE *y, int64_t incy,                          \
-                         const std::vector<cl::sycl::event> &dependencies) {           \
-        return axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies); \
+#define AXPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
+    sycl::event axpy(sycl::queue &queue, int64_t n, TYPE alpha, const TYPE *x, int64_t incx, \
+                     TYPE *y, int64_t incy, const std::vector<sycl::event> &dependencies) {  \
+        return axpy(ROCBLAS_ROUTINE, queue, n, alpha, x, incx, y, incy, dependencies);       \
     }
 
 AXPY_LAUNCHER_USM(float, rocblas_saxpy)
@@ -1517,39 +1484,39 @@ AXPY_LAUNCHER_USM(std::complex<float>, rocblas_caxpy)
 AXPY_LAUNCHER_USM(std::complex<double>, rocblas_zaxpy)
 #undef AXPY_LAUNCHER_USM
 
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                      float beta, float *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
+                  float beta, float *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, double alpha, const double *x,
-                      int64_t incx, double beta, double *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                  double beta, double *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                      const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                      std::complex<float> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
+                  const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                  std::complex<float> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
-cl::sycl::event axpby(cl::sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                      std::complex<double> *y, int64_t incy,
-                      const std::vector<cl::sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
+                  const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                  std::complex<double> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "axpby", "for row_major layout");
 }
 
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event rotg(Func func, cl::sycl::queue &queue, T1 *a, T1 *b, T2 *c, T1 *s,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rotg(Func func, sycl::queue &queue, T1 *a, T1 *b, T2 *c, T1 *s,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "rotg", "for row_major layout");
 }
 
-#define ROTG_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                 \
-    cl::sycl::event rotg(cl::sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
-                         const std::vector<cl::sycl::event> &dependencies) {             \
-        return rotg(ROCBLAS_ROUTINE, queue, a, b, c, s, dependencies);                   \
+#define ROTG_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                         \
+    sycl::event rotg(sycl::queue &queue, TYPE1 *a, TYPE1 *b, TYPE2 *c, TYPE1 *s, \
+                     const std::vector<sycl::event> &dependencies) {             \
+        return rotg(ROCBLAS_ROUTINE, queue, a, b, c, s, dependencies);           \
     }
 
 ROTG_LAUNCHER_USM(float, float, rocblas_srotg)
@@ -1559,17 +1526,15 @@ ROTG_LAUNCHER_USM(std::complex<double>, double, rocblas_zrotg)
 #undef ROTG_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event rotm(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
-                            int64_t incy, T *param,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rotm(Func func, sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
+                        int64_t incy, T *param, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "rotm", "for row_major layout");
 }
 
-#define ROTM_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event rotm(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy, TYPE *param,                                         \
-                         const std::vector<cl::sycl::event> &dependencies) {                \
-        return rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);      \
+#define ROTM_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event rotm(sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, int64_t incy, \
+                     TYPE *param, const std::vector<sycl::event> &dependencies) {                 \
+        return rotm(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, param, dependencies);            \
     }
 
 ROTM_LAUNCHER_USM(float, rocblas_srotm)
@@ -1577,15 +1542,15 @@ ROTM_LAUNCHER_USM(double, rocblas_drotm)
 #undef ROTM_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event copy(Func func, cl::sycl::queue &queue, int64_t n, const T *x, int64_t incx,
-                            T *y, int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event copy(Func func, sycl::queue &queue, int64_t n, const T *x, int64_t incx, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "copy", "for row_major layout");
 }
 
-#define COPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event copy(cl::sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {        \
-        return copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                   \
+#define COPY_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
+    sycl::event copy(sycl::queue &queue, int64_t n, const TYPE *x, int64_t incx, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {        \
+        return copy(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);           \
     }
 
 COPY_LAUNCHER_USM(float, rocblas_scopy)
@@ -1595,17 +1560,17 @@ COPY_LAUNCHER_USM(std::complex<double>, rocblas_zcopy)
 #undef COPY_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event dot(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
-                           const int64_t incx, const T *y, int64_t incy, T *result,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event dot(Func func, sycl::queue &queue, int64_t n, const T *x, const int64_t incx,
+                       const T *y, int64_t incy, T *result,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dot", "for row_major layout");
 }
 
-#define DOT_LAUNCHER_USM(EXT, TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event dot##EXT(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                             const TYPE *y, const int64_t incy, TYPE *result,                      \
-                             const std::vector<cl::sycl::event> &dependencies) {                   \
-        return dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);             \
+#define DOT_LAUNCHER_USM(EXT, TYPE, ROCBLAS_ROUTINE)                                       \
+    sycl::event dot##EXT(sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
+                         const TYPE *y, const int64_t incy, TYPE *result,                  \
+                         const std::vector<sycl::event> &dependencies) {                   \
+        return dot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, result, dependencies);     \
     }
 DOT_LAUNCHER_USM(, float, rocblas_sdot)
 DOT_LAUNCHER_USM(, double, rocblas_ddot)
@@ -1616,17 +1581,16 @@ DOT_LAUNCHER_USM(u, std::complex<double>, rocblas_zdotu)
 #undef DOT_LAUNCHER_USM
 
 template <typename Func, typename T1, typename T2, typename T3>
-inline cl::sycl::event rot(Func func, cl::sycl::queue &queue, int64_t n, T1 *x, const int64_t incx,
-                           T1 *y, int64_t incy, T2 c, T3 s,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rot(Func func, sycl::queue &queue, int64_t n, T1 *x, const int64_t incx, T1 *y,
+                       int64_t incy, T2 c, T3 s, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "rot", "for row_major layout");
 }
 
-#define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                                     \
-    cl::sycl::event rot(cl::sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
-                        int64_t incy, TYPE2 c, TYPE3 s,                                            \
-                        const std::vector<cl::sycl::event> &dependencies) {                        \
-        return rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);               \
+#define ROT_LAUNCHER_USM(TYPE1, TYPE2, TYPE3, ROCBLAS_ROUTINE)                             \
+    sycl::event rot(sycl::queue &queue, int64_t n, TYPE1 *x, const int64_t incx, TYPE1 *y, \
+                    int64_t incy, TYPE2 c, TYPE3 s,                                        \
+                    const std::vector<sycl::event> &dependencies) {                        \
+        return rot(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, c, s, dependencies);       \
     }
 
 ROT_LAUNCHER_USM(float, float, float, rocblas_srot)
@@ -1635,28 +1599,27 @@ ROT_LAUNCHER_USM(std::complex<float>, float, float, rocblas_csrot)
 ROT_LAUNCHER_USM(std::complex<double>, double, double, rocblas_zdrot)
 #undef ROT_LAUNCHER_USM
 
-cl::sycl::event sdsdot(cl::sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
-                       const float *y, int64_t incy, float *result,
-                       const std::vector<cl::sycl::event> &dependencies) {
+sycl::event sdsdot(sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
+                   const float *y, int64_t incy, float *result,
+                   const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "sdsdot", "for row_major layout");
 }
 
-cl::sycl::event dot(cl::sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, double *result,
-                    const std::vector<cl::sycl::event> &dependencies) {
+sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
+                int64_t incy, double *result, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "dot", "for row_major layout");
 }
 
 template <typename Func, typename T>
-inline cl::sycl::event rotmg(Func func, cl::sycl::queue &queue, T *d1, T *d2, T *x1, T y1, T *param,
-                             const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event rotmg(Func func, sycl::queue &queue, T *d1, T *d2, T *x1, T y1, T *param,
+                         const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "rotmg", "for row_major layout");
 }
 
-#define ROTMG_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
-    cl::sycl::event rotmg(cl::sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1,   \
-                          TYPE *param, const std::vector<cl::sycl::event> &dependencies) { \
-        return rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);         \
+#define ROTMG_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
+    sycl::event rotmg(sycl::queue &queue, TYPE *d1, TYPE *d2, TYPE *x1, TYPE y1, TYPE *param, \
+                      const std::vector<sycl::event> &dependencies) {                         \
+        return rotmg(ROCBLAS_ROUTINE, queue, d1, d2, x1, y1, param, dependencies);            \
     }
 
 ROTMG_LAUNCHER_USM(float, rocblas_srotmg)
@@ -1664,16 +1627,15 @@ ROTMG_LAUNCHER_USM(double, rocblas_drotmg)
 #undef ROTMG_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event iamax(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
-                             const int64_t incx, int64_t *result,
-                             const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event iamax(Func func, sycl::queue &queue, int64_t n, const T *x, const int64_t incx,
+                         int64_t *result, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "iamax", "for row_major layout");
 }
 
-#define IAMAX_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event iamax(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
-        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                 \
+#define IAMAX_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
+    sycl::event iamax(sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
+                      int64_t *result, const std::vector<sycl::event> &dependencies) {  \
+        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
     }
 IAMAX_LAUNCHER_USM(float, rocblas_isamax)
 IAMAX_LAUNCHER_USM(double, rocblas_idamax)
@@ -1682,15 +1644,15 @@ IAMAX_LAUNCHER_USM(std::complex<double>, rocblas_izamax)
 #undef IAMAX_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event swap(Func func, cl::sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
-                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event swap(Func func, sycl::queue &queue, int64_t n, T *x, int64_t incx, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "swap", "for row_major layout");
 }
 
-#define SWAP_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event swap(cl::sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {  \
-        return swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);             \
+#define SWAP_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event swap(sycl::queue &queue, int64_t n, TYPE *x, int64_t incx, TYPE *y, int64_t incy, \
+                     const std::vector<sycl::event> &dependencies) {                              \
+        return swap(ROCBLAS_ROUTINE, queue, n, x, incx, y, incy, dependencies);                   \
     }
 
 SWAP_LAUNCHER_USM(float, rocblas_sswap)
@@ -1700,16 +1662,15 @@ SWAP_LAUNCHER_USM(std::complex<double>, rocblas_zswap)
 #undef SWAP_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event iamin(Func func, cl::sycl::queue &queue, int64_t n, const T *x,
-                             const int64_t incx, int64_t *result,
-                             const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event iamin(Func func, sycl::queue &queue, int64_t n, const T *x, const int64_t incx,
+                         int64_t *result, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "iamin", "for row_major layout");
 }
 
-#define IAMIN_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event iamin(cl::sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
-                          int64_t *result, const std::vector<cl::sycl::event> &dependencies) {  \
-        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                 \
+#define IAMIN_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
+    sycl::event iamin(sycl::queue &queue, int64_t n, const TYPE *x, const int64_t incx, \
+                      int64_t *result, const std::vector<sycl::event> &dependencies) {  \
+        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
     }
 IAMIN_LAUNCHER_USM(float, rocblas_isamin)
 IAMIN_LAUNCHER_USM(double, rocblas_idamin)
@@ -1718,16 +1679,15 @@ IAMIN_LAUNCHER_USM(std::complex<double>, rocblas_izamin)
 #undef IAMIN_LAUNCHER_USM
 
 template <typename Func, typename T1, typename T2>
-inline cl::sycl::event nrm2(Func func, cl::sycl::queue &queue, int64_t n, const T1 *x,
-                            const int64_t incx, T2 *result,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event nrm2(Func func, sycl::queue &queue, int64_t n, const T1 *x, const int64_t incx,
+                        T2 *result, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "nrm2", "for row_major layout");
 }
 
-#define NRM2_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                        \
-    cl::sycl::event nrm2(cl::sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
-                         TYPE2 *result, const std::vector<cl::sycl::event> &dependencies) {     \
-        return nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);                  \
+#define NRM2_LAUNCHER_USM(TYPE1, TYPE2, ROCBLAS_ROUTINE)                                \
+    sycl::event nrm2(sycl::queue &queue, int64_t n, const TYPE1 *x, const int64_t incx, \
+                     TYPE2 *result, const std::vector<sycl::event> &dependencies) {     \
+        return nrm2(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);          \
     }
 NRM2_LAUNCHER_USM(float, float, rocblas_snrm2)
 NRM2_LAUNCHER_USM(double, double, rocblas_dnrm2)

--- a/src/blas/backends/rocblas/rocblas_level2.cpp
+++ b/src/blas/backends/rocblas/rocblas_level2.cpp
@@ -33,15 +33,15 @@ namespace column_major {
 // Buffer APIs
 
 template <typename Func, typename T>
-inline void gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void gemv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, m, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -56,11 +56,11 @@ inline void gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m, 
     });
 }
 
-#define GEMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                              \
-    void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha,  \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,    \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {      \
-        gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy); \
+#define GEMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
+    void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha,         \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                           \
+        gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy);    \
     }
 
 GEMV_LAUNCHER(float, rocblas_sgemv)
@@ -70,16 +70,15 @@ GEMV_LAUNCHER(std::complex<double>, rocblas_zgemv)
 #undef GEMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void gbmv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                 int64_t kl, int64_t ku, T alpha, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, T beta, cl::sycl::buffer<T, 1> &y,
-                 int64_t incy) {
+inline void gbmv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
+                 int64_t ku, T alpha, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx, T beta, sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, m, lda, kl, ku, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -94,12 +93,11 @@ inline void gbmv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m, 
     });
 }
 
-#define GBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                       \
-    void gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,           \
-              int64_t ku, TYPE alpha, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,                   \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy) {                                                                      \
-        gbmv(ROCBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy);  \
+#define GBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                      \
+    void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,  \
+              TYPE alpha, sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x,        \
+              int64_t incx, TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                  \
+        gbmv(ROCBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
 GBMV_LAUNCHER(float, rocblas_sgbmv)
@@ -109,15 +107,15 @@ GBMV_LAUNCHER(std::complex<double>, rocblas_zgbmv)
 #undef GBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t n, T alpha,
-                cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void ger(Func func, sycl::queue &queue, int64_t m, int64_t n, T alpha, sycl::buffer<T, 1> &x,
+                int64_t incx, sycl::buffer<T, 1> &y, int64_t incy, sycl::buffer<T, 1> &a,
+                int64_t lda) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, m, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -131,11 +129,11 @@ inline void ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t n, T alpha
     });
 }
 
-#define GER_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                            \
-    void ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,                 \
-                  cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-                  int64_t incy, cl::sycl::buffer<TYPE, 1> &a, int64_t lda) {                \
-        ger(ROCBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda);                 \
+#define GER_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                                  \
+    void ger##EXT(sycl::queue &queue, int64_t m, int64_t n, TYPE alpha, sycl::buffer<TYPE, 1> &x, \
+                  int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, sycl::buffer<TYPE, 1> &a, \
+                  int64_t lda) {                                                                  \
+        ger(ROCBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda);                       \
     }
 
 GER_LAUNCHER(, float, rocblas_sger)
@@ -147,15 +145,15 @@ GER_LAUNCHER(c, std::complex<double>, rocblas_zgerc)
 #undef GER_LAUNCHER
 
 template <typename Func, typename T>
-inline void hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void hbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -171,9 +169,9 @@ inline void hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 #define HBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
-    void hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,       \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,          \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {            \
+    void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,           \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx,    \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
         hbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -182,15 +180,15 @@ HBMV_LAUNCHER(std::complex<double>, rocblas_zhbmv)
 #undef HBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void hemv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -206,9 +204,9 @@ inline void hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 #define HEMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,               \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,       \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {         \
+    void hemv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                   \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                           \
         hemv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -217,16 +215,16 @@ HEMV_LAUNCHER(std::complex<double>, rocblas_zhemv)
 #undef HEMV_LAUNCHER
 
 template <typename Func, typename ScalarType, typename DataType>
-inline void her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
-                cl::sycl::buffer<DataType, 1> &x, int64_t incx, cl::sycl::buffer<DataType, 1> &a,
+inline void her(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
+                sycl::buffer<DataType, 1> &x, int64_t incx, sycl::buffer<DataType, 1> &a,
                 int64_t lda) {
     using rocScalarType = typename RocEquivalentType<ScalarType>::Type;
     using rocDataType = typename RocEquivalentType<DataType>::Type;
     overflow_check(n, lda, incx);
 
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -239,11 +237,11 @@ inline void her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, 
     });
 }
 
-#define HER_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                    \
-    void her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,             \
-             cl::sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, cl::sycl::buffer<DATA_TYPE, 1> &a, \
-             int64_t lda) {                                                                      \
-        her(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);                     \
+#define HER_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                            \
+    void her(sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,         \
+             sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, sycl::buffer<DATA_TYPE, 1> &a, \
+             int64_t lda) {                                                              \
+        her(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);             \
     }
 
 HER_LAUNCHER(float, std::complex<float>, rocblas_cher)
@@ -252,15 +250,15 @@ HER_LAUNCHER(double, std::complex<double>, rocblas_zher)
 #undef HER_LAUNCHER
 
 template <typename Func, typename T>
-inline void her2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void her2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a, int64_t lda) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -274,11 +272,11 @@ inline void her2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
     });
 }
 
-#define HER2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a, int64_t lda) {                \
-        her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);  \
+#define HER2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void her2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda) {                                        \
+        her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);        \
     }
 
 HER2_LAUNCHER(std::complex<float>, rocblas_cher2)
@@ -287,15 +285,15 @@ HER2_LAUNCHER(std::complex<double>, rocblas_zher2)
 #undef HER2_LAUNCHER
 
 template <typename Func, typename T>
-inline void hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x, int64_t incx, T beta,
-                 cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void hpmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -309,11 +307,11 @@ inline void hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
     });
 }
 
-#define HPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                       \
-    void hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                     \
-              cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                        \
-        hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);            \
+#define HPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                 \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                                    \
+        hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);    \
     }
 
 HPMV_LAUNCHER(std::complex<float>, rocblas_chpmv)
@@ -322,14 +320,14 @@ HPMV_LAUNCHER(std::complex<double>, rocblas_zhpmv)
 #undef HPMV_LAUNCHER
 
 template <typename Func, typename ScalarType, typename DataType>
-inline void hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
-                cl::sycl::buffer<DataType, 1> &x, int64_t incx, cl::sycl::buffer<DataType, 1> &a) {
+inline void hpr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
+                sycl::buffer<DataType, 1> &x, int64_t incx, sycl::buffer<DataType, 1> &a) {
     using rocScalarType = typename RocEquivalentType<ScalarType>::Type;
     using rocDataType = typename RocEquivalentType<DataType>::Type;
     overflow_check(n, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -342,10 +340,10 @@ inline void hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, 
     });
 }
 
-#define HPR_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                      \
-    void hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,               \
-             cl::sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, cl::sycl::buffer<DATA_TYPE, 1> &a) { \
-        hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);                            \
+#define HPR_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                              \
+    void hpr(sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,           \
+             sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, sycl::buffer<DATA_TYPE, 1> &a) { \
+        hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);                    \
     }
 
 HPR_LAUNCHER(float, std::complex<float>, rocblas_chpr)
@@ -354,15 +352,15 @@ HPR_LAUNCHER(double, std::complex<double>, rocblas_zhpr)
 #undef HPR_LAUNCHER
 
 template <typename Func, typename T>
-inline void hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a) {
+inline void hpr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -376,11 +374,11 @@ inline void hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
     });
 }
 
-#define HPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a) {                             \
-        hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);       \
+#define HPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a) {                                                     \
+        hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);             \
     }
 
 HPR2_LAUNCHER(std::complex<float>, rocblas_chpr2)
@@ -389,15 +387,15 @@ HPR2_LAUNCHER(std::complex<double>, rocblas_zhpr2)
 #undef HPR2_LAUNCHER
 
 template <typename Func, typename T>
-inline void sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void sbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -413,9 +411,9 @@ inline void sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 #define SBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
-    void sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,       \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,          \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {            \
+    void sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,           \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx,    \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
         sbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -425,15 +423,15 @@ SBMV_LAUNCHER(double, rocblas_dsbmv)
 #undef SBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void symv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -449,9 +447,9 @@ inline void symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 #define SYMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,               \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,       \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {         \
+    void symv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                   \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                           \
         symv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -461,13 +459,13 @@ SYMV_LAUNCHER(double, rocblas_dsymv)
 #undef SYMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void syr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void syr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &a, int64_t lda) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -480,11 +478,10 @@ inline void syr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, 
     });
 }
 
-#define SYR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-             cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &a, \
-             int64_t lda) {                                                            \
-        syr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);           \
+#define SYR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                   \
+    void syr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                     \
+             sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &a, int64_t lda) { \
+        syr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);                  \
     }
 
 SYR_LAUNCHER(float, rocblas_ssyr)
@@ -495,15 +492,15 @@ SYR_LAUNCHER(std::complex<double>, rocblas_zsyr)
 #undef SYR_LAUNCHER
 
 template <typename Func, typename T>
-inline void syr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void syr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a, int64_t lda) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -517,11 +514,11 @@ inline void syr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
     });
 }
 
-#define SYR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a, int64_t lda) {                \
-        syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);  \
+#define SYR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda) {                                        \
+        syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);        \
     }
 
 SYR2_LAUNCHER(float, rocblas_ssyr2)
@@ -533,15 +530,15 @@ SYR2_LAUNCHER(std::complex<double>, rocblas_zsyr2)
 #undef SYR2_LAUNCHER
 
 template <typename Func, typename T>
-inline void spmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x, int64_t incx, T beta,
-                 cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void spmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -555,11 +552,11 @@ inline void spmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
     });
 }
 
-#define SPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                       \
-    void spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                     \
-              cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                        \
-        spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);            \
+#define SPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void spmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                 \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                                    \
+        spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);    \
     }
 
 SPMV_LAUNCHER(float, rocblas_sspmv)
@@ -568,13 +565,13 @@ SPMV_LAUNCHER(double, rocblas_dspmv)
 #undef SPMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void spr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &a) {
+inline void spr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &a) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -587,10 +584,10 @@ inline void spr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, 
     });
 }
 
-#define SPR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                              \
-    void spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,            \
-             cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &a) { \
-        spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);                  \
+#define SPR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                      \
+    void spr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,        \
+             sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &a) { \
+        spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);          \
     }
 
 SPR_LAUNCHER(float, rocblas_sspr)
@@ -599,15 +596,15 @@ SPR_LAUNCHER(double, rocblas_dspr)
 #undef SPR_LAUNCHER
 
 template <typename Func, typename T>
-inline void spr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a) {
+inline void spr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read_write>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto y_acc = y.template get_access<cl::sycl::access::mode::read>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -621,11 +618,11 @@ inline void spr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
     });
 }
 
-#define SPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a) {                             \
-        spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);       \
+#define SPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a) {                                                     \
+        spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);             \
     }
 
 SPR2_LAUNCHER(float, rocblas_sspr2)
@@ -634,14 +631,14 @@ SPR2_LAUNCHER(double, rocblas_dspr2)
 #undef SPR2_LAUNCHER
 
 template <typename Func, typename T>
-inline void tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void tbmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, int64_t k, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -655,11 +652,11 @@ inline void tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose 
     });
 }
 
-#define TBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                \
-    void tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
-              int64_t n, int64_t k, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,              \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx) {                                 \
-        tbmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx); \
+#define TBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              int64_t k, sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x,       \
+              int64_t incx) {                                                                   \
+        tbmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx);     \
     }
 
 TBMV_LAUNCHER(float, rocblas_stbmv)
@@ -670,14 +667,14 @@ TBMV_LAUNCHER(std::complex<double>, rocblas_ztbmv)
 #undef TBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void tbsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, int64_t k, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -691,11 +688,11 @@ inline void tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose 
     });
 }
 
-#define TBSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                \
-    void tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
-              int64_t n, int64_t k, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,              \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx) {                                 \
-        tbsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx); \
+#define TBSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              int64_t k, sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x,       \
+              int64_t incx) {                                                                   \
+        tbsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx);     \
     }
 
 TBSV_LAUNCHER(float, rocblas_stbsv)
@@ -706,14 +703,13 @@ TBSV_LAUNCHER(std::complex<double>, rocblas_ztbsv)
 #undef TBSV_LAUNCHER
 
 template <typename Func, typename T>
-inline void tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx) {
+inline void tpmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -727,11 +723,10 @@ inline void tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose 
     });
 }
 
-#define TPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                             \
-    void tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x,     \
-              int64_t incx) {                                                            \
-        tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);      \
+#define TPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx) {               \
+        tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);             \
     }
 
 TPMV_LAUNCHER(float, rocblas_stpmv)
@@ -742,14 +737,13 @@ TPMV_LAUNCHER(std::complex<double>, rocblas_ztpmv)
 #undef TPMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx) {
+inline void tpsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -763,11 +757,10 @@ inline void tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose 
     });
 }
 
-#define TPSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                             \
-    void tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x,     \
-              int64_t incx) {                                                            \
-        tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);      \
+#define TPSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx) {               \
+        tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);             \
     }
 
 TPSV_LAUNCHER(float, rocblas_stpsv)
@@ -778,14 +771,14 @@ TPSV_LAUNCHER(std::complex<double>, rocblas_ztpsv)
 #undef TPSV_LAUNCHER
 
 template <typename Func, typename T>
-inline void trmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void trmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -799,11 +792,10 @@ inline void trmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose 
     });
 }
 
-#define TRMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                      \
-    void trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,          \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x, \
-              int64_t incx) {                                                                     \
-        trmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);          \
+#define TRMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx) {  \
+        trmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);        \
     }
 
 TRMV_LAUNCHER(float, rocblas_strmv)
@@ -814,14 +806,14 @@ TRMV_LAUNCHER(std::complex<double>, rocblas_ztrmv)
 #undef TRMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void trsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void trsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
-    queue.submit([&](cl::sycl::handler &cgh) {
-        auto a_acc = a.template get_access<cl::sycl::access::mode::read>(cgh);
-        auto x_acc = x.template get_access<cl::sycl::access::mode::read_write>(cgh);
+    queue.submit([&](sycl::handler &cgh) {
+        auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
+        auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         onemkl_rocblas_host_task(cgh, queue, [=](RocblasScopedContextHandler &sc) {
             auto handle = sc.get_handle(queue);
 
@@ -835,11 +827,10 @@ inline void trsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose 
     });
 }
 
-#define TRSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                      \
-    void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,          \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x, \
-              int64_t incx) {                                                                     \
-        trsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);          \
+#define TRSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx) {  \
+        trsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);        \
     }
 
 TRSV_LAUNCHER(float, rocblas_strsv)
@@ -852,13 +843,12 @@ TRSV_LAUNCHER(std::complex<double>, rocblas_ztrsv)
 // USM APIs
 
 template <typename Func, typename T>
-inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
-                            int64_t n, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
-                            T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gemv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                        T alpha, const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, m, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -878,13 +868,12 @@ inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, 
     return done;
 }
 
-#define GEMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                \
-    cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,         \
-                         TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,   \
-                         TYPE beta, TYPE *y, int64_t incy,                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {                    \
-        return gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, \
-                    dependencies);                                                              \
+#define GEMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha,       \
+                     const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {                \
+        return gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy,   \
+                    dependencies);                                                                \
     }
 
 GEMV_LAUNCHER_USM(float, rocblas_sgemv)
@@ -894,13 +883,13 @@ GEMV_LAUNCHER_USM(std::complex<double>, rocblas_zgemv)
 #undef GEMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
-                            int64_t n, int64_t kl, int64_t ku, T alpha, const T *a, int64_t lda,
-                            const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gbmv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                        int64_t kl, int64_t ku, T alpha, const T *a, int64_t lda, const T *x,
+                        int64_t incx, T beta, T *y, int64_t incy,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, m, lda, kl, ku, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -921,10 +910,10 @@ inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, 
 }
 
 #define GBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,           \
-                         int64_t kl, int64_t ku, TYPE alpha, const TYPE *a, int64_t lda,          \
-                         const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,           \
-                         const std::vector<cl::sycl::event> &dependencies) {                      \
+    sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,       \
+                     int64_t ku, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x,           \
+                     int64_t incx, TYPE beta, TYPE *y, int64_t incy,                              \
+                     const std::vector<sycl::event> &dependencies) {                              \
         return gbmv(ROCBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                          \
     }
@@ -936,12 +925,12 @@ GBMV_LAUNCHER_USM(std::complex<double>, rocblas_zgbmv)
 #undef GBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t n, T alpha,
-                           const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event ger(Func func, sycl::queue &queue, int64_t m, int64_t n, T alpha, const T *x,
+                       int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
+                       const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, m, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -961,9 +950,9 @@ inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t
 }
 
 #define GER_LAUNCHER_USM(EXT, TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,           \
-                             const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a,  \
-                             int64_t lda, const std::vector<cl::sycl::event> &dependencies) {    \
+    sycl::event ger##EXT(sycl::queue &queue, int64_t m, int64_t n, TYPE alpha, const TYPE *x,    \
+                         int64_t incx, const TYPE *y, int64_t incy, TYPE *a, int64_t lda,        \
+                         const std::vector<sycl::event> &dependencies) {                         \
         return ger(ROCBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies); \
     }
 
@@ -976,13 +965,12 @@ GER_LAUNCHER_USM(c, std::complex<double>, rocblas_zgerc)
 #undef GER_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                            int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
-                            T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
+                        T alpha, const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1002,13 +990,12 @@ inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define HBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                \
-    cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,        \
-                         TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,   \
-                         TYPE beta, TYPE *y, int64_t incy,                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {                    \
-        return hbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
-                    incy, dependencies);                                                        \
+#define HBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,      \
+                     const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {                \
+        return hbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y,   \
+                    incy, dependencies);                                                          \
     }
 
 HBMV_LAUNCHER_USM(std::complex<float>, rocblas_chbmv)
@@ -1016,12 +1003,12 @@ HBMV_LAUNCHER_USM(std::complex<double>, rocblas_zhbmv)
 #undef HBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hemv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1042,10 +1029,9 @@ inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 }
 
 #define HEMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                   \
-    cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-                         const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,       \
-                         TYPE *y, int64_t incy,                                                    \
-                         const std::vector<cl::sycl::event> &dependencies) {                       \
+    sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a,   \
+                     int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,   \
+                     const std::vector<sycl::event> &dependencies) {                               \
         return hemv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                 \
     }
@@ -1055,14 +1041,14 @@ HEMV_LAUNCHER_USM(std::complex<double>, rocblas_zhemv)
 #undef HEMV_LAUNCHER_USM
 
 template <typename Func, typename ScalarType, typename DataType>
-inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                           const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event her(Func func, sycl::queue &queue, uplo upper_lower, int64_t n,
+                       const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
+                       int64_t lda, const std::vector<sycl::event> &dependencies) {
     using rocScalarType = typename RocEquivalentType<ScalarType>::Type;
     using rocDataType = typename RocEquivalentType<DataType>::Type;
     overflow_check(n, lda, incx);
 
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1081,9 +1067,9 @@ inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 }
 
 #define HER_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                 \
-    cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                      \
-                        const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a,  \
-                        int64_t lda, const std::vector<cl::sycl::event> &dependencies) {          \
+    sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, const SCALAR_TYPE alpha,     \
+                    const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, int64_t lda,                  \
+                    const std::vector<sycl::event> &dependencies) {                               \
         return her(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -1093,12 +1079,12 @@ HER_LAUNCHER_USM(double, std::complex<double>, rocblas_zher)
 #undef HER_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event her2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1117,12 +1103,12 @@ inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define HER2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a,  \
-                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {    \
-        return her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
-                    dependencies);                                                           \
+#define HER2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a, int64_t lda,            \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda,     \
+                    dependencies);                                                               \
     }
 
 HER2_LAUNCHER_USM(std::complex<float>, rocblas_cher2)
@@ -1131,12 +1117,12 @@ HER2_LAUNCHER_USM(std::complex<double>, rocblas_zher2)
 #undef HER2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hpmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1155,12 +1141,12 @@ inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define HPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                              \
-    cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,     \
-                         const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,      \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {    \
-        return hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
-                    dependencies);                                                            \
+#define HPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a, \
+                     const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,              \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy,    \
+                    dependencies);                                                               \
     }
 
 HPMV_LAUNCHER_USM(std::complex<float>, rocblas_chpmv)
@@ -1169,13 +1155,13 @@ HPMV_LAUNCHER_USM(std::complex<double>, rocblas_zhpmv)
 #undef HPMV_LAUNCHER_USM
 
 template <typename Func, typename ScalarType, typename DataType>
-inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                           const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hpr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n,
+                       const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
+                       const std::vector<sycl::event> &dependencies) {
     using rocScalarType = typename RocEquivalentType<ScalarType>::Type;
     using rocDataType = typename RocEquivalentType<DataType>::Type;
     overflow_check(n, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1193,11 +1179,11 @@ inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
     return done;
 }
 
-#define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                \
-    cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
-                        const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        const std::vector<cl::sycl::event> &dependencies) {                      \
-        return hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);     \
+#define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                             \
+    sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, const SCALAR_TYPE alpha, \
+                    const DATA_TYPE *x, int64_t incx, DATA_TYPE *a,                           \
+                    const std::vector<sycl::event> &dependencies) {                           \
+        return hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);  \
     }
 
 HPR_LAUNCHER_USM(float, std::complex<float>, rocblas_chpr)
@@ -1206,12 +1192,12 @@ HPR_LAUNCHER_USM(double, std::complex<double>, rocblas_zhpr)
 #undef HPR_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hpr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1230,12 +1216,12 @@ inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define HPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {                \
-        return hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,     \
-                    dependencies);                                                          \
+#define HPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a,                         \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,          \
+                    dependencies);                                                               \
     }
 
 HPR2_LAUNCHER_USM(std::complex<float>, rocblas_chpr2)
@@ -1244,13 +1230,12 @@ HPR2_LAUNCHER_USM(std::complex<double>, rocblas_zhpr2)
 #undef HPR2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                            int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
-                            T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event sbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
+                        T alpha, const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1270,13 +1255,12 @@ inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define SBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                \
-    cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,        \
-                         TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,   \
-                         TYPE beta, TYPE *y, int64_t incy,                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {                    \
-        return sbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
-                    incy, dependencies);                                                        \
+#define SBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,      \
+                     const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {                \
+        return sbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y,   \
+                    incy, dependencies);                                                          \
     }
 
 SBMV_LAUNCHER_USM(float, rocblas_ssbmv)
@@ -1285,12 +1269,12 @@ SBMV_LAUNCHER_USM(double, rocblas_dsbmv)
 #undef SBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event symv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1311,10 +1295,9 @@ inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 }
 
 #define SYMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                   \
-    cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-                         const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,       \
-                         TYPE *y, int64_t incy,                                                    \
-                         const std::vector<cl::sycl::event> &dependencies) {                       \
+    sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a,   \
+                     int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,   \
+                     const std::vector<sycl::event> &dependencies) {                               \
         return symv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                 \
     }
@@ -1325,12 +1308,12 @@ SYMV_LAUNCHER_USM(double, rocblas_dsymv)
 #undef SYMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                           const T *x, int64_t incx, T *a, int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event syr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                       const T *x, int64_t incx, T *a, int64_t lda,
+                       const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1349,9 +1332,9 @@ inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
 }
 
 #define SYR_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                   \
-    cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-                        const TYPE *x, int64_t incx, TYPE *a, int64_t lda,                        \
-                        const std::vector<cl::sycl::event> &dependencies) {                       \
+    sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x,   \
+                    int64_t incx, TYPE *a, int64_t lda,                                           \
+                    const std::vector<sycl::event> &dependencies) {                               \
         return syr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -1363,12 +1346,12 @@ SYR_LAUNCHER_USM(std::complex<double>, rocblas_zsyr)
 #undef SYR_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event syr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1387,12 +1370,12 @@ inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define SYR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a,  \
-                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {    \
-        return syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
-                    dependencies);                                                           \
+#define SYR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a, int64_t lda,            \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda,     \
+                    dependencies);                                                               \
     }
 
 SYR2_LAUNCHER_USM(float, rocblas_ssyr2)
@@ -1404,12 +1387,12 @@ SYR2_LAUNCHER_USM(std::complex<double>, rocblas_zsyr2)
 #undef SYR2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event spmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1428,12 +1411,12 @@ inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define SPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                              \
-    cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,     \
-                         const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,      \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {    \
-        return spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
-                    dependencies);                                                            \
+#define SPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a, \
+                     const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,              \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy,    \
+                    dependencies);                                                               \
     }
 
 SPMV_LAUNCHER_USM(float, rocblas_sspmv)
@@ -1442,12 +1425,12 @@ SPMV_LAUNCHER_USM(double, rocblas_dspmv)
 #undef SPMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                           const T *x, int64_t incx, T *a,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event spr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                       const T *x, int64_t incx, T *a,
+                       const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1465,11 +1448,10 @@ inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, 
     return done;
 }
 
-#define SPR_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                              \
-    cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,     \
-                        const TYPE *x, int64_t incx, TYPE *a,                                \
-                        const std::vector<cl::sycl::event> &dependencies) {                  \
-        return spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies); \
+#define SPR_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                    int64_t incx, TYPE *a, const std::vector<sycl::event> &dependencies) {      \
+        return spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);    \
     }
 
 SPR_LAUNCHER_USM(float, rocblas_sspr)
@@ -1478,12 +1460,12 @@ SPR_LAUNCHER_USM(double, rocblas_dspr)
 #undef SPR_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event spr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx, incy);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1502,12 +1484,12 @@ inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define SPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {                \
-        return spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,     \
-                    dependencies);                                                          \
+#define SPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a,                         \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,          \
+                    dependencies);                                                               \
     }
 
 SPR2_LAUNCHER_USM(float, rocblas_sspr2)
@@ -1516,12 +1498,12 @@ SPR2_LAUNCHER_USM(double, rocblas_dspr2)
 #undef SPR2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tbmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
+                        int64_t incx, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1541,10 +1523,9 @@ inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 }
 
 #define TBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,               \
-                         diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,        \
-                         TYPE *x, int64_t incx,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {                      \
+    sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,       \
+                     int64_t n, int64_t k, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,     \
+                     const std::vector<sycl::event> &dependencies) {                              \
         return tbmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                                \
     }
@@ -1557,12 +1538,12 @@ TBMV_LAUNCHER_USM(std::complex<double>, rocblas_ztbmv)
 #undef TBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tbsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
+                        int64_t incx, const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, k, lda, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1582,10 +1563,9 @@ inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 }
 
 #define TBSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,               \
-                         diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,        \
-                         TYPE *x, int64_t incx,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {                      \
+    sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,       \
+                     int64_t n, int64_t k, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,     \
+                     const std::vector<sycl::event> &dependencies) {                              \
         return tbsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                                \
     }
@@ -1598,12 +1578,12 @@ TBSV_LAUNCHER_USM(std::complex<double>, rocblas_ztbsv)
 #undef TBSV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tpmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1622,12 +1602,12 @@ inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define TPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
-    cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
-                         diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {              \
-        return tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx, \
-                    dependencies);                                                        \
+#define TPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
+    sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
+                     int64_t n, const TYPE *a, TYPE *x, int64_t incx,                       \
+                     const std::vector<sycl::event> &dependencies) {                        \
+        return tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,   \
+                    dependencies);                                                          \
     }
 
 TPMV_LAUNCHER_USM(float, rocblas_stpmv)
@@ -1638,12 +1618,12 @@ TPMV_LAUNCHER_USM(std::complex<double>, rocblas_ztpmv)
 #undef TPMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tpsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1662,12 +1642,12 @@ inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
     return done;
 }
 
-#define TPSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
-    cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
-                         diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {              \
-        return tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx, \
-                    dependencies);                                                        \
+#define TPSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
+    sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
+                     int64_t n, const TYPE *a, TYPE *x, int64_t incx,                       \
+                     const std::vector<sycl::event> &dependencies) {                        \
+        return tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,   \
+                    dependencies);                                                          \
     }
 
 TPSV_LAUNCHER_USM(float, rocblas_stpsv)
@@ -1678,12 +1658,12 @@ TPSV_LAUNCHER_USM(std::complex<double>, rocblas_ztpsv)
 #undef TPSV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event trmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1703,9 +1683,9 @@ inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 }
 
 #define TRMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,            \
-                         diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,       \
-                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {     \
+    sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
+                     int64_t n, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,             \
+                     const std::vector<sycl::event> &dependencies) {                           \
         return trmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                             \
     }
@@ -1718,12 +1698,12 @@ TRMV_LAUNCHER_USM(std::complex<double>, rocblas_ztrmv)
 #undef TRMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event trsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, lda, incx);
-    auto done = queue.submit([&](cl::sycl::handler &cgh) {
+    auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
@@ -1743,9 +1723,9 @@ inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower,
 }
 
 #define TRSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,            \
-                         diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,       \
-                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {     \
+    sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
+                     int64_t n, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,             \
+                     const std::vector<sycl::event> &dependencies) {                           \
         return trsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                             \
     }
@@ -1763,17 +1743,17 @@ namespace row_major {
 // Buffer APIs
 
 template <typename Func, typename T>
-inline void gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void gemv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "gemv", "for row_major layout");
 }
 
-#define GEMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                              \
-    void gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha,  \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,    \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {      \
-        gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy); \
+#define GEMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
+    void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha,         \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                           \
+        gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy);    \
     }
 
 GEMV_LAUNCHER(float, rocblas_sgemv)
@@ -1783,19 +1763,17 @@ GEMV_LAUNCHER(std::complex<double>, rocblas_zgemv)
 #undef GEMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void gbmv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                 int64_t kl, int64_t ku, T alpha, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, T beta, cl::sycl::buffer<T, 1> &y,
-                 int64_t incy) {
+inline void gbmv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
+                 int64_t ku, T alpha, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx, T beta, sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "gbmv", "for row_major layout");
 }
 
-#define GBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                       \
-    void gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,           \
-              int64_t ku, TYPE alpha, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,                   \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy) {                                                                      \
-        gbmv(ROCBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy);  \
+#define GBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                      \
+    void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,  \
+              TYPE alpha, sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x,        \
+              int64_t incx, TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                  \
+        gbmv(ROCBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
 GBMV_LAUNCHER(float, rocblas_sgbmv)
@@ -1805,17 +1783,17 @@ GBMV_LAUNCHER(std::complex<double>, rocblas_zgbmv)
 #undef GBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t n, T alpha,
-                cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void ger(Func func, sycl::queue &queue, int64_t m, int64_t n, T alpha, sycl::buffer<T, 1> &x,
+                int64_t incx, sycl::buffer<T, 1> &y, int64_t incy, sycl::buffer<T, 1> &a,
+                int64_t lda) {
     throw unimplemented("blas", "ger", "for row_major layout");
 }
 
-#define GER_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                            \
-    void ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,                 \
-                  cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-                  int64_t incy, cl::sycl::buffer<TYPE, 1> &a, int64_t lda) {                \
-        ger(ROCBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda);                 \
+#define GER_LAUNCHER(EXT, TYPE, ROCBLAS_ROUTINE)                                                  \
+    void ger##EXT(sycl::queue &queue, int64_t m, int64_t n, TYPE alpha, sycl::buffer<TYPE, 1> &x, \
+                  int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, sycl::buffer<TYPE, 1> &a, \
+                  int64_t lda) {                                                                  \
+        ger(ROCBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda);                       \
     }
 
 GER_LAUNCHER(, float, rocblas_sger)
@@ -1827,16 +1805,16 @@ GER_LAUNCHER(c, std::complex<double>, rocblas_zgerc)
 #undef GER_LAUNCHER
 
 template <typename Func, typename T>
-inline void hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void hbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "hbmv", "for row_major layout");
 }
 
 #define HBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
-    void hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,       \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,          \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {            \
+    void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,           \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx,    \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
         hbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -1845,16 +1823,16 @@ HBMV_LAUNCHER(std::complex<double>, rocblas_zhbmv)
 #undef HBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void hemv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "hemv", "for row_major layout");
 }
 
 #define HEMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,               \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,       \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {         \
+    void hemv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                   \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                           \
         hemv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -1863,17 +1841,17 @@ HEMV_LAUNCHER(std::complex<double>, rocblas_zhemv)
 #undef HEMV_LAUNCHER
 
 template <typename Func, typename ScalarType, typename DataType>
-inline void her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
-                cl::sycl::buffer<DataType, 1> &x, int64_t incx, cl::sycl::buffer<DataType, 1> &a,
+inline void her(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
+                sycl::buffer<DataType, 1> &x, int64_t incx, sycl::buffer<DataType, 1> &a,
                 int64_t lda) {
     throw unimplemented("blas", "her", "for row_major layout");
 }
 
-#define HER_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                    \
-    void her(cl::sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,             \
-             cl::sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, cl::sycl::buffer<DATA_TYPE, 1> &a, \
-             int64_t lda) {                                                                      \
-        her(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);                     \
+#define HER_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                            \
+    void her(sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,         \
+             sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, sycl::buffer<DATA_TYPE, 1> &a, \
+             int64_t lda) {                                                              \
+        her(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);             \
     }
 
 HER_LAUNCHER(float, std::complex<float>, rocblas_cher)
@@ -1882,17 +1860,17 @@ HER_LAUNCHER(double, std::complex<double>, rocblas_zher)
 #undef HER_LAUNCHER
 
 template <typename Func, typename T>
-inline void her2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void her2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a, int64_t lda) {
     throw unimplemented("blas", "her2", "for row_major layout");
 }
 
-#define HER2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a, int64_t lda) {                \
-        her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);  \
+#define HER2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void her2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda) {                                        \
+        her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);        \
     }
 
 HER2_LAUNCHER(std::complex<float>, rocblas_cher2)
@@ -1901,17 +1879,17 @@ HER2_LAUNCHER(std::complex<double>, rocblas_zher2)
 #undef HER2_LAUNCHER
 
 template <typename Func, typename T>
-inline void hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x, int64_t incx, T beta,
-                 cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void hpmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "hpmv", "for row_major layout");
 }
 
-#define HPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                       \
-    void hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                     \
-              cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                        \
-        hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);            \
+#define HPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                 \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                                    \
+        hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);    \
     }
 
 HPMV_LAUNCHER(std::complex<float>, rocblas_chpmv)
@@ -1920,15 +1898,15 @@ HPMV_LAUNCHER(std::complex<double>, rocblas_zhpmv)
 #undef HPMV_LAUNCHER
 
 template <typename Func, typename ScalarType, typename DataType>
-inline void hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
-                cl::sycl::buffer<DataType, 1> &x, int64_t incx, cl::sycl::buffer<DataType, 1> &a) {
+inline void hpr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, ScalarType alpha,
+                sycl::buffer<DataType, 1> &x, int64_t incx, sycl::buffer<DataType, 1> &a) {
     throw unimplemented("blas", "hpr", "for row_major layout");
 }
 
-#define HPR_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                      \
-    void hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,               \
-             cl::sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, cl::sycl::buffer<DATA_TYPE, 1> &a) { \
-        hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);                            \
+#define HPR_LAUNCHER(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                              \
+    void hpr(sycl::queue &queue, uplo upper_lower, int64_t n, SCALAR_TYPE alpha,           \
+             sycl::buffer<DATA_TYPE, 1> &x, int64_t incx, sycl::buffer<DATA_TYPE, 1> &a) { \
+        hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);                    \
     }
 
 HPR_LAUNCHER(float, std::complex<float>, rocblas_chpr)
@@ -1937,17 +1915,17 @@ HPR_LAUNCHER(double, std::complex<double>, rocblas_zhpr)
 #undef HPR_LAUNCHER
 
 template <typename Func, typename T>
-inline void hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a) {
+inline void hpr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a) {
     throw unimplemented("blas", "hpr2", "for row_major layout");
 }
 
-#define HPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a) {                             \
-        hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);       \
+#define HPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a) {                                                     \
+        hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);             \
     }
 
 HPR2_LAUNCHER(std::complex<float>, rocblas_chpr2)
@@ -1956,16 +1934,16 @@ HPR2_LAUNCHER(std::complex<double>, rocblas_zhpr2)
 #undef HPR2_LAUNCHER
 
 template <typename Func, typename T>
-inline void sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void sbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "sbmv", "for row_major layout");
 }
 
 #define SBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
-    void sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,       \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,          \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {            \
+    void sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,           \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx,    \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                              \
         sbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -1975,16 +1953,16 @@ SBMV_LAUNCHER(double, rocblas_dsbmv)
 #undef SBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda, cl::sycl::buffer<T, 1> &x, int64_t incx,
-                 T beta, cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void symv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "symv", "for row_major layout");
 }
 
 #define SYMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                 \
-    void symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,               \
-              cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x,       \
-              int64_t incx, TYPE beta, cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {         \
+    void symv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                   \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx, \
+              TYPE beta, sycl::buffer<TYPE, 1> &y, int64_t incy) {                           \
         symv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy); \
     }
 
@@ -1994,16 +1972,15 @@ SYMV_LAUNCHER(double, rocblas_dsymv)
 #undef SYMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void syr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void syr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &a, int64_t lda) {
     throw unimplemented("blas", "syr", "for row_major layout");
 }
 
-#define SYR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-             cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &a, \
-             int64_t lda) {                                                            \
-        syr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);           \
+#define SYR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                   \
+    void syr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                     \
+             sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &a, int64_t lda) { \
+        syr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda);                  \
     }
 
 SYR_LAUNCHER(float, rocblas_ssyr)
@@ -2014,17 +1991,17 @@ SYR_LAUNCHER(std::complex<double>, rocblas_zsyr)
 #undef SYR_LAUNCHER
 
 template <typename Func, typename T>
-inline void syr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a, int64_t lda) {
+inline void syr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a, int64_t lda) {
     throw unimplemented("blas", "syr2", "for row_major layout");
 }
 
-#define SYR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a, int64_t lda) {                \
-        syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);  \
+#define SYR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda) {                                        \
+        syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);        \
     }
 
 SYR2_LAUNCHER(float, rocblas_ssyr2)
@@ -2036,17 +2013,17 @@ SYR2_LAUNCHER(std::complex<double>, rocblas_zsyr2)
 #undef SYR2_LAUNCHER
 
 template <typename Func, typename T>
-inline void spmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x, int64_t incx, T beta,
-                 cl::sycl::buffer<T, 1> &y, int64_t incy) {
+inline void spmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx, T beta,
+                 sycl::buffer<T, 1> &y, int64_t incy) {
     throw unimplemented("blas", "spmv", "for row_major layout");
 }
 
-#define SPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                       \
-    void spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                     \
-              cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
-              cl::sycl::buffer<TYPE, 1> &y, int64_t incy) {                                        \
-        spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);            \
+#define SPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
+    void spmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                 \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx, TYPE beta, \
+              sycl::buffer<TYPE, 1> &y, int64_t incy) {                                    \
+        spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);    \
     }
 
 SPMV_LAUNCHER(float, rocblas_sspmv)
@@ -2055,15 +2032,15 @@ SPMV_LAUNCHER(double, rocblas_dspmv)
 #undef SPMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void spr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &a) {
+inline void spr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &a) {
     throw unimplemented("blas", "spr", "for row_major layout");
 }
 
-#define SPR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                              \
-    void spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,            \
-             cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &a) { \
-        spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);                  \
+#define SPR_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                      \
+    void spr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,        \
+             sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &a) { \
+        spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a);          \
     }
 
 SPR_LAUNCHER(float, rocblas_sspr)
@@ -2072,17 +2049,17 @@ SPR_LAUNCHER(double, rocblas_dspr)
 #undef SPR_LAUNCHER
 
 template <typename Func, typename T>
-inline void spr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx, cl::sycl::buffer<T, 1> &y, int64_t incy,
-                 cl::sycl::buffer<T, 1> &a) {
+inline void spr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                 sycl::buffer<T, 1> &x, int64_t incx, sycl::buffer<T, 1> &y, int64_t incy,
+                 sycl::buffer<T, 1> &a) {
     throw unimplemented("blas", "spr2", "for row_major layout");
 }
 
-#define SPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                            \
-    void spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx, cl::sycl::buffer<TYPE, 1> &y, \
-              int64_t incy, cl::sycl::buffer<TYPE, 1> &a) {                             \
-        spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);       \
+#define SPR2_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                  \
+    void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,                    \
+              sycl::buffer<TYPE, 1> &x, int64_t incx, sycl::buffer<TYPE, 1> &y, int64_t incy, \
+              sycl::buffer<TYPE, 1> &a) {                                                     \
+        spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a);             \
     }
 
 SPR2_LAUNCHER(float, rocblas_sspr2)
@@ -2091,17 +2068,17 @@ SPR2_LAUNCHER(double, rocblas_dspr2)
 #undef SPR2_LAUNCHER
 
 template <typename Func, typename T>
-inline void tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void tbmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, int64_t k, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     throw unimplemented("blas", "tbmv", "for row_major layout");
 }
 
-#define TBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                \
-    void tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
-              int64_t n, int64_t k, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,              \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx) {                                 \
-        tbmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx); \
+#define TBMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              int64_t k, sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x,       \
+              int64_t incx) {                                                                   \
+        tbmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx);     \
     }
 
 TBMV_LAUNCHER(float, rocblas_stbmv)
@@ -2112,17 +2089,17 @@ TBMV_LAUNCHER(std::complex<double>, rocblas_ztbmv)
 #undef TBMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, int64_t k, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void tbsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, int64_t k, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     throw unimplemented("blas", "tbsv", "for row_major layout");
 }
 
-#define TBSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                \
-    void tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
-              int64_t n, int64_t k, cl::sycl::buffer<TYPE, 1> &a, int64_t lda,              \
-              cl::sycl::buffer<TYPE, 1> &x, int64_t incx) {                                 \
-        tbsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx); \
+#define TBSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              int64_t k, sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x,       \
+              int64_t incx) {                                                                   \
+        tbsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx);     \
     }
 
 TBSV_LAUNCHER(float, rocblas_stbsv)
@@ -2133,17 +2110,15 @@ TBSV_LAUNCHER(std::complex<double>, rocblas_ztbsv)
 #undef TBSV_LAUNCHER
 
 template <typename Func, typename T>
-inline void tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx) {
+inline void tpmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx) {
     throw unimplemented("blas", "tpmv", "for row_major layout");
 }
 
-#define TPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                             \
-    void tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x,     \
-              int64_t incx) {                                                            \
-        tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);      \
+#define TPMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx) {               \
+        tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);             \
     }
 
 TPMV_LAUNCHER(float, rocblas_stpmv)
@@ -2154,17 +2129,15 @@ TPMV_LAUNCHER(std::complex<double>, rocblas_ztpmv)
 #undef TPMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, cl::sycl::buffer<T, 1> &x,
-                 int64_t incx) {
+inline void tpsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, sycl::buffer<T, 1> &x, int64_t incx) {
     throw unimplemented("blas", "tpsv", "for row_major layout");
 }
 
-#define TPSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                             \
-    void tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, cl::sycl::buffer<TYPE, 1> &x,     \
-              int64_t incx) {                                                            \
-        tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);      \
+#define TPSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, sycl::buffer<TYPE, 1> &x, int64_t incx) {               \
+        tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx);             \
     }
 
 TPSV_LAUNCHER(float, rocblas_stpsv)
@@ -2175,17 +2148,16 @@ TPSV_LAUNCHER(std::complex<double>, rocblas_ztpsv)
 #undef TPSV_LAUNCHER
 
 template <typename Func, typename T>
-inline void trmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void trmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     throw unimplemented("blas", "trmv", "for row_major layout");
 }
 
-#define TRMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                      \
-    void trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,          \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x, \
-              int64_t incx) {                                                                     \
-        trmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);          \
+#define TRMV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx) {  \
+        trmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);        \
     }
 
 TRMV_LAUNCHER(float, rocblas_strmv)
@@ -2196,17 +2168,16 @@ TRMV_LAUNCHER(std::complex<double>, rocblas_ztrmv)
 #undef TRMV_LAUNCHER
 
 template <typename Func, typename T>
-inline void trsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                 diag unit_diag, int64_t n, cl::sycl::buffer<T, 1> &a, int64_t lda,
-                 cl::sycl::buffer<T, 1> &x, int64_t incx) {
+inline void trsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
+                 int64_t n, sycl::buffer<T, 1> &a, int64_t lda, sycl::buffer<T, 1> &x,
+                 int64_t incx) {
     throw unimplemented("blas", "trsv", "for row_major layout");
 }
 
-#define TRSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                      \
-    void trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,          \
-              int64_t n, cl::sycl::buffer<TYPE, 1> &a, int64_t lda, cl::sycl::buffer<TYPE, 1> &x, \
-              int64_t incx) {                                                                     \
-        trsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);          \
+#define TRSV_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                                    \
+    void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n, \
+              sycl::buffer<TYPE, 1> &a, int64_t lda, sycl::buffer<TYPE, 1> &x, int64_t incx) {  \
+        trsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);        \
     }
 
 TRSV_LAUNCHER(float, rocblas_strsv)
@@ -2219,20 +2190,18 @@ TRSV_LAUNCHER(std::complex<double>, rocblas_ztrsv)
 // USM APIs
 
 template <typename Func, typename T>
-inline cl::sycl::event gemv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
-                            int64_t n, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
-                            T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gemv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                        T alpha, const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gemv", "for row_major layout");
 }
 
-#define GEMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                \
-    cl::sycl::event gemv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,         \
-                         TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,   \
-                         TYPE beta, TYPE *y, int64_t incy,                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {                    \
-        return gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy, \
-                    dependencies);                                                              \
+#define GEMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, TYPE alpha,       \
+                     const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {                \
+        return gemv(ROCBLAS_ROUTINE, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy,   \
+                    dependencies);                                                                \
     }
 
 GEMV_LAUNCHER_USM(float, rocblas_sgemv)
@@ -2242,18 +2211,18 @@ GEMV_LAUNCHER_USM(std::complex<double>, rocblas_zgemv)
 #undef GEMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event gbmv(Func func, cl::sycl::queue &queue, transpose trans, int64_t m,
-                            int64_t n, int64_t kl, int64_t ku, T alpha, const T *a, int64_t lda,
-                            const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event gbmv(Func func, sycl::queue &queue, transpose trans, int64_t m, int64_t n,
+                        int64_t kl, int64_t ku, T alpha, const T *a, int64_t lda, const T *x,
+                        int64_t incx, T beta, T *y, int64_t incy,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "gbmv", "for row_major layout");
 }
 
 #define GBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event gbmv(cl::sycl::queue &queue, transpose trans, int64_t m, int64_t n,           \
-                         int64_t kl, int64_t ku, TYPE alpha, const TYPE *a, int64_t lda,          \
-                         const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,           \
-                         const std::vector<cl::sycl::event> &dependencies) {                      \
+    sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,       \
+                     int64_t ku, TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x,           \
+                     int64_t incx, TYPE beta, TYPE *y, int64_t incy,                              \
+                     const std::vector<sycl::event> &dependencies) {                              \
         return gbmv(ROCBLAS_ROUTINE, queue, trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y, \
                     incy, dependencies);                                                          \
     }
@@ -2265,16 +2234,16 @@ GBMV_LAUNCHER_USM(std::complex<double>, rocblas_zgbmv)
 #undef GBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event ger(Func func, cl::sycl::queue &queue, int64_t m, int64_t n, T alpha,
-                           const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event ger(Func func, sycl::queue &queue, int64_t m, int64_t n, T alpha, const T *x,
+                       int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "ger", "for row_major layout");
 }
 
 #define GER_LAUNCHER_USM(EXT, TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event ger##EXT(cl::sycl::queue &queue, int64_t m, int64_t n, TYPE alpha,           \
-                             const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a,  \
-                             int64_t lda, const std::vector<cl::sycl::event> &dependencies) {    \
+    sycl::event ger##EXT(sycl::queue &queue, int64_t m, int64_t n, TYPE alpha, const TYPE *x,    \
+                         int64_t incx, const TYPE *y, int64_t incy, TYPE *a, int64_t lda,        \
+                         const std::vector<sycl::event> &dependencies) {                         \
         return ger(ROCBLAS_ROUTINE, queue, m, n, alpha, x, incx, y, incy, a, lda, dependencies); \
     }
 
@@ -2287,20 +2256,18 @@ GER_LAUNCHER_USM(c, std::complex<double>, rocblas_zgerc)
 #undef GER_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                            int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
-                            T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
+                        T alpha, const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "hbmv", "for row_major layout");
 }
 
-#define HBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                \
-    cl::sycl::event hbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,        \
-                         TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,   \
-                         TYPE beta, TYPE *y, int64_t incy,                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {                    \
-        return hbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
-                    incy, dependencies);                                                        \
+#define HBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,      \
+                     const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {                \
+        return hbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y,   \
+                    incy, dependencies);                                                          \
     }
 
 HBMV_LAUNCHER_USM(std::complex<float>, rocblas_chbmv)
@@ -2308,17 +2275,16 @@ HBMV_LAUNCHER_USM(std::complex<double>, rocblas_zhbmv)
 #undef HBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hemv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hemv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "hemv", "for row_major layout");
 }
 
 #define HEMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                   \
-    cl::sycl::event hemv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-                         const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,       \
-                         TYPE *y, int64_t incy,                                                    \
-                         const std::vector<cl::sycl::event> &dependencies) {                       \
+    sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a,   \
+                     int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,   \
+                     const std::vector<sycl::event> &dependencies) {                               \
         return hemv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                 \
     }
@@ -2328,16 +2294,16 @@ HEMV_LAUNCHER_USM(std::complex<double>, rocblas_zhemv)
 #undef HEMV_LAUNCHER_USM
 
 template <typename Func, typename ScalarType, typename DataType>
-inline cl::sycl::event her(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                           const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           int64_t lda, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event her(Func func, sycl::queue &queue, uplo upper_lower, int64_t n,
+                       const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
+                       int64_t lda, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "her", "for row_major layout");
 }
 
 #define HER_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                 \
-    cl::sycl::event her(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                      \
-                        const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a,  \
-                        int64_t lda, const std::vector<cl::sycl::event> &dependencies) {          \
+    sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, const SCALAR_TYPE alpha,     \
+                    const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, int64_t lda,                  \
+                    const std::vector<sycl::event> &dependencies) {                               \
         return her(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -2347,18 +2313,18 @@ HER_LAUNCHER_USM(double, std::complex<double>, rocblas_zher)
 #undef HER_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event her2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event her2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "her2", "for row_major layout");
 }
 
-#define HER2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event her2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a,  \
-                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {    \
-        return her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
-                    dependencies);                                                           \
+#define HER2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a, int64_t lda,            \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return her2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda,     \
+                    dependencies);                                                               \
     }
 
 HER2_LAUNCHER_USM(std::complex<float>, rocblas_cher2)
@@ -2367,18 +2333,18 @@ HER2_LAUNCHER_USM(std::complex<double>, rocblas_zher2)
 #undef HER2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hpmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "hpmv", "for row_major layout");
 }
 
-#define HPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                              \
-    cl::sycl::event hpmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,     \
-                         const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,      \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {    \
-        return hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
-                    dependencies);                                                            \
+#define HPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a, \
+                     const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,              \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return hpmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy,    \
+                    dependencies);                                                               \
     }
 
 HPMV_LAUNCHER_USM(std::complex<float>, rocblas_chpmv)
@@ -2387,17 +2353,17 @@ HPMV_LAUNCHER_USM(std::complex<double>, rocblas_zhpmv)
 #undef HPMV_LAUNCHER_USM
 
 template <typename Func, typename ScalarType, typename DataType>
-inline cl::sycl::event hpr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                           const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hpr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n,
+                       const ScalarType alpha, const DataType *x, int64_t incx, DataType *a,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "hpr", "for row_major layout");
 }
 
-#define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                                \
-    cl::sycl::event hpr(cl::sycl::queue &queue, uplo upper_lower, int64_t n,                     \
-                        const SCALAR_TYPE alpha, const DATA_TYPE *x, int64_t incx, DATA_TYPE *a, \
-                        const std::vector<cl::sycl::event> &dependencies) {                      \
-        return hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);     \
+#define HPR_LAUNCHER_USM(SCALAR_TYPE, DATA_TYPE, ROCBLAS_ROUTINE)                             \
+    sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, const SCALAR_TYPE alpha, \
+                    const DATA_TYPE *x, int64_t incx, DATA_TYPE *a,                           \
+                    const std::vector<sycl::event> &dependencies) {                           \
+        return hpr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);  \
     }
 
 HPR_LAUNCHER_USM(float, std::complex<float>, rocblas_chpr)
@@ -2406,18 +2372,18 @@ HPR_LAUNCHER_USM(double, std::complex<double>, rocblas_zhpr)
 #undef HPR_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event hpr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event hpr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "hpr2", "for row_major layout");
 }
 
-#define HPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event hpr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {                \
-        return hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,     \
-                    dependencies);                                                          \
+#define HPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a,                         \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return hpr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,          \
+                    dependencies);                                                               \
     }
 
 HPR2_LAUNCHER_USM(std::complex<float>, rocblas_chpr2)
@@ -2426,20 +2392,18 @@ HPR2_LAUNCHER_USM(std::complex<double>, rocblas_zhpr2)
 #undef HPR2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event sbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n,
-                            int64_t k, T alpha, const T *a, int64_t lda, const T *x, int64_t incx,
-                            T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event sbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
+                        T alpha, const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "sbmv", "for row_major layout");
 }
 
-#define SBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                \
-    cl::sycl::event sbmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,        \
-                         TYPE alpha, const TYPE *a, int64_t lda, const TYPE *x, int64_t incx,   \
-                         TYPE beta, TYPE *y, int64_t incy,                                      \
-                         const std::vector<cl::sycl::event> &dependencies) {                    \
-        return sbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y, \
-                    incy, dependencies);                                                        \
+#define SBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
+    sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, TYPE alpha,      \
+                     const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, \
+                     int64_t incy, const std::vector<sycl::event> &dependencies) {                \
+        return sbmv(ROCBLAS_ROUTINE, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y,   \
+                    incy, dependencies);                                                          \
     }
 
 SBMV_LAUNCHER_USM(float, rocblas_ssbmv)
@@ -2448,17 +2412,16 @@ SBMV_LAUNCHER_USM(double, rocblas_dsbmv)
 #undef SBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event symv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
-                            int64_t incy, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event symv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, int64_t lda, const T *x, int64_t incx, T beta, T *y,
+                        int64_t incy, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "symv", "for row_major layout");
 }
 
 #define SYMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                   \
-    cl::sycl::event symv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-                         const TYPE *a, int64_t lda, const TYPE *x, int64_t incx, TYPE beta,       \
-                         TYPE *y, int64_t incy,                                                    \
-                         const std::vector<cl::sycl::event> &dependencies) {                       \
+    sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a,   \
+                     int64_t lda, const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,   \
+                     const std::vector<sycl::event> &dependencies) {                               \
         return symv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, \
                     dependencies);                                                                 \
     }
@@ -2469,16 +2432,16 @@ SYMV_LAUNCHER_USM(double, rocblas_dsymv)
 #undef SYMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event syr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                           const T *x, int64_t incx, T *a, int64_t lda,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event syr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                       const T *x, int64_t incx, T *a, int64_t lda,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syr", "for row_major layout");
 }
 
 #define SYR_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                   \
-    cl::sycl::event syr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,          \
-                        const TYPE *x, int64_t incx, TYPE *a, int64_t lda,                        \
-                        const std::vector<cl::sycl::event> &dependencies) {                       \
+    sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x,   \
+                    int64_t incx, TYPE *a, int64_t lda,                                           \
+                    const std::vector<sycl::event> &dependencies) {                               \
         return syr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, lda, dependencies); \
     }
 
@@ -2490,18 +2453,18 @@ SYR_LAUNCHER_USM(std::complex<double>, rocblas_zsyr)
 #undef SYR_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event syr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event syr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a, int64_t lda,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "syr2", "for row_major layout");
 }
 
-#define SYR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                             \
-    cl::sycl::event syr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,    \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a,  \
-                         int64_t lda, const std::vector<cl::sycl::event> &dependencies) {    \
-        return syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda, \
-                    dependencies);                                                           \
+#define SYR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a, int64_t lda,            \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return syr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda,     \
+                    dependencies);                                                               \
     }
 
 SYR2_LAUNCHER_USM(float, rocblas_ssyr2)
@@ -2513,18 +2476,18 @@ SYR2_LAUNCHER_USM(std::complex<double>, rocblas_zsyr2)
 #undef SYR2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event spmv(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event spmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *a, const T *x, int64_t incx, T beta, T *y, int64_t incy,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "spmv", "for row_major layout");
 }
 
-#define SPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                              \
-    cl::sycl::event spmv(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,     \
-                         const TYPE *a, const TYPE *x, int64_t incx, TYPE beta, TYPE *y,      \
-                         int64_t incy, const std::vector<cl::sycl::event> &dependencies) {    \
-        return spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy, \
-                    dependencies);                                                            \
+#define SPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *a, \
+                     const TYPE *x, int64_t incx, TYPE beta, TYPE *y, int64_t incy,              \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return spmv(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy,    \
+                    dependencies);                                                               \
     }
 
 SPMV_LAUNCHER_USM(float, rocblas_sspmv)
@@ -2533,17 +2496,16 @@ SPMV_LAUNCHER_USM(double, rocblas_dspmv)
 #undef SPMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event spr(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                           const T *x, int64_t incx, T *a,
-                           const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event spr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                       const T *x, int64_t incx, T *a,
+                       const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "spr", "for row_major layout");
 }
 
-#define SPR_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                              \
-    cl::sycl::event spr(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,     \
-                        const TYPE *x, int64_t incx, TYPE *a,                                \
-                        const std::vector<cl::sycl::event> &dependencies) {                  \
-        return spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies); \
+#define SPR_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                    int64_t incx, TYPE *a, const std::vector<sycl::event> &dependencies) {      \
+        return spr(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, a, dependencies);    \
     }
 
 SPR_LAUNCHER_USM(float, rocblas_sspr)
@@ -2552,18 +2514,18 @@ SPR_LAUNCHER_USM(double, rocblas_dspr)
 #undef SPR_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event spr2(Func func, cl::sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
-                            const T *x, int64_t incx, const T *y, int64_t incy, T *a,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event spr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T alpha,
+                        const T *x, int64_t incx, const T *y, int64_t incy, T *a,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "spr2", "for row_major layout");
 }
 
-#define SPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
-    cl::sycl::event spr2(cl::sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha,   \
-                         const TYPE *x, int64_t incx, const TYPE *y, int64_t incy, TYPE *a, \
-                         const std::vector<cl::sycl::event> &dependencies) {                \
-        return spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,     \
-                    dependencies);                                                          \
+#define SPR2_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                 \
+    sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, TYPE alpha, const TYPE *x, \
+                     int64_t incx, const TYPE *y, int64_t incy, TYPE *a,                         \
+                     const std::vector<sycl::event> &dependencies) {                             \
+        return spr2(ROCBLAS_ROUTINE, queue, upper_lower, n, alpha, x, incx, y, incy, a,          \
+                    dependencies);                                                               \
     }
 
 SPR2_LAUNCHER_USM(float, rocblas_sspr2)
@@ -2572,17 +2534,16 @@ SPR2_LAUNCHER_USM(double, rocblas_dspr2)
 #undef SPR2_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tbmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tbmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
+                        int64_t incx, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "tbmv", "for row_major layout");
 }
 
 #define TBMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event tbmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,               \
-                         diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,        \
-                         TYPE *x, int64_t incx,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {                      \
+    sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,       \
+                     int64_t n, int64_t k, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,     \
+                     const std::vector<sycl::event> &dependencies) {                              \
         return tbmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                                \
     }
@@ -2595,17 +2556,16 @@ TBMV_LAUNCHER_USM(std::complex<double>, rocblas_ztbmv)
 #undef TBMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tbsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
-                            int64_t incx, const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tbsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, int64_t k, const T *a, int64_t lda, T *x,
+                        int64_t incx, const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "tbsv", "for row_major layout");
 }
 
 #define TBSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                                  \
-    cl::sycl::event tbsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,               \
-                         diag unit_diag, int64_t n, int64_t k, const TYPE *a, int64_t lda,        \
-                         TYPE *x, int64_t incx,                                                   \
-                         const std::vector<cl::sycl::event> &dependencies) {                      \
+    sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,       \
+                     int64_t n, int64_t k, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,     \
+                     const std::vector<sycl::event> &dependencies) {                              \
         return tbsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx, \
                     dependencies);                                                                \
     }
@@ -2618,18 +2578,18 @@ TBSV_LAUNCHER_USM(std::complex<double>, rocblas_ztbsv)
 #undef TBSV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tpmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tpmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "tpmv", "for row_major layout");
 }
 
-#define TPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
-    cl::sycl::event tpmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
-                         diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {              \
-        return tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx, \
-                    dependencies);                                                        \
+#define TPMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
+    sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
+                     int64_t n, const TYPE *a, TYPE *x, int64_t incx,                       \
+                     const std::vector<sycl::event> &dependencies) {                        \
+        return tpmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,   \
+                    dependencies);                                                          \
     }
 
 TPMV_LAUNCHER_USM(float, rocblas_stpmv)
@@ -2640,18 +2600,18 @@ TPMV_LAUNCHER_USM(std::complex<double>, rocblas_ztpmv)
 #undef TPMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event tpsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event tpsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "tpsv", "for row_major layout");
 }
 
-#define TPSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                          \
-    cl::sycl::event tpsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,       \
-                         diag unit_diag, int64_t n, const TYPE *a, TYPE *x, int64_t incx, \
-                         const std::vector<cl::sycl::event> &dependencies) {              \
-        return tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx, \
-                    dependencies);                                                        \
+#define TPSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                            \
+    sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, \
+                     int64_t n, const TYPE *a, TYPE *x, int64_t incx,                       \
+                     const std::vector<sycl::event> &dependencies) {                        \
+        return tpsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, x, incx,   \
+                    dependencies);                                                          \
     }
 
 TPSV_LAUNCHER_USM(float, rocblas_stpsv)
@@ -2662,16 +2622,16 @@ TPSV_LAUNCHER_USM(std::complex<double>, rocblas_ztpsv)
 #undef TPSV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event trmv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event trmv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trmv", "for row_major layout");
 }
 
 #define TRMV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event trmv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,            \
-                         diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,       \
-                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {     \
+    sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
+                     int64_t n, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,             \
+                     const std::vector<sycl::event> &dependencies) {                           \
         return trmv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                             \
     }
@@ -2684,16 +2644,16 @@ TRMV_LAUNCHER_USM(std::complex<double>, rocblas_ztrmv)
 #undef TRMV_LAUNCHER_USM
 
 template <typename Func, typename T>
-inline cl::sycl::event trsv(Func func, cl::sycl::queue &queue, uplo upper_lower, transpose trans,
-                            diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
-                            const std::vector<cl::sycl::event> &dependencies) {
+inline sycl::event trsv(Func func, sycl::queue &queue, uplo upper_lower, transpose trans,
+                        diag unit_diag, int64_t n, const T *a, int64_t lda, T *x, int64_t incx,
+                        const std::vector<sycl::event> &dependencies) {
     throw unimplemented("blas", "trsv", "for row_major layout");
 }
 
 #define TRSV_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                               \
-    cl::sycl::event trsv(cl::sycl::queue &queue, uplo upper_lower, transpose trans,            \
-                         diag unit_diag, int64_t n, const TYPE *a, int64_t lda, TYPE *x,       \
-                         int64_t incx, const std::vector<cl::sycl::event> &dependencies) {     \
+    sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,    \
+                     int64_t n, const TYPE *a, int64_t lda, TYPE *x, int64_t incx,             \
+                     const std::vector<sycl::event> &dependencies) {                           \
         return trsv(ROCBLAS_ROUTINE, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx, \
                     dependencies);                                                             \
     }

--- a/src/blas/backends/rocblas/rocblas_scope_handle_hipsycl.cpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle_hipsycl.cpp
@@ -45,13 +45,13 @@ rocblas_handle_container::~rocblas_handle_container() noexcept(false) {
 thread_local rocblas_handle_container RocblasScopedContextHandler::handle_helper =
     rocblas_handle_container{};
 
-RocblasScopedContextHandler::RocblasScopedContextHandler(cl::sycl::queue queue,
-                                                         cl::sycl::interop_handle &ih)
+RocblasScopedContextHandler::RocblasScopedContextHandler(sycl::queue queue,
+                                                         sycl::interop_handle &ih)
         : interop_h(ih) {}
 
-rocblas_handle RocblasScopedContextHandler::get_handle(const cl::sycl::queue &queue) {
-    cl::sycl::device device = queue.get_device();
-    int current_device = interop_h.get_native_device<cl::sycl::backend::hip>();
+rocblas_handle RocblasScopedContextHandler::get_handle(const sycl::queue &queue) {
+    sycl::device device = queue.get_device();
+    int current_device = interop_h.get_native_device<sycl::backend::hip>();
     hipStream_t streamId = get_stream(queue);
     rocblas_status err;
     auto it = handle_helper.rocblas_handle_mapper_.find(current_device);
@@ -84,8 +84,8 @@ rocblas_handle RocblasScopedContextHandler::get_handle(const cl::sycl::queue &qu
     return handle;
 }
 
-hipStream_t RocblasScopedContextHandler::get_stream(const cl::sycl::queue &queue) {
-    return interop_h.get_native_queue<cl::sycl::backend::hip>();
+hipStream_t RocblasScopedContextHandler::get_stream(const sycl::queue &queue) {
+    return interop_h.get_native_queue<sycl::backend::hip>();
 }
 
 } // namespace rocblas

--- a/src/blas/backends/rocblas/rocblas_scope_handle_hipsycl.hpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle_hipsycl.hpp
@@ -37,21 +37,21 @@ struct rocblas_handle_container {
 };
 
 class RocblasScopedContextHandler {
-    cl::sycl::interop_handle interop_h;
+    sycl::interop_handle interop_h;
     static thread_local rocblas_handle_container handle_helper;
-    cl::sycl::context get_context(const cl::sycl::queue &queue);
-    hipStream_t get_stream(const cl::sycl::queue &queue);
+    sycl::context get_context(const sycl::queue &queue);
+    hipStream_t get_stream(const sycl::queue &queue);
 
 public:
-    RocblasScopedContextHandler(cl::sycl::queue queue, cl::sycl::interop_handle &ih);
+    RocblasScopedContextHandler(sycl::queue queue, sycl::interop_handle &ih);
 
-    rocblas_handle get_handle(const cl::sycl::queue &queue);
+    rocblas_handle get_handle(const sycl::queue &queue);
 
     // This is a work-around function for reinterpret_casting the memory. This
     // will be fixed when SYCL-2020 has been implemented for Pi backend.
     template <typename T, typename U>
     inline T get_mem(U acc) {
-        return reinterpret_cast<T>(interop_h.get_native_mem<cl::sycl::backend::hip>(acc));
+        return reinterpret_cast<T>(interop_h.get_native_mem<sycl::backend::hip>(acc));
     }
 };
 

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -29,9 +29,7 @@
 #include <CL/sycl/detail/pi.hpp>
 #else
 #include "rocblas_scope_handle_hipsycl.hpp"
-namespace cl::sycl {
-using interop_handler = cl::sycl::interop_handle;
-}
+
 #endif
 namespace oneapi {
 namespace mkl {
@@ -40,23 +38,23 @@ namespace rocblas {
 
 #ifdef __HIPSYCL__
 template <typename H, typename F>
-static inline void host_task_internal(H &cgh, cl::sycl::queue queue, F f) {
-    cgh.hipSYCL_enqueue_custom_operation([f, queue](cl::sycl::interop_handle ih) {
+static inline void host_task_internal(H &cgh, sycl::queue queue, F f) {
+    cgh.hipSYCL_enqueue_custom_operation([f, queue](sycl::interop_handle ih) {
         auto sc = RocblasScopedContextHandler(queue, ih);
         f(sc);
     });
 }
 #else
 template <typename H, typename F>
-static inline void host_task_internal(H &cgh, cl::sycl::queue queue, F f) {
-    cgh.interop_task([f, queue](cl::sycl::interop_handler ih) {
+static inline void host_task_internal(H &cgh, sycl::queue queue, F f) {
+    cgh.interop_task([f, queue](sycl::interop_handler ih) {
         auto sc = RocblasScopedContextHandler(queue, ih);
         f(sc);
     });
 }
 #endif
 template <typename H, typename F>
-static inline void onemkl_rocblas_host_task(H &cgh, cl::sycl::queue queue, F f) {
+static inline void onemkl_rocblas_host_task(H &cgh, sycl::queue queue, F f) {
     (void)host_task_internal(cgh, queue, f);
 }
 


### PR DESCRIPTION
# Description
similarly to #167 this PR removes the use of the cl::sycl namespace from the rocBLAS backend. This change depends on #191 

# Checklist

## All Submissions

Tested rebased on #191 merged 

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

[2022-04-25-hipsycl-rocblas-rt-test.txt](https://github.com/oneapi-src/oneMKL/files/8558505/2022-04-25-hipsycl-rocblas-rt-test.txt)
[2022-04-25-hipsycl-rocblas-ct-test.txt](https://github.com/oneapi-src/oneMKL/files/8558506/2022-04-25-hipsycl-rocblas-ct-test.txt)


