### PR TITLE
[llvm][dpc++] update deprecated SYCL functions

### DIFF
--- a/examples/blas/run_time_dispatching/level3/gemm_usm.cpp
+++ b/examples/blas/run_time_dispatching/level3/gemm_usm.cpp
@@ -214,7 +214,7 @@ int main(int argc, char** argv) {
     print_example_banner();
 
     try {
-        sycl::device dev((sycl::default_selector()));
+        sycl::device dev = sycl::device();
 
         if (dev.is_gpu()) {
             std::cout << "Running BLAS GEMM USM example on GPU device." << std::endl;

--- a/examples/lapack/run_time_dispatching/getrs_usm.cpp
+++ b/examples/lapack/run_time_dispatching/getrs_usm.cpp
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
     print_example_banner();
 
     try {
-        sycl::device dev((sycl::default_selector()));
+        sycl::device dev = sycl::device();
         if (dev.is_gpu()) {
             std::cout << "Running LAPACK getrs example on GPU device." << std::endl;
             std::cout << "Device name is: " << dev.get_info<sycl::info::device::name>()

--- a/examples/rng/run_time_dispatching/uniform_usm.cpp
+++ b/examples/rng/run_time_dispatching/uniform_usm.cpp
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
     print_example_banner();
 
     try {
-        sycl::device my_dev((sycl::default_selector()));
+        sycl::device my_dev = sycl::device();
 
         if (my_dev.is_gpu()) {
             std::cout << "Running RNG uniform usm example on GPU device" << std::endl;

--- a/include/oneapi/mkl/detail/backend_selector_predicates.hpp
+++ b/include/oneapi/mkl/detail/backend_selector_predicates.hpp
@@ -40,7 +40,11 @@ inline void backend_selector_precondition(sycl::queue& queue){};
 template <>
 inline void backend_selector_precondition<backend::netlib>(sycl::queue& queue) {
 #ifndef ONEMKL_DISABLE_PREDICATES
+#ifdef __HIPSYCL__
     if (!(queue.is_host() || queue.get_device().is_cpu())) {
+#else
+    if (!queue.get_device().is_cpu()) {
+#endif
         throw unsupported_device("",
                                  "backend_selector<backend::" + backend_map[backend::netlib] + ">",
                                  queue.get_device());
@@ -51,7 +55,11 @@ inline void backend_selector_precondition<backend::netlib>(sycl::queue& queue) {
 template <>
 inline void backend_selector_precondition<backend::mklcpu>(sycl::queue& queue) {
 #ifndef ONEMKL_DISABLE_PREDICATES
+#ifdef __HIPSYCL__
     if (!(queue.is_host() || queue.get_device().is_cpu())) {
+#else
+    if (!queue.get_device().is_cpu()) {
+#endif
         throw unsupported_device("",
                                  "backend_selector<backend::" + backend_map[backend::mklcpu] + ">",
                                  queue.get_device());

--- a/include/oneapi/mkl/detail/get_device_id.hpp
+++ b/include/oneapi/mkl/detail/get_device_id.hpp
@@ -42,10 +42,12 @@ namespace mkl {
 
 inline oneapi::mkl::device get_device_id(sycl::queue &queue) {
     oneapi::mkl::device device_id;
-    if (queue.is_host())
+    if (queue.get_device().is_cpu())
         device_id = device::x86cpu;
-    else if (queue.get_device().is_cpu())
+#ifdef __HIPSYCL__
+    else if (queue.is_host())
         device_id = device::x86cpu;
+#endif
     else if (queue.get_device().is_gpu()) {
         unsigned int vendor_id =
             static_cast<unsigned int>(queue.get_device().get_info<sycl::info::device::vendor_id>());

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -113,9 +113,15 @@
 #define TEST_RUN_AMDGPU_ROCSOLVER_SELECT(q, func, ...)
 #endif
 
+#ifndef __HIPSYCL__
+#define CHECK_HOST_OR_CPU(q) q.get_device().is_cpu()
+#else
+#define CHECK_HOST_OR_CPU(q) q.is_host() || q.get_device().is_cpu()
+#endif
+
 #define TEST_RUN_CT_SELECT(q, func, ...)                                   \
     do {                                                                   \
-        if (q.is_host() || q.get_device().is_cpu())                        \
+        if (CHECK_HOST_OR_CPU(q))                                          \
             TEST_RUN_INTELCPU_SELECT(q, func, __VA_ARGS__);                \
         else if (q.get_device().is_gpu()) {                                \
             unsigned int vendor_id = static_cast<unsigned int>(            \

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -95,7 +95,9 @@ int main(int argc, char** argv) {
 
     auto platforms = sycl::platform::get_platforms();
     for (auto plat : platforms) {
+#ifdef __HIPSYCL__
         if (!plat.is_host()) {
+#endif
             auto plat_devs = plat.get_devices();
             for (auto dev : plat_devs) {
                 try {
@@ -138,11 +140,17 @@ int main(int argc, char** argv) {
                     std::cout << "Exception while accessing device: " << e.what() << "\n";
                 }
             }
+#ifdef __HIPSYCL__
         }
+#endif
     }
 
 #if defined(ENABLE_MKLCPU_BACKEND) || defined(ENABLE_NETLIB_BACKEND)
+#ifdef __HIPSYCL__
     local_devices.push_back(sycl::device(sycl::cpu_selector()));
+#else
+    local_devices.push_back(sycl::device(sycl::cpu_selector_v));
+#endif
 #endif
 #define GET_NAME(d) (d).template get_info<sycl::info::device::name>()
     for (auto& local_dev : local_devices) {


### PR DESCRIPTION
# Description

This PR removed deprecated `is_host` and updates deprecated `cpu_selector` to `cpu_selector_v`. Changes are applied only for LLVM opensource compiler and Intel DPC++ compiler.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
     - Tested with Intel DPC++ 2023.0 and Intel oneMKL 2023.0
     - GetrsBatchGroup failed on GPU with  `Native API failed. Native API returns: -50 (PI_ERROR_INVALID_ARG_VALUE) -50 (PI_ERROR_INVALID_ARG_VALUE`, existing issue
- [x] Have you formatted the code using clang-format?


