### PR TITLE
[DFT] Disable the MKLCPU DFT backend

### DIFF
--- a/examples/dft/run_time_dispatching/CMakeLists.txt
+++ b/examples/dft/run_time_dispatching/CMakeLists.txt
@@ -29,9 +29,6 @@ endif()
 # If users build more than one backend (i.e. mklcpu and mklgpu, or mklcpu and CUDA), they may need to
 # overwrite SYCL_DEVICE_FILTER in their environment to run on the desired backend
 set(DEVICE_FILTERS "")
-if(ENABLE_MKLCPU_BACKEND)
-  list(APPEND DEVICE_FILTERS "cpu")
-endif()
 if(ENABLE_MKLGPU_BACKEND)
   list(APPEND DEVICE_FILTERS "gpu")
 endif()

--- a/src/dft/backends/CMakeLists.txt
+++ b/src/dft/backends/CMakeLists.txt
@@ -20,7 +20,3 @@
 if(ENABLE_MKLGPU_BACKEND)
   add_subdirectory(mklgpu)
 endif()
-
-if(ENABLE_MKLCPU_BACKEND)
-  add_subdirectory(mklcpu)
-endif()


### PR DESCRIPTION
# Description

The MKLCPU backend is not yet supported (and currently causing the build to break due to a [copy-paste mistake](https://github.com/oneapi-src/oneMKL/blame/develop/src/dft/backends/mklcpu/descriptor.cpp#L35) by me), so we should disable it from building until #288 is complete.

The build error can be reproduce using this cmake command: `cmake -GNinja ../ -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DMKL_ROOT=/opt/intel/oneapi/mkl/2023.0.0 -DBUILD_FUNCTIONAL_TESTS=OFF`
This is because `ENABLE_MKLCPU_BACKEND` is defaulted to ON and when no `TARGET_DOMAIN` is specified it will add `dft` automatically.

Fixes #294

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? Attach a log.
- [N/A] Have you formatted the code using clang-format?