### PR TITLE
[cuSolver] Avoid repeated ctxCreate/Destroy for all Lapack API calls.

### DIFF
--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -32,7 +32,7 @@ void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
         if (pimpl_) {
             pimpl_->get_queue().wait();
         }
-        pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
+        pimpl_.reset(mklcpu::create_commit(*this, selector.get_queue()));
     }
     pimpl_->commit(values_);
 }

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
@@ -23,8 +23,10 @@
 #else
 #include <CL/sycl.hpp>
 #endif
-#if __has_include(<sycl/backend/cuda.hpp>)
+#if __has_include(<sycl/context.hpp>)
+#if __SYCL_COMPILER_VERSION <= 20220930
 #include <sycl/backend/cuda.hpp>
+#endif
 #include <sycl/context.hpp>
 #include <sycl/detail/pi.hpp>
 #else
@@ -77,7 +79,7 @@ cuSolver handle to the SYCL context.
 
 class CusolverScopedContextHandler {
     CUcontext original_;
-    sycl::context placedContext_;
+    sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handler &ih;
     static thread_local cusolver_handle<pi_context> handle_helper;


### PR DESCRIPTION

# Description

Mainly improve the performance of Lapack for CUDA backend by avoiding repeated cuCtxCreate/Destroy calls.

* Apply the same logic as cuBlas to cuSolver at placedContext_. 
  This could avoid calling cuCtxCreate & cuCtxDestroy every time when using multiple lapck APIs.
  For example, when solving Ax=b with Cholesky factorization, one needs to use both lapack::potrf & lapack::potrs APIs.
  cuCtxCreate/Destroy takes much longer than most GPU lapack kernels, see the below images from nvvp diagnostics:

  Before modification:
  ![image](https://user-images.githubusercontent.com/109200794/228778191-2a7c83f7-a001-4327-a77d-9b054d8084a6.png)
  After modification:
  ![image](https://user-images.githubusercontent.com/109200794/228780964-7ef42312-0e0e-46e0-a0b5-b873d8ce4079.png)

* Fix deprecation warnings from cuda.hpp for cuSolver (#295).

* Fix the bug in dft (mklgpu => mklcpu).

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[unit_test_lapack.txt](https://github.com/oneapi-src/oneMKL/files/11109598/unit_test_lapack.txt)
[unit_test_rand.txt](https://github.com/oneapi-src/oneMKL/files/11109599/unit_test_rand.txt)
[unit_test_blas.txt](https://github.com/oneapi-src/oneMKL/files/11109600/unit_test_blas.txt)

- [x] Have you formatted the code using clang-format?

