### PR TITLE
[BLAS] fix deprecation warnings from cuda.hpp

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -23,8 +23,10 @@
 #else
 #include <CL/sycl.hpp>
 #endif
-#if __has_include(<sycl/backend/cuda.hpp>)
+#if __has_include(<sycl/context.hpp>)
+#if __SYCL_COMPILER_VERSION <= 20220930
 #include <sycl/backend/cuda.hpp>
+#endif
 #include <sycl/context.hpp>
 #include <sycl/detail/pi.hpp>
 #else


### PR DESCRIPTION
# Description

Recent compilers issue warnings when we `#include "cuda.hpp"` from the LLVM SYCL backends. This PR removes those warnings.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Log attached: [test.txt](https://github.com/oneapi-src/oneMKL/files/11094562/test.txt)
- [x] Have you formatted the code using clang-format?

