### PR TITLE
[BLAS] fix default dependencies in netlib backend

### DIFF
--- a/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/netlib/blas_ct.hxx
@@ -3789,7 +3789,7 @@ sycl::event omatcopy_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t m, std::int64_t n, float alpha, const float *a,
                            std::int64_t lda, std::int64_t stride_a, float *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
         dependencies);
@@ -3800,7 +3800,7 @@ sycl::event omatcopy_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t m, std::int64_t n, double alpha, const double *a,
                            std::int64_t lda, std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
         dependencies);
@@ -3812,7 +3812,7 @@ sycl::event omatcopy_batch(backend_selector<backend::netlib> selector, transpose
                            const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
         dependencies);
@@ -3824,7 +3824,7 @@ sycl::event omatcopy_batch(backend_selector<backend::netlib> selector, transpose
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
         dependencies);
@@ -3834,7 +3834,7 @@ sycl::event omatcopy_batch(backend_selector<backend::netlib> selector, transpose
 sycl::event imatcopy_batch(backend_selector<backend::netlib> selector, transpose trans,
                            std::int64_t m, std::int64_t n, float alpha, float *ab, std::int64_t lda,
                            std::int64_t ldb, std::int64_t stride, std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::imatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
     return done;
@@ -3844,7 +3844,7 @@ sycl::event imatcopy_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t m, std::int64_t n, double alpha, double *ab,
                            std::int64_t lda, std::int64_t ldb, std::int64_t stride,
                            std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::imatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
     return done;
@@ -3854,7 +3854,7 @@ sycl::event imatcopy_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t m, std::int64_t n, std::complex<float> alpha,
                            std::complex<float> *ab, std::int64_t lda, std::int64_t ldb,
                            std::int64_t stride, std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::imatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
     return done;
@@ -3864,7 +3864,7 @@ sycl::event imatcopy_batch(backend_selector<backend::netlib> selector, transpose
                            std::int64_t m, std::int64_t n, std::complex<double> alpha,
                            std::complex<double> *ab, std::int64_t lda, std::int64_t ldb,
                            std::int64_t stride, std::int64_t batch_size,
-                           const std::vector<sycl::event> &dependencies = {}) {
+                           const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::imatcopy_batch(
         selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
     return done;
@@ -3875,7 +3875,7 @@ sycl::event omatadd_batch(backend_selector<backend::netlib> selector, transpose 
                           const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                           const float *b, std::int64_t ldb, std::int64_t stride_b, float *c,
                           std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-                          const std::vector<sycl::event> &dependencies = {}) {
+                          const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatadd_batch(
         selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
         c, ldc, stride_c, batch_size, dependencies);
@@ -3887,7 +3887,7 @@ sycl::event omatadd_batch(backend_selector<backend::netlib> selector, transpose 
                           const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                           const double *b, std::int64_t ldb, std::int64_t stride_b, double *c,
                           std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
-                          const std::vector<sycl::event> &dependencies = {}) {
+                          const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatadd_batch(
         selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
         c, ldc, stride_c, batch_size, dependencies);
@@ -3901,7 +3901,7 @@ sycl::event omatadd_batch(backend_selector<backend::netlib> selector, transpose 
                           const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
                           std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size,
-                          const std::vector<sycl::event> &dependencies = {}) {
+                          const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatadd_batch(
         selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
         c, ldc, stride_c, batch_size, dependencies);
@@ -3915,7 +3915,7 @@ sycl::event omatadd_batch(backend_selector<backend::netlib> selector, transpose 
                           const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                           std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size,
-                          const std::vector<sycl::event> &dependencies = {}) {
+                          const std::vector<sycl::event> &dependencies) {
     auto done = oneapi::mkl::blas::netlib::MAJOR::omatadd_batch(
         selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
         c, ldc, stride_c, batch_size, dependencies);


### PR DESCRIPTION
# Description

Fixes build failures in Netlib backend where `netlib/blas_ct.hxx` wrongly included a default argument for dependencies.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? [build.txt](https://github.com/oneapi-src/oneMKL/files/9871938/build.txt) (build log attached because errors were in build)
- [x] Have you formatted the code using clang-format?
