### PR TITLE
[BLAS] fix linking issue for rotm() with oneMKL 2023.0

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -51,7 +51,9 @@ foreach(lib ${MKL_LIBRARIES})
   find_library(${lib}_file NAMES ${lib}
           HINTS $ENV{MKLROOT} ${MKL_ROOT}
           PATH_SUFFIXES lib/intel64)
-  find_package_handle_standard_args(MKL REQUIRED_VARS ${lib}_file)
+  find_package_handle_standard_args(MKL
+          REQUIRED_VARS ${lib}_file
+          VERSION_VAR MKL_VERSION)
 endforeach()
 
 get_filename_component(MKL_LIB_DIR ${mkl_core_file} DIRECTORY)
@@ -60,11 +62,16 @@ find_path(MKL_INCLUDE mkl.h
           HINTS $ENV{MKLROOT} ${MKL_ROOT}
           PATH_SUFFIXES include)
 
+file(READ "${MKL_INCLUDE}/mkl_version.h" mkl_version_h)
+string(REGEX MATCH "INTEL_MKL_VERSION      ([0-9]*)" _ ${mkl_version_h})
+set(MKL_VERSION ${CMAKE_MATCH_1})
+
 if(${CMAKE_SIZEOF_VOID_P} EQUAL 8 OR USE_DPCPP_API)
   set(MKL_COPT "-DMKL_ILP64")
 else()
   set(MKL_COPT "")
 endif()
+list(APPEND MKL_COPT "-DINTEL_MKL_VERSION=${MKL_VERSION}")
 
 if(UNIX)
   list(APPEND MKL_LINK_PREFIX "-Wl,-rpath,${MKL_LIB_DIR}")
@@ -92,7 +99,11 @@ if (ENABLE_MKLCPU_BACKEND OR ENABLE_MKLGPU_BACKEND)
 endif()
 
 if (USE_DPCPP_API)
-  find_package_handle_standard_args(MKL REQUIRED_VARS MKL_INCLUDE MKL_COPT MKL_LINK_SYCL)
+  find_package_handle_standard_args(MKL
+    REQUIRED_VARS MKL_INCLUDE MKL_COPT MKL_LINK_SYCL
+    VERSION_VAR MKL_VERSION)
 else(ENABLE_MKLCPU_BACKEND)
-  find_package_handle_standard_args(MKL REQUIRED_VARS MKL_INCLUDE MKL_COPT MKL_LINK_C)
+  find_package_handle_standard_args(MKL
+    REQUIRED_VARS MKL_INCLUDE MKL_COPT MKL_LINK_C
+    VERSION_VAR MKL_VERSION)
 endif()

--- a/src/blas/backends/mkl_common/mkl_blas_backend.hxx
+++ b/src/blas/backends/mkl_common/mkl_blas_backend.hxx
@@ -1308,6 +1308,7 @@ sycl::event rotg(sycl::queue &queue, std::complex<float> *a, std::complex<float>
 sycl::event rotg(sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
                  std::complex<double> *s, const std::vector<sycl::event> &dependencies = {});
 
+#if defined(INTEL_MKL_VERSION) && (INTEL_MKL_VERSION < 20230000)
 sycl::event rotm(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                  std::int64_t incy, float *param,
                  const std::vector<sycl::event> &dependencies = {});
@@ -1315,6 +1316,15 @@ sycl::event rotm(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx
 sycl::event rotm(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
                  std::int64_t incy, double *param,
                  const std::vector<sycl::event> &dependencies = {});
+#else
+sycl::event rotm(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
+                 std::int64_t incy, const float *param,
+                 const std::vector<sycl::event> &dependencies = {});
+
+sycl::event rotm(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
+                 std::int64_t incy, const double *param,
+                 const std::vector<sycl::event> &dependencies = {});
+#endif
 
 sycl::event rotmg(sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
                   const std::vector<sycl::event> &dependencies = {});

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
     }
 
 #if defined(ENABLE_MKLCPU_BACKEND) || defined(ENABLE_NETLIB_BACKEND)
-    local_devices.push_back(sycl::device(sycl::host_selector()));
+    local_devices.push_back(sycl::device(sycl::cpu_selector()));
 #endif
 #define GET_NAME(d) (d).template get_info<sycl::info::device::name>()
     for (auto& local_dev : local_devices) {


### PR DESCRIPTION
# Description

This is a proposed fix for linking issues with the mklcpu backend seen when linking with upcoming oneMKL 2023.0 where the `rotm` routine has a different API in the newer version.

~The proposed fix works with the newer oneMKL but will not link with previous MKL versions, because the macro we are checking is not in fact defined. I am looking for a robust way to do this but I'm not sure it's easy.~

The proposed fix includes a relatively ugly hack to accommodate different versions of the MKL backend that have different function signatures for `rotm`.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Log: [test_2023.txt](https://github.com/oneapi-src/oneMKL/files/9924723/test_2023.txt)
- [x] Have you formatted the code using clang-format?
