### PR TITLE
[DFT] Split descriptor tests that do not need a device

### DIFF
--- a/cmake/WarningsUtils.cmake
+++ b/cmake/WarningsUtils.cmake
@@ -26,7 +26,6 @@ set(ONEMKL_WARNINGS "")
 include(CheckCXXCompilerFlag)
 macro(add_warning flag)
   check_cxx_compiler_flag(${flag} IS_SUPPORTED)
-  message(STATUS "DBG '${flag}': ${IS_SUPPORTED}")
   if(${IS_SUPPORTED})
     list(APPEND ONEMKL_WARNINGS ${flag})
   else()
@@ -40,7 +39,7 @@ add_warning("-Wshadow")
 add_warning("-Wconversion")
 add_warning("-Wpedantic")
 
-message(STATUS "Using warnings: ${ONEMKL_WARNINGS}")
+message(VERBOSE "Domains with warnings enabled use: ${ONEMKL_WARNINGS}")
 
 # The onemkl_warnings target can be linked to any other target to enable warnings.
 target_compile_options(onemkl_warnings INTERFACE ${ONEMKL_WARNINGS})

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -42,7 +42,7 @@ constexpr std::int64_t default_1d_lengths = 4;
 const std::vector<std::int64_t> default_3d_lengths{ 124, 5, 3 };
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
-inline void set_and_get_lengths(sycl::queue& sycl_queue) {
+static void set_and_get_lengths() {
     /* Negative Testing */
     {
         oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_3d_lengths };
@@ -70,8 +70,6 @@ inline void set_and_get_lengths(sycl::queue& sycl_queue) {
         descriptor.get_value(oneapi::mkl::dft::config_param::DIMENSION, &dimensions_after_set);
         EXPECT_EQ(new_lengths, lengths_value);
         EXPECT_EQ(dimensions, dimensions_after_set);
-
-        commit_descriptor(descriptor, sycl_queue);
     }
 
     /* >= 2D */
@@ -101,7 +99,7 @@ inline void set_and_get_lengths(sycl::queue& sycl_queue) {
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
-inline void set_and_get_strides(sycl::queue& sycl_queue) {
+static void set_and_get_strides() {
     oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_3d_lengths };
 
     EXPECT_THROW(descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, nullptr),
@@ -156,7 +154,7 @@ inline void set_and_get_strides(sycl::queue& sycl_queue) {
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
-inline void set_and_get_values(sycl::queue& sycl_queue) {
+static void set_and_get_values() {
     oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
 
     using Precision_Type =
@@ -164,7 +162,7 @@ inline void set_and_get_values(sycl::queue& sycl_queue) {
                                     double>;
 
     {
-        Precision_Type forward_scale_set_value{ 143.5 };
+        auto forward_scale_set_value = Precision_Type(143.5);
         Precision_Type forward_scale_before_set;
         Precision_Type forward_scale_after_set;
 
@@ -179,7 +177,7 @@ inline void set_and_get_values(sycl::queue& sycl_queue) {
     }
 
     {
-        Precision_Type backward_scale_set_value{ 143.5 };
+        auto backward_scale_set_value = Precision_Type(143.5);
         Precision_Type backward_scale_before_set;
         Precision_Type backward_scale_after_set;
 
@@ -349,7 +347,7 @@ inline void set_and_get_values(sycl::queue& sycl_queue) {
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
-inline void get_readonly_values(sycl::queue& sycl_queue) {
+static void get_readonly_values() {
     oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
 
     oneapi::mkl::dft::domain domain_value;
@@ -371,14 +369,10 @@ inline void get_readonly_values(sycl::queue& sycl_queue) {
     oneapi::mkl::dft::config_value commit_status;
     descriptor.get_value(oneapi::mkl::dft::config_param::COMMIT_STATUS, &commit_status);
     EXPECT_EQ(commit_status, oneapi::mkl::dft::config_value::UNCOMMITTED);
-
-    commit_descriptor(descriptor, sycl_queue);
-    descriptor.get_value(oneapi::mkl::dft::config_param::COMMIT_STATUS, &commit_status);
-    EXPECT_EQ(commit_status, oneapi::mkl::dft::config_value::COMMITTED);
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
-inline void set_readonly_values(sycl::queue& sycl_queue) {
+static void set_readonly_values() {
     oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
 
     EXPECT_THROW(descriptor.set_value(oneapi::mkl::dft::config_param::FORWARD_DOMAIN,
@@ -405,8 +399,16 @@ inline void set_readonly_values(sycl::queue& sycl_queue) {
     EXPECT_THROW(descriptor.set_value(oneapi::mkl::dft::config_param::COMMIT_STATUS,
                                       oneapi::mkl::dft::config_value::UNCOMMITTED),
                  oneapi::mkl::invalid_argument);
+}
 
+template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
+static void get_commited(sycl::queue& sycl_queue) {
+    oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
     commit_descriptor(descriptor, sycl_queue);
+
+    oneapi::mkl::dft::config_value commit_status;
+    descriptor.get_value(oneapi::mkl::dft::config_param::COMMIT_STATUS, &commit_status);
+    EXPECT_EQ(commit_status, oneapi::mkl::dft::config_value::COMMITTED);
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
@@ -542,21 +544,28 @@ inline void swap_out_dead_queue(sycl::queue& sycl_queue) {
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
-int test(sycl::device* dev) {
+static int test_getter_setter() {
+    set_and_get_lengths<precision, domain>();
+    set_and_get_strides<precision, domain>();
+    set_and_get_values<precision, domain>();
+    get_readonly_values<precision, domain>();
+    set_readonly_values<precision, domain>();
+
+    return !::testing::Test::HasFailure();
+}
+
+template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
+int test_commit(sycl::device* dev) {
     sycl::queue sycl_queue(*dev, exception_handler);
 
     if constexpr (precision == oneapi::mkl::dft::precision::DOUBLE) {
-        if (!sycl_queue.get_device().has(sycl::aspect::fp64)) {
+        if (!dev->has(sycl::aspect::fp64)) {
             std::cout << "Device does not support double precision." << std::endl;
             return test_skipped;
         }
     }
 
-    set_and_get_lengths<precision, domain>(sycl_queue);
-    set_and_get_strides<precision, domain>(sycl_queue);
-    set_and_get_values<precision, domain>(sycl_queue);
-    get_readonly_values<precision, domain>(sycl_queue);
-    set_readonly_values<precision, domain>(sycl_queue);
+    get_commited<precision, domain>(sycl_queue);
     recommit_values<precision, domain>(sycl_queue);
     change_queue_causes_wait<precision, domain>(sycl_queue);
     swap_out_dead_queue<precision, domain>(sycl_queue);
@@ -564,29 +573,53 @@ int test(sycl::device* dev) {
     return !::testing::Test::HasFailure();
 }
 
-class DescriptorTests : public ::testing::TestWithParam<sycl::device*> {};
-
-TEST_P(DescriptorTests, DescriptorTestsRealSingle) {
-    EXPECT_TRUEORSKIP(
-        (test<oneapi::mkl::dft::precision::SINGLE, oneapi::mkl::dft::domain::REAL>(GetParam())));
+TEST(DescriptorTests, DescriptorTestsRealSingle) {
+    EXPECT_TRUE((
+        test_getter_setter<oneapi::mkl::dft::precision::SINGLE, oneapi::mkl::dft::domain::REAL>()));
 }
 
-TEST_P(DescriptorTests, DescriptorTestsRealDouble) {
-    EXPECT_TRUEORSKIP(
-        (test<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::REAL>(GetParam())));
+TEST(DescriptorTests, DescriptorTestsRealDouble) {
+    EXPECT_TRUE((
+        test_getter_setter<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::REAL>()));
 }
 
-TEST_P(DescriptorTests, DescriptorTestsComplexSingle) {
-    EXPECT_TRUEORSKIP(
-        (test<oneapi::mkl::dft::precision::SINGLE, oneapi::mkl::dft::domain::COMPLEX>(GetParam())));
+TEST(DescriptorTests, DescriptorTestsComplexSingle) {
+    EXPECT_TRUE((test_getter_setter<oneapi::mkl::dft::precision::SINGLE,
+                                    oneapi::mkl::dft::domain::COMPLEX>()));
 }
 
-TEST_P(DescriptorTests, DescriptorTestsComplexDouble) {
-    EXPECT_TRUEORSKIP(
-        (test<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::COMPLEX>(GetParam())));
+TEST(DescriptorTests, DescriptorTestsComplexDouble) {
+    EXPECT_TRUE((test_getter_setter<oneapi::mkl::dft::precision::DOUBLE,
+                                    oneapi::mkl::dft::domain::COMPLEX>()));
 }
 
-INSTANTIATE_TEST_SUITE_P(DescriptorTestSuite, DescriptorTests, testing::ValuesIn(devices),
-                         ::DeviceNamePrint());
+class DescriptorCommitTests : public ::testing::TestWithParam<sycl::device*> {};
+
+TEST_P(DescriptorCommitTests, DescriptorCommitTestsRealSingle) {
+    EXPECT_TRUEORSKIP(
+        (test_commit<oneapi::mkl::dft::precision::SINGLE, oneapi::mkl::dft::domain::REAL>(
+            GetParam())));
+}
+
+TEST_P(DescriptorCommitTests, DescriptorCommitTestsRealDouble) {
+    EXPECT_TRUEORSKIP(
+        (test_commit<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::REAL>(
+            GetParam())));
+}
+
+TEST_P(DescriptorCommitTests, DescriptorCommitTestsComplexSingle) {
+    EXPECT_TRUEORSKIP(
+        (test_commit<oneapi::mkl::dft::precision::SINGLE, oneapi::mkl::dft::domain::COMPLEX>(
+            GetParam())));
+}
+
+TEST_P(DescriptorCommitTests, DescriptorCommitTestsComplexDouble) {
+    EXPECT_TRUEORSKIP(
+        (test_commit<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::COMPLEX>(
+            GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(DescriptorCommitTestSuite, DescriptorCommitTests,
+                         testing::ValuesIn(devices), ::DeviceNamePrint());
 
 } // anonymous namespace


### PR DESCRIPTION
# Description

This builds on https://github.com/oneapi-src/oneMKL/pull/259.

Some descriptor tests do not need a device as we do not need to commit
them. This follows from the discussion in https://github.com/oneapi-src/oneMKL/pull/261#discussion_r1101780387.
The descriptor is now only committed to check that the commit status is
updated.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
