### PR TITLE
Refactor sycl header file

### DIFF
--- a/docs/create_new_backend.rst
+++ b/docs/create_new_backend.rst
@@ -270,7 +270,11 @@ The following code snippet is updated for ``src/blas/backends/newlib/newlib_wrap
 
 .. code-block:: diff
 
+        #if __has_include(<sycl/sycl.hpp>)
+        #include <sycl/sycl.hpp>
+        #else
         #include <CL/sycl.hpp>
+        #endif
         
         #include "oneapi/mkl/types.hpp"
         

--- a/examples/blas/compile_time_dispatching/level3/gemm_usm_mklcpu_cublas.cpp
+++ b/examples/blas/compile_time_dispatching/level3/gemm_usm_mklcpu_cublas.cpp
@@ -42,7 +42,11 @@
 #include <vector>
 
 // oneMKL/SYCL includes
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl.hpp"
 
 // local includes
@@ -218,14 +222,12 @@ void run_gemm_example(const sycl::device &cpu_dev, const sycl::device &gpu_dev) 
     // output the top 2x2 block of C matrix from GPU
     print_2x2_matrix_values(result_gpu.data(), ldC, "(GPU) C");
 
-
     sycl::free(gpu_C, gpu_queue);
     sycl::free(gpu_B, gpu_queue);
     sycl::free(gpu_A, gpu_queue);
     sycl::free(cpu_C, cpu_queue);
     sycl::free(cpu_B, cpu_queue);
     sycl::free(cpu_A, cpu_queue);
-
 }
 
 //

--- a/examples/blas/run_time_dispatching/level3/gemm_usm.cpp
+++ b/examples/blas/run_time_dispatching/level3/gemm_usm.cpp
@@ -42,7 +42,11 @@
 #include <iostream>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl.hpp"
 
 #include "example_helper.hpp"

--- a/examples/lapack/compile_time_dispatching/getrs_usm_mklcpu_cusolver.cpp
+++ b/examples/lapack/compile_time_dispatching/getrs_usm_mklcpu_cusolver.cpp
@@ -36,7 +36,11 @@
 #include <vector>
 
 // oneMKL/SYCL includes
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl.hpp"
 
 // local includes
@@ -144,8 +148,8 @@ void run_getrs_example(const sycl::device& cpu_device, const sycl::device& gpu_d
     std::int64_t cpu_getrf_scratchpad_size = oneapi::mkl::lapack::getrf_scratchpad_size<float>(
         oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue }, m, n, lda);
     std::int64_t cpu_getrs_scratchpad_size = oneapi::mkl::lapack::getrs_scratchpad_size<float>(
-        oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue },
-        trans, n, nrhs, lda, ldb);
+        oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue }, trans, n, nrhs,
+        lda, ldb);
     float* cpu_getrf_scratchpad = sycl::malloc_device<float>(
         cpu_getrf_scratchpad_size * sizeof(float), cpu_device, cpu_context);
     float* cpu_getrs_scratchpad = sycl::malloc_device<float>(
@@ -174,8 +178,8 @@ void run_getrs_example(const sycl::device& cpu_device, const sycl::device& gpu_d
     std::int64_t gpu_getrf_scratchpad_size = oneapi::mkl::lapack::getrf_scratchpad_size<float>(
         oneapi::mkl::backend_selector<oneapi::mkl::backend::cusolver>{ gpu_queue }, m, n, lda);
     std::int64_t gpu_getrs_scratchpad_size = oneapi::mkl::lapack::getrs_scratchpad_size<float>(
-        oneapi::mkl::backend_selector<oneapi::mkl::backend::cusolver>{ gpu_queue },
-        trans, n, nrhs, lda, ldb);
+        oneapi::mkl::backend_selector<oneapi::mkl::backend::cusolver>{ gpu_queue }, trans, n, nrhs,
+        lda, ldb);
     float* gpu_getrf_scratchpad = sycl::malloc_device<float>(
         gpu_getrf_scratchpad_size * sizeof(float), gpu_device, gpu_context);
     float* gpu_getrs_scratchpad = sycl::malloc_device<float>(
@@ -196,16 +200,16 @@ void run_getrs_example(const sycl::device& cpu_device, const sycl::device& gpu_d
         oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue }, m, n, cpu_A, lda,
         cpu_ipiv, cpu_getrf_scratchpad, cpu_getrf_scratchpad_size);
     cpu_getrs_done = oneapi::mkl::lapack::getrs(
-        oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue },
-        trans, n, nrhs, cpu_A, lda, cpu_ipiv, cpu_B, ldb,
-        cpu_getrs_scratchpad, cpu_getrs_scratchpad_size, { cpu_getrf_done });
+        oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue }, trans, n, nrhs,
+        cpu_A, lda, cpu_ipiv, cpu_B, ldb, cpu_getrs_scratchpad, cpu_getrs_scratchpad_size,
+        { cpu_getrf_done });
     gpu_getrf_done = oneapi::mkl::lapack::getrf(
         oneapi::mkl::backend_selector<oneapi::mkl::backend::cusolver>{ gpu_queue }, m, n, gpu_A,
         lda, gpu_ipiv, gpu_getrf_scratchpad, gpu_getrf_scratchpad_size);
     gpu_getrs_done = oneapi::mkl::lapack::getrs(
-        oneapi::mkl::backend_selector<oneapi::mkl::backend::cusolver>{ gpu_queue },
-        trans, n, nrhs, gpu_A, lda, gpu_ipiv, gpu_B, ldb,
-        gpu_getrs_scratchpad, gpu_getrs_scratchpad_size, { gpu_getrf_done });
+        oneapi::mkl::backend_selector<oneapi::mkl::backend::cusolver>{ gpu_queue }, trans, n, nrhs,
+        gpu_A, lda, gpu_ipiv, gpu_B, ldb, gpu_getrs_scratchpad, gpu_getrs_scratchpad_size,
+        { gpu_getrf_done });
 
     // Wait until calculations are done
     cpu_queue.wait_and_throw();
@@ -219,7 +223,6 @@ void run_getrs_example(const sycl::device& cpu_device, const sycl::device& gpu_d
 
     // copy data from GPU device back to host
     gpu_queue.memcpy(result_gpu.data(), gpu_B, B_size * sizeof(float)).wait_and_throw();
-
 
     // Print results
     std::cout << "\n\t\tGETRF and GETRS parameters:" << std::endl;
@@ -252,7 +255,6 @@ void run_getrs_example(const sycl::device& cpu_device, const sycl::device& gpu_d
     sycl::free(cpu_ipiv, cpu_queue);
     sycl::free(cpu_B, cpu_queue);
     sycl::free(cpu_A, cpu_queue);
-
 }
 
 //

--- a/examples/rng/compile_time_dispatching/uniform_usm_mklcpu_curand.cpp
+++ b/examples/rng/compile_time_dispatching/uniform_usm_mklcpu_curand.cpp
@@ -37,7 +37,11 @@
 #include <vector>
 
 // oneMKL/SYCL includes
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl.hpp"
 
 // local includes
@@ -155,7 +159,6 @@ void run_uniform_example(const sycl::device& cpu_dev, const sycl::device& gpu_de
 
     sycl::free(dev_gpu, gpu_queue);
     sycl::free(dev_cpu, cpu_queue);
-
 }
 
 //

--- a/examples/rng/run_time_dispatching/uniform_usm.cpp
+++ b/examples/rng/run_time_dispatching/uniform_usm.cpp
@@ -37,7 +37,11 @@
 #include <vector>
 
 // oneMKL/SYCL includes
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl.hpp"
 
 // local includes
@@ -118,7 +122,6 @@ void run_uniform_example(const sycl::device& dev) {
     std::cout << std::endl;
 
     sycl::free(dev_r, queue);
-
 }
 
 //

--- a/include/oneapi/mkl/blas.hpp
+++ b/include/oneapi/mkl/blas.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_BLAS_HPP_
 #define _ONEMKL_BLAS_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/blas_ct_backends.hpp
+++ b/include/oneapi/mkl/blas/detail/blas_ct_backends.hpp
@@ -20,7 +20,11 @@
 #ifndef _BLAS_CT_BACKENDS_HPP__
 #define _BLAS_CT_BACKENDS_HPP__
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/blas_loader.hpp
+++ b/include/oneapi/mkl/blas/detail/blas_loader.hpp
@@ -22,7 +22,11 @@
 
 #include <complex>
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 

--- a/include/oneapi/mkl/blas/detail/cublas/blas_ct.hpp
+++ b/include/oneapi/mkl/blas/detail/cublas/blas_ct.hpp
@@ -20,7 +20,11 @@
 #ifndef _DETAIL_CUBLAS_BLAS_CT_HPP_
 #define _DETAIL_CUBLAS_BLAS_CT_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hpp
+++ b/include/oneapi/mkl/blas/detail/cublas/onemkl_blas_cublas.hpp
@@ -18,7 +18,11 @@
 **************************************************************************/
 #ifndef _ONEMKL_BLAS_CUBLAS_HPP_
 #define _ONEMKL_BLAS_CUBLAS_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 #include <string>

--- a/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hpp
+++ b/include/oneapi/mkl/blas/detail/mklcpu/blas_ct.hpp
@@ -20,7 +20,11 @@
 #ifndef _DETAIL_MKLCPU_BLAS_CT_HPP__
 #define _DETAIL_MKLCPU_BLAS_CT_HPP__
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp
+++ b/include/oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp
@@ -19,7 +19,11 @@
 
 #ifndef _ONEMKL_BLAS_MKLCPU_HPP_
 #define _ONEMKL_BLAS_MKLCPU_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 #include "oneapi/mkl/types.hpp"

--- a/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hpp
+++ b/include/oneapi/mkl/blas/detail/mklgpu/blas_ct.hpp
@@ -20,7 +20,11 @@
 #ifndef _DETAIL_MKLGPU_BLAS_CT_HPP__
 #define _DETAIL_MKLGPU_BLAS_CT_HPP__
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/mklgpu/onemkl_blas_mklgpu.hpp
+++ b/include/oneapi/mkl/blas/detail/mklgpu/onemkl_blas_mklgpu.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_BLAS_MKLGPU_HPP_
 #define _ONEMKL_BLAS_MKLGPU_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/netlib/blas_ct.hpp
+++ b/include/oneapi/mkl/blas/detail/netlib/blas_ct.hpp
@@ -20,7 +20,11 @@
 #ifndef _DETAIL_NETLIB_BLAS_CT_HPP_
 #define _DETAIL_NETLIB_BLAS_CT_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/netlib/onemkl_blas_netlib.hpp
+++ b/include/oneapi/mkl/blas/detail/netlib/onemkl_blas_netlib.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_BLAS_NETLIB_HPP_
 #define _ONEMKL_BLAS_NETLIB_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include <complex>
 #include <cstdint>

--- a/include/oneapi/mkl/blas/detail/rocblas/blas_ct.hpp
+++ b/include/oneapi/mkl/blas/detail/rocblas/blas_ct.hpp
@@ -22,7 +22,11 @@
 #ifndef _DETAIL_ROCBLAS_BLAS_CT_HPP_
 #define _DETAIL_ROCBLAS_BLAS_CT_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/blas/detail/rocblas/onemkl_blas_rocblas.hpp
+++ b/include/oneapi/mkl/blas/detail/rocblas/onemkl_blas_rocblas.hpp
@@ -20,7 +20,11 @@
 **************************************************************************/
 #ifndef _ONEMKL_BLAS_ROCBLAS_HPP_
 #define _ONEMKL_BLAS_ROCBLAS_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 #include <string>

--- a/include/oneapi/mkl/blas/predicates.hpp
+++ b/include/oneapi/mkl/blas/predicates.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_BLAS_PREDICATES_HPP_
 #define _ONEMKL_BLAS_PREDICATES_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/detail/backend_selector.hpp
+++ b/include/oneapi/mkl/detail/backend_selector.hpp
@@ -27,8 +27,6 @@
 namespace oneapi {
 namespace mkl {
 
-using namespace cl;
-
 template <backend Backend>
 class backend_selector {
 public:

--- a/include/oneapi/mkl/detail/backend_selector_predicates.hpp
+++ b/include/oneapi/mkl/detail/backend_selector_predicates.hpp
@@ -21,7 +21,11 @@
 #define _ONEMKL_BACKEND_SELECTOR_PREDICATES_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/exceptions.hpp"
 #include "oneapi/mkl/detail/backends.hpp"

--- a/include/oneapi/mkl/detail/backends_table.hpp
+++ b/include/oneapi/mkl/detail/backends_table.hpp
@@ -23,7 +23,11 @@
 #include <string>
 #include <vector>
 #include <map>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/detail/config.hpp"
 

--- a/include/oneapi/mkl/detail/get_device_id.hpp
+++ b/include/oneapi/mkl/detail/get_device_id.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_GET_DEVICE_ID_HPP_
 #define _ONEMKL_GET_DEVICE_ID_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/detail/backends_table.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/include/oneapi/mkl/exceptions.hpp
+++ b/include/oneapi/mkl/exceptions.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_EXCEPTIONS_HPP_
 #define _ONEMKL_EXCEPTIONS_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <exception>
 #include <string>
 

--- a/include/oneapi/mkl/lapack/detail/cusolver/lapack_ct.hpp
+++ b/include/oneapi/mkl/lapack/detail/cusolver/lapack_ct.hpp
@@ -20,7 +20,11 @@
 #ifndef _DETAIL_CUSOLVER_LAPACK_CT_HPP_
 #define _DETAIL_CUSOLVER_LAPACK_CT_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/lapack/detail/cusolver/onemkl_lapack_cusolver.hpp
+++ b/include/oneapi/mkl/lapack/detail/cusolver/onemkl_lapack_cusolver.hpp
@@ -18,7 +18,11 @@
 **************************************************************************/
 #ifndef _ONEMKL_LAPACK_CUSOLVER_HPP_
 #define _ONEMKL_LAPACK_CUSOLVER_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 #include <string>

--- a/include/oneapi/mkl/lapack/detail/lapack_loader.hpp
+++ b/include/oneapi/mkl/lapack/detail/lapack_loader.hpp
@@ -22,7 +22,11 @@
 #include <complex>
 #include <cstdint>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/include/oneapi/mkl/lapack/detail/lapack_rt.hpp
+++ b/include/oneapi/mkl/lapack/detail/lapack_rt.hpp
@@ -22,7 +22,11 @@
 #include <complex>
 #include <cstdint>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/include/oneapi/mkl/lapack/detail/mklcpu/lapack_ct.hpp
+++ b/include/oneapi/mkl/lapack/detail/mklcpu/lapack_ct.hpp
@@ -22,7 +22,11 @@
 #include <complex>
 #include <cstdint>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/include/oneapi/mkl/lapack/detail/mklcpu/onemkl_lapack_mklcpu.hpp
+++ b/include/oneapi/mkl/lapack/detail/mklcpu/onemkl_lapack_mklcpu.hpp
@@ -22,7 +22,11 @@
 #include <complex>
 #include <cstdint>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/include/oneapi/mkl/lapack/detail/mklgpu/lapack_ct.hpp
+++ b/include/oneapi/mkl/lapack/detail/mklgpu/lapack_ct.hpp
@@ -19,7 +19,11 @@
 
 #pragma once
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/lapack/detail/mklgpu/onemkl_lapack_mklgpu.hpp
+++ b/include/oneapi/mkl/lapack/detail/mklgpu/onemkl_lapack_mklgpu.hpp
@@ -22,7 +22,11 @@
 #include <complex>
 #include <cstdint>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/include/oneapi/mkl/lapack/types.hpp
+++ b/include/oneapi/mkl/lapack/types.hpp
@@ -22,7 +22,11 @@
 #include <complex>
 #include <cstdint>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 namespace oneapi {
 namespace mkl {

--- a/include/oneapi/mkl/rng.hpp
+++ b/include/oneapi/mkl/rng.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_RNG_HPP_
 #define _ONEMKL_RNG_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/include/oneapi/mkl/rng/detail/curand/onemkl_rng_curand.hpp
+++ b/include/oneapi/mkl/rng/detail/curand/onemkl_rng_curand.hpp
@@ -59,7 +59,11 @@
 #ifndef _ONEMKL_RNG_CURAND_HPP_
 #define _ONEMKL_RNG_CURAND_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <cstdint>
 
 #include "oneapi/mkl/detail/export.hpp"

--- a/include/oneapi/mkl/rng/detail/engine_impl.hpp
+++ b/include/oneapi/mkl/rng/detail/engine_impl.hpp
@@ -21,7 +21,11 @@
 #define _ONEMKL_RNG_ENGINE_IMPL_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/detail/export.hpp"
 #include "oneapi/mkl/detail/get_device_id.hpp"

--- a/include/oneapi/mkl/rng/detail/mklcpu/onemkl_rng_mklcpu.hpp
+++ b/include/oneapi/mkl/rng/detail/mklcpu/onemkl_rng_mklcpu.hpp
@@ -21,7 +21,11 @@
 #define _ONEMKL_RNG_MKLCPU_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/detail/export.hpp"
 #include "oneapi/mkl/rng/detail/engine_impl.hpp"

--- a/include/oneapi/mkl/rng/detail/mklgpu/onemkl_rng_mklgpu.hpp
+++ b/include/oneapi/mkl/rng/detail/mklgpu/onemkl_rng_mklgpu.hpp
@@ -21,7 +21,11 @@
 #define _ONEMKL_RNG_MKLGPU_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/detail/export.hpp"
 #include "oneapi/mkl/rng/detail/engine_impl.hpp"

--- a/include/oneapi/mkl/rng/detail/rng_loader.hpp
+++ b/include/oneapi/mkl/rng/detail/rng_loader.hpp
@@ -21,7 +21,11 @@
 #define _ONEMKL_RNG_LOADER_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/detail/export.hpp"
 #include "oneapi/mkl/detail/get_device_id.hpp"

--- a/include/oneapi/mkl/rng/detail/rocrand/onemkl_rng_rocrand.hpp
+++ b/include/oneapi/mkl/rng/detail/rocrand/onemkl_rng_rocrand.hpp
@@ -61,7 +61,11 @@
 #ifndef _ONEMKL_RNG_ROCRAND_HPP_
 #define _ONEMKL_RNG_ROCRAND_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <cstdint>
 
 #include "oneapi/mkl/detail/export.hpp"

--- a/include/oneapi/mkl/rng/distributions.hpp
+++ b/include/oneapi/mkl/rng/distributions.hpp
@@ -22,7 +22,11 @@
 
 #include <cstdint>
 #include <limits>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/exceptions.hpp"
 

--- a/include/oneapi/mkl/rng/engines.hpp
+++ b/include/oneapi/mkl/rng/engines.hpp
@@ -23,7 +23,11 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/exceptions.hpp"
 #include "oneapi/mkl/detail/backend_selector.hpp"

--- a/include/oneapi/mkl/rng/functions.hpp
+++ b/include/oneapi/mkl/rng/functions.hpp
@@ -21,7 +21,11 @@
 #define _ONEMKL_RNG_FUNCTIONS_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/exceptions.hpp"
 #include "oneapi/mkl/rng/predicates.hpp"

--- a/include/oneapi/mkl/rng/predicates.hpp
+++ b/include/oneapi/mkl/rng/predicates.hpp
@@ -21,7 +21,11 @@
 #define _ONEMKL_RNG_PREDICATES_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/exceptions.hpp"
 #include "oneapi/mkl/types.hpp"

--- a/include/oneapi/mkl/types.hpp
+++ b/include/oneapi/mkl/types.hpp
@@ -21,10 +21,10 @@
 #define _ONEMKL_TYPES_HPP_
 
 #include "oneapi/mkl/bfloat16.hpp"
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
-
-#ifdef __HIPSYCL__
-namespace sycl = cl::sycl;
 #endif
 
 namespace oneapi {

--- a/scripts/generate_backend_api.py
+++ b/scripts/generate_backend_api.py
@@ -86,7 +86,11 @@ out_file.write("""//
 
 #pragma once
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include <complex>
 #include <cstdint>

--- a/scripts/generate_ct_instant.py
+++ b/scripts/generate_ct_instant.py
@@ -93,7 +93,11 @@ out_file.write("""//
 
 #pragma once
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/scripts/generate_ct_templates.py
+++ b/scripts/generate_ct_templates.py
@@ -82,7 +82,11 @@ out_file.write("""//
 
 #pragma once
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 #include <cstdint>
 

--- a/scripts/generate_wrappers.py
+++ b/scripts/generate_wrappers.py
@@ -88,7 +88,11 @@ out_file.write("""//
 // generated file
 //
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 

--- a/src/blas/backends/cublas/cublas_helper.hpp
+++ b/src/blas/backends/cublas/cublas_helper.hpp
@@ -23,7 +23,11 @@
  */
 #ifndef _CUBLAS_HELPER_HPP_
 #define _CUBLAS_HELPER_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <cublas_v2.h>
 #include <cuda.h>
 #include <cuda_fp16.h>

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -18,7 +18,11 @@
 **************************************************************************/
 #ifndef _CUBLAS_SCOPED_HANDLE_HPP_
 #define _CUBLAS_SCOPED_HANDLE_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/pi.hpp>

--- a/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
@@ -18,7 +18,11 @@
 **************************************************************************/
 #ifndef CUBLAS_SCOPED_HANDLE_HIPSYCL_HPP
 #define CUBLAS_SCOPED_HANDLE_HIPSYCL_HPP
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <memory>
 #include <thread>
 #include <unordered_map>

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -3,7 +3,11 @@
 #include <cublas_v2.h>
 #include <cuda.h>
 #include <complex>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "cublas_scope_handle.hpp"

--- a/src/blas/backends/mklcpu/mklcpu_batch.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_batch.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/exceptions.hpp"
 #include "mklcpu_common.hpp"

--- a/src/blas/backends/mklcpu/mklcpu_common.hpp
+++ b/src/blas/backends/mklcpu/mklcpu_common.hpp
@@ -23,7 +23,11 @@
 #define MKL_Complex8  std::complex<float>
 #define MKL_Complex16 std::complex<double>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 
 #include "mkl_blas.h"

--- a/src/blas/backends/mklcpu/mklcpu_extensions.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_extensions.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "mklcpu_common.hpp"
 #include "oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp"

--- a/src/blas/backends/mklcpu/mklcpu_level1.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_level1.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "mklcpu_common.hpp"
 #include "oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp"

--- a/src/blas/backends/mklcpu/mklcpu_level2.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_level2.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "mklcpu_common.hpp"
 #include "oneapi/mkl/blas/detail/mklcpu/onemkl_blas_mklcpu.hpp"

--- a/src/blas/backends/mklcpu/mklcpu_level3.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_level3.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/exceptions.hpp"
 #include "mklcpu_common.hpp"

--- a/src/blas/backends/mklgpu/mklgpu_batch.cpp
+++ b/src/blas/backends/mklgpu/mklgpu_batch.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/blas/detail/mklgpu/onemkl_blas_mklgpu.hpp"
 #include "oneapi/mkl/types.hpp"

--- a/src/blas/backends/mklgpu/mklgpu_common.hpp
+++ b/src/blas/backends/mklgpu/mklgpu_common.hpp
@@ -20,7 +20,11 @@
 #ifndef _MKLGPU_COMMON_HPP_
 #define _MKLGPU_COMMON_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 
 typedef enum { MKL_ROW_MAJOR = 101, MKL_COL_MAJOR = 102 } MKL_LAYOUT;

--- a/src/blas/backends/mklgpu/mklgpu_extensions.cpp
+++ b/src/blas/backends/mklgpu/mklgpu_extensions.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/blas/detail/mklgpu/onemkl_blas_mklgpu.hpp"
 #include "oneapi/mkl/types.hpp"

--- a/src/blas/backends/mklgpu/mklgpu_level1.cpp
+++ b/src/blas/backends/mklgpu/mklgpu_level1.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/blas/detail/mklgpu/onemkl_blas_mklgpu.hpp"
 #include "oneapi/mkl/types.hpp"

--- a/src/blas/backends/mklgpu/mklgpu_level2.cpp
+++ b/src/blas/backends/mklgpu/mklgpu_level2.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/blas/detail/mklgpu/onemkl_blas_mklgpu.hpp"
 #include "oneapi/mkl/types.hpp"

--- a/src/blas/backends/mklgpu/mklgpu_level3.cpp
+++ b/src/blas/backends/mklgpu/mklgpu_level3.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/blas/detail/mklgpu/onemkl_blas_mklgpu.hpp"
 #include "oneapi/mkl/types.hpp"

--- a/src/blas/backends/netlib/netlib_batch.cpp
+++ b/src/blas/backends/netlib/netlib_batch.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "netlib_common.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/src/blas/backends/netlib/netlib_common.hpp
+++ b/src/blas/backends/netlib/netlib_common.hpp
@@ -20,7 +20,11 @@
 #ifndef _NETLIB_COMMON_HPP_
 #define _NETLIB_COMMON_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <complex>
 
 #include "cblas.h"

--- a/src/blas/backends/netlib/netlib_extensions.cpp
+++ b/src/blas/backends/netlib/netlib_extensions.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "netlib_common.hpp"
 #include "oneapi/mkl/blas/detail/netlib/onemkl_blas_netlib.hpp"

--- a/src/blas/backends/netlib/netlib_level1.cpp
+++ b/src/blas/backends/netlib/netlib_level1.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "netlib_common.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/src/blas/backends/netlib/netlib_level2.cpp
+++ b/src/blas/backends/netlib/netlib_level2.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "netlib_common.hpp"
 #include "oneapi/mkl/blas/detail/netlib/onemkl_blas_netlib.hpp"

--- a/src/blas/backends/netlib/netlib_level3.cpp
+++ b/src/blas/backends/netlib/netlib_level3.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "netlib_common.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/src/blas/backends/rocblas/rocblas_scope_handle_hipsycl.hpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle_hipsycl.hpp
@@ -20,7 +20,11 @@
 **************************************************************************/
 #ifndef _ROCBLAS_SCOPED_HANDLE_HPP_
 #define _ROCBLAS_SCOPED_HANDLE_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <memory>
 #include <thread>
 #include <unordered_map>

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -22,7 +22,11 @@
 #define _ROCBLAS_TASK_HPP_
 #include <rocblas.h>
 #include <complex>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "rocblas_scope_handle.hpp"

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -22,7 +22,11 @@
 
 #include <complex>
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl/types.hpp"
 
 typedef struct {

--- a/src/include/runtime_support_helper.hpp
+++ b/src/include/runtime_support_helper.hpp
@@ -20,7 +20,11 @@
 #ifndef _ONEMKL_RUNTIME_SUPPORT_HELPER_HPP_
 #define _ONEMKL_RUNTIME_SUPPORT_HELPER_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <type_traits>
 
 // Utility function to verify that a given set of types is supported by the

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -56,7 +56,11 @@
  * so.
  ******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <CL/sycl/backend/cuda.hpp>
 #include <iostream>
 

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -56,7 +56,11 @@
  * so.
  ******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <CL/sycl/backend/cuda.hpp>
 #include <iostream>
 

--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -20,7 +20,11 @@
 #ifndef _RNG_CPU_COMMON_HPP_
 #define _RNG_CPU_COMMON_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -18,7 +18,11 @@
 *******************************************************************************/
 
 #include <iostream>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "mkl_vsl.h"
 
@@ -32,8 +36,6 @@ namespace oneapi {
 namespace mkl {
 namespace rng {
 namespace mklcpu {
-
-using namespace cl;
 
 class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -18,7 +18,11 @@
 *******************************************************************************/
 
 #include <iostream>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "mkl_vsl.h"
 
@@ -32,8 +36,6 @@ namespace oneapi {
 namespace mkl {
 namespace rng {
 namespace mklcpu {
-
-using namespace cl;
 
 class philox4x32x10_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:

--- a/src/rng/backends/mklgpu/mkl_internal_rng_gpu.hpp
+++ b/src/rng/backends/mklgpu/mkl_internal_rng_gpu.hpp
@@ -20,7 +20,11 @@
 #ifndef _MKL_INTERNAL_RNG_GPU_HPP_
 #define _MKL_INTERNAL_RNG_GPU_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/rng/backends/mklgpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklgpu/mrg32k3a.cpp
@@ -18,7 +18,11 @@
 *******************************************************************************/
 
 #include <iostream>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "mkl_version.h"
 

--- a/src/rng/backends/mklgpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklgpu/philox4x32x10.cpp
@@ -18,7 +18,11 @@
 *******************************************************************************/
 
 #include <iostream>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "mkl_version.h"
 

--- a/src/rng/backends/rocrand/mrg32k3a.cpp
+++ b/src/rng/backends/rocrand/mrg32k3a.cpp
@@ -58,7 +58,11 @@
  * so.
  ******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #ifndef __HIPSYCL__
 #include <CL/sycl/backend/cuda.hpp>
 #endif

--- a/src/rng/backends/rocrand/philox4x32x10.cpp
+++ b/src/rng/backends/rocrand/philox4x32x10.cpp
@@ -58,7 +58,11 @@
  * so.
  ******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #ifndef __HIPSYCL__
 #include <CL/sycl/backend/cuda.hpp>
 #endif

--- a/src/rng/backends/rocrand/rocrand_common.hpp
+++ b/src/rng/backends/rocrand/rocrand_common.hpp
@@ -22,7 +22,11 @@
 #ifndef _RNG_ROCRAND_COMMON_HPP_
 #define _RNG_ROCRAND_COMMON_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "rocrand_helper.hpp"
 
 namespace oneapi {

--- a/src/rng/function_table.hpp
+++ b/src/rng/function_table.hpp
@@ -21,7 +21,11 @@
 #define _RNG_FUNCTION_TABLE_HPP_
 
 #include <cstdint>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/rng/detail/engine_impl.hpp"
 

--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/copy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -26,7 +26,11 @@
 #include <stdexcept>
 #include <type_traits>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #define MAX_NUM_PRINT 20
 

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/axpby_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpby_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -23,7 +23,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "allocator_helper.hpp"
 #include "cblas.h"
 #include "oneapi/mkl.hpp"

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -24,7 +24,11 @@
 #include <string>
 #include <tuple>
 #include <gtest/gtest.h>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/lapack/common/dependency_check.cpp
+++ b/tests/unit_tests/lapack/common/dependency_check.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "lapack_common.hpp"
 

--- a/tests/unit_tests/lapack/include/lapack_common.hpp
+++ b/tests/unit_tests/lapack/include/lapack_common.hpp
@@ -25,7 +25,11 @@
 #include <stdexcept>
 #include <type_traits>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/tests/unit_tests/lapack/include/lapack_test_controller.hpp
+++ b/tests/unit_tests/lapack/include/lapack_test_controller.hpp
@@ -24,7 +24,11 @@
 #include <string>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "lapack_common.hpp"
 #include "oneapi/mkl/exceptions.hpp"

--- a/tests/unit_tests/lapack/source/gebrd.cpp
+++ b/tests/unit_tests/lapack/source/gebrd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/geqrf.cpp
+++ b/tests/unit_tests/lapack/source/geqrf.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/geqrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/geqrf_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/gerqf.cpp
+++ b/tests/unit_tests/lapack/source/gerqf.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/gesvd.cpp
+++ b/tests/unit_tests/lapack/source/gesvd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getrf.cpp
+++ b/tests/unit_tests/lapack/source/getrf.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrf_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getrf_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getri.cpp
+++ b/tests/unit_tests/lapack/source/getri.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getri_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getri_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getri_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getri_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getrs.cpp
+++ b/tests/unit_tests/lapack/source/getrs.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getrs_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrs_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/getrs_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getrs_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/heevd.cpp
+++ b/tests/unit_tests/lapack/source/heevd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/hegvd.cpp
+++ b/tests/unit_tests/lapack/source/hegvd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/hetrd.cpp
+++ b/tests/unit_tests/lapack/source/hetrd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/hetrf.cpp
+++ b/tests/unit_tests/lapack/source/hetrf.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/orgbr.cpp
+++ b/tests/unit_tests/lapack/source/orgbr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/orgqr.cpp
+++ b/tests/unit_tests/lapack/source/orgqr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/orgqr_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/orgtr.cpp
+++ b/tests/unit_tests/lapack/source/orgtr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ormqr.cpp
+++ b/tests/unit_tests/lapack/source/ormqr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ormrq.cpp
+++ b/tests/unit_tests/lapack/source/ormrq.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ormtr.cpp
+++ b/tests/unit_tests/lapack/source/ormtr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/potrf.cpp
+++ b/tests/unit_tests/lapack/source/potrf.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/potrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/potrf_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/potrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/potrf_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/potri.cpp
+++ b/tests/unit_tests/lapack/source/potri.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/potrs.cpp
+++ b/tests/unit_tests/lapack/source/potrs.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/potrs_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/potrs_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/syevd.cpp
+++ b/tests/unit_tests/lapack/source/syevd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/sygvd.cpp
+++ b/tests/unit_tests/lapack/source/sygvd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/sytrd.cpp
+++ b/tests/unit_tests/lapack/source/sytrd.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/sytrf.cpp
+++ b/tests/unit_tests/lapack/source/sytrf.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/trtrs.cpp
+++ b/tests/unit_tests/lapack/source/trtrs.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ungbr.cpp
+++ b/tests/unit_tests/lapack/source/ungbr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ungqr.cpp
+++ b/tests/unit_tests/lapack/source/ungqr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
@@ -22,7 +22,11 @@
 #include <numeric>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ungqr_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_stride.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/ungtr.cpp
+++ b/tests/unit_tests/lapack/source/ungtr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/unmqr.cpp
+++ b/tests/unit_tests/lapack/source/unmqr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/unmrq.cpp
+++ b/tests/unit_tests/lapack/source/unmrq.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/lapack/source/unmtr.cpp
+++ b/tests/unit_tests/lapack/source/unmtr.cpp
@@ -20,7 +20,11 @@
 #include <complex>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 #include "lapack_common.hpp"

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -18,7 +18,11 @@
 *******************************************************************************/
 
 #include <gtest/gtest.h>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <string>
 #include "test_helper.hpp"
 #include "oneapi/mkl/detail/config.hpp"

--- a/tests/unit_tests/rng/include/engines_api_tests.hpp
+++ b/tests/unit_tests/rng/include/engines_api_tests.hpp
@@ -24,7 +24,11 @@
 #include <iostream>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 

--- a/tests/unit_tests/rng/include/skip_ahead_test.hpp
+++ b/tests/unit_tests/rng/include/skip_ahead_test.hpp
@@ -24,7 +24,11 @@
 #include <iostream>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 

--- a/tests/unit_tests/rng/include/statistics_check.hpp
+++ b/tests/unit_tests/rng/include/statistics_check.hpp
@@ -20,7 +20,11 @@
 #ifndef _RNG_TEST_STATISTICS_CHECK_HPP__
 #define _RNG_TEST_STATISTICS_CHECK_HPP__
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -24,7 +24,11 @@
 #include <iostream>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl.hpp"
 
@@ -44,7 +48,6 @@
 
 #define POISSON_ARGS 0.5
 
-using namespace cl;
 template <typename Distr, typename Engine>
 class statistics_test {
 public:


### PR DESCRIPTION
# Description

This PR is refactoring sycl header file by using sycl/sycl.hpp whenever it is available, like in hipSYCL case. 

For DPC++ and LLVM, we will start using sycl/sycl.hpp whenever it becomes available. 

This PR is fixing #193 and partially fixing #198

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? 
Tested the below combinations

gen9, mklcpu, mklgpu: blas: all pass
gen9: mklcpu, mklgpu: lapack: I see errors which are not related to this PR. They also exist in develop.
gen9: mklcpu, mklgpu: rng: all pass

nvidia, mklcpu, cublas: blas: all pass
nvidia, mklcpu, cusolver: lapack: all pass
nvidia, mklcpu, curand: rng: all pass

with hipSYCL:
amd, mklcpu, rocblas: blas: all pass
amd, mklcpu, rocrand: rng: all pass except 4 tests. These failures are due to ROCM version. Will be fixed in ROCM 5.1.

- [X] Have you formatted the code using clang-format?

