### PR TITLE
[BLAS:: SYCL-BLAS backend] Enable sycl blas routines

### DIFF
--- a/src/blas/backends/syclblas/syclblas_level1.cxx
+++ b/src/blas/backends/syclblas/syclblas_level1.cxx
@@ -150,10 +150,8 @@ void rotm(sycl::queue &queue, std::int64_t n, sycl::buffer<real_t, 1> &x, std::i
 
 void rotmg(sycl::queue &queue, sycl::buffer<real_t, 1> &d1, sycl::buffer<real_t, 1> &d2,
            sycl::buffer<real_t, 1> &x1, real_t y1, sycl::buffer<real_t, 1> &param) {
-    //TODO(codeplay): Enable rotmg
-    //sycl::buffer<real_t, 1> y1_buffer(&y1, sycl::range<1>{ 1 });
-    //CALL_SYCLBLAS_FN(::blas::_rotmg, queue, d1, d2, x1, y1_buffer, param);
-    throw unimplemented("blas", "rotmg", "");
+    sycl::buffer<real_t, 1> y1_buffer(&y1, sycl::range<1>{ 1 });
+    CALL_SYCLBLAS_FN(::blas::_rotmg, queue, d1, d2, x1, y1_buffer, param);
 }
 
 void scal(sycl::queue &queue, std::int64_t n, real_t alpha, sycl::buffer<real_t, 1> &x,

--- a/src/blas/backends/syclblas/syclblas_level2.cxx
+++ b/src/blas/backends/syclblas/syclblas_level2.cxx
@@ -186,7 +186,7 @@ void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transp
 void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<real_t, 1> &a,
           sycl::buffer<real_t, 1> &x, std::int64_t incx) {
-    throw unimplemented("blas", "tpmv", "");
+    CALL_SYCLBLAS_FN(::blas::_tpmv, queue, upper_lower, trans, unit_diag, n, a, x, incx);
 }
 
 void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,

--- a/src/blas/backends/syclblas/syclblas_level2.cxx
+++ b/src/blas/backends/syclblas/syclblas_level2.cxx
@@ -118,7 +118,8 @@ void hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
 void sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
           real_t alpha, sycl::buffer<real_t, 1> &a, std::int64_t lda, sycl::buffer<real_t, 1> &x,
           std::int64_t incx, real_t beta, sycl::buffer<real_t, 1> &y, std::int64_t incy) {
-    throw unimplemented("blas", "sbmv", "");
+    CALL_SYCLBLAS_FN(::blas::_sbmv, queue, upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                     incy);
 }
 
 void symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, real_t alpha,
@@ -142,7 +143,7 @@ void syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, rea
 void spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, real_t alpha,
           sycl::buffer<real_t, 1> &a, sycl::buffer<real_t, 1> &x, std::int64_t incx, real_t beta,
           sycl::buffer<real_t, 1> &y, std::int64_t incy) {
-    throw unimplemented("blas", "spmv", "");
+    CALL_SYCLBLAS_FN(::blas::_spmv, queue, upper_lower, n, alpha, a, x, incx, beta, y, incy);
 }
 
 void spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, real_t alpha,
@@ -159,7 +160,7 @@ void spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, rea
 void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<real_t, 1> &a,
           std::int64_t lda, sycl::buffer<real_t, 1> &x, std::int64_t incx) {
-    throw unimplemented("blas", "tbmv", "");
+    CALL_SYCLBLAS_FN(::blas::_tbmv, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
 }
 
 void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -172,7 +173,7 @@ void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transp
 void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<real_t, 1> &a,
           std::int64_t lda, sycl::buffer<real_t, 1> &x, std::int64_t incx) {
-    throw unimplemented("blas", "tbsv", "");
+    CALL_SYCLBLAS_FN(::blas::_tbsv, queue, upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
 }
 
 void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -221,7 +222,7 @@ void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transp
 void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<real_t, 1> &a, std::int64_t lda,
           sycl::buffer<real_t, 1> &x, std::int64_t incx) {
-    throw unimplemented("blas", "trsv", "");
+    CALL_SYCLBLAS_FN(::blas::_trsv, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);
 }
 
 void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,


### PR DESCRIPTION
# Description

This PR enables the following routines in the SYCL-BLAS backend: sbmv, tbmv, spmv, tpmv, tbsv, trsv and rotmg.

This patch depends on https://github.com/oneapi-src/oneMKL/pull/262 and https://github.com/oneapi-src/oneMKL/pull/264.

# Checklist

## All Submissions

- [*] Do all unit tests pass locally? Logs: [test_results.txt](https://github.com/oneapi-src/oneMKL/files/11625587/rotmg_sbmv_tbmv_spmv_tbsv_trsv_tpmv_test_results.txt)
Failing ones are due to `requiring fp64 support: Intel(R) UHD Graphics 770 [0x4680] is not supported`.

- [*] Have you formatted the code using clang-format?

## New features

- [*] Have you provided motivation for adding a new feature?
- [*] Have you added relevant tests?
