### PR TITLE
Fix cuda/hip backend location

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -17,7 +17,11 @@
 *
 **************************************************************************/
 #include "cublas_scope_handle.hpp"
+#if __has_include(<sycl/detail/common.hpp>)
+#include <sycl/detail/common.hpp>
+#else
 #include <CL/sycl/detail/common.hpp>
+#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -23,9 +23,15 @@
 #else
 #include <CL/sycl.hpp>
 #endif
+#if __has_include(<sycl/backend/cuda.hpp>)
+#include <sycl/backend/cuda.hpp>
+#include <sycl/context.hpp>
+#include <sycl/detail/pi.hpp>
+#else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#endif
 #include <atomic>
 #include <memory>
 #include <thread>

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -11,7 +11,11 @@
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "cublas_scope_handle.hpp"
+#if __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
+#else
 #include <CL/sycl/detail/pi.hpp>
+#endif
 #else
 #include "cublas_scope_handle_hipsycl.hpp"
 namespace sycl {

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -30,7 +30,11 @@
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "rocblas_scope_handle.hpp"
+#if __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
+#else
 #include <CL/sycl/detail/pi.hpp>
+#endif
 #else
 #include "rocblas_scope_handle_hipsycl.hpp"
 

--- a/src/lapack/backends/cusolver/cusolver_helper.hpp
+++ b/src/lapack/backends/cusolver/cusolver_helper.hpp
@@ -23,7 +23,11 @@
  */
 #ifndef _CUSOLVER_HELPER_HPP_
 #define _CUSOLVER_HELPER_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <cublas_v2.h>
 #include <cusolverDn.h>
 #include <cuda.h>

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
@@ -17,7 +17,11 @@
 *
 **************************************************************************/
 #include "cusolver_scope_handle.hpp"
+#if __has_include(<sycl/detail/common.hpp>)
+#include <sycl/detail/common.hpp>
+#else
 #include <CL/sycl/detail/common.hpp>
+#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
@@ -19,9 +19,15 @@
 #ifndef _CUSOLVER_SCOPED_HANDLE_HPP_
 #define _CUSOLVER_SCOPED_HANDLE_HPP_
 #include <CL/sycl.hpp>
+#if __has_include(<sycl/backend/cuda.hpp>)
+#include <sycl/backend/cuda.hpp>
+#include <sycl/context.hpp>
+#include <sycl/detail/pi.hpp>
+#else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#endif
 #include <atomic>
 #include <memory>
 #include <thread>

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
@@ -18,7 +18,11 @@
 **************************************************************************/
 #ifndef _CUSOLVER_SCOPED_HANDLE_HPP_
 #define _CUSOLVER_SCOPED_HANDLE_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #if __has_include(<sycl/backend/cuda.hpp>)
 #include <sycl/backend/cuda.hpp>
 #include <sycl/context.hpp>

--- a/src/lapack/backends/cusolver/cusolver_task.hpp
+++ b/src/lapack/backends/cusolver/cusolver_task.hpp
@@ -23,7 +23,11 @@
 #include <cublas_v2.h>
 #include <cusolverDn.h>
 #include <complex>
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "oneapi/mkl/types.hpp"
 #include "cusolver_scope_handle.hpp"
 #if __has_include(<sycl/detail/pi.hpp>)

--- a/src/lapack/backends/cusolver/cusolver_task.hpp
+++ b/src/lapack/backends/cusolver/cusolver_task.hpp
@@ -26,7 +26,11 @@
 #include <CL/sycl.hpp>
 #include "oneapi/mkl/types.hpp"
 #include "cusolver_scope_handle.hpp"
+#if __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
+#else
 #include <CL/sycl/detail/pi.hpp>
+#endif
 namespace oneapi {
 namespace mkl {
 namespace lapack {

--- a/src/lapack/backends/mklcpu/mkl_lapack.cpp
+++ b/src/lapack/backends/mklcpu/mkl_lapack.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/src/lapack/backends/mklgpu/mkl_lapack.cpp
+++ b/src/lapack/backends/mklgpu/mkl_lapack.cpp
@@ -17,7 +17,11 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/lapack/types.hpp"

--- a/src/lapack/function_table.hpp
+++ b/src/lapack/function_table.hpp
@@ -22,7 +22,11 @@
 #include <complex>
 #include <cstdint>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 
 #include "oneapi/mkl/types.hpp"
 

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -61,7 +61,11 @@
 #else
 #include <CL/sycl.hpp>
 #endif
+#if __has_include(<sycl/backend/cuda.hpp>)
+#include <sycl/backend/cuda.hpp>
+#else
 #include <CL/sycl/backend/cuda.hpp>
+#endif
 #include <iostream>
 
 #include "curand_helper.hpp"

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -61,7 +61,11 @@
 #else
 #include <CL/sycl.hpp>
 #endif
+#if __has_include(<sycl/backend/cuda.hpp>)
+#include <sycl/backend/cuda.hpp>
+#else
 #include <CL/sycl/backend/cuda.hpp>
+#endif
 #include <iostream>
 
 #include "oneapi/mkl/rng/detail/engine_impl.hpp"

--- a/src/rng/backends/rocrand/mrg32k3a.cpp
+++ b/src/rng/backends/rocrand/mrg32k3a.cpp
@@ -64,7 +64,11 @@
 #include <CL/sycl.hpp>
 #endif
 #ifndef __HIPSYCL__
+#if __has_include(<sycl/backend/cuda.hpp>)
+#include <sycl/backend/cuda.hpp>
+#else
 #include <CL/sycl/backend/cuda.hpp>
+#endif
 #endif
 #include <iostream>
 

--- a/src/rng/backends/rocrand/philox4x32x10.cpp
+++ b/src/rng/backends/rocrand/philox4x32x10.cpp
@@ -64,7 +64,11 @@
 #include <CL/sycl.hpp>
 #endif
 #ifndef __HIPSYCL__
+#if __has_include(<sycl/backend/cuda.hpp>)
+#include <sycl/backend/cuda.hpp>
+#else
 #include <CL/sycl/backend/cuda.hpp>
+#endif
 #endif
 #include <iostream>
 

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -24,7 +24,11 @@
 #include <limits>
 #include <vector>
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include "cblas.h"
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/detail/config.hpp"


### PR DESCRIPTION
# Description

From https://github.com/intel/llvm/pull/6407, it moves almost all headers from CL/sycl to sycl
I followed https://github.com/oneapi-src/oneMKL/pull/199 way 
make the header can use sycl/* if they exist and allow the old intel llvm.
I also update the CL/sycl.hpp which are not changed before.

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log. A: It is a compiling issue.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests? A: It is a compiling issue.
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?

Reproduce:
compile the latest intel llvm and this repo, it will not be able to compile due to missing headers.
