### PR TITLE
[DFT] Add more warning flags 

### DIFF
--- a/cmake/WarningsUtils.cmake
+++ b/cmake/WarningsUtils.cmake
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2023 Codeplay Software Ltd.
+# Copyright Codeplay Software Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/WarningsUtils.cmake
+++ b/cmake/WarningsUtils.cmake
@@ -1,0 +1,49 @@
+#===============================================================================
+# Copyright 2023 Codeplay Software Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+#
+# SPDX-License-Identifier: Apache-2.0
+#===============================================================================
+
+include_guard(GLOBAL)
+
+add_library(onemkl_warnings INTERFACE)
+
+set(ONEMKL_WARNINGS "")
+
+include(CheckCXXCompilerFlag)
+macro(add_warning flag)
+  check_cxx_compiler_flag(${flag} IS_SUPPORTED)
+  message(STATUS "DBG '${flag}': ${IS_SUPPORTED}")
+  if(${IS_SUPPORTED})
+    list(APPEND ONEMKL_WARNINGS ${flag})
+  else()
+    message(WARNING "Compiler does not support ${flag}")
+  endif()
+endmacro()
+
+add_warning("-Wall")
+add_warning("-Wextra")
+add_warning("-Wshadow")
+add_warning("-Wconversion")
+add_warning("-Wpedantic")
+
+message(STATUS "Using warnings: ${ONEMKL_WARNINGS}")
+
+# The onemkl_warnings target can be linked to any other target to enable warnings.
+target_compile_options(onemkl_warnings INTERFACE ${ONEMKL_WARNINGS})
+
+# Add the library to install package
+install(TARGETS onemkl_warnings EXPORT oneMKLTargets)

--- a/examples/dft/compile_time_dispatching/CMakeLists.txt
+++ b/examples/dft/compile_time_dispatching/CMakeLists.txt
@@ -23,6 +23,8 @@ if(ENABLE_MKLGPU_BACKEND)
   list(APPEND DFTI_CT_SOURCES "complex_fwd_buffer_mklgpu")
 endif()
 
+include(WarningsUtils)
+
 foreach(dfti_ct_sources ${DFTI_CT_SOURCES})
   add_executable(example_${domain}_${dfti_ct_sources} ${dfti_ct_sources}.cpp)
   target_include_directories(example_${domain}_${dfti_ct_sources}
@@ -34,10 +36,11 @@ foreach(dfti_ct_sources ${DFTI_CT_SOURCES})
     add_dependencies(example_${domain}_${dfti_ct_sources} onemkl_${domain}_mklgpu)
     list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklgpu)
   endif()
-  target_link_libraries(example_${domain}_${dfti_ct_sources} PUBLIC
-      ${ONEMKL_LIBRARIES_${domain}}
-      ONEMKL::SYCL::SYCL
+  target_link_libraries(example_${domain}_${dfti_ct_sources}
+      PUBLIC ${ONEMKL_LIBRARIES_${domain}}
+      PUBLIC ONEMKL::SYCL::SYCL
+      PRIVATE onemkl_warnings
   )
   # Register example as ctest
- add_test(NAME ${domain}/EXAMPLE/CT/${dfti_ct_sources} COMMAND example_${domain}_${dfti_ct_sources})
+  add_test(NAME ${domain}/EXAMPLE/CT/${dfti_ct_sources} COMMAND example_${domain}_${dfti_ct_sources})
 endforeach(dfti_ct_sources)

--- a/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
+++ b/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
@@ -29,7 +29,7 @@
 #include "oneapi/mkl.hpp"
 
 void run_example(const sycl::device& gpu_device) {
-    constexpr int N = 10;
+    constexpr std::size_t N = 10;
 
     // Catch asynchronous exceptions for cpu
     auto gpu_error_handler = [&](sycl::exception_list exceptions) {
@@ -55,7 +55,7 @@ void run_example(const sycl::device& gpu_device) {
     // 1. create descriptors
     oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
                                  oneapi::mkl::dft::domain::COMPLEX>
-        desc(N);
+        desc(static_cast<std::int64_t>(N));
 
     // 2. variadic set_value
     desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
@@ -100,7 +100,7 @@ void print_example_banner() {
 //
 // Main entry point for example.
 //
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
     print_example_banner();
 
     try {

--- a/examples/dft/run_time_dispatching/CMakeLists.txt
+++ b/examples/dft/run_time_dispatching/CMakeLists.txt
@@ -25,6 +25,8 @@ if(ENABLE_MKLGPU_BACKEND)
   list(APPEND DFT_RT_SOURCES "real_fwd_usm")
 endif()
 
+include(WarningsUtils)
+
 # Set up for the right backend for run-time dispatching examples
 # If users build more than one backend (i.e. mklcpu and mklgpu, or mklcpu and CUDA), they may need to
 # overwrite SYCL_DEVICE_FILTER in their environment to run on the desired backend
@@ -52,10 +54,11 @@ foreach(dft_rt_sources ${DFT_RT_SOURCES})
     add_sycl_to_target(TARGET example_${domain}_${dft_rt_sources} SOURCES ${DFT_RT_SOURCES})
   endif()
 
-  target_link_libraries(example_${domain}_${dft_rt_sources} PUBLIC
-      onemkl
-      ONEMKL::SYCL::SYCL
-      ${CMAKE_DL_LIBS}
+  target_link_libraries(example_${domain}_${dft_rt_sources}
+      PUBLIC onemkl
+      PUBLIC ONEMKL::SYCL::SYCL
+      PUBLIC ${CMAKE_DL_LIBS}
+      PRIVATE onemkl_warnings
   )
 
   # Register example as ctest

--- a/examples/dft/run_time_dispatching/real_fwd_usm.cpp
+++ b/examples/dft/run_time_dispatching/real_fwd_usm.cpp
@@ -31,7 +31,7 @@
 #include "oneapi/mkl.hpp"
 
 void run_example(const sycl::device& dev) {
-    int N = 16;
+    constexpr std::size_t N = 16;
 
     // Catch asynchronous exceptions
     auto exception_handler = [](sycl::exception_list exceptions) {
@@ -55,10 +55,10 @@ void run_example(const sycl::device& dev) {
     // 1. create descriptors
     oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
                                  oneapi::mkl::dft::domain::REAL>
-        desc(N);
+        desc(static_cast<std::int64_t>(N));
 
     // 2. variadic set_value
-    desc.set_value(oneapi::mkl::dft::config_param::FORWARD_SCALE, 1.f / N);
+    desc.set_value(oneapi::mkl::dft::config_param::FORWARD_SCALE, 1.f / static_cast<float>(N));
     desc.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
                    static_cast<std::int64_t>(1));
     desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
@@ -103,7 +103,7 @@ void print_example_banner() {
 // Main entry point for example.
 //
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
     print_example_banner();
 
     try {

--- a/include/oneapi/mkl/bfloat16.hpp
+++ b/include/oneapi/mkl/bfloat16.hpp
@@ -64,13 +64,13 @@ static inline float raw_to_float(std::uint32_t i) {
 struct bfloat16 {
     std::uint16_t raw;
 
-    bfloat16(int raw_, bool) : raw(raw_) {}
+    bfloat16(int raw_, bool) : raw(static_cast<std::uint16_t>(raw_)) {}
 
     bfloat16() = default;
     inline bfloat16(float f);
     bfloat16(double d) : bfloat16(float(d)) {}
     template <typename T>
-    bfloat16(T i, typename std::enable_if<std::is_integral<T>::value>::type *_ = nullptr)
+    bfloat16(T i, typename std::enable_if<std::is_integral<T>::value>::type * = nullptr)
             : bfloat16(float(i)) {}
 
     inline operator float() const;
@@ -219,7 +219,7 @@ bfloat16::bfloat16(float f) {
 }
 
 inline bfloat16::operator float() const {
-    return bfloat16_impl::raw_to_float(raw << 16);
+    return bfloat16_impl::raw_to_float(static_cast<std::uint32_t>(raw << 16));
 }
 
 } /* namespace mkl */

--- a/include/oneapi/mkl/detail/backend_selector_predicates.hpp
+++ b/include/oneapi/mkl/detail/backend_selector_predicates.hpp
@@ -35,7 +35,7 @@ namespace oneapi {
 namespace mkl {
 
 template <backend Backend>
-inline void backend_selector_precondition(sycl::queue& queue){};
+inline void backend_selector_precondition(sycl::queue&){};
 
 template <>
 inline void backend_selector_precondition<backend::netlib>(sycl::queue& queue) {

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -34,7 +34,7 @@ namespace oneapi::mkl::dft::detail {
 
 class commit_impl {
 public:
-    commit_impl(sycl::queue queue, mkl::backend backend) : queue_(queue), backend_(backend) {}
+    commit_impl(sycl::queue queue, mkl::backend backend) : backend_(backend), queue_(queue) {}
 
     // rule of three
     commit_impl(const commit_impl& other) = delete;

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -80,6 +80,8 @@ private:
     dft_values<prec, dom> values_;
 
     friend commit_impl* get_commit<prec, dom>(descriptor<prec, dom>&);
+
+    using real_t = typename precision_t<prec>::real_t;
 };
 
 template <precision prec, domain dom>

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -29,11 +29,17 @@ namespace mkl {
 namespace dft {
 namespace detail {
 
-typedef int DFT_ERROR;
+typedef long DFT_ERROR;
 
 #define DFT_NOTSET -1
 
 enum class precision { SINGLE, DOUBLE };
+
+template <precision prec>
+struct precision_t {
+    using real_t = std::conditional_t<prec == precision::SINGLE, float, double>;
+};
+
 enum class domain { REAL, COMPLEX };
 enum class config_param {
     FORWARD_DOMAIN,
@@ -97,7 +103,7 @@ enum class config_value {
 template <precision prec, domain dom>
 class dft_values {
 private:
-    using real_t = std::conditional_t<prec == precision::SINGLE, float, double>;
+    using real_t = typename precision_t<prec>::real_t;
 
 public:
     std::vector<std::int64_t> input_strides;

--- a/include/oneapi/mkl/lapack/exceptions.hpp
+++ b/include/oneapi/mkl/lapack/exceptions.hpp
@@ -26,9 +26,9 @@ namespace lapack {
 class exception {
 public:
     exception(oneapi::mkl::exception *_ex, std::int64_t info, std::int64_t detail = 0)
-            : _ex(_ex),
-              _info(info),
-              _detail(detail) {}
+            : _info(info),
+              _detail(detail),
+              _ex(_ex) {}
     std::int64_t info() const {
         return _info;
     }

--- a/include/oneapi/mkl/rng/predicates.hpp
+++ b/include/oneapi/mkl/rng/predicates.hpp
@@ -37,7 +37,7 @@ namespace rng {
 // Buffer APIs
 
 template <typename Distr, typename Engine>
-inline void generate_precondition(const Distr& distr, Engine& engine, std::int64_t n,
+inline void generate_precondition(const Distr& /*distr*/, Engine& /*engine*/, std::int64_t n,
                                   sycl::buffer<typename Distr::result_type, 1>& r) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     if (n < 0 || n > r.size()) {
@@ -49,9 +49,9 @@ inline void generate_precondition(const Distr& distr, Engine& engine, std::int64
 // USM APIs
 
 template <typename Distr, typename Engine>
-inline void generate_precondition(const Distr& distr, Engine& engine, std::int64_t n,
+inline void generate_precondition(const Distr& /*distr*/, Engine& /*engine*/, std::int64_t n,
                                   typename Distr::result_type* r,
-                                  const std::vector<sycl::event>& dependencies) {
+                                  const std::vector<sycl::event>& /*dependencies*/) {
 #ifndef ONEMKL_DISABLE_PREDICATES
     if (n < 0) {
         throw oneapi::mkl::invalid_argument("rng", "generate", "n");

--- a/src/dft/CMakeLists.txt
+++ b/src/dft/CMakeLists.txt
@@ -43,4 +43,7 @@ else()
   target_link_libraries(onemkl_dft PUBLIC ONEMKL::SYCL::SYCL)
 endif()
 
+include(WarningsUtils)
+target_link_libraries(onemkl_dft PRIVATE onemkl_warnings)
+
 endif()

--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -29,41 +29,41 @@ using depends_vec_t = const std::vector<sycl::event> &;
 
 #define ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)         \
     /* Buffer API */                                                                            \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T & desc,     \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T &,          \
                                                                        sycl::buffer<REAL_T> &); \
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T>(                     \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                       \
+        DESCRIPTOR_T &, sycl::buffer<BACKWARD_T> &);                                            \
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(          \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);            \
+        DESCRIPTOR_T &, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);                 \
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                         \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                   \
+        DESCRIPTOR_T &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                        \
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                   \
+        DESCRIPTOR_T &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                        \
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                    \
-        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                        \
+        DESCRIPTOR_T &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &, \
+        sycl::buffer<REAL_T> &);                                                                \
                                                                                                 \
     /* USM API */                                                                               \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                  \
-        DESCRIPTOR_T & desc, REAL_T *, depends_vec_t);                                          \
+        DESCRIPTOR_T &, REAL_T *, depends_vec_t);                                               \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T>(              \
-        DESCRIPTOR_T & desc, BACKWARD_T *, depends_vec_t);                                      \
+        DESCRIPTOR_T &, BACKWARD_T *, depends_vec_t);                                           \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(   \
-        DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, depends_vec_t);                         \
+        DESCRIPTOR_T &, BACKWARD_T *, FORWARD_T *, depends_vec_t);                              \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                  \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, depends_vec_t);                                \
+        DESCRIPTOR_T &, REAL_T *, REAL_T *, depends_vec_t);                                     \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, depends_vec_t);                                \
+        DESCRIPTOR_T &, REAL_T *, REAL_T *, depends_vec_t);                                     \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, depends_vec_t);
+        DESCRIPTOR_T &, REAL_T *, REAL_T *, REAL_T *, REAL_T *, depends_vec_t);
 
 #define ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, COMPLEX_T)                \
     /* Buffer API */                                                                         \
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>(        \
-        DESCRIPTOR_T & desc, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);          \
+        DESCRIPTOR_T &, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);               \
     /* USM API */                                                                            \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>( \
-        DESCRIPTOR_T & desc, COMPLEX_T *, COMPLEX_T *, depends_vec_t);
+        DESCRIPTOR_T &, COMPLEX_T *, COMPLEX_T *, depends_vec_t);
 
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(desc_rf_t, float, float, std::complex<float>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(desc_rf_t, std::complex<float>)

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -27,43 +27,43 @@ using desc_cd_t =
     dft::detail::descriptor<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>;
 using depends_vec_t = const std::vector<sycl::event> &;
 
-#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)         \
-    /* Buffer API */                                                                           \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T & desc,     \
-                                                                      sycl::buffer<REAL_T> &); \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, BACKWARD_T>(                     \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                      \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(          \
-        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);           \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                         \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                  \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                  \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                   \
-        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                       \
-                                                                                               \
-    /* USM API */                                                                              \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                  \
-        DESCRIPTOR_T & desc, REAL_T *, depends_vec_t);                                         \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, BACKWARD_T>(              \
-        DESCRIPTOR_T & desc, BACKWARD_T *, depends_vec_t);                                     \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(   \
-        DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, depends_vec_t);                        \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                  \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, depends_vec_t);                               \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, depends_vec_t);                               \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, depends_vec_t);
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)          \
+    /* Buffer API */                                                                            \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T &,           \
+                                                                      sycl::buffer<REAL_T> &);  \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, BACKWARD_T>(                      \
+        DESCRIPTOR_T &, sycl::buffer<BACKWARD_T> &);                                            \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(           \
+        DESCRIPTOR_T &, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);                 \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                          \
+        DESCRIPTOR_T &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                        \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                  \
+        DESCRIPTOR_T &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                        \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                  \
+        DESCRIPTOR_T &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &, \
+        sycl::buffer<REAL_T> &);                                                                \
+                                                                                                \
+    /* USM API */                                                                               \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                   \
+        DESCRIPTOR_T &, REAL_T *, depends_vec_t);                                               \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, BACKWARD_T>(               \
+        DESCRIPTOR_T &, BACKWARD_T *, depends_vec_t);                                           \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(    \
+        DESCRIPTOR_T &, FORWARD_T *, BACKWARD_T *, depends_vec_t);                              \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                   \
+        DESCRIPTOR_T &, REAL_T *, REAL_T *, depends_vec_t);                                     \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(           \
+        DESCRIPTOR_T &, REAL_T *, REAL_T *, depends_vec_t);                                     \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(           \
+        DESCRIPTOR_T &, REAL_T *, REAL_T *, REAL_T *, REAL_T *, depends_vec_t);
 
 #define ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, COMPLEX_T)                \
     /* Buffer API */                                                                        \
     template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>(        \
-        DESCRIPTOR_T & desc, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);         \
+        DESCRIPTOR_T &, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);              \
     /* USM API */                                                                           \
     template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>( \
-        DESCRIPTOR_T & desc, COMPLEX_T *, COMPLEX_T *, depends_vec_t);
+        DESCRIPTOR_T &, COMPLEX_T *, COMPLEX_T *, depends_vec_t);
 
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(desc_rf_t, float, float, std::complex<float>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(desc_rf_t, std::complex<float>)

--- a/src/dft/backends/mklcpu/CMakeLists.txt
+++ b/src/dft/backends/mklcpu/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIB_OBJ ${LIB_NAME}_obj)
 
 set(USE_DPCPP_API ON)
 find_package(MKL REQUIRED)
+include(WarningsUtils)
 
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
@@ -44,7 +45,11 @@ target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT} ${MKL_COPT} -DBUI
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})
 endif()
-target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ${MKL_LINK_SYCL})
+target_link_libraries(${LIB_OBJ}
+  PUBLIC ONEMKL::SYCL::SYCL
+  PUBLIC ${MKL_LINK_SYCL}
+  PRIVATE onemkl_warnings
+)
 
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -39,30 +39,33 @@ namespace mklcpu {
 
 //In-place transform
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+ONEMKL_EXPORT void compute_backward(descriptor_type& /*desc*/,
+                                    sycl::buffer<data_type, 1>& /*inout*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
-                                    sycl::buffer<data_type, 1> &inout_im) {
+ONEMKL_EXPORT void compute_backward(descriptor_type& /*desc*/,
+                                    sycl::buffer<data_type, 1>& /*inout_re*/,
+                                    sycl::buffer<data_type, 1>& /*inout_im*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
 //Out-of-place transform
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
-                                    sycl::buffer<output_type, 1> &out) {
+ONEMKL_EXPORT void compute_backward(descriptor_type& /*desc*/, sycl::buffer<input_type, 1>& /*in*/,
+                                    sycl::buffer<output_type, 1>& /*out*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
-                                    sycl::buffer<input_type, 1> &in_im,
-                                    sycl::buffer<output_type, 1> &out_re,
-                                    sycl::buffer<output_type, 1> &out_im) {
+ONEMKL_EXPORT void compute_backward(descriptor_type& /*desc*/,
+                                    sycl::buffer<input_type, 1>& /*in_re*/,
+                                    sycl::buffer<input_type, 1>& /*in_im*/,
+                                    sycl::buffer<output_type, 1>& /*out_re*/,
+                                    sycl::buffer<output_type, 1>& /*out_im*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
@@ -70,35 +73,36 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
 
 //In-place transform
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout,
-                                           const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type& /*desc*/, data_type* /*inout*/,
+                                           const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
     return sycl::event{};
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
-                                           data_type *inout_im,
-                                           const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type& /*desc*/, data_type* /*inout_re*/,
+                                           data_type* /*inout_im*/,
+                                           const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
     return sycl::event{};
 }
 
 //Out-of-place transform
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
-                                           const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type& /*desc*/, input_type* /*in*/,
+                                           output_type* /*out*/,
+                                           const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
     return sycl::event{};
 }
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
-                                           input_type *in_im, output_type *out_re,
-                                           output_type *out_im,
-                                           const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type& /*desc*/, input_type* /*in_re*/,
+                                           input_type* /*in_im*/, output_type* /*out_re*/,
+                                           output_type* /*out_im*/,
+                                           const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
     return sycl::event{};
 }

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -45,13 +45,13 @@ public:
     commit_derived_impl(sycl::queue queue, const detail::dft_values<prec, dom>& config_values)
             : detail::commit_impl(queue, backend::mklcpu) {
         DFT_ERROR status = DFT_NOTSET;
-        if (config_values.dimensions.size() == 1) {
+        const auto rank = static_cast<std::int64_t>(config_values.dimensions.size());
+        if (rank == 1) {
             status = DftiCreateDescriptor(&handle, get_precision(prec), get_domain(dom), 1,
                                           config_values.dimensions[0]);
         }
         else {
-            status = DftiCreateDescriptor(&handle, get_precision(prec), get_domain(dom),
-                                          config_values.dimensions.size(),
+            status = DftiCreateDescriptor(&handle, get_precision(prec), get_domain(dom), rank,
                                           config_values.dimensions.data());
         }
         if (status != DFTI_NO_ERROR) {

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -37,30 +37,33 @@ namespace mklcpu {
 
 //In-place transform
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+ONEMKL_EXPORT void compute_forward(descriptor_type& /*desc*/,
+                                   sycl::buffer<data_type, 1>& /*inout*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
-                                   sycl::buffer<data_type, 1> &inout_im) {
+ONEMKL_EXPORT void compute_forward(descriptor_type& /*desc*/,
+                                   sycl::buffer<data_type, 1>& /*inout_re*/,
+                                   sycl::buffer<data_type, 1>& /*inout_im*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
 //Out-of-place transform
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
-                                   sycl::buffer<output_type, 1> &out) {
+ONEMKL_EXPORT void compute_forward(descriptor_type& /*desc*/, sycl::buffer<input_type, 1>& /*in*/,
+                                   sycl::buffer<output_type, 1>& /*out*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
-                                   sycl::buffer<input_type, 1> &in_im,
-                                   sycl::buffer<output_type, 1> &out_re,
-                                   sycl::buffer<output_type, 1> &out_im) {
+ONEMKL_EXPORT void compute_forward(descriptor_type& /*desc*/,
+                                   sycl::buffer<input_type, 1>& /*in_re*/,
+                                   sycl::buffer<input_type, 1>& /*in_im*/,
+                                   sycl::buffer<output_type, 1>& /*out_re*/,
+                                   sycl::buffer<output_type, 1>& /*out_im*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
@@ -68,35 +71,36 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
 
 //In-place transform
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout,
-                                          const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type& /*desc*/, data_type* /*inout*/,
+                                          const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
     return sycl::event{};
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
-                                          data_type *inout_im,
-                                          const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type& /*desc*/, data_type* /*inout_re*/,
+                                          data_type* /*inout_im*/,
+                                          const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
     return sycl::event{};
 }
 
 //Out-of-place transform
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
-                                          const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type& /*desc*/, input_type* /*in*/,
+                                          output_type* /*out*/,
+                                          const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
     return sycl::event{};
 }
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
-                                          input_type *in_im, output_type *out_re,
-                                          output_type *out_im,
-                                          const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type& /*desc*/, input_type* /*in_re*/,
+                                          input_type* /*in_im*/, output_type* /*out_re*/,
+                                          output_type* /*out_im*/,
+                                          const std::vector<sycl::event>& /*dependencies*/) {
     throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
     return sycl::event{};
 }

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LIB_NAME onemkl_dft_mklgpu)
 set(LIB_OBJ ${LIB_NAME}_obj)
 
 find_package(MKL REQUIRED)
+include(WarningsUtils)
 
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
@@ -41,7 +42,11 @@ target_include_directories(${LIB_OBJ}
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT} ${MKL_COPT})
 
-target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ${MKL_LINK_SYCL})
+target_link_libraries(${LIB_OBJ}
+  PUBLIC ONEMKL::SYCL::SYCL
+  PUBLIC ${MKL_LINK_SYCL}
+  PRIVATE onemkl_warnings
+)
 
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -87,8 +87,9 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_typ
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
-                                    sycl::buffer<data_type, 1> &inout_im) {
+ONEMKL_EXPORT void compute_backward(descriptor_type & /*desc*/,
+                                    sycl::buffer<data_type, 1> & /*inout_re*/,
+                                    sycl::buffer<data_type, 1> & /*inout_im*/) {
     throw mkl::unimplemented("DFT", "compute_backward",
                              "MKLGPU does not support compute_backward(desc, inout_re, inout_im).");
 }
@@ -105,10 +106,10 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
-                                    sycl::buffer<input_type, 1> &in_im,
-                                    sycl::buffer<output_type, 1> &out_re,
-                                    sycl::buffer<output_type, 1> &out_im) {
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> & /*in_re*/,
+                                    sycl::buffer<input_type, 1> & /*in_im*/,
+                                    sycl::buffer<output_type, 1> & /*out_re*/,
+                                    sycl::buffer<output_type, 1> & /*out_im*/) {
     detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
                           dft::detail::config_value::REAL_REAL>(
         desc, "Unexpected value for complex storage");
@@ -130,11 +131,12 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *ino
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
-                                           data_type *inout_im,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw mkl::unimplemented("DFT", "compute_backward",
-                             "MKLGPU does not support compute_backward(desc, inout_re, inout_im).");
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type & /*desc*/, data_type * /*inout_re*/,
+                                           data_type * /*inout_im*/,
+                                           const std::vector<sycl::event> & /*dependencies*/) {
+    throw mkl::unimplemented(
+        "DFT", "compute_backward",
+        "MKLGPU does not support compute_backward(desc, inout_re, inout_im, dependencies).");
 }
 
 //Out-of-place transform
@@ -149,10 +151,10 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
-                                           input_type *in_im, output_type *out_re,
-                                           output_type *out_im,
-                                           const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type * /*in_re*/,
+                                           input_type * /*in_im*/, output_type * /*out_re*/,
+                                           output_type * /*out_im*/,
+                                           const std::vector<sycl::event> & /*dependencies*/) {
     detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
                           dft::detail::config_value::REAL_REAL>(
         desc, "Unexpected value for complex storage");

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -94,8 +94,9 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
-                                   sycl::buffer<data_type, 1> &inout_im) {
+ONEMKL_EXPORT void compute_forward(descriptor_type & /*desc*/,
+                                   sycl::buffer<data_type, 1> & /*inout_re*/,
+                                   sycl::buffer<data_type, 1> & /*inout_im*/) {
     throw mkl::unimplemented("DFT", "compute_forward",
                              "MKLGPU does not support compute_forward(desc, inout_re, inout_im).");
 }
@@ -112,10 +113,10 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
-                                   sycl::buffer<input_type, 1> &in_im,
-                                   sycl::buffer<output_type, 1> &out_re,
-                                   sycl::buffer<output_type, 1> &out_im) {
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> & /*in_re*/,
+                                   sycl::buffer<input_type, 1> & /*in_im*/,
+                                   sycl::buffer<output_type, 1> & /*out_re*/,
+                                   sycl::buffer<output_type, 1> & /*out_im*/) {
     detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
                           dft::detail::config_value::REAL_REAL>(
         desc, "Unexpected value for complex storage");
@@ -137,11 +138,12 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inou
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename data_type>
-ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
-                                          data_type *inout_im,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw mkl::unimplemented("DFT", "compute_forward",
-                             "MKLGPU does not support compute_forward(desc, inout_re, inout_im).");
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type & /*desc*/, data_type * /*inout_re*/,
+                                          data_type * /*inout_im*/,
+                                          const std::vector<sycl::event> & /*dependencies*/) {
+    throw mkl::unimplemented(
+        "DFT", "compute_forward",
+        "MKLGPU does not support compute_forward(desc, inout_re, inout_im, dependencies).");
 }
 
 //Out-of-place transform
@@ -156,15 +158,15 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in,
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
 template <typename descriptor_type, typename input_type, typename output_type>
-ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
-                                          input_type *in_im, output_type *out_re,
-                                          output_type *out_im,
-                                          const std::vector<sycl::event> &dependencies) {
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type * /*in_re*/,
+                                          input_type * /*in_im*/, output_type * /*out_re*/,
+                                          output_type * /*out_im*/,
+                                          const std::vector<sycl::event> & /*dependencies*/) {
     detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
                           dft::detail::config_value::REAL_REAL>(
         desc, "Unexpected value for complex storage");
     throw oneapi::mkl::unimplemented(
-        "DFT", "compute_forward(desc, in_re, in_im, out_re, out_im, deps)",
+        "DFT", "compute_forward(desc, in_re, in_im, out_re, out_im, dependencies)",
         "MKLGPU does not support out-of-place FFT with real-real complex storage.");
 }
 

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -32,9 +32,9 @@ namespace detail {
 void compute_default_strides(const std::vector<std::int64_t>& dimensions,
                              std::vector<std::int64_t>& input_strides,
                              std::vector<std::int64_t>& output_strides) {
-    int rank = dimensions.size();
+    auto rank = dimensions.size();
     std::vector<std::int64_t> strides(rank + 1, 1);
-    for (int i = rank - 1; i > 0; --i) {
+    for (auto i = rank - 1; i > 0; --i) {
         strides[i] = strides[i + 1] * dimensions[i];
     }
     strides[0] = 0;
@@ -79,10 +79,12 @@ void descriptor<prec, dom>::set_value(config_param param, ...) {
         }
         // VA arg promotes float args to double, so the following is always double:
         case config_param::FORWARD_SCALE:
-            detail::set_value<config_param::FORWARD_SCALE>(values_, va_arg(vl, double));
+            detail::set_value<config_param::FORWARD_SCALE>(values_,
+                                                           static_cast<real_t>(va_arg(vl, double)));
             break;
         case config_param::BACKWARD_SCALE:
-            detail::set_value<config_param::BACKWARD_SCALE>(values_, va_arg(vl, double));
+            detail::set_value<config_param::BACKWARD_SCALE>(
+                values_, static_cast<real_t>(va_arg(vl, double)));
             break;
         case config_param::NUMBER_OF_TRANSFORMS:
             detail::set_value<config_param::NUMBER_OF_TRANSFORMS>(values_,
@@ -140,8 +142,8 @@ descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions) {
     }
     // Assume forward transform.
     compute_default_strides(dimensions, values_.input_strides, values_.output_strides);
-    values_.bwd_scale = 1.0;
-    values_.fwd_scale = 1.0;
+    values_.bwd_scale = real_t(1.0);
+    values_.fwd_scale = real_t(1.0);
     values_.number_of_transforms = 1;
     values_.fwd_dist = 1;
     values_.bwd_dist = 1;
@@ -165,8 +167,6 @@ descriptor<prec, dom>::~descriptor() {}
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::get_value(config_param param, ...) const {
-    int err = 0;
-    using real_t = std::conditional_t<prec == precision::SINGLE, float, double>;
     va_list vl;
     va_start(vl, param);
     if (va_arg(vl, void*) == nullptr) {

--- a/src/dft/descriptor_config_helper.hpp
+++ b/src/dft/descriptor_config_helper.hpp
@@ -98,7 +98,7 @@ void set_value(dft_values<prec, dom>& vals,
         if (set_val == nullptr) {
             throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
         }
-        for (int i{ 0 }; i < vals.dimensions.size(); ++i) {
+        for (std::size_t i{ 0 }; i < vals.dimensions.size(); ++i) {
             if (set_val[i] <= 0) {
                 throw mkl::invalid_argument("DFT", "set_value",
                                             "Invalid length value (negative or 0).");

--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -28,11 +28,11 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
         return test_skipped;
     }
 
-    descriptor_t descriptor{ size };
+    descriptor_t descriptor{ static_cast<std::int64_t>(size) };
     descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                          oneapi::mkl::dft::config_value::INPLACE);
 
-    const size_t container_size =
+    const std::size_t container_size =
         domain == oneapi::mkl::dft::domain::REAL ? conjugate_even_size : size;
 
     std::vector<FwdInputType> inout_host(container_size, static_cast<FwdInputType>(0));
@@ -52,7 +52,7 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         std::vector<FwdInputType> out_host_ref_conjugate =
             std::vector<FwdInputType>(conjugate_even_size);
-        for (int i = 0; i < out_host_ref_conjugate.size(); i += 2) {
+        for (std::size_t i = 0; i < out_host_ref_conjugate.size(); i += 2) {
             out_host_ref_conjugate[i] = out_host_ref[i / 2].real();
             out_host_ref_conjugate[i + 1] = out_host_ref[i / 2].imag();
         }
@@ -68,10 +68,11 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
                                        std::cout));
     }
 
-    descriptor_t descriptor_back{ size };
+    descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
     descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                               oneapi::mkl::dft::config_value::INPLACE);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+    double scale = 1.0 / static_cast<double>(size);
+    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
     commit_descriptor(descriptor_back, sycl_queue);
 
     try {
@@ -97,12 +98,12 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
         return test_skipped;
     }
 
-    descriptor_t descriptor{ size };
+    descriptor_t descriptor{ static_cast<std::int64_t>(size) };
     descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                          oneapi::mkl::dft::config_value::INPLACE);
     commit_descriptor(descriptor, sycl_queue);
 
-    const size_t container_size =
+    const std::size_t container_size =
         domain == oneapi::mkl::dft::domain::REAL ? conjugate_even_size : size;
 
     auto ua_input = usm_allocator_t<FwdInputType>(cxt, *dev);
@@ -124,7 +125,7 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         std::vector<FwdInputType> out_host_ref_conjugate =
             std::vector<FwdInputType>(conjugate_even_size);
-        for (int i = 0; i < out_host_ref_conjugate.size(); i += 2) {
+        for (std::size_t i = 0; i < out_host_ref_conjugate.size(); i += 2) {
             out_host_ref_conjugate[i] = out_host_ref[i / 2].real();
             out_host_ref_conjugate[i + 1] = out_host_ref[i / 2].imag();
         }
@@ -136,10 +137,11 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
                                        abs_error_margin, rel_error_margin, std::cout));
     }
 
-    descriptor_t descriptor_back{ size };
+    descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
     descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                               oneapi::mkl::dft::config_value::INPLACE);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+    double scale = 1.0 / static_cast<double>(size);
+    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
     commit_descriptor(descriptor_back, sycl_queue);
 
     try {

--- a/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
@@ -32,18 +32,16 @@ int DFT_Test<precision, domain>::test_in_place_real_real_USM() {
 
     try {
         descriptor_t descriptor{ sizes };
+        PrecisionType backward_scale = 1.f / static_cast<PrecisionType>(forward_elements);
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::INPLACE);
         descriptor.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                              oneapi::mkl::dft::config_value::REAL_REAL);
         descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                             (1.0 / forward_elements));
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, backward_scale);
         commit_descriptor(descriptor, sycl_queue);
 
         auto ua_input = usm_allocator_t<PrecisionType>(cxt, *dev);
@@ -84,18 +82,16 @@ int DFT_Test<precision, domain>::test_in_place_real_real_buffer() {
 
     try {
         descriptor_t descriptor{ sizes };
+        PrecisionType backward_scale = 1.f / static_cast<PrecisionType>(forward_elements);
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::INPLACE);
         descriptor.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                              oneapi::mkl::dft::config_value::REAL_REAL);
         descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                             (1.0 / forward_elements));
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, backward_scale);
         commit_descriptor(descriptor, sycl_queue);
 
         sycl::buffer<PrecisionType, 1> inout_re_buf{ input_re.data(), sycl::range<1>(size_total) };

--- a/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
@@ -31,7 +31,7 @@ int DFT_Test<precision, domain>::test_in_place_real_real_USM() {
     }
 
     try {
-        descriptor_t descriptor{ size };
+        descriptor_t descriptor{ static_cast<std::int64_t>(size) };
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::INPLACE);
@@ -51,13 +51,14 @@ int DFT_Test<precision, domain>::test_in_place_real_real_USM() {
             descriptor, inout_re.data(), inout_im.data(), dependencies);
         done.wait();
 
-        descriptor_t descriptor_back{ size };
+        descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
 
         descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                                   oneapi::mkl::dft::config_value::INPLACE);
         descriptor_back.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                                   oneapi::mkl::dft::config_value::REAL_REAL);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+        double scale = 1.0 / static_cast<double>(size);
+        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
         commit_descriptor(descriptor_back, sycl_queue);
 
         done =
@@ -86,7 +87,7 @@ int DFT_Test<precision, domain>::test_in_place_real_real_buffer() {
     }
 
     try {
-        descriptor_t descriptor{ size };
+        descriptor_t descriptor{ static_cast<std::int64_t>(size) };
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::INPLACE);
@@ -100,13 +101,14 @@ int DFT_Test<precision, domain>::test_in_place_real_real_buffer() {
         oneapi::mkl::dft::compute_forward<descriptor_t, PrecisionType>(descriptor, inout_re_buf,
                                                                        inout_im_buf);
 
-        descriptor_t descriptor_back{ size };
+        descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
 
         descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                                   oneapi::mkl::dft::config_value::INPLACE);
         descriptor_back.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                                   oneapi::mkl::dft::config_value::REAL_REAL);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+        double scale = 1.0 / static_cast<double>(size);
+        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
         commit_descriptor(descriptor_back, sycl_queue);
 
         oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor_back)>,

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -29,17 +29,18 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
         return test_skipped;
     }
 
-    const size_t bwd_size = domain == oneapi::mkl::dft::domain::REAL ? (size / 2) + 1 : size;
+    const std::size_t bwd_size = domain == oneapi::mkl::dft::domain::REAL ? (size / 2) + 1 : size;
 
-    descriptor_t descriptor{ size };
+    descriptor_t descriptor{ static_cast<std::int64_t>(size) };
     descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                          oneapi::mkl::dft::config_value::NOT_INPLACE);
     commit_descriptor(descriptor, sycl_queue);
 
-    descriptor_t descriptor_back{ size };
+    descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
     descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                               oneapi::mkl::dft::config_value::NOT_INPLACE);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+    double scale = 1.0 / static_cast<double>(size);
+    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
     commit_descriptor(descriptor_back, sycl_queue);
 
     std::vector<FwdInputType> fwd_data(input);
@@ -88,17 +89,18 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
     }
     const std::vector<sycl::event> no_dependencies;
 
-    const size_t bwd_size = domain == oneapi::mkl::dft::domain::REAL ? (size / 2) + 1 : size;
+    const std::size_t bwd_size = domain == oneapi::mkl::dft::domain::REAL ? (size / 2) + 1 : size;
 
-    descriptor_t descriptor{ size };
+    descriptor_t descriptor{ static_cast<std::int64_t>(size) };
     descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                          oneapi::mkl::dft::config_value::NOT_INPLACE);
     commit_descriptor(descriptor, sycl_queue);
 
-    descriptor_t descriptor_back{ size };
+    descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
     descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                               oneapi::mkl::dft::config_value::NOT_INPLACE);
-    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+    double scale = 1.0 / static_cast<double>(size);
+    descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
     commit_descriptor(descriptor_back, sycl_queue);
 
     auto ua_input = usm_allocator_t<FwdInputType>(cxt, *dev);

--- a/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
@@ -31,7 +31,7 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_USM() {
     }
 
     try {
-        descriptor_t descriptor{ size };
+        descriptor_t descriptor{ static_cast<std::int64_t>(size) };
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::NOT_INPLACE);
@@ -58,13 +58,14 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_USM() {
                 descriptor, in_re.data(), in_im.data(), out_re.data(), out_im.data(), dependencies);
         done.wait();
 
-        descriptor_t descriptor_back{ size };
+        descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
 
         descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                                   oneapi::mkl::dft::config_value::NOT_INPLACE);
         descriptor_back.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                                   oneapi::mkl::dft::config_value::REAL_REAL);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+        double scale = 1.0 / static_cast<double>(size);
+        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
         commit_descriptor(descriptor_back, sycl_queue);
 
         done =
@@ -94,7 +95,7 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_buffer() {
     }
 
     try {
-        descriptor_t descriptor{ size };
+        descriptor_t descriptor{ static_cast<std::int64_t>(size) };
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::NOT_INPLACE);
@@ -112,13 +113,14 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_buffer() {
         oneapi::mkl::dft::compute_forward<descriptor_t, PrecisionType, PrecisionType>(
             descriptor, in_dev_re, in_dev_im, out_dev_re, out_dev_im);
 
-        descriptor_t descriptor_back{ size };
+        descriptor_t descriptor_back{ static_cast<std::int64_t>(size) };
 
         descriptor_back.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                                   oneapi::mkl::dft::config_value::NOT_INPLACE);
         descriptor_back.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                                   oneapi::mkl::dft::config_value::REAL_REAL);
-        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (1.0 / size));
+        double scale = 1.0 / static_cast<double>(size);
+        descriptor_back.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, scale);
         commit_descriptor(descriptor_back, sycl_queue);
 
         oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor_back)>,

--- a/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
@@ -32,18 +32,16 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_USM() {
 
     try {
         descriptor_t descriptor{ sizes };
+        PrecisionType backward_scale = 1.f / static_cast<PrecisionType>(forward_elements);
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::NOT_INPLACE);
         descriptor.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                              oneapi::mkl::dft::config_value::REAL_REAL);
         descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                             (1.0 / forward_elements));
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, backward_scale);
         commit_descriptor(descriptor, sycl_queue);
 
         auto ua_input = usm_allocator_t<PrecisionType>(cxt, *dev);
@@ -91,18 +89,16 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_buffer() {
 
     try {
         descriptor_t descriptor{ sizes };
+        PrecisionType backward_scale = 1.f / static_cast<PrecisionType>(forward_elements);
 
         descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                              oneapi::mkl::dft::config_value::NOT_INPLACE);
         descriptor.set_value(oneapi::mkl::dft::config_param::COMPLEX_STORAGE,
                              oneapi::mkl::dft::config_value::REAL_REAL);
         descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
-        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE,
-                             static_cast<std::int64_t>(forward_elements));
-        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
-                             (1.0 / forward_elements));
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, forward_elements);
+        descriptor.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, backward_scale);
         commit_descriptor(descriptor, sycl_queue);
 
         sycl::buffer<PrecisionType, 1> in_dev_re{ input_re.data(), sycl::range<1>(size_total) };

--- a/tests/unit_tests/dft/include/compute_tester.hpp
+++ b/tests/unit_tests/dft/include/compute_tester.hpp
@@ -49,8 +49,8 @@ struct DFT_Test {
 
     enum class MemoryAccessModel { buffer, usm };
 
-    const std::int64_t size;
-    const std::int64_t conjugate_even_size;
+    const std::size_t size;
+    const std::size_t conjugate_even_size;
     double abs_error_margin;
     double rel_error_margin;
 
@@ -63,8 +63,8 @@ struct DFT_Test {
     std::vector<PrecisionType> input_im;
     std::vector<FwdOutputType> out_host_ref;
 
-    DFT_Test(sycl::device* dev, std::int64_t size)
-            : size{ static_cast<std::int64_t>(size) },
+    DFT_Test(sycl::device* dev, std::size_t size)
+            : size{ size },
               conjugate_even_size{ 2 * (size / 2 + 1) },
               abs_error_margin{ 0 },
               rel_error_margin{ 0 },
@@ -83,13 +83,13 @@ struct DFT_Test {
         rand_vector(input, size);
 
         if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
-            for (int i = 0; i < input.size(); ++i) {
+            for (std::size_t i = 0; i < input.size(); ++i) {
                 input_re[i] = { input[i] };
                 input_im[i] = 0;
             }
         }
         else {
-            for (int i = 0; i < input.size(); ++i) {
+            for (std::size_t i = 0; i < input.size(); ++i) {
                 input_re[i] = { input[i].real() };
                 input_im[i] = { input[i].imag() };
             }
@@ -118,8 +118,8 @@ struct DFT_Test {
                                                   return std::abs(a) < std::abs(b);
                                               });
         // Heuristic for the average-case error margins
-        abs_error_margin = std::abs(max_norm_ref) * std::log2((double)size);
-        rel_error_margin = 5.0 * std::log2((double)size);
+        abs_error_margin = std::abs(max_norm_ref) * std::log2(static_cast<double>(size));
+        rel_error_margin = 5.0 * std::log2(static_cast<double>(size));
         return !skip_test(type);
     }
 

--- a/tests/unit_tests/dft/include/compute_tester.hpp
+++ b/tests/unit_tests/dft/include/compute_tester.hpp
@@ -54,7 +54,7 @@ struct DFT_Test {
     const std::vector<std::int64_t> sizes;
     const std::int64_t batches;
     const std::int64_t forward_elements;
-    const std::int64_t size_total;
+    const std::size_t size_total;
     double abs_error_margin{ 0 };
     double rel_error_margin{ 0 };
 
@@ -72,7 +72,7 @@ struct DFT_Test {
               batches{ batches_ },
               forward_elements{ std::accumulate(sizes.begin(), sizes.end(), 1,
                                                 std::multiplies<>{}) },
-              size_total{ forward_elements * batches },
+              size_total{ cast_unsigned(forward_elements * batches) },
               dev{ dev },
               sycl_queue{ *dev, exception_handler },
               cxt{ sycl_queue.get_context() } {

--- a/tests/unit_tests/dft/include/reference_dft.hpp
+++ b/tests/unit_tests/dft/include/reference_dft.hpp
@@ -113,7 +113,7 @@ struct reference<TypeIn, TypeOut, 3> {
 **/
 template <typename TypeIn, typename TypeOut>
 void reference_forward_dft(const std::vector<std::int64_t> &sizes, const TypeIn *in, TypeOut *out) {
-    std::vector<std::size_t> unsigned_sizes;
+    std::vector<std::size_t> unsigned_sizes(sizes.size());
     std::transform(sizes.begin(), sizes.end(), unsigned_sizes.begin(),
                    [](std::int64_t size) { return cast_unsigned(size); });
     switch (unsigned_sizes.size()) {

--- a/tests/unit_tests/dft/include/reference_dft.hpp
+++ b/tests/unit_tests/dft/include/reference_dft.hpp
@@ -51,7 +51,7 @@ void reference_forward_dft(const std::vector<TypeIn> &in, std::vector<TypeOut> &
 
     const ref_t TWOPI = 2.0L * 3.141592653589793238462643383279502884197L;
 
-    const size_t N = out.size();
+    const std::size_t N = out.size();
     for (std::size_t k = 0; k < N; ++k) {
         std::complex<ref_t> out_temp = 0;
         const auto partial_expo = (static_cast<ref_t>(k) * TWOPI) / static_cast<ref_t>(N);

--- a/tests/unit_tests/dft/include/test_common.hpp
+++ b/tests/unit_tests/dft/include/test_common.hpp
@@ -65,8 +65,8 @@ bool check_equal(fp x, fp x_ref, double abs_error_mag, double rel_error_mag, std
             return std::numeric_limits<fp_real>::epsilon();
         }
     }();
-    const fp_real abs_bound = abs_error_mag * epsilon;
-    const fp_real rel_bound = rel_error_mag * epsilon;
+    const auto abs_bound = static_cast<fp_real>(abs_error_mag) * epsilon;
+    const auto rel_bound = static_cast<fp_real>(rel_error_mag) * epsilon;
 
     const auto aerr = std::abs(x - x_ref);
     const auto rerr = aerr / std::abs(x_ref);
@@ -80,8 +80,8 @@ bool check_equal(fp x, fp x_ref, double abs_error_mag, double rel_error_mag, std
 }
 
 template <typename vec1, typename vec2>
-bool check_equal_vector(vec1 &&v, vec2 &&v_ref, int n, double abs_error_mag, double rel_error_mag,
-                        std::ostream &out) {
+bool check_equal_vector(vec1 &&v, vec2 &&v_ref, std::size_t n, double abs_error_mag,
+                        double rel_error_mag, std::ostream &out) {
     constexpr int max_print = 20;
     int count = 0;
     bool good = true;
@@ -117,10 +117,10 @@ inline t rand_scalar() {
 }
 
 template <typename vec>
-void rand_vector(vec &v, int n) {
+void rand_vector(vec &v, std::size_t n) {
     using fp = typename vec::value_type;
     v.resize(n);
-    for (int i = 0; i < n; i++) {
+    for (std::size_t i = 0; i < n; i++) {
         v[i] = rand_scalar<fp>();
     }
 }
@@ -151,9 +151,9 @@ void commit_descriptor(oneapi::mkl::dft::descriptor<precision, domain> &descript
 class DimensionsDeviceNamePrint {
 public:
     std::string operator()(
-        testing::TestParamInfo<std::tuple<sycl::device *, std::int64_t>> dev) const {
-        std::string size = "size_" + std::to_string(std::get<1>(dev.param));
-        std::string dev_name = std::get<0>(dev.param)->get_info<sycl::info::device::name>();
+        testing::TestParamInfo<std::tuple<sycl::device *, std::size_t>> params) const {
+        std::string size = "size_" + std::to_string(std::get<1>(params.param));
+        std::string dev_name = std::get<0>(params.param)->get_info<sycl::info::device::name>();
         for (std::string::size_type i = 0; i < dev_name.size(); ++i) {
             if (!isalnum(dev_name[i]))
                 dev_name[i] = '_';

--- a/tests/unit_tests/dft/source/CMakeLists.txt
+++ b/tests/unit_tests/dft/source/CMakeLists.txt
@@ -19,6 +19,8 @@
 
 set(DFT_SOURCES "compute_tests.cpp" "descriptor_tests.cpp")
 
+include(WarningsUtils)
+
 if (BUILD_SHARED_LIBS)
     add_library(dft_source_rt OBJECT ${DFT_SOURCES})
     target_compile_options(dft_source_rt PRIVATE -DCALL_RT_API -DNOMINMAX)
@@ -35,6 +37,7 @@ if (BUILD_SHARED_LIBS)
     else ()
         target_link_libraries(dft_source_rt PUBLIC ONEMKL::SYCL::SYCL)
     endif ()
+    target_link_libraries(dft_source_rt PRIVATE onemkl_warnings)
 endif ()
 
 add_library(dft_source_ct OBJECT ${DFT_SOURCES})
@@ -56,4 +59,5 @@ else ()
             ONEMKL::SYCL::SYCL
             )
 endif ()
+target_link_libraries(dft_source_ct PRIVATE onemkl_warnings)
 

--- a/tests/unit_tests/dft/source/compute_tests.cpp
+++ b/tests/unit_tests/dft/source/compute_tests.cpp
@@ -39,9 +39,9 @@ extern std::vector<sycl::device *> devices;
 
 namespace {
 
-class ComputeTests : public ::testing::TestWithParam<std::tuple<sycl::device *, std::int64_t>> {};
+class ComputeTests : public ::testing::TestWithParam<std::tuple<sycl::device *, std::size_t>> {};
 
-std::vector<std::int64_t> lengths{ 8, 21, 128 };
+std::vector<std::size_t> lengths{ 8, 21, 128 };
 
 /* test_in_place_buffer() */
 TEST_P(ComputeTests, RealSinglePrecisionInPlaceBuffer) {

--- a/tests/unit_tests/dft/source/compute_tests.cpp
+++ b/tests/unit_tests/dft/source/compute_tests.cpp
@@ -73,7 +73,7 @@ class ComputeTests_real_real_out_of_place
 INSTANTIATE_TEST_DIMENSIONS_PRECISION_DOMAIN_PLACE_LAYOUT(buffer)
 INSTANTIATE_TEST_DIMENSIONS_PRECISION_DOMAIN_PLACE_LAYOUT(USM)
 
-using shape = std::vector<int64_t>;
+using shape = std::vector<std::int64_t>;
 using i64 = std::int64_t;
 // Parameter format - { shape of transform, number of transforms }
 std::vector<DFTParams> test_params{

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -430,8 +430,8 @@ inline void recommit_values(sycl::queue& sycl_queue) {
         // not changeable
         // FORWARD_DOMAIN, PRECISION, DIMENSION, COMMIT_STATUS
         { std::make_pair(config_param::LENGTHS, std::int64_t{ 10 }),
-          std::make_pair(config_param::FORWARD_SCALE, PrecisionType{ 1.2 }),
-          std::make_pair(config_param::BACKWARD_SCALE, PrecisionType{ 3.4 }) },
+          std::make_pair(config_param::FORWARD_SCALE, PrecisionType(1.2)),
+          std::make_pair(config_param::BACKWARD_SCALE, PrecisionType(3.4)) },
         { std::make_pair(config_param::NUMBER_OF_TRANSFORMS, std::int64_t{ 5 }),
           std::make_pair(config_param::COMPLEX_STORAGE, config_value::COMPLEX_COMPLEX),
           std::make_pair(config_param::REAL_STORAGE, config_value::REAL_REAL),
@@ -447,7 +447,7 @@ inline void recommit_values(sycl::queue& sycl_queue) {
           std::make_pair(config_param::PACKED_FORMAT, config_value::CCE_FORMAT) }
     };
 
-    for (int i = 0; i < argument_groups.size(); i += 1) {
+    for (std::size_t i = 0; i < argument_groups.size(); i += 1) {
         for (auto argument : argument_groups[i]) {
             std::visit([&descriptor, p = argument.first](auto&& a) { descriptor.set_value(p, a); },
                        argument.second);

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -217,6 +217,7 @@ static inline void aligned_free(void *p) {
 
 /* Support for Unified Shared Memory allocations for different backends */
 static inline void *malloc_shared(size_t align, size_t size, sycl::device dev, sycl::context ctx) {
+    (void)align;
 #ifdef _WIN64
     return sycl::malloc_shared(size, dev, ctx);
 #else


### PR DESCRIPTION
# Description

This PR builds on https://github.com/oneapi-src/oneMKL/pull/259.

Fix warnings when compiling the DFT domain with some warning flags:
`-Wall -Wextra -Wshadow -Wconversion -Wpedantic`.
The same warnings can be added to more domains if desired.

As part of fixes the warnings this also splits the DFT descriptor tests
as the device was not needed for some of them.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
