### PR TITLE
skip the rot and rotg tests when the blas library cannot be found

### DIFF
--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -56,6 +56,13 @@ static LIB_TYPE cblas_library() {
         h = GET_LIB_HANDLE("libblas.so");
 #endif
     }
+    if (h == NULL) {
+#ifdef _WIN64
+        throw oneapi::mkl::unimplemented("blas", "", "- could not find libblas.dll or blas.dll\n");
+#else
+        throw oneapi::mkl::unimplemented("blas", "", "- could not find libblas.so\n");
+#endif
+    }
     return h;
 }
 
@@ -68,8 +75,18 @@ static void csrot_wrapper(const int *N, void *X, const int *incX, void *Y, const
         if (csrot_p == NULL)
             csrot_p = (void (*)(const int *N, void *X, const int *incX, void *Y, const int *incY,
                                 const float *c, const float *s))GET_FUNC(h, "CSROT");
-        if (csrot_p != NULL)
+        if (csrot_p != NULL) {
             csrot_p(N, X, incX, Y, incY, c, s);
+        }
+        else {
+#ifdef _WIN64
+            throw oneapi::mkl::unimplemented(
+                "blas", __func__, "could not find csrot function in libblas.dll or blas.dll\n");
+#else
+            throw oneapi::mkl::unimplemented("blas", __func__,
+                                             "could not find csrot function in libblas.so\n");
+#endif
+        }
     }
 }
 
@@ -82,8 +99,18 @@ static void zdrot_wrapper(const int *N, void *X, const int *incX, void *Y, const
         if (zdrot_p == NULL)
             zdrot_p = (void (*)(const int *N, void *X, const int *incX, void *Y, const int *incY,
                                 const double *c, const double *s))GET_FUNC(h, "ZDROT");
-        if (zdrot_p != NULL)
+        if (zdrot_p != NULL) {
             zdrot_p(N, X, incX, Y, incY, c, s);
+        }
+        else {
+#ifdef _WIN64
+            throw oneapi::mkl::unimplemented(
+                "blas", __func__, "could not find zdrot function in libblas.dll or blas.dll\n");
+#else
+            throw oneapi::mkl::unimplemented("blas", __func__,
+                                             "could not find zdrot function in libblas.so\n");
+#endif
+        }
     }
 }
 
@@ -93,8 +120,18 @@ static void crotg_wrapper(void *a, void *b, const float *c, void *s) {
             crotg_p = (void (*)(void *a, void *b, const float *c, void *s))GET_FUNC(h, "crotg_");
         if (crotg_p == NULL)
             crotg_p = (void (*)(void *a, void *b, const float *c, void *s))GET_FUNC(h, "CROTG");
-        if (crotg_p != NULL)
+        if (crotg_p != NULL) {
             crotg_p(a, b, c, s);
+        }
+        else {
+#ifdef _WIN64
+            throw oneapi::mkl::unimplemented(
+                "blas", __func__, "could not find crotg function in libblas.dll or blas.dll\n");
+#else
+            throw oneapi::mkl::unimplemented("blas", __func__,
+                                             "could not find crotg function in libblas.so\n");
+#endif
+        }
     }
 }
 
@@ -104,8 +141,18 @@ static void zrotg_wrapper(void *a, void *b, const double *c, void *s) {
             zrotg_p = (void (*)(void *a, void *b, const double *c, void *s))GET_FUNC(h, "zrotg_");
         if (zrotg_p == NULL)
             zrotg_p = (void (*)(void *a, void *b, const double *c, void *s))GET_FUNC(h, "ZROTG");
-        if (zrotg_p != NULL)
+        if (zrotg_p != NULL) {
             zrotg_p(a, b, c, s);
+        }
+        else {
+#ifdef _WIN64
+            throw oneapi::mkl::unimplemented(
+                "blas", __func__, "could not find zrotg function in libblas.dll or blas.dll\n");
+#else
+            throw oneapi::mkl::unimplemented("blas", __func__,
+                                             "could not find zrotg function in libblas.so\n");
+#endif
+        }
     }
 }
 }

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -59,8 +59,14 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     using fp_ref = typename ref_type_info<fp>::type;
     const int N_ref = N, incx_ref = incx, incy_ref = incy;
 
-    ::rot(&N_ref, (fp_ref *)x_ref.data(), &incx_ref, (fp_ref *)y_ref.data(), &incy_ref,
-          (fp_scalar *)&c, (fp_scalar *)&s);
+    try {
+        ::rot(&N_ref, (fp_ref *)x_ref.data(), &incx_ref, (fp_ref *)y_ref.data(), &incy_ref,
+              (fp_scalar *)&c, (fp_scalar *)&s);
+    }
+    catch (const oneapi::mkl::unimplemented &e) { // Did not find the library blas or the symbol
+        std::cout << "Caught synchronous SYCL exception during ROT:\n" << e.what() << std::endl;
+        return test_skipped;
+    }
 
     // Call DPC++ ROT.
 

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -80,8 +80,14 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
     using fp_ref = typename ref_type_info<fp>::type;
     const int N_ref = N, incx_ref = incx, incy_ref = incy;
 
-    ::rot(&N_ref, (fp_ref *)x_ref.data(), &incx_ref, (fp_ref *)y_ref.data(), &incy_ref,
-          (fp_scalar *)&c, (fp_scalar *)&s);
+    try {
+        ::rot(&N_ref, (fp_ref *)x_ref.data(), &incx_ref, (fp_ref *)y_ref.data(), &incy_ref,
+              (fp_scalar *)&c, (fp_scalar *)&s);
+    }
+    catch (const oneapi::mkl::unimplemented &e) { // Did not find the library blas or the symbol
+        std::cout << "Caught synchronous SYCL exception during ROT:\n" << e.what() << std::endl;
+        return test_skipped;
+    }
 
     // Call DPC++ ROT.
 

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -64,7 +64,13 @@ int test(device *dev, oneapi::mkl::layout layout) {
     // Call Reference ROTG.
     using fp_ref = typename ref_type_info<fp>::type;
 
-    ::rotg((fp_ref *)&a_ref, (fp_ref *)&b_ref, (fp_scalar *)&c_ref, (fp_ref *)&s_ref);
+    try {
+        ::rotg((fp_ref *)&a_ref, (fp_ref *)&b_ref, (fp_scalar *)&c_ref, (fp_ref *)&s_ref);
+    }
+    catch (const oneapi::mkl::unimplemented &e) { // Did not find the library blas or the symbol
+        std::cout << "Caught synchronous SYCL exception during ROTG:\n" << e.what() << std::endl;
+        return test_skipped;
+    }
 
     // Call DPC++ ROTG.
 

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -83,7 +83,13 @@ int test(device *dev, oneapi::mkl::layout layout) {
     // Call Reference ROTG.
     using fp_ref = typename ref_type_info<fp>::type;
 
-    ::rotg((fp_ref *)&a_ref, (fp_ref *)&b_ref, (fp_scalar *)&c_ref, (fp_ref *)&s_ref);
+    try {
+        ::rotg((fp_ref *)&a_ref, (fp_ref *)&b_ref, (fp_scalar *)&c_ref, (fp_ref *)&s_ref);
+    }
+    catch (const oneapi::mkl::unimplemented &e) { // Did not find the library blas or the symbol
+        std::cout << "Caught synchronous SYCL exception during ROTG:\n" << e.what() << std::endl;
+        return test_skipped;
+    }
 
     // Call DPC++ ROTG.
     fp *a_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);


### PR DESCRIPTION
# Description

I use the `oneapi::mkl::unimplemented` exception to specify that the blas library can't be found or that the symbols can't be found in the library, because that's the best exception to say what's going on right now in oneMKL.

So I use the *try catch* clause in the rot test files to handle the exception and skip the test when we trigger it. I think this is the best solution because it's not a computational error, so it's not viable to fail the test.

Below you will see a file that shows what happens when the blas library cannot be found:
[log_rotg_skip.log](https://github.com/oneapi-src/oneMKL/files/8815264/log_rotg_skip.log)

Fixes #195 (GitHub issue)

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? Attach a log.
[logfile.log](https://github.com/oneapi-src/oneMKL/files/8815834/logfile.log)
(All tests passed, except GEMMT but it is not related to this PR, it is due to the library I tested)
- [X] Have you formatted the code using clang-format?

## Bug fixes

- [ ] ~~Have you added relevant regression tests?~~ (does not need it)
- [X] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
