### PR TITLE
Fix out of bounds accesses in imatcopy tests

### DIFF
--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
@@ -67,13 +67,13 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     int64_t stride_a, stride_b, stride;
     switch (layout) {
         case oneapi::mkl::layout::column_major:
-            stride_a = lda * m;
-            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * m : ldb * n;
+            stride_a = lda * n;
+            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * n : ldb * m;
             stride = std::max(stride_a, stride_b);
             break;
         case oneapi::mkl::layout::row_major:
-            stride_a = lda * n;
-            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * n : ldb * m;
+            stride_a = lda * m;
+            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * m : ldb * n;
             stride = std::max(stride_a, stride_b);
             break;
         default: break;

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
@@ -86,13 +86,13 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     int64_t stride_a, stride_b, stride;
     switch (layout) {
         case oneapi::mkl::layout::column_major:
-            stride_a = lda * m;
-            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * m : ldb * n;
+            stride_a = lda * n;
+            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * n : ldb * m;
             stride = std::max(stride_a, stride_b);
             break;
         case oneapi::mkl::layout::row_major:
-            stride_a = lda * n;
-            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * n : ldb * m;
+            stride_a = lda * m;
+            stride_b = (trans == oneapi::mkl::transpose::nontrans) ? ldb * m : ldb * n;
             stride = std::max(stride_a, stride_b);
             break;
         default: break;


### PR DESCRIPTION
# Description

This patch fixes an issue where the imatcopy tests would occasionally segfault during the reference computation.

The issue was in the computation of the matrix size, for example taking the row major case, `lda` is used as the stride for the input matrix, so in row major, it means that the allocation needs at least `lda` number of rows. And `lda` is the maximum of `m` and `n`.

So if `lda` is `m`, there's no issue to use `m x n` as the size of the matrix, but if `lda` is `n`, that also means `m < n`, and therefore a `m x n` matrix size will lead to out of bound accesses, when using `lda` as a stride.

So here instead of taking `lda x m` for the row major matrix size, we need to take `lda x n` to ensure we have enough rows. And similarly, for row major we need `lda x m`.

This is also consistent with how it's done in
`unit_tests/blas/extensions/imatcopy.cpp`, I'm not sure why these two tests had it flipped.


May be related to: https://github.com/oneapi-src/oneMKL/issues/245

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
  - I have tested this with cuBLAS and rocBLAS which were both showing occasional segfaults and they work fine, however they skip the actual tests so I'm not 100% sure the actual data is correct.
- [x] Have you formatted the code using clang-format?

## Bug fixes

To reproduce the crashes simply run the imatcopy tests with either cuBLAS or rocBLAS (although it should fail for all the backends since it's in the reference code), and run multiple times, as it depends on which random values of `m` and `n` are picked, or manually set `n` to be larger than `m` and it should trigger the issue.

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
