### PR TITLE
[DFT] Allow the descriptor to be modified and recommitted

### DIFF
--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -57,7 +57,7 @@ public:
 
     virtual void* get_handle() noexcept = 0;
 
-    virtual void commit(sycl::queue& queue, const dft_values<prec, dom>&) = 0;
+    virtual void commit(const dft_values<prec, dom>&) = 0;
 
 private:
     mkl::backend backend_;

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -32,6 +32,12 @@ enum class backend;
 
 namespace oneapi::mkl::dft::detail {
 
+enum class precision;
+enum class domain;
+template <precision prec, domain dom>
+class dft_values;
+
+template <precision prec, domain dom>
 class commit_impl {
 public:
     commit_impl(sycl::queue queue, mkl::backend backend) : queue_(queue), backend_(backend) {}
@@ -50,6 +56,8 @@ public:
     }
 
     virtual void* get_handle() noexcept = 0;
+
+    virtual void commit(sycl::queue& queue, const dft_values<prec, dom>&) = 0;
 
 private:
     mkl::backend backend_;

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -41,7 +41,7 @@ template <precision prec, domain dom>
 class descriptor;
 
 template <precision prec, domain dom>
-inline commit_impl* get_commit(descriptor<prec, dom>& desc);
+inline commit_impl<prec, dom>* get_commit(descriptor<prec, dom>& desc);
 
 template <precision prec, domain dom>
 class descriptor {
@@ -74,16 +74,16 @@ public:
 
 private:
     // Has a value when the descriptor is committed.
-    std::unique_ptr<commit_impl> pimpl_;
+    std::unique_ptr<commit_impl<prec, dom>> pimpl_;
 
     // descriptor configuration values_ and structs
     dft_values<prec, dom> values_;
 
-    friend commit_impl* get_commit<prec, dom>(descriptor<prec, dom>&);
+    friend commit_impl<prec, dom>* get_commit<prec, dom>(descriptor<prec, dom>&);
 };
 
 template <precision prec, domain dom>
-inline commit_impl* get_commit(descriptor<prec, dom>& desc) {
+inline commit_impl<prec, dom>* get_commit(descriptor<prec, dom>& desc) {
     return desc.pimpl_.get();
 }
 

--- a/include/oneapi/mkl/dft/detail/dft_ct.hxx
+++ b/include/oneapi/mkl/dft/detail/dft_ct.hxx
@@ -20,7 +20,7 @@
 // Commit
 
 template <dft::detail::precision prec, dft::detail::domain dom>
-ONEMKL_EXPORT dft::detail::commit_impl *create_commit(
+ONEMKL_EXPORT dft::detail::commit_impl<prec, dom> *create_commit(
     const dft::detail::descriptor<prec, dom> &desc, sycl::queue &sycl_queue);
 
 // BUFFER version

--- a/include/oneapi/mkl/dft/detail/dft_loader.hpp
+++ b/include/oneapi/mkl/dft/detail/dft_loader.hpp
@@ -34,13 +34,15 @@ namespace mkl {
 namespace dft {
 namespace detail {
 
+template <precision prec, domain dom>
 class commit_impl;
 
 template <precision prec, domain dom>
 class descriptor;
 
 template <precision prec, domain dom>
-ONEMKL_EXPORT commit_impl* create_commit(const descriptor<prec, dom>& desc, sycl::queue& queue);
+ONEMKL_EXPORT commit_impl<prec, dom>* create_commit(const descriptor<prec, dom>& desc,
+                                                    sycl::queue& queue);
 
 } // namespace detail
 } // namespace dft

--- a/include/oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp
+++ b/include/oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp
@@ -35,6 +35,7 @@ namespace dft {
 
 namespace detail {
 // Forward declarations
+template <precision prec, domain dom>
 class commit_impl;
 
 template <precision prec, domain dom>

--- a/include/oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp
+++ b/include/oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp
@@ -35,6 +35,7 @@ namespace dft {
 
 namespace detail {
 // Forward declarations
+template <precision prec, domain dom>
 class commit_impl;
 
 template <precision prec, domain dom>

--- a/src/dft/backends/descriptor.cpp
+++ b/src/dft/backends/descriptor.cpp
@@ -28,7 +28,7 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(sycl::queue &queue) {
-    if (!pimpl_) {
+    if (!pimpl_ || pimpl_->get_queue() != queue) {
         pimpl_.reset(detail::create_commit(*this, queue));
     }
     pimpl_->commit(values_);

--- a/src/dft/backends/descriptor.cpp
+++ b/src/dft/backends/descriptor.cpp
@@ -28,7 +28,10 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(sycl::queue &queue) {
-    pimpl_.reset(detail::create_commit(*this, queue));
+    if (!pimpl_) {
+        pimpl_.reset(detail::create_commit(*this, queue));
+    }
+    pimpl_->commit(queue, values_);
 }
 template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(sycl::queue &);
 template void descriptor<precision::SINGLE, domain::REAL>::commit(sycl::queue &);

--- a/src/dft/backends/descriptor.cpp
+++ b/src/dft/backends/descriptor.cpp
@@ -31,7 +31,7 @@ void descriptor<prec, dom>::commit(sycl::queue &queue) {
     if (!pimpl_) {
         pimpl_.reset(detail::create_commit(*this, queue));
     }
-    pimpl_->commit(queue, values_);
+    pimpl_->commit(values_);
 }
 template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(sycl::queue &);
 template void descriptor<precision::SINGLE, domain::REAL>::commit(sycl::queue &);

--- a/src/dft/backends/descriptor.cpp
+++ b/src/dft/backends/descriptor.cpp
@@ -29,6 +29,9 @@ namespace dft {
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(sycl::queue &queue) {
     if (!pimpl_ || pimpl_->get_queue() != queue) {
+        if (pimpl_) {
+            pimpl_->get_queue().wait();
+        }
         pimpl_.reset(detail::create_commit(*this, queue));
     }
     pimpl_->commit(values_);

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -60,7 +60,7 @@ public:
         }
     }
 
-    void commit(sycl::queue&, const detail::dft_values<prec, dom>& config_values) override {
+    void commit(const detail::dft_values<prec, dom>& config_values) override {
         set_value(handle, config_values);
         if (auto status = DftiCommitDescriptor(handle); status != DFTI_NO_ERROR) {
             throw oneapi::mkl::exception("dft/backends/mklcpu", "commit",

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -63,7 +63,8 @@ public:
 
     void commit(const detail::dft_values<prec, dom>& config_values) override {
         set_value(handle, config_values);
-        if (auto status = DftiCommitDescriptor(handle); status != DFTI_NO_ERROR) {
+        auto status = DftiCommitDescriptor(handle);
+        if (status != DFTI_NO_ERROR) {
             throw oneapi::mkl::exception(
                 "dft/backends/mklcpu", "commit",
                 "DftiCommitDescriptor failed with status: " + std::to_string(status));

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -40,10 +40,10 @@ namespace dft {
 namespace mklcpu {
 
 template <precision prec, domain dom>
-class commit_derived_impl final : public detail::commit_impl {
+class commit_derived_impl final : public detail::commit_impl<prec, dom> {
 public:
     commit_derived_impl(sycl::queue queue, const detail::dft_values<prec, dom>& config_values)
-            : detail::commit_impl(queue, backend::mklcpu) {
+            : detail::commit_impl<prec, dom>(queue, backend::mklcpu) {
         DFT_ERROR status = DFT_NOTSET;
         if (config_values.dimensions.size() == 1) {
             status = DftiCreateDescriptor(&handle, get_precision(prec), get_domain(dom), 1,
@@ -58,11 +58,11 @@ public:
             throw oneapi::mkl::exception("dft/backends/mklcpu", "commit",
                                          "DftiCreateDescriptor failed");
         }
+    }
 
+    void commit(sycl::queue&, const detail::dft_values<prec, dom>& config_values) override {
         set_value(handle, config_values);
-
-        status = DftiCommitDescriptor(handle);
-        if (status != DFTI_NO_ERROR) {
+        if (auto status = DftiCommitDescriptor(handle); status != DFTI_NO_ERROR) {
             throw oneapi::mkl::exception("dft/backends/mklcpu", "commit",
                                          "DftiCommitDescriptor failed");
         }
@@ -122,18 +122,19 @@ private:
 };
 
 template <precision prec, domain dom>
-detail::commit_impl* create_commit(const descriptor<prec, dom>& desc, sycl::queue& sycl_queue) {
+detail::commit_impl<prec, dom>* create_commit(const descriptor<prec, dom>& desc,
+                                              sycl::queue& sycl_queue) {
     return new commit_derived_impl<prec, dom>(sycl_queue, desc.get_values());
 }
 
-template detail::commit_impl* create_commit(const descriptor<precision::SINGLE, domain::REAL>&,
-                                            sycl::queue&);
-template detail::commit_impl* create_commit(const descriptor<precision::SINGLE, domain::COMPLEX>&,
-                                            sycl::queue&);
-template detail::commit_impl* create_commit(const descriptor<precision::DOUBLE, domain::REAL>&,
-                                            sycl::queue&);
-template detail::commit_impl* create_commit(const descriptor<precision::DOUBLE, domain::COMPLEX>&,
-                                            sycl::queue&);
+template detail::commit_impl<precision::SINGLE, domain::REAL>* create_commit(
+    const descriptor<precision::SINGLE, domain::REAL>&, sycl::queue&);
+template detail::commit_impl<precision::SINGLE, domain::COMPLEX>* create_commit(
+    const descriptor<precision::SINGLE, domain::COMPLEX>&, sycl::queue&);
+template detail::commit_impl<precision::DOUBLE, domain::REAL>* create_commit(
+    const descriptor<precision::DOUBLE, domain::REAL>&, sycl::queue&);
+template detail::commit_impl<precision::DOUBLE, domain::COMPLEX>* create_commit(
+    const descriptor<precision::DOUBLE, domain::COMPLEX>&, sycl::queue&);
 
 } // namespace mklcpu
 } // namespace dft

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -55,16 +55,18 @@ public:
                                           config_values.dimensions.data());
         }
         if (status != DFTI_NO_ERROR) {
-            throw oneapi::mkl::exception("dft/backends/mklcpu", "commit",
-                                         "DftiCreateDescriptor failed");
+            throw oneapi::mkl::exception(
+                "dft/backends/mklcpu", "commit",
+                "DftiCreateDescriptor failed with status: " + std::to_string(status));
         }
     }
 
     void commit(const detail::dft_values<prec, dom>& config_values) override {
         set_value(handle, config_values);
         if (auto status = DftiCommitDescriptor(handle); status != DFTI_NO_ERROR) {
-            throw oneapi::mkl::exception("dft/backends/mklcpu", "commit",
-                                         "DftiCommitDescriptor failed");
+            throw oneapi::mkl::exception(
+                "dft/backends/mklcpu", "commit",
+                "DftiCommitDescriptor failed with status: " + std::to_string(status));
         }
     }
 

--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -28,7 +28,10 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
-    pimpl_.reset(mklcpu::create_commit(*this, selector.get_queue()));
+    if (!pimpl_) {
+        pimpl_.reset(mklcpu::create_commit(*this, selector.get_queue()));
+    }
+    pimpl_->commit(selector.get_queue(), values_);
 }
 
 template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(

--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -28,8 +28,8 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
-    if (!pimpl_) {
-        pimpl_.reset(mklcpu::create_commit(*this, selector.get_queue()));
+    if (!pimpl_ || pimpl_->get_queue() != selector.get_queue()) {
+        pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
     }
     pimpl_->commit(values_);
 }

--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -29,6 +29,9 @@ namespace dft {
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
     if (!pimpl_ || pimpl_->get_queue() != selector.get_queue()) {
+        if (pimpl_) {
+            pimpl_->get_queue().wait();
+        }
         pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
     }
     pimpl_->commit(values_);

--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -31,7 +31,7 @@ void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
     if (!pimpl_) {
         pimpl_.reset(mklcpu::create_commit(*this, selector.get_queue()));
     }
-    pimpl_->commit(selector.get_queue(), values_);
+    pimpl_->commit(values_);
 }
 
 template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -71,11 +71,10 @@ public:
         }
     }
 
-    virtual void commit(sycl::queue& queue,
-                        const dft::detail::dft_values<prec, dom>& config_values) override {
+    virtual void commit(const dft::detail::dft_values<prec, dom>& config_values) override {
         set_value(handle, config_values);
         try {
-            handle.commit(queue);
+            handle.commit(this->get_queue());
         }
         catch (const std::exception& mkl_exception) {
             // Catching the real MKL exception causes headaches with naming.

--- a/src/dft/backends/mklgpu/descriptor.cpp
+++ b/src/dft/backends/mklgpu/descriptor.cpp
@@ -28,7 +28,10 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklgpu> selector) {
-    pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
+    if (!pimpl_) {
+        pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
+    }
+    pimpl_->commit(selector.get_queue(), values_);
 }
 
 template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(

--- a/src/dft/backends/mklgpu/descriptor.cpp
+++ b/src/dft/backends/mklgpu/descriptor.cpp
@@ -31,7 +31,7 @@ void descriptor<prec, dom>::commit(backend_selector<backend::mklgpu> selector) {
     if (!pimpl_) {
         pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
     }
-    pimpl_->commit(selector.get_queue(), values_);
+    pimpl_->commit(values_);
 }
 
 template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(

--- a/src/dft/backends/mklgpu/descriptor.cpp
+++ b/src/dft/backends/mklgpu/descriptor.cpp
@@ -28,7 +28,7 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklgpu> selector) {
-    if (!pimpl_) {
+    if (!pimpl_ || pimpl_->get_queue() != selector.get_queue()) {
         pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
     }
     pimpl_->commit(values_);

--- a/src/dft/backends/mklgpu/descriptor.cpp
+++ b/src/dft/backends/mklgpu/descriptor.cpp
@@ -29,6 +29,9 @@ namespace dft {
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklgpu> selector) {
     if (!pimpl_ || pimpl_->get_queue() != selector.get_queue()) {
+        if (pimpl_) {
+            pimpl_->get_queue().wait();
+        }
         pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
     }
     pimpl_->commit(values_);

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -44,10 +44,6 @@ void compute_default_strides(const std::vector<std::int64_t>& dimensions,
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::set_value(config_param param, ...) {
-    if (pimpl_) {
-        throw mkl::invalid_argument("DFT", "set_value",
-                                    "Cannot set value on committed descriptor.");
-    }
     va_list vl;
     va_start(vl, param);
     switch (param) {

--- a/src/dft/dft_loader.cpp
+++ b/src/dft/dft_loader.cpp
@@ -34,28 +34,28 @@ static oneapi::mkl::detail::table_initializer<mkl::domain::dft, dft_function_tab
     function_tables;
 
 template <>
-commit_impl* create_commit<precision::SINGLE, domain::COMPLEX>(
+commit_impl<precision::SINGLE, domain::COMPLEX>* create_commit<precision::SINGLE, domain::COMPLEX>(
     const descriptor<precision::SINGLE, domain::COMPLEX>& desc, sycl::queue& sycl_queue) {
     auto libkey = get_device_id(sycl_queue);
     return function_tables[libkey].create_commit_sycl_fz(desc, sycl_queue);
 }
 
 template <>
-commit_impl* create_commit<precision::DOUBLE, domain::COMPLEX>(
+commit_impl<precision::DOUBLE, domain::COMPLEX>* create_commit<precision::DOUBLE, domain::COMPLEX>(
     const descriptor<precision::DOUBLE, domain::COMPLEX>& desc, sycl::queue& sycl_queue) {
     auto libkey = get_device_id(sycl_queue);
     return function_tables[libkey].create_commit_sycl_dz(desc, sycl_queue);
 }
 
 template <>
-commit_impl* create_commit<precision::SINGLE, domain::REAL>(
+commit_impl<precision::SINGLE, domain::REAL>* create_commit<precision::SINGLE, domain::REAL>(
     const descriptor<precision::SINGLE, domain::REAL>& desc, sycl::queue& sycl_queue) {
     auto libkey = get_device_id(sycl_queue);
     return function_tables[libkey].create_commit_sycl_fr(desc, sycl_queue);
 }
 
 template <>
-commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
+commit_impl<precision::DOUBLE, domain::REAL>* create_commit<precision::DOUBLE, domain::REAL>(
     const descriptor<precision::DOUBLE, domain::REAL>& desc, sycl::queue& sycl_queue) {
     auto libkey = get_device_id(sycl_queue);
     return function_tables[libkey].create_commit_sycl_dr(desc, sycl_queue);

--- a/src/dft/function_table.hpp
+++ b/src/dft/function_table.hpp
@@ -35,19 +35,25 @@
 
 typedef struct {
     int version;
-    oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_fz)(
+    oneapi::mkl::dft::detail::commit_impl<oneapi::mkl::dft::precision::SINGLE,
+                                          oneapi::mkl::dft::domain::COMPLEX>* (
+        *create_commit_sycl_fz)(
         const oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
                                            oneapi::mkl::dft::domain::COMPLEX>& desc,
         sycl::queue& sycl_queue);
-    oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_dz)(
+    oneapi::mkl::dft::detail::commit_impl<oneapi::mkl::dft::precision::DOUBLE,
+                                          oneapi::mkl::dft::domain::COMPLEX>* (
+        *create_commit_sycl_dz)(
         const oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
                                            oneapi::mkl::dft::domain::COMPLEX>& desc,
         sycl::queue& sycl_queue);
-    oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_fr)(
+    oneapi::mkl::dft::detail::commit_impl<oneapi::mkl::dft::precision::SINGLE,
+                                          oneapi::mkl::dft::domain::REAL>* (*create_commit_sycl_fr)(
         const oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
                                            oneapi::mkl::dft::domain::REAL>& desc,
         sycl::queue& sycl_queue);
-    oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_dr)(
+    oneapi::mkl::dft::detail::commit_impl<oneapi::mkl::dft::precision::DOUBLE,
+                                          oneapi::mkl::dft::domain::REAL>* (*create_commit_sycl_dr)(
         const oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
                                            oneapi::mkl::dft::domain::REAL>& desc,
         sycl::queue& sycl_queue);

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -89,8 +89,11 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
 
         if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
             const auto complex_strides = get_conjugate_even_complex_strides(sizes);
+            auto real_strides = get_default_strides(sizes);
             descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
                                  complex_strides.data());
+            descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                                 real_strides.data());
             commit_descriptor(descriptor, sycl_queue);
         }
 
@@ -168,7 +171,9 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
 
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         const auto complex_strides = get_conjugate_even_complex_strides(sizes);
+        auto real_strides = get_default_strides(sizes);
         descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, complex_strides.data());
+        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, real_strides.data());
         commit_descriptor(descriptor, sycl_queue);
     }
 

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -48,27 +48,13 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
     descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
+    descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / forward_elements));
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         const auto complex_strides = get_conjugate_even_complex_strides(sizes);
         descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
                              complex_strides.data());
     }
     commit_descriptor(descriptor, sycl_queue);
-
-    descriptor_t descriptor_back{ sizes };
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
-                              oneapi::mkl::dft::config_value::NOT_INPLACE);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                              (1.0 / forward_elements));
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
-    if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
-        const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                                  complex_strides.data());
-    }
-    commit_descriptor(descriptor_back, sycl_queue);
 
     std::vector<FwdInputType> fwd_data(input);
 
@@ -101,10 +87,17 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
             }
         }
 
+        if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
+            const auto complex_strides = get_conjugate_even_complex_strides(sizes);
+            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                                 complex_strides.data());
+            commit_descriptor(descriptor, sycl_queue);
+        }
+
         try {
-            oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor_back)>,
-                                               FwdOutputType, FwdInputType>(descriptor_back,
-                                                                            bwd_buf, fwd_buf);
+            oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
+                                               FwdOutputType, FwdInputType>(descriptor, bwd_buf,
+                                                                            fwd_buf);
         }
         catch (oneapi::mkl::unimplemented &e) {
             std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;
@@ -133,27 +126,13 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
     descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
+    descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / forward_elements));
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         const auto complex_strides = get_conjugate_even_complex_strides(sizes);
         descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
                              complex_strides.data());
     }
     commit_descriptor(descriptor, sycl_queue);
-
-    descriptor_t descriptor_back{ sizes };
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
-                              oneapi::mkl::dft::config_value::NOT_INPLACE);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                              (1.0 / forward_elements));
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
-    if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
-        const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                                  complex_strides.data());
-    }
-    commit_descriptor(descriptor_back, sycl_queue);
 
     auto ua_input = usm_allocator_t<FwdInputType>(cxt, *dev);
     auto ua_output = usm_allocator_t<FwdOutputType>(cxt, *dev);
@@ -187,9 +166,15 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
         }
     }
 
+    if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
+        const auto complex_strides = get_conjugate_even_complex_strides(sizes);
+        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, complex_strides.data());
+        commit_descriptor(descriptor, sycl_queue);
+    }
+
     try {
-        oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor_back)>,
-                                           FwdOutputType, FwdInputType>(descriptor_back, bwd.data(),
+        oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
+                                           FwdOutputType, FwdInputType>(descriptor, bwd.data(),
                                                                         fwd.data(), no_dependencies)
             .wait();
     }

--- a/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
@@ -42,6 +42,8 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_USM() {
                              static_cast<std::int64_t>(forward_elements));
         descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
                              static_cast<std::int64_t>(forward_elements));
+        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
+                             (1.0 / forward_elements));
         commit_descriptor(descriptor, sycl_queue);
 
         auto ua_input = usm_allocator_t<PrecisionType>(cxt, *dev);
@@ -63,26 +65,9 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_USM() {
                 descriptor, in_re.data(), in_im.data(), out_re.data(), out_im.data(), dependencies);
         done.wait();
 
-        descriptor_t descriptor_back{ sizes };
-
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
-                                  oneapi::mkl::dft::config_value::NOT_INPLACE);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
-                                  oneapi::mkl::dft::config_value::REAL_REAL);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                                  (1.0 / forward_elements));
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE,
-                                  static_cast<std::int64_t>(forward_elements));
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
-                                  static_cast<std::int64_t>(forward_elements));
-        commit_descriptor(descriptor_back, sycl_queue);
-
-        done =
-            oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor_back)>,
-                                               PrecisionType, PrecisionType>(
-                descriptor_back, out_re.data(), out_im.data(), out_back_re.data(),
-                out_back_im.data());
+        done = oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
+                                                  PrecisionType, PrecisionType>(
+            descriptor, out_re.data(), out_im.data(), out_back_re.data(), out_back_im.data());
         done.wait();
     }
     catch (oneapi::mkl::unimplemented &e) {
@@ -116,6 +101,8 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_buffer() {
                              static_cast<std::int64_t>(forward_elements));
         descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
                              static_cast<std::int64_t>(forward_elements));
+        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
+                             (1.0 / forward_elements));
         commit_descriptor(descriptor, sycl_queue);
 
         sycl::buffer<PrecisionType, 1> in_dev_re{ input_re.data(), sycl::range<1>(size_total) };
@@ -128,24 +115,9 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_buffer() {
         oneapi::mkl::dft::compute_forward<descriptor_t, PrecisionType, PrecisionType>(
             descriptor, in_dev_re, in_dev_im, out_dev_re, out_dev_im);
 
-        descriptor_t descriptor_back{ sizes };
-
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
-                                  oneapi::mkl::dft::config_value::NOT_INPLACE);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
-                                  oneapi::mkl::dft::config_value::REAL_REAL);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                                  (1.0 / forward_elements));
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE,
-                                  static_cast<std::int64_t>(forward_elements));
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
-                                  static_cast<std::int64_t>(forward_elements));
-        commit_descriptor(descriptor_back, sycl_queue);
-
-        oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor_back)>,
+        oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
                                            PrecisionType, PrecisionType>(
-            descriptor_back, out_dev_re, out_dev_im, out_back_dev_re, out_back_dev_im);
+            descriptor, out_dev_re, out_dev_im, out_back_dev_re, out_back_dev_im);
     }
     catch (oneapi::mkl::unimplemented &e) {
         std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;

--- a/tests/unit_tests/dft/include/test_common.hpp
+++ b/tests/unit_tests/dft/include/test_common.hpp
@@ -148,12 +148,33 @@ void commit_descriptor(oneapi::mkl::dft::descriptor<precision, domain> &descript
 #endif
 }
 
-inline std::vector<std::int64_t> get_conjugate_even_complex_strides(
+// is it assumed that the unused elements of the array are ignored
+inline std::array<std::int64_t, 4> get_conjugate_even_complex_strides(
     const std::vector<std::int64_t> &sizes) {
     switch (sizes.size()) {
         case 1: return { 0, 1 };
         case 2: return { 0, sizes[1] / 2 + 1, 1 };
         case 3: return { 0, sizes[1] * (sizes[2] / 2 + 1), (sizes[2] / 2 + 1), 1 };
+        default:
+            throw oneapi::mkl::unimplemented(
+                "dft/test_common", __FUNCTION__,
+                "not implemented for " + std::to_string(sizes.size()) + " dimensions");
+            return {};
+    }
+}
+
+// is it assumed that the unused elements of the array are ignored
+inline std::array<std::int64_t, 4> get_default_strides(const std::vector<std::int64_t> &sizes) {
+    if (sizes.size() > 3) {
+        throw oneapi::mkl::unimplemented(
+            "dft/test_common", __FUNCTION__,
+            "not implemented for " + std::to_string(sizes.size()) + " dimensions");
+    }
+
+    switch (sizes.size()) {
+        case 1: return { 0, 1 };
+        case 2: return { 0, sizes[1], 1 };
+        case 3: return { 0, sizes[1] * sizes[2], sizes[2], 1 };
         default:
             throw oneapi::mkl::unimplemented(
                 "dft/test_common", __FUNCTION__,

--- a/tests/unit_tests/dft/source/CMakeLists.txt
+++ b/tests/unit_tests/dft/source/CMakeLists.txt
@@ -28,7 +28,6 @@ if (BUILD_SHARED_LIBS)
             PUBLIC ${PROJECT_SOURCE_DIR}/include
             PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
             PUBLIC ${CMAKE_BINARY_DIR}/bin
-            PUBLIC ${CBLAS_INCLUDE}
             )
     if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
         add_sycl_to_target(TARGET dft_source_rt SOURCES ${DFT_SOURCES})
@@ -45,7 +44,6 @@ target_include_directories(dft_source_ct
         PUBLIC ${PROJECT_SOURCE_DIR}/include
         PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
         PUBLIC ${CMAKE_BINARY_DIR}/bin
-        PUBLIC ${CBLAS_INCLUDE}
         )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
     add_sycl_to_target(TARGET dft_source_ct SOURCES ${DFT_SOURCES})

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -436,7 +436,7 @@ inline void recommit_values(sycl::queue& sycl_queue) {
           std::make_pair(config_param::COMPLEX_STORAGE, config_value::COMPLEX_COMPLEX),
           std::make_pair(config_param::REAL_STORAGE, config_value::REAL_REAL),
           std::make_pair(config_param::CONJUGATE_EVEN_STORAGE, config_value::COMPLEX_COMPLEX) },
-        { std::make_pair(config_param::PLACEMENT, config_value::INPLACE),
+        { std::make_pair(config_param::PLACEMENT, config_value::NOT_INPLACE),
           std::make_pair(config_param::INPUT_STRIDES, strides.data()),
           std::make_pair(config_param::OUTPUT_STRIDES, strides.data()),
           std::make_pair(config_param::FWD_DISTANCE, std::int64_t{ 60 }),

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -474,7 +474,7 @@ inline void change_queue_causes_wait(sycl::queue& busy_queue) {
     // signal used to avoid spurious wakeups
     bool signal = false;
 
-    sycl::queue free_queue;
+    sycl::queue free_queue(busy_queue.get_device(), exception_handler);
 
     // commit the descriptor on the "busy" queue
     oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
@@ -517,7 +517,7 @@ inline void swap_out_dead_queue(sycl::queue& sycl_queue) {
     // commit the descriptor on the "busy" queue
     oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
     {
-        sycl::queue transient_queue;
+        sycl::queue transient_queue(sycl_queue.get_device(), exception_handler);
         EXPECT_NO_THROW(commit_descriptor(descriptor, transient_queue));
     }
     EXPECT_NO_THROW(commit_descriptor(descriptor, sycl_queue));

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -362,7 +362,6 @@ inline void get_readonly_values(sycl::queue& sycl_queue) {
     EXPECT_EQ(dimension_value, 1);
 
     oneapi::mkl::dft::descriptor<precision, domain> descriptor3D{ default_3d_lengths };
-
     descriptor3D.get_value(oneapi::mkl::dft::config_param::DIMENSION, &dimension_value);
     EXPECT_EQ(dimension_value, 3);
 
@@ -446,9 +445,8 @@ inline void recommit_values(sycl::queue& sycl_queue) {
     };
 
     for (int i = 0; i < arguments.size(); i += 1) {
-        std::visit(
-            [&arguments, &descriptor, i](auto&& a) { descriptor.set_value(arguments[i].first, a); },
-            arguments[i].second);
+        std::visit([&descriptor, p = arguments[i].first](auto&& a) { descriptor.set_value(p, a); },
+                   arguments[i].second);
         try {
             commit_descriptor(descriptor, sycl_queue);
         }


### PR DESCRIPTION
# Description

Allows the descriptor class for DFTs to be modified and recommitted. Some backends will likely need to regenerate the descriptor completely, but this will allow for those that don't.

This builds on top of #259

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New features

- [x] Have you provided motivation for adding a new feature?
- [x] Have you added relevant tests?