### PR TITLE
[DFT] Fix MKLCPU DFT backend build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $> clang++ -fsycl app.o –L$ONEMKL/lib –lonemkl_blas_mklcpu –lonemkl_blas_c
 
 ### Supported Configurations:
 
-Supported domains: BLAS, LAPACK, RNG
+Supported domains: BLAS, LAPACK, RNG, DFT
 
 #### Linux*
 

--- a/examples/dft/run_time_dispatching/CMakeLists.txt
+++ b/examples/dft/run_time_dispatching/CMakeLists.txt
@@ -29,9 +29,6 @@ endif()
 # If users build more than one backend (i.e. mklcpu and mklgpu, or mklcpu and CUDA), they may need to
 # overwrite SYCL_DEVICE_FILTER in their environment to run on the desired backend
 set(DEVICE_FILTERS "")
-if(ENABLE_MKLCPU_BACKEND)
-  list(APPEND DEVICE_FILTERS "cpu")
-endif()
 if(ENABLE_MKLGPU_BACKEND)
   list(APPEND DEVICE_FILTERS "gpu")
 endif()

--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -32,7 +32,7 @@ void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
         if (pimpl_) {
             pimpl_->get_queue().wait();
         }
-        pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
+        pimpl_.reset(mklcpu::create_commit(*this, selector.get_queue()));
     }
     pimpl_->commit(values_);
 }

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -552,6 +552,13 @@ int test(sycl::device* dev) {
         }
     }
 
+    // TODO remove after #288
+    if (sycl_queue.get_device().get_info<sycl::info::device::device_type>() ==
+        sycl::info::device_type::cpu) {
+        std::cout << "MKLCPU not implemented, skipping.\n";
+        return test_skipped;
+    }
+
     set_and_get_lengths<precision, domain>(sycl_queue);
     set_and_get_strides<precision, domain>(sycl_queue);
     set_and_get_values<precision, domain>(sycl_queue);


### PR DESCRIPTION
# Description

Fix a build issue introduced to the MKLCPU backend. This backend is not currently supported so the tests haven't been run.
This can be reproduced with the cmake setup 
```
cmake -GNinja -Bbuild -S. -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/icpx -DCMAKE_C_COMPILER=/opt/intel/oneapi/compiler/2023.0.0/linux/bin/icx -DMKL_ROOT=/opt/intel/oneapi/mkl/2023.0.0
```
 since ENABLE_MKLCPU_BACKEND is defaulted to ON and when no TARGET_DOMAIN is specified it will add dft automatically.

I've also updated the README because DFT was not listed as a supported domain.

Fixes #294 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you added relevant regression tests? - **NA**
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
