### PR TITLE
Add option to enable tests on OpenCL devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(HIP_TARGETS "" CACHE STRING "Target HIP architectures")
 
 ## Testing
 option(BUILD_FUNCTIONAL_TESTS "" ON)
+option(ENABLE_OPENCL_TESTS "" OFF)
 
 ## Examples
 option(BUILD_EXAMPLES "" ON)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -75,6 +75,10 @@ foreach(domain ${TARGET_DOMAINS})
     target_compile_options(test_main_${domain}_ct PRIVATE -fsycl)
   endif()
 
+  if (ENABLE_OPENCL_TESTS)
+    target_compile_definitions(test_main_${domain}_ct PRIVATE ENABLE_OPENCL_TESTS)
+  endif()
+
   if(BUILD_SHARED_LIBS)
     add_executable(test_main_${domain}_rt main_test.cpp)
     target_include_directories(test_main_${domain}_rt PUBLIC ${GTEST_INCLUDE_DIR})
@@ -90,6 +94,10 @@ foreach(domain ${TARGET_DOMAINS})
     )
     if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
       add_sycl_to_target(TARGET test_main_${domain}_rt SOURCES main_test.cpp)
+    endif()
+
+    if (ENABLE_OPENCL_TESTS)
+      target_compile_definitions(test_main_${domain}_rt PRIVATE ENABLE_OPENCL_TESTS)
     endif()
   endif()
 

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -101,10 +101,12 @@ int main(int argc, char** argv) {
             auto plat_devs = plat.get_devices();
             for (auto dev : plat_devs) {
                 try {
+#ifndef ENABLE_OPENCL_TESTS
                     /* Do not test for OpenCL backend on GPU */
                     if (dev.is_gpu() && plat.get_info<sycl::info::platform::name>().find(
                                             "OpenCL") != std::string::npos)
                         continue;
+#endif
                     if (unique_devices.find(dev.get_info<sycl::info::device::name>()) ==
                         unique_devices.end()) {
                         unique_devices.insert(dev.get_info<sycl::info::device::name>());


### PR DESCRIPTION
We are working on adding support for a wider range of devices. In that context it makes sense to allow testing on more devices.

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
