### PR TITLE
cusolver: add path to config.hpp

### DIFF
--- a/src/lapack/backends/cusolver/CMakeLists.txt
+++ b/src/lapack/backends/cusolver/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src/include
           ${PROJECT_SOURCE_DIR}/src
+          ${CMAKE_BINARY_DIR}/bin
 )
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ONEMKL::cuSOLVER::cuSOLVER)


### PR DESCRIPTION
# Description

cuSolver build fails with 
```
$ mkdir build && cd build
$ cmake .. -G Ninja -DENABLE_CUSOLVER_BACKEND=True -DENABLE_MKLCPU_BACKEND=False -DENABLE_MKLGPU_BACKEND=False -DBUILD_FUNCTIONAL_TESTS=False
$ cmake --build . -j 24
...
In file included from ../include/oneapi/mkl/lapack/detail/cusolver/onemkl_lapack_cusolver.hpp:27:
../include/oneapi/mkl/detail/export.hpp:23:10: fatal error: 'oneapi/mkl/detail/config.hpp' file not found
#include "oneapi/mkl/detail/config.hpp"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```

This PR adds path to autogenerated file `config.hpp`

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? With this fix cuSolver backend builds successfully
```
$ mkdir build && cd build
$ cmake .. -G Ninja -DENABLE_CUSOLVER_BACKEND=True -DENABLE_MKLCPU_BACKEND=False -DENABLE_MKLGPU_BACKEND=False -DBUILD_FUNCTIONAL_TESTS=False
$ cmake --build . -j 24
...
[9/9] Creating library symlink lib/libonemkl_lapack_cusolver.so
```

- [X] Have you formatted the code using clang-format? Yes

## Bug fixes

- [X] Have you added relevant regression tests? Build issue, N/A
- [X] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
