### PR TITLE
[netlib] fix build with DPC++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,12 @@ if(WIN32 AND ONEMKL_SYCL_IMPLEMENTATION STREQUAL "dpc++")
   set(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -fsycl /nologo <DEFINES> <INCLUDES> /EHsc <FLAGS> /Fo<OBJECT> -c <SOURCE>")
   set(CMAKE_CXX_CREATE_STATIC_LIBRARY "lib /nologo <OBJECTS> /out:<TARGET>")
   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> -fsycl -fsycl-device-code-split=per_kernel /nologo <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-  find_library(MKL_SYCL_LIB NAMES mkl_sycl
-    HINTS $ENV{MKLROOT} ${MKL_ROOT}
-    PATH_SUFFIXES lib/intel64)
+  set(MKL_SYCL_LIB "")
+  if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
+    find_library(MKL_SYCL_LIB NAMES mkl_sycl
+      HINTS $ENV{MKLROOT} ${MKL_ROOT}
+      PATH_SUFFIXES lib/intel64)
+  endif()
   set(CMAKE_CXX_CREATE_SHARED_LIBRARY "<CMAKE_CXX_COMPILER> -fsycl -fsycl-device-code-split=per_kernel /nologo <OBJECTS> ${MKL_SYCL_LIB} /link /out:<TARGET> /implib:<TARGET_IMPLIB> /pdb:<TARGET_PDB> /dll /version:<TARGET_VERSION_MAJOR>.<TARGET_VERSION_MINOR> <LINK_FLAGS> <LINK_LIBRARIES>")
 endif()
 


### PR DESCRIPTION
# Description

Small fix for shared libraries build for Netlib backend on Windows in case of DPC++ or LLVM* compiler https://github.com/oneapi-src/oneMKL#windows. MKL_SYCL_LIB shouldn't be required for non-Intel oneMKL related backends.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 100% tests passed, 0 tests failed out of 1892
- [x] Have you formatted the code using clang-format?

