### PR TITLE
[BLAS] fix bug in reference omatadd

### DIFF
--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -2135,7 +2135,7 @@ void omatadd_ref(oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
             }
         }
     }
-    else if (transa == oneapi::mkl::transpose::trans) {
+    else if (transb == oneapi::mkl::transpose::trans) {
         for (int64_t j = 0; j < logical_n; j++) {
             for (int64_t i = 0; i < logical_m; i++) {
                 C[j * ldc + i] += beta * B[i * ldb + j];


### PR DESCRIPTION
# Description

Fixes a bug that appeared in CI testing for omatadd, because the reference implementation we tested against had a typo.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Log: [test.txt](https://github.com/oneapi-src/oneMKL/files/10016813/test.txt)
- [x] Have you formatted the code using clang-format?

