### PR TITLE
[BLAS, hipSYCL] Add CUDA_CUDA_LIBRARY to also link against libcuda.so

### DIFF
--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -43,11 +43,12 @@ if(NOT TARGET ONEMKL::cuBLAS::cuBLAS)
           CUDA_cublas_LIBRARY
           CUDA_LIBRARIES
           CUDA_CUDART_LIBRARY
+	  CUDA_CUDA_LIBRARY
     )
     set_target_properties(ONEMKL::cuBLAS::cuBLAS PROPERTIES
         IMPORTED_LOCATION ${CUDA_cublas_LIBRARY}
         INTERFACE_INCLUDE_DIRECTORIES "${CUDA_TOOLKIT_INCLUDE}"
-        INTERFACE_LINK_LIBRARIES "Threads::Threads;${CUDA_LIBRARIES};${CUDA_CUDART_LIBRARY}"
+        INTERFACE_LINK_LIBRARIES "Threads::Threads;${CUDA_LIBRARIES};${CUDA_CUDART_LIBRARY};${CUDA_CUDA_LIBRARY}"
     )
   else()
     find_package_handle_standard_args(cuBLAS


### PR DESCRIPTION
# Description

PR #228 added calls to `cuStreamSynchronize` in the cuBLAS backend. This function is located in `libcuda.so` but this library is not linked against when using hipSYCL to compile oneMKL. This PR adds `CUDA_CUDA_LIBRARY` in `FindcuBLAS.cmake` to fix this.

# Checklist

- [ ] Do all unit tests pass locally? Attach a log.
    The tests do not pass currently on my setup, see #245, but it seems very unlikely that this is related to the change in this PR.
- [ ] Have you formatted the code using clang-format?
    Does not apply here.
