### PR TITLE
[BLAS::SYCL-BLAS backend] Enable syclblas spr level 2 operator

### DIFF
--- a/src/blas/backends/syclblas/CMakeLists.txt
+++ b/src/blas/backends/syclblas/CMakeLists.txt
@@ -140,7 +140,7 @@ if (NOT sycl_blas_FOUND)
   FetchContent_Declare(
     sycl-blas
     GIT_REPOSITORY https://github.com/codeplaysoftware/sycl-blas
-    GIT_TAG        20bfe691be07c9a2a316715094a2441f30e497d7
+    GIT_TAG        2c6c6a8a909e5a666d3426692bd33e55ba2be529
   )
   FetchContent_MakeAvailable(sycl-blas)
   message(STATUS "Looking for sycl_blas - downloaded")

--- a/src/blas/backends/syclblas/CMakeLists.txt
+++ b/src/blas/backends/syclblas/CMakeLists.txt
@@ -140,7 +140,7 @@ if (NOT sycl_blas_FOUND)
   FetchContent_Declare(
     sycl-blas
     GIT_REPOSITORY https://github.com/codeplaysoftware/sycl-blas
-    GIT_TAG        2c6c6a8a909e5a666d3426692bd33e55ba2be529
+    GIT_TAG        master
   )
   FetchContent_MakeAvailable(sycl-blas)
   message(STATUS "Looking for sycl_blas - downloaded")

--- a/src/blas/backends/syclblas/syclblas_level2.cxx
+++ b/src/blas/backends/syclblas/syclblas_level2.cxx
@@ -147,7 +147,7 @@ void spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, rea
 
 void spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, real_t alpha,
          sycl::buffer<real_t, 1> &x, std::int64_t incx, sycl::buffer<real_t, 1> &a) {
-    throw unimplemented("blas", "spr", "");
+    CALL_SYCLBLAS_FN(::blas::_spr, queue, upper_lower, n, alpha, x, incx, a);
 }
 
 void spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, real_t alpha,


### PR DESCRIPTION
# Description

This PR enables the `spr` Level 2 operator in SYCL-BLAS backend for oneMKL. 

FYI: this PR is blocked by #262  and #264.
 
# Checklist

## All Submissions
- [x] Do all unit tests pass locally? 
- [syclblas_ct.txt](https://github.com/oneapi-src/oneMKL/files/10943146/syclblas_ct.txt)
- [syclblas_rt.txt](https://github.com/oneapi-src/oneMKL/files/10943147/syclblas_rt.txt)
- The failures for double-precision functions on an iGPU that does not support double precision. In these cases, the backend throws `mkl::unsupported_device`, which results in a test failure.
- The tests were run with `--gtest_filter=-ImatcopyBatchStrideTestSuite*` because this test suite segfaults. This function is not implemented in SYCL-BLAS.
- [x] Have you formatted the code using clang-format?
