### PR TITLE
Add hipSYCL curand support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Supported domains: BLAS, LAPACK, RNG
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuRAND</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">LLVM*</td>
+            <td align="center">LLVM*, hipSYCL</td>
         </tr>
         <tr>
             <td align="center">AMD GPU</td>

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -310,8 +310,44 @@ Building for oneMKL
      ctest
      cmake --install . --prefix <path_to_install_dir>
 
-Building for CUDA
-^^^^^^^^^^^^^^^^^
+Building for CUDA (with hipSYCL)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* On Linux*
+
+With the cuBLAS backend:
+
+.. code-block:: bash
+
+   # Inside <path to onemkl>
+   mkdir build && cd build
+   cmake .. -DENABLE_CUBLAS_BACKEND=True \
+            -DENABLE_MKLGPU_BACKEND=False                                # Disable all backends except for cuBLAS
+            -DENABLE_MKLCPU_BACKEND=False \
+            -DENABLE_NETLIB_BACKEND=False \
+            -DENABLE_ROCBLAS_BACKEND=False \
+            -DHIPSYCL_TARGETS=cuda:sm_75 \                               # Specify the targeted device architectures 
+            -DONEMKL_SYCL_IMPLEMENTATION=hipSYCL \
+            [-DREF_BLAS_ROOT=<reference_blas_install_prefix>]            # required only for testing
+   cmake --build .
+   ctest
+   cmake --install . --prefix <path_to_install_dir>
+
+To build with the cuRAND backend instead simply replace:
+
+.. code-block:: bash
+
+   -DENABLE_CUBLAS_BACKEND=True   \
+
+With:
+
+.. code-block:: bash
+
+   -DENABLE_CURAND_BACKEND=True   \
+
+
+Building for CUDA (with clang++)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * On Linux*
 
@@ -342,6 +378,7 @@ With:
 .. code-block:: bash
 
    -DENABLE_CURAND_BACKEND=True   \
+
 
 Building for ROCm (with hipSYCL)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/selecting_a_compiler.rst
+++ b/docs/selecting_a_compiler.rst
@@ -9,9 +9,8 @@ application.
 * If your application requires Intel GPU, use
   `Intel(R) oneAPI DPC++ Compiler <https://software.intel.com/en-us/oneapi/dpc-compiler>`_ ``icpx`` on Linux or ``icx`` on Windows.
 * If your application requires NVIDIA GPU, use the latest release of
-  ``clang++`` from `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_.
-* If your application requires AMD GPU, use ``hipSYCL`` from the `hipSYCL repository <https://github.com/illuhad/hipSYCL>`_
-  or use the latest release of ``clang++`` from `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_.
+  ``clang++`` from `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_ or use ``hipSYCL`` from the `hipSYCL repository <https://github.com/illuhad/hipSYCL>`_ (except for LAPACK domain).
+* If your application requires AMD GPU, use ``hipSYCL`` or use the latest release of ``clang++`` from `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_.
 * If no Intel GPU, NVIDIA GPU, or AMD GPU is required, on Linux you can use either
   `Intel(R) oneAPI DPC++ Compiler <https://software.intel.com/en-us/oneapi/dpc-compiler>`_
   ``icpx``, ``clang++``, or ``hipSYCL`` and on Windows you can use either

--- a/src/rng/backends/curand/curand_task.hpp
+++ b/src/rng/backends/curand/curand_task.hpp
@@ -7,47 +7,63 @@
 #include <CL/sycl.hpp>
 #endif
 
+#include "curand_helper.hpp"
+
 namespace oneapi {
 namespace mkl {
 namespace rng {
 namespace curand {
 #ifdef __HIPSYCL__
-template <typename H, typename A, typename F>
-static inline void host_task_internal(H &cgh, A acc, F f) {
-    cgh.hipSYCL_enqueue_custom_operation([f, acc](sycl::interop_handle ih) {
+template <typename H, typename A, typename E, typename F>
+static inline void host_task_internal(H &cgh, A acc, E e, F f) {
+    cgh.hipSYCL_enqueue_custom_operation([=](sycl::interop_handle ih) {
+        curandStatus_t status;
+        CURAND_CALL(curandSetStream, status, e, ih.get_native_queue<sycl::backend::cuda>());
         auto r_ptr =
             reinterpret_cast<typename A::value_type *>(ih.get_native_mem<sycl::backend::cuda>(acc));
         f(r_ptr);
     });
 }
 
-template <typename H, typename F>
-static inline void host_task_internal(H &cgh, F f) {
-    cgh.hipSYCL_enqueue_custom_operation([f](sycl::interop_handle ih) { f(ih); });
+template <typename H, typename E, typename F>
+static inline void host_task_internal(H &cgh, E e, F f) {
+    cgh.hipSYCL_enqueue_custom_operation([=](sycl::interop_handle ih) {
+        curandStatus_t status;
+        CURAND_CALL(curandSetStream, status, e, ih.get_native_queue<sycl::backend::cuda>());
+        f(ih);
+    });
 }
 #else
-template <typename H, typename A, typename F>
-static inline void host_task_internal(H &cgh, A acc, F f) {
-    cgh.host_task([f, acc](sycl::interop_handle ih) {
+template <typename H, typename A, typename E, typename F>
+static inline void host_task_internal(H &cgh, A acc, E e, F f) {
+    cgh.host_task([=](sycl::interop_handle ih) {
+        curandStatus_t status;
+        auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
+        CURAND_CALL(curandSetStream, status, e, stream);
         auto r_ptr = reinterpret_cast<typename A::value_type *>(
             ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
         f(r_ptr);
     });
 }
 
-template <typename H, typename F>
-static inline void host_task_internal(H &cgh, F f) {
-    cgh.host_task([f](sycl::interop_handle ih) { f(ih); });
+template <typename H, typename E, typename F>
+static inline void host_task_internal(H &cgh, E e, F f) {
+    cgh.host_task([=](sycl::interop_handle ih) {
+        curandStatus_t status;
+        auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
+        CURAND_CALL(curandSetStream, status, e, stream);
+        f(ih);
+    });
 }
 #endif
-template <typename H, typename A, typename F>
-static inline void onemkl_curand_host_task(H &cgh, A acc, F f) {
-    host_task_internal(cgh, acc, f);
+template <typename H, typename A, typename E, typename F>
+static inline void onemkl_curand_host_task(H &cgh, A acc, E e, F f) {
+    host_task_internal(cgh, acc, e, f);
 }
 
-template <typename H, typename F>
-static inline void onemkl_curand_host_task(H &cgh, F f) {
-    host_task_internal(cgh, f);
+template <typename H, typename Engine, typename F>
+static inline void onemkl_curand_host_task(H &cgh, Engine e, F f) {
+    host_task_internal(cgh, e, f);
 }
 
 } // namespace curand

--- a/src/rng/backends/curand/curand_task.hpp
+++ b/src/rng/backends/curand/curand_task.hpp
@@ -21,11 +21,9 @@ static inline void host_task_internal(H &cgh, A acc, F f) {
     });
 }
 
-  template <typename H, typename F>
+template <typename H, typename F>
 static inline void host_task_internal(H &cgh, F f) {
-    cgh.hipSYCL_enqueue_custom_operation([f](sycl::interop_handle ih) {
-        f(ih);
-    });
+    cgh.hipSYCL_enqueue_custom_operation([f](sycl::interop_handle ih) { f(ih); });
 }
 #else
 template <typename H, typename A, typename F>
@@ -37,11 +35,9 @@ static inline void host_task_internal(H &cgh, A acc, F f) {
     });
 }
 
-  template <typename H, typename F>
-static inline void host_task_internal(H &cgh, A acc, F f) {
-    cgh.host_task([f](sycl::interop_handle ih) {
-        f(ih);
-    });
+template <typename H, typename F>
+static inline void host_task_internal(H &cgh, F f) {
+    cgh.host_task([f](sycl::interop_handle ih) { f(ih); });
 }
 #endif
 template <typename H, typename A, typename F>
@@ -53,9 +49,8 @@ template <typename H, typename F>
 static inline void onemkl_curand_host_task(H &cgh, F f) {
     host_task_internal(cgh, f);
 }
-  
-}
-// namespace curand
+
+} // namespace curand
 } // namespace rng
 } // namespace mkl
 } // namespace oneapi

--- a/src/rng/backends/curand/curand_task.hpp
+++ b/src/rng/backends/curand/curand_task.hpp
@@ -1,0 +1,42 @@
+#ifndef _MKL_RNG_CURAND_TASK_HPP_
+#define _MKL_RNG_CURAND_TASK_HPP_
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+namespace oneapi {
+namespace mkl {
+namespace rng {
+namespace curand {
+#ifdef __HIPSYCL__
+template <typename H, typename A, typename F>
+static inline void host_task_internal(sycl::handler &cgh, A acc, sycl::queue, F f) {
+    cgh.hipSYCL_enqueue_custom_operation([f, acc](sycl::interop_handle ih) {
+        auto r_ptr =
+            reinterpret_cast<typename A::value_type *>(ih.get_native_mem<sycl::backend::cuda>(acc));
+        f(r_ptr);
+    });
+}
+#else
+template <typename H, typename A, typename F, typename NumberTyp>
+static inline void host_task_internal(H &cgh, A acc, F f) {
+    cgh.host_task([f, acc](sycl::interop_handle ih) {
+        auto r_ptr = reinterpret_cast<typename A::value_type *>(
+            ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+        f(r_ptr);
+    });
+}
+#endif
+template <typename H, typename A, typename F>
+static inline void onemkl_curand_host_task(H &cgh, A acc, F f) {
+    host_task_internal(cgh, acc, f);
+}
+} // namespace curand
+} // namespace rng
+} // namespace mkl
+} // namespace oneapi
+
+#endif

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -320,7 +320,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -335,7 +335,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -352,7 +352,7 @@ public:
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
@@ -367,7 +367,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -382,7 +382,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -397,7 +397,7 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -411,7 +411,7 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -443,7 +443,7 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
@@ -456,7 +456,7 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
@@ -522,7 +522,7 @@ public:
                                  const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -322,6 +322,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -337,6 +339,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -354,6 +358,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
             })
@@ -369,6 +375,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -384,6 +392,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -399,6 +409,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -413,6 +425,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -445,6 +459,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
         });
@@ -458,6 +474,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
             });
@@ -524,6 +542,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });
         });

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -109,7 +109,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -124,7 +124,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -140,7 +140,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = ib.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });
@@ -155,7 +155,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -170,7 +170,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -185,7 +185,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -200,7 +200,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -231,7 +231,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -246,7 +246,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -304,7 +304,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.template get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });
@@ -320,10 +320,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -337,10 +335,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -356,10 +352,8 @@ public:
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
             })
@@ -373,10 +367,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -390,10 +382,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -407,10 +397,8 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -423,10 +411,8 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -457,10 +443,8 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
         });
@@ -472,10 +456,8 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
             });
@@ -540,10 +522,8 @@ public:
                                  const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });
         });

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -61,10 +61,12 @@
 #else
 #include <CL/sycl.hpp>
 #endif
+#ifndef __HIPSYCL__
 #if __has_include(<sycl/backend/cuda.hpp>)
 #include <sycl/backend/cuda.hpp>
 #else
 #include <CL/sycl/backend/cuda.hpp>
+#endif
 #endif
 #include <iostream>
 

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -69,6 +69,7 @@
 #include <iostream>
 
 #include "curand_helper.hpp"
+#include "curand_task.hpp"
 #include "oneapi/mkl/exceptions.hpp"
 #include "oneapi/mkl/rng/detail/curand/onemkl_rng_curand.hpp"
 #include "oneapi/mkl/rng/detail/engine_impl.hpp"
@@ -108,9 +109,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -125,9 +124,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -143,11 +140,9 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = ib.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto ib_ptr = reinterpret_cast<std::uint32_t*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
-                    CURAND_CALL(curandGenerate, status, engine_, ib_ptr, n);
+                    CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });
             })
             .wait_and_throw();
@@ -160,9 +155,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -177,9 +170,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -194,9 +185,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -211,9 +200,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -244,9 +231,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -261,9 +246,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -321,9 +304,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.template get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<std::uint32_t*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -71,6 +71,7 @@
 #include "oneapi/mkl/rng/detail/engine_impl.hpp"
 // #include "oneapi/mkl/rng/engines.hpp"
 #include "curand_helper.hpp"
+#include "curand_task.hpp"
 #include "oneapi/mkl/exceptions.hpp"
 #include "oneapi/mkl/rng/detail/curand/onemkl_rng_curand.hpp"
 
@@ -131,9 +132,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -148,9 +147,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -166,9 +163,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = ib.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<std::uint32_t*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });
@@ -183,9 +178,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -200,9 +193,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -217,9 +208,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -234,9 +223,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -267,9 +254,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<float*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -284,9 +269,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<double*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -344,9 +327,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.template get_access<sycl::access::mode::read_write>(cgh);
-                cgh.host_task([=](sycl::interop_handle ih) {
-                    auto r_ptr = reinterpret_cast<std::uint32_t*>(
-                        ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
+                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -343,7 +343,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-              onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -343,7 +343,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+              onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -358,7 +358,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -375,7 +375,7 @@ public:
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
@@ -390,7 +390,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
@@ -405,7 +405,7 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                cgh.host_task([=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
@@ -420,7 +420,7 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -434,7 +434,7 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
@@ -466,7 +466,7 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
@@ -479,7 +479,7 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
@@ -545,7 +545,7 @@ public:
                                  const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            cgh.host_task([=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -132,7 +132,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -147,7 +147,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -163,7 +163,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = ib.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });
@@ -178,7 +178,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniform, status, engine_, r_ptr, n);
                 });
@@ -193,7 +193,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r_ptr, n);
                 });
@@ -208,7 +208,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormal, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -223,7 +223,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateNormalDouble, status, engine_, r_ptr, n, distr.mean(),
                                 distr.stddev());
@@ -254,7 +254,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](float* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormal, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -269,7 +269,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](double* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r_ptr, n, distr.m(),
                                 distr.s());
@@ -327,7 +327,7 @@ public:
         queue_
             .submit([&](sycl::handler& cgh) {
                 auto acc = r.template get_access<sycl::access::mode::read_write>(cgh);
-                onemkl_curand_host_task(cgh, acc, [=](std::uint32_t* r_ptr) {
+                onemkl_curand_host_task(cgh, acc, engine_, [=](std::uint32_t* r_ptr) {
                     curandStatus_t status;
                     CURAND_CALL(curandGenerate, status, engine_, r_ptr, n);
                 });
@@ -343,10 +343,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -360,10 +358,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -379,10 +375,8 @@ public:
             n * sizeof(std::uint32_t), queue_.get_device(), queue_.get_context());
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
             })
@@ -396,10 +390,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -413,10 +405,8 @@ public:
         sycl::event::wait_and_throw(dependencies);
         queue_
             .submit([&](sycl::handler& cgh) {
-                onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+                onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
-                    CURAND_CALL(curandSetStream, status, engine_,
-                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -430,10 +420,8 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -446,10 +434,8 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -480,10 +466,8 @@ public:
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
         });
@@ -495,10 +479,8 @@ public:
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
             });
@@ -563,10 +545,8 @@ public:
                                  const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
         return queue_.submit([&](sycl::handler& cgh) {
-            onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
+            onemkl_curand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
-                CURAND_CALL(curandSetStream, status, engine_,
-                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });
         });

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -61,10 +61,12 @@
 #else
 #include <CL/sycl.hpp>
 #endif
+#ifndef __HIPSYCL__
 #if __has_include(<sycl/backend/cuda.hpp>)
 #include <sycl/backend/cuda.hpp>
 #else
 #include <CL/sycl/backend/cuda.hpp>
+#endif
 #endif
 #include <iostream>
 

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -345,6 +345,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -360,6 +362,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -377,6 +381,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerate, status, engine_, ib, n);
                 });
             })
@@ -392,6 +398,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniform, status, engine_, r, n);
                 });
             })
@@ -407,6 +415,8 @@ public:
             .submit([&](sycl::handler& cgh) {
                 onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                     curandStatus_t status;
+                    CURAND_CALL(curandSetStream, status, engine_,
+                                ih.get_native_queue<sycl::backend::cuda>());
                     CURAND_CALL(curandGenerateUniformDouble, status, engine_, r, n);
                 });
             })
@@ -422,6 +432,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormal, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -436,6 +448,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateNormalDouble, status, engine_, r, n, distr.mean(),
                             distr.stddev());
             });
@@ -468,6 +482,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormal, status, engine_, r, n, distr.m(), distr.s());
             });
         });
@@ -481,6 +497,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerateLogNormalDouble, status, engine_, r, n, distr.m(),
                             distr.s());
             });
@@ -547,6 +565,8 @@ public:
         return queue_.submit([&](sycl::handler& cgh) {
             onemkl_curand_host_task(cgh, [=](sycl::interop_handle ih) {
                 curandStatus_t status;
+                CURAND_CALL(curandSetStream, status, engine_,
+                            ih.get_native_queue<sycl::backend::cuda>());
                 CURAND_CALL(curandGenerate, status, engine_, r, n);
             });
         });


### PR DESCRIPTION
# Description

This PR adds support to use the cuRAND backend with hipSYCL. 
The approach is similar though simpler than #144: Since hipSYCL does not support `host_task` but instead implements the extension `hipSYCL_enqueue_custom_operation`, a wrapper function `onemkl_curand_host_task` is introduced that calls either `host_task` or `hipSYCL_enqueue_custom_operation` depending on which compiler is used.

Further, calls to `curandSetStream` before calling the cuRAND `generate`-functions were added. This is important since previously, the call to `wait_and_throw` after submitting the CUDA calls might not wait for the cuRAND random number generation to finish if it was started on a different stream. In fact, increasing the amount of random numbers generated in the unit tests (and thereby increasing the time spent generating numbers) made some tests fail (both when using hipSYCL and dpc++), since the result might be read before random number generation is finished. Now all tests pass also when increasing the number of random samples to be generated.

## Test logs
The tests were executed on Ubuntu 20.04 using CUDA 11.6.
[curand_dpcpp_test.log](https://github.com/oneapi-src/oneMKL/files/9543303/curand_dpcpp_test.log)
[curand_hipsycl_test.log](https://github.com/oneapi-src/oneMKL/files/9543304/curand_hipsycl_test.log)

# Checklist
- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
