### PR TITLE
[blas][netlib] remove duplicate symbol omatcopy_batch and fix usm tests

### DIFF
--- a/src/blas/backends/netlib/netlib_extensions.cxx
+++ b/src/blas/backends/netlib/netlib_extensions.cxx
@@ -247,52 +247,6 @@ void omatadd(sycl::queue &queue, transpose transa, transpose transb, int64_t m, 
 #endif
 }
 
-void omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n, float* alpha,
-                    const float** a, int64_t* lda, float** b, int64_t* ldb, int64_t group_count,
-                    int64_t* groupsize) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}
-
-void omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n, double* alpha,
-                    const double** a, int64_t* lda, double** b, int64_t* ldb, int64_t group_count,
-                    int64_t* groupsize) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}
-
-void omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n,
-                    std::complex<float>* alpha, const std::complex<float>** a, int64_t* lda,
-                    std::complex<float>** b, int64_t* ldb, int64_t group_count,
-                    int64_t* groupsize) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}
-
-void omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n,
-                    std::complex<double>* alpha, const std::complex<double>** a, int64_t* lda,
-                    std::complex<double>** b, int64_t* ldb, int64_t group_count,
-                    int64_t* groupsize) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}
-
 // USM APIs
 
 sycl::event gemm_bias(sycl::queue &queue, transpose transa, transpose transb,
@@ -537,51 +491,4 @@ sycl::event omatadd(sycl::queue &queue, transpose transa, transpose transb, int6
 #endif
 }
 
-sycl::event omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n,
-                           float* alpha, const float** a, int64_t* lda, float** b, int64_t* ldb,
-                           int64_t group_count, int64_t* groupsize,
-                           const std::vector<sycl::event>& dependencies) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}
 
-sycl::event omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n,
-                           double* alpha, const double** a, int64_t* lda, double** b, int64_t* ldb,
-                           int64_t group_count, int64_t* groupsize,
-                           const std::vector<sycl::event>& dependencies) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}
-
-sycl::event omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n,
-                           std::complex<float>* alpha, const std::complex<float>** a, int64_t* lda,
-                           std::complex<float>** b, int64_t* ldb, int64_t group_count,
-                           int64_t* groupsize, const std::vector<sycl::event>& dependencies) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}
-
-sycl::event omatcopy_batch(sycl::queue& queue, transpose* trans, int64_t* m, int64_t* n,
-                           std::complex<double>* alpha, const std::complex<double>** a,
-                           int64_t* lda, std::complex<double>** b, int64_t* ldb,
-                           int64_t group_count, int64_t* groupsize,
-                           const std::vector<sycl::event>& dependencies) {
-#ifdef COLUMN_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for column_major layout");
-#endif
-#ifdef ROW_MAJOR
-    throw unimplemented("blas", "omatcopy_batch", "for row_major layout");
-#endif
-}

--- a/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
@@ -151,6 +151,10 @@ int test(device *dev, oneapi::mkl::layout layout) {
         print_error_code(e);
     }
 
+    catch (const oneapi::mkl::unimplemented &e) {
+        return test_skipped;
+    }
+
     catch (const std::runtime_error &error) {
         std::cout << "Error raised during execution of IMATCOPY:\n"
                   << error.what() << std::endl;

--- a/tests/unit_tests/blas/extensions/omatadd_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd_usm.cpp
@@ -167,6 +167,10 @@ int test(device *dev, oneapi::mkl::layout layout) {
         print_error_code(e);
     }
 
+    catch (const oneapi::mkl::unimplemented &e) {
+        return test_skipped;
+    }
+
     catch (const std::runtime_error &error) {
         std::cout << "Error raised during execution of OMATADD:\n"
                   << error.what() << std::endl;

--- a/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
@@ -154,6 +154,10 @@ int test(device *dev, oneapi::mkl::layout layout) {
         print_error_code(e);
     }
 
+    catch (const oneapi::mkl::unimplemented &e) {
+        return test_skipped;
+    }
+
     catch (const std::runtime_error &error) {
         std::cout << "Error raised during execution of OMATCOPY:\n"
                   << error.what() << std::endl;


### PR DESCRIPTION
# Description

This PR fixes two problems in Netlib backend:
1. Netlib backend build failed because of duplicate symbol `omatcopy_batch` with the same parameters introduced in both netlib_extensions.cxx and netlib_batch.cxx.
2. USM tests for imatcopy, omatadd, and omatcopy missed check for unimplemented exception, as the results these tests failed with Netlib backend instead of being skipped.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally?
```
          Start    1: BLAS/RT/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
   1/1892 Test    #1: BLAS/RT/Nrm2TestSuite/Nrm2Tests.RealSinglePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz ..........................................   Passed    0.34 sec
...
              Start 1888: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.RealDoublePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
1888/1892 Test #1888: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.RealDoublePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz .................................   Passed    0.61 sec
          Start 1889: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexSinglePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
1889/1892 Test #1889: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexSinglePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz ...........................   Passed    0.59 sec
          Start 1890: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexSinglePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
1890/1892 Test #1890: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexSinglePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz ..............................   Passed    0.60 sec
          Start 1891: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexDoublePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
1891/1892 Test #1891: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexDoublePrecision/Column_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz ...........................   Passed    0.52 sec
          Start 1892: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexDoublePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz
1892/1892 Test #1892: BLAS/CT/OmataddUsmTestSuite/OmataddUsmTests.ComplexDoublePrecision/Row_Major_Intel_R__Core_TM__i7_6770HQ_CPU___2_60GHz ..............................   Passed    0.61 sec

100% tests passed, 0 tests failed out of 1892
```
- [x] Have you formatted the code using clang-format?
