### PR TITLE
Fix clang format

### DIFF
--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -43,7 +43,7 @@ namespace detail {
 /// Forward a MKLGPU DFT call to the backend, checking that the commit impl is valid.
 /// Assumes backend descriptor values match those of the frontend.
 template <dft::detail::precision prec, dft::detail::domain dom, typename... ArgTs>
-inline auto compute_backward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&...args) {
+inline auto compute_backward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&... args) {
     using mklgpu_desc_t = dft::descriptor<to_mklgpu(prec), to_mklgpu(dom)>;
     auto commit_handle = dft::detail::get_commit(desc);
     if (commit_handle == nullptr || commit_handle->get_backend() != backend::mklgpu) {

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -50,7 +50,7 @@ namespace detail {
 /// Forward a MKLGPU DFT call to the backend, checking that the commit impl is valid.
 /// Assumes backend descriptor values match those of the frontend.
 template <dft::detail::precision prec, dft::detail::domain dom, typename... ArgTs>
-inline auto compute_forward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&...args) {
+inline auto compute_forward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&... args) {
     using mklgpu_desc_t = dft::descriptor<to_mklgpu(prec), to_mklgpu(dom)>;
     auto commit_handle = dft::detail::get_commit(desc);
     if (commit_handle == nullptr || commit_handle->get_backend() != backend::mklgpu) {

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -572,8 +572,8 @@ bool check_equal_matrix(acc1 &M, acc2 &M_ref, oneapi::mkl::layout layout, int m,
 }
 
 template <typename fp>
-bool check_equal_matrix(const fp *M, const fp *M_ref, oneapi::mkl::layout layout, int m,
-                        int n, int ld, int error_mag, std::ostream &out) {
+bool check_equal_matrix(const fp *M, const fp *M_ref, oneapi::mkl::layout layout, int m, int n,
+                        int ld, int error_mag, std::ostream &out) {
     bool good = true;
     int idx, count = 0;
     for (int j = 0; j < n; j++) {

--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -58,12 +58,14 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
         }
         auto acc_host = inout_buf.template get_host_access();
         EXPECT_TRUE(check_equal_vector(acc_host.get_pointer(), out_host_ref_conjugate.data(),
-                                       inout_host.size(), abs_error_margin, rel_error_margin, std::cout));
+                                       inout_host.size(), abs_error_margin, rel_error_margin,
+                                       std::cout));
     }
     else {
         auto acc_host = inout_buf.template get_host_access();
         EXPECT_TRUE(check_equal_vector(acc_host.get_pointer(), out_host_ref.data(),
-                                       inout_host.size(), abs_error_margin, rel_error_margin, std::cout));
+                                       inout_host.size(), abs_error_margin, rel_error_margin,
+                                       std::cout));
     }
 
     descriptor_t descriptor_back{ size };
@@ -152,8 +154,8 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
         return test_skipped;
     }
 
-    EXPECT_TRUE(
-        check_equal_vector(inout.data(), input.data(), input.size(), abs_error_margin, rel_error_margin, std::cout));
+    EXPECT_TRUE(check_equal_vector(inout.data(), input.data(), input.size(), abs_error_margin,
+                                   rel_error_margin, std::cout));
 
     return !::testing::Test::HasFailure();
 }

--- a/tests/unit_tests/dft/include/compute_tester.hpp
+++ b/tests/unit_tests/dft/include/compute_tester.hpp
@@ -54,7 +54,7 @@ struct DFT_Test {
     double abs_error_margin;
     double rel_error_margin;
 
-    sycl::device *dev;
+    sycl::device* dev;
     sycl::queue sycl_queue;
     sycl::context cxt;
 
@@ -63,11 +63,11 @@ struct DFT_Test {
     std::vector<PrecisionType> input_im;
     std::vector<FwdOutputType> out_host_ref;
 
-    DFT_Test(sycl::device *dev, std::int64_t size)
+    DFT_Test(sycl::device* dev, std::int64_t size)
             : size{ static_cast<std::int64_t>(size) },
               conjugate_even_size{ 2 * (size / 2 + 1) },
-              abs_error_margin{0},
-              rel_error_margin{0},
+              abs_error_margin{ 0 },
+              rel_error_margin{ 0 },
               dev{ dev },
               sycl_queue{ *dev, exception_handler },
               cxt{ sycl_queue.get_context() } {
@@ -114,7 +114,9 @@ struct DFT_Test {
     bool init(MemoryAccessModel type) {
         reference_forward_dft<FwdInputType, FwdOutputType>(input, out_host_ref);
         auto max_norm_ref = *std::max_element(std::begin(out_host_ref), std::end(out_host_ref),
-          [](const FwdOutputType& a, const FwdOutputType& b) { return std::abs(a) < std::abs(b); });
+                                              [](const FwdOutputType& a, const FwdOutputType& b) {
+                                                  return std::abs(a) < std::abs(b);
+                                              });
         // Heuristic for the average-case error margins
         abs_error_margin = std::abs(max_norm_ref) * std::log2((double)size);
         rel_error_margin = 5.0 * std::log2((double)size);

--- a/tests/unit_tests/dft/include/test_common.hpp
+++ b/tests/unit_tests/dft/include/test_common.hpp
@@ -73,17 +73,15 @@ bool check_equal(fp x, fp x_ref, double abs_error_mag, double rel_error_mag, std
     const bool ok = (rerr <= rel_bound) || (aerr <= abs_bound);
     if (!ok) {
         out << "Mismatching results: actual = " << x << " vs. reference = " << x_ref << "\n";
-        out << " relative error = " << rerr
-            << " absolute error = " << aerr
-            << " relative bound = " << rel_bound
-            << " absolute bound = " << abs_bound
-            << "\n";
+        out << " relative error = " << rerr << " absolute error = " << aerr
+            << " relative bound = " << rel_bound << " absolute bound = " << abs_bound << "\n";
     }
     return ok;
 }
 
 template <typename vec1, typename vec2>
-bool check_equal_vector(vec1 &&v, vec2 &&v_ref, int n, double abs_error_mag, double rel_error_mag, std::ostream &out) {
+bool check_equal_vector(vec1 &&v, vec2 &&v_ref, int n, double abs_error_mag, double rel_error_mag,
+                        std::ostream &out) {
     constexpr int max_print = 20;
     int count = 0;
     bool good = true;

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -127,7 +127,7 @@
 
 #define TEST_RUN_CT_SELECT_NO_ARGS(q, func)                                \
     do {                                                                   \
-        if (CHECK_HOST_OR_CPU(q))   {                                      \
+        if (CHECK_HOST_OR_CPU(q)) {                                        \
             TEST_RUN_INTELCPU_SELECT_NO_ARGS(q, func);                     \
         }                                                                  \
         else if (q.get_device().is_gpu()) {                                \

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -128,10 +128,12 @@ int main(int argc, char** argv) {
                         if (dev.is_gpu() && vendor_id == AMD_ID)
                             continue;
 #endif
+// clang-format off
 #ifdef __HIPSYCL__
                         if (dev.is_accelerator())
 #else
                         if (!dev.is_accelerator())
+// clang-format on
 #endif
                             local_devices.push_back(dev);
                     }


### PR DESCRIPTION
This PR fixes the code format and adds an exception in `tests/unit_tests/main_test.cpp`. Without the exception, `clang-format` will format the code incorrectly as:
```c
#ifdef __HIPSYCL__
                        if (dev.is_accelerator())
#else
                    if (!dev.is_accelerator())
#endif
                            local_devices.push_back(dev);
```

The positions of `// clang-format off` and `// clang-format on` don't make logical sense. This is because `clang-format` also formats the comments and accepts the one in the PR and the following indentations:
```c
#ifdef __HIPSYCL__
                        if (dev.is_accelerator())
#else
                    // clang-format off
                        if (!dev.is_accelerator())
// clang-format on
#endif
                            local_devices.push_back(dev);
```
```c
#ifdef __HIPSYCL__
                        if (dev.is_accelerator())
// clang-format off
#else
                        if (!dev.is_accelerator())
#endif
                            // clang-format on
                            local_devices.push_back(dev);
```
```c
// clang-format off
#ifdef __HIPSYCL__
                        if (dev.is_accelerator())
#else
                        if (!dev.is_accelerator())
#endif
                            // clang-format on
                            local_devices.push_back(dev);
```
```c
// clang-format off
#ifdef __HIPSYCL__
                        if (dev.is_accelerator())
#else
                        if (!dev.is_accelerator())
#endif
                            local_devices.push_back(dev);
                        // clang-format on
```

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? N/A
- [X] Have you formatted the code using clang-format?