### PR TITLE
[LAPACK] allocation of pointer arrays in group batch tests

### DIFF
--- a/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
@@ -81,8 +81,8 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
 
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> tau_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> tau_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** tau_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -120,12 +120,12 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
         queue.wait_and_throw();
 
 #ifdef CALL_RT_API
-        oneapi::mkl::lapack::geqrf_batch(queue, m_vec.data(), n_vec.data(), A_dev_ptrs.data(),
-                                         lda_vec.data(), tau_dev_ptrs.data(), group_count,
+        oneapi::mkl::lapack::geqrf_batch(queue, m_vec.data(), n_vec.data(), A_dev_ptrs,
+                                         lda_vec.data(), tau_dev_ptrs, group_count,
                                          group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #else
         TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::geqrf_batch, m_vec.data(), n_vec.data(),
-                           A_dev_ptrs.data(), lda_vec.data(), tau_dev_ptrs.data(), group_count,
+                           A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
                            group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
@@ -137,6 +137,15 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             device_to_host_copy(queue, tau_dev_ptrs[global_id], tau_iter->data(), tau_iter->size());
         }
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (tau_dev_ptrs) {
+            sycl::free(tau_dev_ptrs, queue);
+        }
     }
 
     bool result = true;
@@ -209,8 +218,8 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
 
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> tau_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> tau_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** tau_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -251,19 +260,28 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::geqrf_batch(
-            queue, m_vec.data(), n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
-            tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-            scratchpad_size, std::vector<sycl::event>{ in_event });
+            queue, m_vec.data(), n_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs,
+            group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::geqrf_batch, m_vec.data(),
-                           n_vec.data(), A_dev_ptrs.data(), lda_vec.data(), tau_dev_ptrs.data(),
-                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+                           n_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
+                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
                            std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (tau_dev_ptrs) {
+            sycl::free(tau_dev_ptrs, queue);
+        }
     }
 
     return result;

--- a/tests/unit_tests/lapack/source/getri_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getri_batch_group.cpp
@@ -89,8 +89,8 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<int64_t, sycl::usm_allocator<int64_t, sycl::usm::alloc::shared>>>
             ipiv_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<int64_t*> ipiv_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        int64_t** ipiv_dev_ptrs = sycl::malloc_shared<int64_t*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -134,13 +134,13 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
         queue.wait_and_throw();
 
 #ifdef CALL_RT_API
-        oneapi::mkl::lapack::getri_batch(queue, n_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
-                                         ipiv_dev_ptrs.data(), group_count, group_sizes_vec.data(),
+        oneapi::mkl::lapack::getri_batch(queue, n_vec.data(), A_dev_ptrs, lda_vec.data(),
+                                         ipiv_dev_ptrs, group_count, group_sizes_vec.data(),
                                          scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getri_batch, n_vec.data(), A_dev_ptrs.data(),
-                           lda_vec.data(), ipiv_dev_ptrs.data(), group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getri_batch, n_vec.data(), A_dev_ptrs,
+                           lda_vec.data(), ipiv_dev_ptrs, group_count, group_sizes_vec.data(),
+                           scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -149,6 +149,15 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             device_to_host_copy(queue, A_dev_ptrs[global_id], A_iter->data(), A_iter->size());
         }
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (ipiv_dev_ptrs) {
+            sycl::free(ipiv_dev_ptrs, queue);
+        }
     }
 
     bool result = true;
@@ -228,8 +237,8 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<int64_t, sycl::usm_allocator<int64_t, sycl::usm::alloc::shared>>>
             ipiv_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<int64_t*> ipiv_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        int64_t** ipiv_dev_ptrs = sycl::malloc_shared<int64_t*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -276,19 +285,28 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::getri_batch(
-            queue, n_vec.data(), A_dev_ptrs.data(), lda_vec.data(), ipiv_dev_ptrs.data(),
-            group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+            queue, n_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, group_count,
+            group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getri_batch, n_vec.data(),
-                           A_dev_ptrs.data(), lda_vec.data(), ipiv_dev_ptrs.data(), group_count,
+                           A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, group_count,
                            group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
                            std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (ipiv_dev_ptrs) {
+            sycl::free(ipiv_dev_ptrs, queue);
+        }
     }
 
     return result;

--- a/tests/unit_tests/lapack/source/getrs_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrs_batch_group.cpp
@@ -106,9 +106,9 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> B_dev_list;
         std::list<std::vector<int64_t, sycl::usm_allocator<int64_t, sycl::usm::alloc::shared>>>
             ipiv_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> B_dev_ptrs(batch_size, nullptr);
-        std::vector<int64_t*> ipiv_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** B_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        int64_t** ipiv_dev_ptrs = sycl::malloc_shared<int64_t*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -163,14 +163,14 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
 
 #ifdef CALL_RT_API
         oneapi::mkl::lapack::getrs_batch(queue, trans_vec.data(), n_vec.data(), nrhs_vec.data(),
-                                         A_dev_ptrs.data(), lda_vec.data(), ipiv_dev_ptrs.data(),
-                                         B_dev_ptrs.data(), ldb_vec.data(), group_count,
-                                         group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+                                         A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, B_dev_ptrs,
+                                         ldb_vec.data(), group_count, group_sizes_vec.data(),
+                                         scratchpad_dev, scratchpad_size);
 #else
         TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getrs_batch, trans_vec.data(), n_vec.data(),
-                           nrhs_vec.data(), A_dev_ptrs.data(), lda_vec.data(), ipiv_dev_ptrs.data(),
-                           B_dev_ptrs.data(), ldb_vec.data(), group_count, group_sizes_vec.data(),
-                           scratchpad_dev, scratchpad_size);
+                           nrhs_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, B_dev_ptrs,
+                           ldb_vec.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
+                           scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -179,6 +179,18 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             device_to_host_copy(queue, B_dev_ptrs[global_id], B_iter->data(), B_iter->size());
         }
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (B_dev_ptrs) {
+            sycl::free(B_dev_ptrs, queue);
+        }
+        if (ipiv_dev_ptrs) {
+            sycl::free(ipiv_dev_ptrs, queue);
+        }
     }
 
     bool result = true;
@@ -280,9 +292,9 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> B_dev_list;
         std::list<std::vector<int64_t, sycl::usm_allocator<int64_t, sycl::usm::alloc::shared>>>
             ipiv_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> B_dev_ptrs(batch_size, nullptr);
-        std::vector<int64_t*> ipiv_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** B_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        int64_t** ipiv_dev_ptrs = sycl::malloc_shared<int64_t*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -339,21 +351,31 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::getrs_batch(
-            queue, trans_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs.data(),
-            lda_vec.data(), ipiv_dev_ptrs.data(), B_dev_ptrs.data(), ldb_vec.data(), group_count,
-            group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-            std::vector<sycl::event>{ in_event });
+            queue, trans_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs, lda_vec.data(),
+            ipiv_dev_ptrs, B_dev_ptrs, ldb_vec.data(), group_count, group_sizes_vec.data(),
+            scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrs_batch, trans_vec.data(),
-                           n_vec.data(), nrhs_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
-                           ipiv_dev_ptrs.data(), B_dev_ptrs.data(), ldb_vec.data(), group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+                           n_vec.data(), nrhs_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs,
+                           B_dev_ptrs, ldb_vec.data(), group_count, group_sizes_vec.data(),
+                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (B_dev_ptrs) {
+            sycl::free(B_dev_ptrs, queue);
+        }
+        if (ipiv_dev_ptrs) {
+            sycl::free(ipiv_dev_ptrs, queue);
+        }
     }
 
     return result;

--- a/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
@@ -87,8 +87,8 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
 
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> tau_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> tau_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** tau_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -131,13 +131,12 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
 
 #ifdef CALL_RT_API
         oneapi::mkl::lapack::orgqr_batch(queue, m_vec.data(), n_vec.data(), k_vec.data(),
-                                         A_dev_ptrs.data(), lda_vec.data(), tau_dev_ptrs.data(),
-                                         group_count, group_sizes_vec.data(), scratchpad_dev,
-                                         scratchpad_size);
+                                         A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
+                                         group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #else
         TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::orgqr_batch, m_vec.data(), n_vec.data(),
-                           k_vec.data(), A_dev_ptrs.data(), lda_vec.data(), tau_dev_ptrs.data(),
-                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+                           k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
+                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -146,6 +145,15 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             device_to_host_copy(queue, A_dev_ptrs[global_id], A_iter->data(), A_iter->size());
         }
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (tau_dev_ptrs) {
+            sycl::free(tau_dev_ptrs, queue);
+        }
     }
 
     bool result = true;
@@ -223,8 +231,8 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
 
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> tau_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> tau_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** tau_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -269,19 +277,28 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::orgqr_batch(
-            queue, m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
-            tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-            scratchpad_size, std::vector<sycl::event>{ in_event });
+            queue, m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(),
+            tau_dev_ptrs, group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgqr_batch, m_vec.data(),
-                           n_vec.data(), k_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
-                           tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+                           n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs,
+                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (tau_dev_ptrs) {
+            sycl::free(tau_dev_ptrs, queue);
+        }
     }
 
     return result;

--- a/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
@@ -87,8 +87,8 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
 
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> tau_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> tau_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** tau_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -131,13 +131,12 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
 
 #ifdef CALL_RT_API
         oneapi::mkl::lapack::ungqr_batch(queue, m_vec.data(), n_vec.data(), k_vec.data(),
-                                         A_dev_ptrs.data(), lda_vec.data(), tau_dev_ptrs.data(),
-                                         group_count, group_sizes_vec.data(), scratchpad_dev,
-                                         scratchpad_size);
+                                         A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
+                                         group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #else
         TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ungqr_batch, m_vec.data(), n_vec.data(),
-                           k_vec.data(), A_dev_ptrs.data(), lda_vec.data(), tau_dev_ptrs.data(),
-                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+                           k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
+                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -146,6 +145,15 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             device_to_host_copy(queue, A_dev_ptrs[global_id], A_iter->data(), A_iter->size());
         }
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (tau_dev_ptrs) {
+            sycl::free(tau_dev_ptrs, queue);
+        }
     }
 
     bool result = true;
@@ -223,8 +231,8 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
 
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> A_dev_list;
         std::list<std::vector<fp, sycl::usm_allocator<fp, sycl::usm::alloc::shared>>> tau_dev_list;
-        std::vector<fp*> A_dev_ptrs(batch_size, nullptr);
-        std::vector<fp*> tau_dev_ptrs(batch_size, nullptr);
+        fp** A_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
+        fp** tau_dev_ptrs = sycl::malloc_shared<fp*>(batch_size, queue);
 
         /* Allocate on device */
         sycl::usm_allocator<fp, sycl::usm::alloc::shared> usm_fp_allocator{ queue.get_context(),
@@ -269,19 +277,28 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
         auto in_event = create_dependency(queue);
 #ifdef CALL_RT_API
         sycl::event func_event = oneapi::mkl::lapack::ungqr_batch(
-            queue, m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
-            tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-            scratchpad_size, std::vector<sycl::event>{ in_event });
+            queue, m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(),
+            tau_dev_ptrs, group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+            std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
         TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungqr_batch, m_vec.data(),
-                           n_vec.data(), k_vec.data(), A_dev_ptrs.data(), lda_vec.data(),
-                           tau_dev_ptrs.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+                           n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs,
+                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+                           std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 
         queue.wait_and_throw();
+        if (scratchpad_dev) {
+            sycl::free(scratchpad_dev, queue);
+        }
+        if (A_dev_ptrs) {
+            sycl::free(A_dev_ptrs, queue);
+        }
+        if (tau_dev_ptrs) {
+            sycl::free(tau_dev_ptrs, queue);
+        }
     }
 
     return result;


### PR DESCRIPTION
# Description

The LAPACK group batch tests were allocating the array of pointers to matrix data using std::vector, so it resides on the host. This changes the allocation to sycl::malloc_shared so the array of pointers can be accessed on the device.
Before this change, some of the group batch tests were failing with oneMKL backend on GPU.

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? [GroupTestsLog.txt](https://github.com/oneapi-src/oneMKL/files/10876970/GroupTestsLog.txt)

- [X] Have you formatted the code using clang-format?


