### PR TITLE
[doc] Fix stride_{a,b} descriptions in getrs_batch (LAPACK)

### DIFF
--- a/docs/domains/lapack/getrs_batch.rst
+++ b/docs/domains/lapack/getrs_batch.rst
@@ -79,7 +79,7 @@ lda
   Leading dimension of :math:`A_i`.
 
 stride_a
-  Stride between the beginnings of matrices :math:`B_i` inside the batch array ``b``.
+  Stride between the beginnings of matrices :math:`A_i` inside the batch array ``a``.
 
 ipiv
   ``ipiv`` array, as returned by the Strided API of the :ref:`onemkl_lapack_getrf_batch_buffer` function.
@@ -92,6 +92,9 @@ b
 
 ldb
   Leading dimension of :math:`B_i`.
+
+stride_b
+  Stride between the beginnings of matrices :math:`B_i` inside the batch array ``b``.
 
 batch_size
   Specifies the number of problems in a batch.
@@ -243,7 +246,7 @@ lda
   Leading dimension of :math:`A_i`.
 
 stride_a  
-  Stride between the beginnings of matrices :math:`B_i` inside the batch array ``b``.
+  Stride between the beginnings of matrices :math:`A_i` inside the batch array ``a``.
 
 ipiv
   ``ipiv`` array, as returned by getrf_batch (USM) function.
@@ -256,6 +259,9 @@ b
 
 ldb
   Leading dimensions of :math:`B_i`.
+
+stride_b
+  Stride between the beginnings of matrices :math:`B_i` inside the batch array ``b``.
 
 batch_size
   Number of problems in a batch.

--- a/docs/domains/lapack/getrs_batch_scratchpad_size.rst
+++ b/docs/domains/lapack/getrs_batch_scratchpad_size.rst
@@ -114,13 +114,16 @@ lda
   Leading dimension of :math:`A_i`.
 
 stride_a
-  Stride between the beginnings of matrices :math:`B_i` inside the batch array ``b``.
+  Stride between the beginnings of matrices :math:`A_i` inside the batch array ``a``.
 
 stride_ipiv
-  Stride between the beginnings of arrays ipivi inside the array ``ipiv``.
+  Stride between the beginnings of arrays :math:`ipiv_i` inside the array ``ipiv``.
 
 ldb
   Leading dimension of :math:`B_i`.
+
+stride_b
+  Stride between the beginnings of matrices :math:`B_i` inside the batch array ``b``.
 
 batch_size
   Number of problems in a batch.


### PR DESCRIPTION
# Description

For getrs_batch functions with a stride_b input (getrs_batch strided for USM and BUFFER API, plus scratchpad_size), the stride_b description is missing, and the description of stride_a refers to the B matrices instead of the A matrices.