### PR TITLE
[BLAS] allow device pointers in cublas output scalars

### DIFF
--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -761,13 +761,19 @@ inline sycl::event rotg(const char *func_name, Func func, sycl::queue &queue, T1
     using cuDataType1 = typename CudaEquivalentType<T1>::Type;
     using cuDataType2 = typename CudaEquivalentType<T2>::Type;
     auto ctx = queue.get_context();
-    bool results_on_device = sycl::get_pointer_type(a, ctx) == sycl::usm::alloc::device;
+    bool results_on_device =
+        (sycl::get_pointer_type(a, ctx) == sycl::usm::alloc::device ||
+         sycl::get_pointer_type(b, ctx) == sycl::usm::alloc::device ||
+         sycl::get_pointer_type(c, ctx) == sycl::usm::alloc::device ||
+         sycl::get_pointer_type(s, ctx) == sycl::usm::alloc::device);
     if (results_on_device) {
-        if (sycl::get_pointer_type(b, ctx) == sycl::usm::alloc::unknown ||
+        if (sycl::get_pointer_type(a, ctx) == sycl::usm::alloc::unknown
+            sycl::get_pointer_type(b, ctx) == sycl::usm::alloc::unknown ||
             sycl::get_pointer_type(c, ctx) == sycl::usm::alloc::unknown ||
             sycl::get_pointer_type(s, ctx) == sycl::usm::alloc::unknown) {
             throw oneapi::mkl::exception(
-                "blas", "rotg", "If any pointer is device-only, all must be device accessible");
+                "blas", "rotg",
+                "If any pointer is only device accessible, all must be device accessible");
         }
     }
     auto done = queue.submit([&](sycl::handler &cgh) {
@@ -1014,12 +1020,17 @@ inline sycl::event rotmg(const char *func_name, Func func, sycl::queue &queue, T
                          T y1, T *param, const std::vector<sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     auto ctx = queue.get_context();
-    bool results_on_device = sycl::get_pointer_type(d1, ctx) == sycl::usm::alloc::device;
+    bool results_on_device =
+        (sycl::get_pointer_type(d1, ctx) == sycl::usm::alloc::device ||
+         sycl::get_pointer_type(d2, ctx) == sycl::usm::alloc::device ||
+         sycl::get_pointer_type(x1, ctx) == sycl::usm::alloc::device);
     if (results_on_device) {
-        if (sycl::get_pointer_type(d2, ctx) == sycl::usm::alloc::unknown ||
+        if (sycl::get_pointer_type(d1, ctx) == sycl::usm::alloc::unknown ||
+            sycl::get_pointer_type(d2, ctx) == sycl::usm::alloc::unknown ||
             sycl::get_pointer_type(x1, ctx) == sycl::usm::alloc::unknown) {
             throw oneapi::mkl::exception(
-                "blas", "rotmg", "If any pointer is device-only, all must be device accessible");
+                "blas", "rotmg",
+                "If any pointer is only device accessible, all must be device accessible");
         }
     }
     cuDataType *y1_;

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -761,15 +761,13 @@ inline sycl::event rotg(const char *func_name, Func func, sycl::queue &queue, T1
     using cuDataType1 = typename CudaEquivalentType<T1>::Type;
     using cuDataType2 = typename CudaEquivalentType<T2>::Type;
     auto ctx = queue.get_context();
-    bool results_on_device =
-        sycl::get_pointer_type(a, ctx) == sycl::usm::alloc::device;
+    bool results_on_device = sycl::get_pointer_type(a, ctx) == sycl::usm::alloc::device;
     if (results_on_device) {
         if (sycl::get_pointer_type(b, ctx) == sycl::usm::alloc::unknown ||
             sycl::get_pointer_type(c, ctx) == sycl::usm::alloc::unknown ||
             sycl::get_pointer_type(s, ctx) == sycl::usm::alloc::unknown) {
             throw oneapi::mkl::exception(
-                "blas", "rotg",
-                "If any pointer is device-only, all must be device accessible");
+                "blas", "rotg", "If any pointer is device-only, all must be device accessible");
         }
     }
     auto done = queue.submit([&](sycl::handler &cgh) {
@@ -790,7 +788,7 @@ inline sycl::event rotg(const char *func_name, Func func, sycl::queue &queue, T1
             CUBLAS_ERROR_FUNC_T_SYNC(func_name, func, err, handle, a_, b_, c_, s_);
             if (results_on_device) {
                 cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
-            }           
+            }
         });
     });
     return done;
@@ -1016,17 +1014,15 @@ inline sycl::event rotmg(const char *func_name, Func func, sycl::queue &queue, T
                          T y1, T *param, const std::vector<sycl::event> &dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     auto ctx = queue.get_context();
-    bool results_on_device =
-        sycl::get_pointer_type(d1, ctx) == sycl::usm::alloc::device;
+    bool results_on_device = sycl::get_pointer_type(d1, ctx) == sycl::usm::alloc::device;
     if (results_on_device) {
         if (sycl::get_pointer_type(d2, ctx) == sycl::usm::alloc::unknown ||
             sycl::get_pointer_type(x1, ctx) == sycl::usm::alloc::unknown) {
             throw oneapi::mkl::exception(
-                "blas", "rotmg",
-                "If any pointer is device-only, all must be device accessible");
+                "blas", "rotmg", "If any pointer is device-only, all must be device accessible");
         }
     }
-    cuDataType* y1_;
+    cuDataType *y1_;
     if (results_on_device) {
         y1_ = sycl::malloc_device<cuDataType>(1, queue);
         queue.memcpy(y1_, &y1, sizeof(cuDataType)).wait();
@@ -1084,7 +1080,7 @@ inline sycl::event iamax(const char *func_name, Func func, sycl::queue &queue, i
     // This change may cause failure as the result of integer overflow
     // based on the size.
     int int_res = 0;
-    int * int_res_p = nullptr;
+    int *int_res_p = nullptr;
     bool result_on_device =
         sycl::get_pointer_type(result, queue.get_context()) == sycl::usm::alloc::device;
     if (result_on_device) {
@@ -1122,7 +1118,7 @@ inline sycl::event iamax(const char *func_name, Func func, sycl::queue &queue, i
         int host_int;
         int64_t host_int64;
         queue.memcpy(&host_int, int_res_p, sizeof(int)).wait();
-        host_int64 = std::max((int64_t) host_int - 1, int64_t{ 0 });
+        host_int64 = std::max((int64_t)host_int - 1, int64_t{ 0 });
         auto last_ev = queue.memcpy(result, &host_int64, sizeof(int64_t));
         last_ev.wait();
         sycl::free(int_res_p, queue);
@@ -1191,7 +1187,7 @@ inline sycl::event iamin(const char *func_name, Func func, sycl::queue &queue, i
     // This change may cause failure as the result of integer overflow
     // based on the size.
     int int_res = 0;
-    int * int_res_p = nullptr;
+    int *int_res_p = nullptr;
     bool result_on_device =
         sycl::get_pointer_type(result, queue.get_context()) == sycl::usm::alloc::device;
     if (result_on_device) {
@@ -1229,7 +1225,7 @@ inline sycl::event iamin(const char *func_name, Func func, sycl::queue &queue, i
         int host_int;
         int64_t host_int64;
         queue.memcpy(&host_int, int_res_p, sizeof(int)).wait();
-        host_int64 = std::max((int64_t) host_int - 1, int64_t{ 0 });
+        host_int64 = std::max((int64_t)host_int - 1, int64_t{ 0 });
         auto last_ev = queue.memcpy(result, &host_int64, sizeof(int64_t));
         last_ev.wait();
         sycl::free(int_res_p, queue);

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -461,6 +461,13 @@ typename std::enable_if<std::is_integral<fp>::value, bool>::type check_equal(fp 
 }
 
 template <typename fp>
+bool check_equal_ptr(sycl::queue queue, fp *x, fp x_ref, int error_mag) {
+    fp x_host;
+    queue.memcpy(&x_host, x, sizeof(fp)).wait();
+    return check_equal(x_host, x_ref, error_mag);
+}
+
+template <typename fp>
 bool check_equal_trsm(fp x, fp x_ref, int error_mag) {
     using fp_real = typename complex_info<fp>::real_type;
     fp_real bound = std::max(fp_real(5e-5), (error_mag * num_components<fp>() *
@@ -485,6 +492,14 @@ bool check_equal(fp x, fp x_ref, int error_mag, std::ostream &out) {
         out << "Difference in result: DPC++ " << x << " vs. Reference " << x_ref << std::endl;
     }
     return good;
+}
+
+template <typename fp>
+bool check_equal_ptr(sycl::queue queue, fp *x, fp x_ref, int error_mag,
+                     std::ostream &out) {
+    fp x_host;
+    queue.memcpy(&x_host, x, sizeof(fp)).wait();
+    return check_equal(x_host, x_ref, error_mag, out);
 }
 
 template <typename fp>

--- a/tests/unit_tests/blas/include/test_common.hpp
+++ b/tests/unit_tests/blas/include/test_common.hpp
@@ -495,8 +495,7 @@ bool check_equal(fp x, fp x_ref, int error_mag, std::ostream &out) {
 }
 
 template <typename fp>
-bool check_equal_ptr(sycl::queue queue, fp *x, fp x_ref, int error_mag,
-                     std::ostream &out) {
+bool check_equal_ptr(sycl::queue queue, fp *x, fp x_ref, int error_mag, std::ostream &out) {
     fp x_host;
     queue.memcpy(&x_host, x, sizeof(fp)).wait();
     return check_equal(x_host, x_ref, error_mag, out);

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -45,8 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp, typename fp_res,
-          usm::alloc alloc_type=usm::alloc::shared>
+template <typename fp, typename fp_res, usm::alloc alloc_type = usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -152,9 +151,8 @@ TEST_P(AsumUsmTests, RealSinglePrecision) {
         (::test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
         (::test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1)));
-    EXPECT_TRUEORSKIP(
-        (::test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
-                                                  std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((::test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
+                                                                std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         (::test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
@@ -164,9 +162,8 @@ TEST_P(AsumUsmTests, RealDoublePrecision) {
         (::test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
         (::test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1)));
-    EXPECT_TRUEORSKIP(
-        (::test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
-                                                    std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((::test<double, double, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         (::test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
@@ -176,9 +173,8 @@ TEST_P(AsumUsmTests, ComplexSinglePrecision) {
                                                           std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((::test<std::complex<float>, float>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 1)));
-    EXPECT_TRUEORSKIP(
-        (::test<std::complex<float>, float, usm::alloc::device>(
-            std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((::test<std::complex<float>, float, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP((::test<std::complex<float>, float>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, -3)));
 }
@@ -188,9 +184,8 @@ TEST_P(AsumUsmTests, ComplexDoublePrecision) {
                                                           std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 1)));
-    EXPECT_TRUEORSKIP(
-        (::test<std::complex<double>, double, usm::alloc::device>(
-            std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((::test<std::complex<double>, double, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, -3)));
 }

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -87,7 +87,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
         result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
     }
     else if constexpr (alloc_type == usm::alloc::device) {
-        result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
+        result_p = (fp_res*)oneapi::mkl::malloc_device(64, sizeof(fp_res), *dev, cxt);
     }
     else {
         throw std::runtime_error("Bad alloc_type");
@@ -137,9 +137,9 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    bool good = check_equal(*result_p, result_ref, N, std::cout);
+    bool good = check_equal_ptr(main_queue, result_p, result_ref, N, std::cout);
 
-    oneapi::mkl::free_shared(result_p, cxt);
+    oneapi::mkl::free_usm(result_p, cxt);
 
     return (int)good;
 }

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -86,7 +86,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
         result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
     }
     else if constexpr (alloc_type == usm::alloc::device) {
-        result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
+        result_p = (fp_res*)oneapi::mkl::malloc_device(64, sizeof(fp_res), *dev, cxt);
     }
     else {
         throw std::runtime_error("Bad alloc_type");
@@ -135,9 +135,9 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    bool good = check_equal(*result_p, result_ref, N, std::cout);
+    bool good = check_equal_ptr(main_queue, result_p, result_ref, N, std::cout);
 
-    oneapi::mkl::free_shared(result_p, cxt);
+    oneapi::mkl::free_usm(result_p, cxt);
 
     return (int)good;
 }

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp, typename fp_res>
+template <typename fp, typename fp_res, usm::alloc alloc_type=usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -81,7 +81,16 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 
     // Call DPC++ DOT.
 
-    auto result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
+    fp_res* result_p;
+    if constexpr (alloc_type == usm::alloc::shared) {
+        result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
+    }
+    else if constexpr (alloc_type == usm::alloc::device) {
+        result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
+    }
+    else {
+        throw std::runtime_error("Bad alloc_type");
+    }
 
     try {
 #ifdef CALL_RT_API
@@ -142,6 +151,9 @@ TEST_P(DotUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1)));
     EXPECT_TRUEORSKIP(
+        (test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
+                                                std::get<1>(GetParam()), 101, 1, 1)));
+    EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotUsmTests, RealDoublePrecision) {
@@ -150,6 +162,9 @@ TEST_P(DotUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1)));
     EXPECT_TRUEORSKIP(
+        (test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                  std::get<1>(GetParam()), 101, 1, 1)));
+    EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotUsmTests, RealDoubleSinglePrecision) {
@@ -157,6 +172,9 @@ TEST_P(DotUsmTests, RealDoubleSinglePrecision) {
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1)));
+    EXPECT_TRUEORSKIP(
+        (test<float, double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                 std::get<1>(GetParam()), 101, 1, 1)));
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp, typename fp_res, usm::alloc alloc_type=usm::alloc::shared>
+template <typename fp, typename fp_res, usm::alloc alloc_type = usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -150,9 +150,8 @@ TEST_P(DotUsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1)));
-    EXPECT_TRUEORSKIP(
-        (test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
-                                                std::get<1>(GetParam()), 101, 1, 1)));
+    EXPECT_TRUEORSKIP((test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
+                                                              std::get<1>(GetParam()), 101, 1, 1)));
     EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
@@ -161,9 +160,8 @@ TEST_P(DotUsmTests, RealDoublePrecision) {
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1)));
-    EXPECT_TRUEORSKIP(
-        (test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
-                                                  std::get<1>(GetParam()), 101, 1, 1)));
+    EXPECT_TRUEORSKIP((test<double, double, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, 1)));
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
@@ -172,9 +170,8 @@ TEST_P(DotUsmTests, RealDoubleSinglePrecision) {
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1)));
-    EXPECT_TRUEORSKIP(
-        (test<float, double, usm::alloc::device>(std::get<0>(GetParam()),
-                                                 std::get<1>(GetParam()), 101, 1, 1)));
+    EXPECT_TRUEORSKIP((test<float, double, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, 1)));
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp, usm::alloc alloc_type=usm::alloc::shared>
+template <typename fp, usm::alloc alloc_type = usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -147,17 +147,15 @@ class IamaxUsmTests
 TEST_P(IamaxUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        (test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                         101, 1)));
+    EXPECT_TRUEORSKIP((
+        test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        (test<double, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                          101, 1)));
+    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                        std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
@@ -165,9 +163,8 @@ TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        (test<std::complex<float>, usm::alloc::device>(std::get<0>(GetParam()),
-                                                       std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((test<std::complex<float>, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
@@ -176,9 +173,8 @@ TEST_P(IamaxUsmTests, ComplexDoublePrecision) {
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        (test<std::complex<double>, usm::alloc::device>(std::get<0>(GetParam()),
-                                                        std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((test<std::complex<double>, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp>
+template <typename fp, usm::alloc alloc_type=usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -80,7 +80,16 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Call DPC++ IAMAX.
 
-    auto result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+    int64_t* result_p;
+    if constexpr (alloc_type == usm::alloc::shared) {
+        result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+    }
+    else if constexpr (alloc_type == usm::alloc::device) {
+        result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+    }
+    else {
+        throw std::runtime_error("Bad alloc_type");
+    }
 
     try {
 #ifdef CALL_RT_API
@@ -138,11 +147,17 @@ class IamaxUsmTests
 TEST_P(IamaxUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+    EXPECT_TRUEORSKIP(
+        (test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                         101, 1)));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+    EXPECT_TRUEORSKIP(
+        (test<double, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                          101, 1)));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
@@ -151,6 +166,9 @@ TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
     EXPECT_TRUEORSKIP(
+        (test<std::complex<float>, usm::alloc::device>(std::get<0>(GetParam()),
+                                                       std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, ComplexDoublePrecision) {
@@ -158,6 +176,9 @@ TEST_P(IamaxUsmTests, ComplexDoublePrecision) {
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+    EXPECT_TRUEORSKIP(
+        (test<std::complex<double>, usm::alloc::device>(std::get<0>(GetParam()),
+                                                        std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -85,7 +85,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
         result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
     }
     else if constexpr (alloc_type == usm::alloc::device) {
-        result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+        result_p = (int64_t*)oneapi::mkl::malloc_device(64, sizeof(int64_t), *dev, cxt);
     }
     else {
         throw std::runtime_error("Bad alloc_type");
@@ -135,8 +135,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    bool good = check_equal(*result_p, result_ref, 0, std::cout);
-    oneapi::mkl::free_shared(result_p, cxt);
+    bool good = check_equal_ptr(main_queue, result_p, result_ref, 0, std::cout);
+    oneapi::mkl::free_usm(result_p, cxt);
 
     return (int)good;
 }

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp>
+template <typename fp, usm::alloc alloc_type=usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -80,7 +80,16 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Call DPC++ IAMIN.
 
-    auto result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+    int64_t* result_p;
+    if constexpr (alloc_type == usm::alloc::shared) {
+        result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+    }
+    else if constexpr (alloc_type == usm::alloc::device) {
+        result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+    }
+    else {
+        throw std::runtime_error("Bad alloc_type");
+    }
 
     try {
 #ifdef CALL_RT_API
@@ -138,11 +147,15 @@ class IaminUsmTests
 TEST_P(IaminUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(std::get<0>(GetParam()),
+                                                       std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                        std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, ComplexSinglePrecision) {
@@ -151,6 +164,9 @@ TEST_P(IaminUsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
     EXPECT_TRUEORSKIP(
+        (test<std::complex<float>, usm::alloc::device>(std::get<0>(GetParam()),
+                                                       std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, ComplexDoublePrecision) {
@@ -158,6 +174,9 @@ TEST_P(IaminUsmTests, ComplexDoublePrecision) {
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+    EXPECT_TRUEORSKIP(
+        (test<std::complex<double>, usm::alloc::device>(std::get<0>(GetParam()),
+                                                        std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp, usm::alloc alloc_type=usm::alloc::shared>
+template <typename fp, usm::alloc alloc_type = usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -147,8 +147,8 @@ class IaminUsmTests
 TEST_P(IaminUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(std::get<0>(GetParam()),
-                                                       std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((
+        test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, RealDoublePrecision) {
@@ -163,9 +163,8 @@ TEST_P(IaminUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        (test<std::complex<float>, usm::alloc::device>(std::get<0>(GetParam()),
-                                                       std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((test<std::complex<float>, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
@@ -174,9 +173,8 @@ TEST_P(IaminUsmTests, ComplexDoublePrecision) {
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        (test<std::complex<double>, usm::alloc::device>(std::get<0>(GetParam()),
-                                                        std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((test<std::complex<double>, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -85,7 +85,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
         result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
     }
     else if constexpr (alloc_type == usm::alloc::device) {
-        result_p = (int64_t*)oneapi::mkl::malloc_shared(64, sizeof(int64_t), *dev, cxt);
+        result_p = (int64_t*)oneapi::mkl::malloc_device(64, sizeof(int64_t), *dev, cxt);
     }
     else {
         throw std::runtime_error("Bad alloc_type");
@@ -135,8 +135,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    bool good = check_equal(*result_p, result_ref, 0, std::cout);
-    oneapi::mkl::free_shared(result_p, cxt);
+    bool good = check_equal_ptr(main_queue, result_p, result_ref, 0, std::cout);
+    oneapi::mkl::free_usm(result_p, cxt);
 
     return (int)good;
 }

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -45,7 +45,8 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp, typename fp_res>
+template <typename fp, typename fp_res,
+          usm::alloc alloc_type=usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -81,7 +82,16 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Call DPC++ NRM2.
 
-    auto result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
+    fp_res* result_p;
+    if constexpr (alloc_type == usm::alloc::shared) {
+        result_p = (fp_res*)oneapi::mkl::malloc_shared(64, sizeof(fp_res), *dev, cxt);
+    }
+    else if constexpr (alloc_type == usm::alloc::device) {
+        result_p = (fp_res*)oneapi::mkl::malloc_device(64, sizeof(fp_res), *dev, cxt);
+    }
+    else {
+        throw std::runtime_error("Bad alloc_type");
+    }
 
     try {
 #ifdef CALL_RT_API
@@ -127,8 +137,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    bool good = check_equal(*result_p, result_ref, N, std::cout);
-    oneapi::mkl::free_shared(result_p, cxt);
+    bool good = check_equal_ptr(main_queue, result_p, result_ref, N, std::cout);
+    oneapi::mkl::free_usm(result_p, cxt);
 
     return (int)good;
 }
@@ -142,6 +152,9 @@ TEST_P(Nrm2UsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1)));
     EXPECT_TRUEORSKIP(
+        (test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
+                                                std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2UsmTests, RealDoublePrecision) {
@@ -150,6 +163,9 @@ TEST_P(Nrm2UsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1)));
     EXPECT_TRUEORSKIP(
+        (test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                  std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2UsmTests, ComplexSinglePrecision) {
@@ -157,6 +173,8 @@ TEST_P(Nrm2UsmTests, ComplexSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((test<std::complex<float>, float>(std::get<0>(GetParam()),
                                                         std::get<1>(GetParam()), 1357, 1)));
+    EXPECT_TRUEORSKIP((test<std::complex<float>, float, usm::alloc::device>(
+                          std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP((test<std::complex<float>, float>(std::get<0>(GetParam()),
                                                         std::get<1>(GetParam()), 1357, -3)));
 }
@@ -165,6 +183,8 @@ TEST_P(Nrm2UsmTests, ComplexDoublePrecision) {
                                                           std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 1)));
+    EXPECT_TRUEORSKIP((test<std::complex<double>, double, usm::alloc::device>(
+                          std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, -3)));
 }

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -45,8 +45,7 @@ extern std::vector<sycl::device*> devices;
 
 namespace {
 
-template <typename fp, typename fp_res,
-          usm::alloc alloc_type=usm::alloc::shared>
+template <typename fp, typename fp_res, usm::alloc alloc_type = usm::alloc::shared>
 int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -151,9 +150,8 @@ TEST_P(Nrm2UsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1)));
-    EXPECT_TRUEORSKIP(
-        (test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
-                                                std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((test<float, float, usm::alloc::device>(std::get<0>(GetParam()),
+                                                              std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
@@ -162,9 +160,8 @@ TEST_P(Nrm2UsmTests, RealDoublePrecision) {
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1)));
-    EXPECT_TRUEORSKIP(
-        (test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
-                                                  std::get<1>(GetParam()), 101, 1)));
+    EXPECT_TRUEORSKIP((test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                                std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
@@ -174,7 +171,7 @@ TEST_P(Nrm2UsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP((test<std::complex<float>, float>(std::get<0>(GetParam()),
                                                         std::get<1>(GetParam()), 1357, 1)));
     EXPECT_TRUEORSKIP((test<std::complex<float>, float, usm::alloc::device>(
-                          std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP((test<std::complex<float>, float>(std::get<0>(GetParam()),
                                                         std::get<1>(GetParam()), 1357, -3)));
 }
@@ -184,7 +181,7 @@ TEST_P(Nrm2UsmTests, ComplexDoublePrecision) {
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 1)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double, usm::alloc::device>(
-                          std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, -3)));
 }

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -45,8 +45,7 @@ extern std::vector<sycl::device *> devices;
 
 namespace {
 
-template <typename fp, typename fp_scalar,
-          usm::alloc alloc_type=usm::alloc::shared>
+template <typename fp, typename fp_scalar, usm::alloc alloc_type = usm::alloc::shared>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -175,27 +174,25 @@ class RotgUsmTests
 
 TEST_P(RotgUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP((test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
-    EXPECT_TRUEORSKIP((test<float, float, usm::alloc::device>(
-                           std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP(
+        (test<float, float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
-    EXPECT_TRUEORSKIP((test<double, double, usm::alloc::device>(
-                           std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP((test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                                std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(
         (test<std::complex<float>, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
-    EXPECT_TRUEORSKIP(
-        (test<std::complex<float>, float, usm::alloc::device>(
-            std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP((test<std::complex<float>, float, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, ComplexDoublePrecision) {
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
-    EXPECT_TRUEORSKIP(
-        (test<std::complex<double>, double, usm::alloc::device>(
-            std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP((test<std::complex<double>, double, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 
 INSTANTIATE_TEST_SUITE_P(RotgUsmTestSuite, RotgUsmTests,

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -45,7 +45,8 @@ extern std::vector<sycl::device *> devices;
 
 namespace {
 
-template <typename fp, typename fp_scalar>
+template <typename fp, typename fp_scalar,
+          usm::alloc alloc_type=usm::alloc::shared>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -86,15 +87,29 @@ int test(device *dev, oneapi::mkl::layout layout) {
     ::rotg((fp_ref *)&a_ref, (fp_ref *)&b_ref, (fp_scalar *)&c_ref, (fp_ref *)&s_ref);
 
     // Call DPC++ ROTG.
-    fp *a_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
-    fp *b_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
-    fp *s_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
-    fp_scalar *c_p = (fp_scalar *)oneapi::mkl::malloc_shared(64, sizeof(fp_scalar), *dev, cxt);
+    fp *a_p, *b_p, *s_p;
+    fp_scalar *c_p;
+    if constexpr (alloc_type == usm::alloc::shared) {
+        a_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
+        b_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
+        s_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
+        c_p = (fp_scalar *)oneapi::mkl::malloc_shared(64, sizeof(fp_scalar), *dev, cxt);
+    }
+    else if constexpr (alloc_type == usm::alloc::device) {
+        a_p = (fp *)oneapi::mkl::malloc_device(64, sizeof(fp), *dev, cxt);
+        b_p = (fp *)oneapi::mkl::malloc_device(64, sizeof(fp), *dev, cxt);
+        s_p = (fp *)oneapi::mkl::malloc_device(64, sizeof(fp), *dev, cxt);
+        c_p = (fp_scalar *)oneapi::mkl::malloc_device(64, sizeof(fp_scalar), *dev, cxt);
+    }
+    else {
+        throw std::runtime_error("Bad alloc_type");
+    }
 
-    a_p[0] = a;
-    b_p[0] = b;
-    s_p[0] = s;
-    c_p[0] = c;
+    main_queue.memcpy(a_p, &a, sizeof(fp)).wait();
+    main_queue.memcpy(b_p, &b, sizeof(fp)).wait();
+    main_queue.memcpy(s_p, &s, sizeof(fp)).wait();
+    main_queue.memcpy(c_p, &c, sizeof(fp_scalar)).wait();
+    main_queue.wait();
 
     try {
 #ifdef CALL_RT_API
@@ -140,17 +155,17 @@ int test(device *dev, oneapi::mkl::layout layout) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    bool good_a = check_equal(a_p[0], a_ref, 4, std::cout);
-    bool good_b = check_equal(b_p[0], b_ref, 4, std::cout);
-    bool good_s = check_equal(s_p[0], s_ref, 4, std::cout);
-    bool good_c = check_equal(c_p[0], c_ref, 4, std::cout);
+    bool good_a = check_equal_ptr(main_queue, a_p, a_ref, 4, std::cout);
+    bool good_b = check_equal_ptr(main_queue, b_p, b_ref, 4, std::cout);
+    bool good_s = check_equal_ptr(main_queue, s_p, s_ref, 4, std::cout);
+    bool good_c = check_equal_ptr(main_queue, c_p, c_ref, 4, std::cout);
 
     bool good = good_a && good_b && good_c && good_s;
 
-    oneapi::mkl::free_shared(a_p, cxt);
-    oneapi::mkl::free_shared(b_p, cxt);
-    oneapi::mkl::free_shared(s_p, cxt);
-    oneapi::mkl::free_shared(c_p, cxt);
+    oneapi::mkl::free_usm(a_p, cxt);
+    oneapi::mkl::free_usm(b_p, cxt);
+    oneapi::mkl::free_usm(s_p, cxt);
+    oneapi::mkl::free_usm(c_p, cxt);
 
     return (int)good;
 }
@@ -160,17 +175,27 @@ class RotgUsmTests
 
 TEST_P(RotgUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP((test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP((test<float, float, usm::alloc::device>(
+                           std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP((test<double, double, usm::alloc::device>(
+                           std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(
         (test<std::complex<float>, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP(
+        (test<std::complex<float>, float, usm::alloc::device>(
+            std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, ComplexDoublePrecision) {
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP(
+        (test<std::complex<double>, double, usm::alloc::device>(
+            std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 
 INSTANTIATE_TEST_SUITE_P(RotgUsmTestSuite, RotgUsmTests,

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -104,10 +104,10 @@ int test(device *dev, oneapi::mkl::layout layout) {
         throw std::runtime_error("Bad alloc_type");
     }
 
-    main_queue.memcpy(a_p, &a, sizeof(fp)).wait();
-    main_queue.memcpy(b_p, &b, sizeof(fp)).wait();
-    main_queue.memcpy(s_p, &s, sizeof(fp)).wait();
-    main_queue.memcpy(c_p, &c, sizeof(fp_scalar)).wait();
+    main_queue.memcpy(a_p, &a, sizeof(fp));
+    main_queue.memcpy(b_p, &b, sizeof(fp));
+    main_queue.memcpy(s_p, &s, sizeof(fp));
+    main_queue.memcpy(c_p, &c, sizeof(fp_scalar));
     main_queue.wait();
 
     try {

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device *> devices;
 
 namespace {
 
-template <typename fp, usm::alloc alloc_type=usm::alloc::shared>
+template <typename fp, usm::alloc alloc_type = usm::alloc::shared>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -167,13 +167,13 @@ class RotmgUsmTests
 
 TEST_P(RotmgUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam())));
-    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(std::get<0>(GetParam()),
-                                                       std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP(
+        (test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotmgUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
-    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(std::get<0>(GetParam()),
-                                                        std::get<1>(GetParam()))));
+    EXPECT_TRUEORSKIP(
+        (test<double, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 
 INSTANTIATE_TEST_SUITE_P(RotmgUsmTestSuite, RotmgUsmTests,

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -45,7 +45,7 @@ extern std::vector<sycl::device *> devices;
 
 namespace {
 
-template <typename fp>
+template <typename fp, usm::alloc alloc_type=usm::alloc::shared>
 int test(device *dev, oneapi::mkl::layout layout) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
@@ -80,17 +80,30 @@ int test(device *dev, oneapi::mkl::layout layout) {
     d2_ref = d2;
     x1_ref = x1;
 
+    fp *d1_p, *d2_p, *x1_p;
+    if constexpr (alloc_type == usm::alloc::device) {
+        d1_p = (fp *)oneapi::mkl::malloc_device(64, sizeof(fp), *dev, cxt);
+        d2_p = (fp *)oneapi::mkl::malloc_device(64, sizeof(fp), *dev, cxt);
+        x1_p = (fp *)oneapi::mkl::malloc_device(64, sizeof(fp), *dev, cxt);
+    }
+    else if constexpr (alloc_type == usm::alloc::shared) {
+        d1_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
+        d2_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
+        x1_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
+    }
+    else {
+        throw std::runtime_error("Bad alloc_type");
+    }
+    main_queue.memcpy(d1_p, &d1, sizeof(fp));
+    main_queue.memcpy(d2_p, &d2, sizeof(fp));
+    main_queue.memcpy(x1_p, &x1, sizeof(fp));
+    main_queue.wait();
+
     // Call Reference ROTMG.
 
     ::rotmg(&d1_ref, &d2_ref, &x1_ref, &y1, (fp *)param_ref.data());
 
     // Call DPC++ ROTMG.
-    fp *d1_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
-    fp *d2_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
-    fp *x1_p = (fp *)oneapi::mkl::malloc_shared(64, sizeof(fp), *dev, cxt);
-    d1_p[0] = d1;
-    d2_p[0] = d2;
-    x1_p[0] = x1;
 
     try {
 #ifdef CALL_RT_API
@@ -136,15 +149,15 @@ int test(device *dev, oneapi::mkl::layout layout) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    bool good_d1 = check_equal(d1_p[0], d1_ref, 1, std::cout);
-    bool good_d2 = check_equal(d2_p[0], d2_ref, 1, std::cout);
-    bool good_x1 = check_equal(x1_p[0], x1_ref, 1, std::cout);
+    bool good_d1 = check_equal_ptr(main_queue, d1_p, d1_ref, 1, std::cout);
+    bool good_d2 = check_equal_ptr(main_queue, d2_p, d2_ref, 1, std::cout);
+    bool good_x1 = check_equal_ptr(main_queue, x1_p, x1_ref, 1, std::cout);
     bool good_param = check_equal_vector(param, param_ref, 5, 1, 1, std::cout);
     bool good = good_d1 && good_d2 && good_x1 && good_param;
 
-    oneapi::mkl::free_shared(d1_p, cxt);
-    oneapi::mkl::free_shared(d2_p, cxt);
-    oneapi::mkl::free_shared(x1_p, cxt);
+    oneapi::mkl::free_usm(d1_p, cxt);
+    oneapi::mkl::free_usm(d2_p, cxt);
+    oneapi::mkl::free_usm(x1_p, cxt);
 
     return (int)good;
 }
@@ -154,9 +167,13 @@ class RotmgUsmTests
 
 TEST_P(RotmgUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam())));
+    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(std::get<0>(GetParam()),
+                                                       std::get<1>(GetParam()))));
 }
 TEST_P(RotmgUsmTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
+    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(std::get<0>(GetParam()),
+                                                        std::get<1>(GetParam()))));
 }
 
 INSTANTIATE_TEST_SUITE_P(RotmgUsmTestSuite, RotmgUsmTests,

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -229,7 +229,24 @@ static inline void *malloc_shared(size_t align, size_t size, sycl::device dev, s
 #endif
 }
 
+static inline void *malloc_device(size_t align, size_t size, sycl::device dev, sycl::context ctx) {
+#ifdef _WIN64
+    return sycl::malloc_device(size, dev, ctx);
+#else
+#if defined(ENABLE_CUBLAS_BACKEND) || defined(ENABLE_ROCBLAS_BACKEND)
+    return sycl::aligned_alloc_device(align, size, dev, ctx);
+#endif
+#if !defined(ENABLE_CUBLAS_BACKEND) && !defined(ENABLE_ROCBLAS_BACKEND)
+    return sycl::malloc_device(size, dev, ctx);
+#endif
+#endif
+}
+
 static inline void free_shared(void *p, sycl::context ctx) {
+    sycl::free(p, ctx);
+}
+
+static inline void free_usm(void *p, sycl::context ctx) {
     sycl::free(p, ctx);
 }
 


### PR DESCRIPTION
# Description

For Level-1 BLAS functions that return a scalar (asum, iamax, iamin, dot, nrm2, rotg, rotmg), we previously assumed in the USM interfaces that the pointers were host-accessible. This PR allows such pointers to be device USM pointers.

For iamax, iamin, and rotmg the changes are somewhat ugly because of the need to copy data back and forth to satisfy the appropriate interface, but the result is similar to what is already done in the buffer APIs.

Fixes #280

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? [test.txt](https://github.com/oneapi-src/oneMKL/files/11266186/test.txt)
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
