### PR TITLE
[doc] add note about multiple CUDA backends limitation

### DIFF
--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -585,6 +585,10 @@ CMake.
   the targeted hardware. This backend has only been tested for the ``gfx90a``
   architecture (MI210) at the time of writing.
 
+.. note::
+  When building with ``BUILD_FUNCTIONAL_TESTS=yes`` (default option) only single CUDA backend can be built
+  (`#270 <https://github.com/oneapi-src/oneMKL/issues/270>`_).
+
 .. _project_cleanup:
 
 Project Cleanup


### PR DESCRIPTION
# Description

As it was mentioned in #270 we have a limitation about building multiple CUDA backends cause problems in functional testing.
This PR adds a note about this limitation to build instructions.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. N/A
- [x] Have you formatted the code using clang-format? N/A

