### PR TITLE
Get rid of warning when we #include "cuda.hpp" from the LLVM SYCL backends for RNG

### DIFF
--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -62,7 +62,11 @@
 #include <CL/sycl.hpp>
 #endif
 #ifndef __HIPSYCL__
-#if !__has_include(<sycl/backend/cuda.hpp>)
+#if __has_include(<sycl/context.hpp>)
+#if __SYCL_COMPILER_VERSION <= 20220930
+#include <sycl/backend/cuda.hpp>
+#endif
+#else
 #include <CL/sycl/backend/cuda.hpp>
 #endif
 #endif

--- a/src/rng/backends/curand/mrg32k3a.cpp
+++ b/src/rng/backends/curand/mrg32k3a.cpp
@@ -62,9 +62,7 @@
 #include <CL/sycl.hpp>
 #endif
 #ifndef __HIPSYCL__
-#if __has_include(<sycl/backend/cuda.hpp>)
-#include <sycl/backend/cuda.hpp>
-#else
+#if !__has_include(<sycl/backend/cuda.hpp>)
 #include <CL/sycl/backend/cuda.hpp>
 #endif
 #endif

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -62,7 +62,11 @@
 #include <CL/sycl.hpp>
 #endif
 #ifndef __HIPSYCL__
-#if !__has_include(<sycl/backend/cuda.hpp>)
+#if __has_include(<sycl/context.hpp>)
+#if __SYCL_COMPILER_VERSION <= 20220930
+#include <sycl/backend/cuda.hpp>
+#endif
+#else
 #include <CL/sycl/backend/cuda.hpp>
 #endif
 #endif

--- a/src/rng/backends/curand/philox4x32x10.cpp
+++ b/src/rng/backends/curand/philox4x32x10.cpp
@@ -62,9 +62,7 @@
 #include <CL/sycl.hpp>
 #endif
 #ifndef __HIPSYCL__
-#if __has_include(<sycl/backend/cuda.hpp>)
-#include <sycl/backend/cuda.hpp>
-#else
+#if !__has_include(<sycl/backend/cuda.hpp>)
 #include <CL/sycl/backend/cuda.hpp>
 #endif
 #endif


### PR DESCRIPTION
# Description

Recent compilers issue warnings when we `#include "cuda.hpp"` from the LLVM SYCL backends. This PR removes those warnings.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
