### PR TITLE
[DFT] Rearrange DFT compute tests so unimplemented always skips

### DIFF
--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -222,7 +222,7 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
     std::vector<sycl::event> no_dependencies;
     oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType>(descriptor, inout.data(),
                                                                   no_dependencies)
-        .wait();
+        .wait_and_throw();
 
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         std::vector<FwdInputType> conjugate_even_ref =
@@ -247,7 +247,7 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
     sycl::event done =
         oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
                                            FwdInputType>(descriptor, inout.data(), no_dependencies);
-    done.wait();
+    done.wait_and_throw();
 
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         for (std::size_t j = 0; j < real_first_dims; j++) {

--- a/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
@@ -56,7 +56,7 @@ int DFT_Test<precision, domain>::test_in_place_real_real_USM() {
         std::vector<sycl::event> no_dependencies;
         oneapi::mkl::dft::compute_forward<descriptor_t, PrecisionType>(
             descriptor, inout_re.data(), inout_im.data(), no_dependencies)
-            .wait();
+            .wait_and_throw();
 
         std::vector<FwdOutputType> output_data(size_total);
         for (std::size_t i = 0; i < output_data.size(); ++i) {
@@ -68,7 +68,7 @@ int DFT_Test<precision, domain>::test_in_place_real_real_USM() {
         oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
                                            PrecisionType>(descriptor, inout_re.data(),
                                                           inout_im.data(), no_dependencies)
-            .wait();
+            .wait_and_throw();
 
         for (std::size_t i = 0; i < output_data.size(); ++i) {
             output_data[i] = { inout_re[i], inout_im[i] };

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -64,14 +64,8 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
         sycl::buffer<FwdOutputType, 1> bwd_buf{ sycl::range<1>(
             cast_unsigned(backward_distance * batches)) };
 
-        try {
-            oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType, FwdOutputType>(
-                descriptor, fwd_buf, bwd_buf);
-        }
-        catch (oneapi::mkl::unimplemented &e) {
-            std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;
-            return test_skipped;
-        }
+        oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType, FwdOutputType>(
+            descriptor, fwd_buf, bwd_buf);
 
         {
             auto acc_bwd = bwd_buf.template get_host_access();
@@ -99,15 +93,9 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
             commit_descriptor(descriptor, sycl_queue);
         }
 
-        try {
-            oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
-                                               FwdOutputType, FwdInputType>(descriptor, bwd_buf,
-                                                                            fwd_buf);
-        }
-        catch (oneapi::mkl::unimplemented &e) {
-            std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;
-            return test_skipped;
-        }
+        oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
+                                           FwdOutputType, FwdInputType>(descriptor, bwd_buf,
+                                                                        fwd_buf);
     }
 
     EXPECT_TRUE(check_equal_vector(fwd_data.data(), input.data(), input.size(), abs_error_margin,
@@ -147,15 +135,9 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
     std::vector<FwdOutputType, decltype(ua_output)> bwd(cast_unsigned(backward_distance * batches),
                                                         ua_output);
 
-    try {
-        oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType, FwdOutputType>(
-            descriptor, fwd.data(), bwd.data(), no_dependencies)
-            .wait();
-    }
-    catch (oneapi::mkl::unimplemented &e) {
-        std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;
-        return test_skipped;
-    }
+    oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType, FwdOutputType>(
+        descriptor, fwd.data(), bwd.data(), no_dependencies)
+        .wait();
 
     {
         auto bwd_iter = bwd.begin();
@@ -181,16 +163,10 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
         commit_descriptor(descriptor, sycl_queue);
     }
 
-    try {
-        oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
-                                           FwdOutputType, FwdInputType>(descriptor, bwd.data(),
-                                                                        fwd.data(), no_dependencies)
-            .wait();
-    }
-    catch (oneapi::mkl::unimplemented &e) {
-        std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;
-        return test_skipped;
-    }
+    oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>, FwdOutputType,
+                                       FwdInputType>(descriptor, bwd.data(), fwd.data(),
+                                                     no_dependencies)
+        .wait();
 
     EXPECT_TRUE(check_equal_vector(fwd.data(), input.data(), input.size(), abs_error_margin,
                                    rel_error_margin, std::cout));

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -137,7 +137,7 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
 
     oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType, FwdOutputType>(
         descriptor, fwd.data(), bwd.data(), no_dependencies)
-        .wait();
+        .wait_and_throw();
 
     {
         auto bwd_iter = bwd.begin();
@@ -166,7 +166,7 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
     oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>, FwdOutputType,
                                        FwdInputType>(descriptor, bwd.data(), fwd.data(),
                                                      no_dependencies)
-        .wait();
+        .wait_and_throw();
 
     EXPECT_TRUE(check_equal_vector(fwd.data(), input.data(), input.size(), abs_error_margin,
                                    rel_error_margin, std::cout));

--- a/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
@@ -65,7 +65,7 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_USM() {
 
         oneapi::mkl::dft::compute_forward<descriptor_t, PrecisionType, PrecisionType>(
             descriptor, in_re.data(), in_im.data(), out_re.data(), out_im.data(), no_dependencies)
-            .wait();
+            .wait_and_throw();
         std::vector<FwdOutputType> output_data(size_total);
         for (std::size_t i = 0; i < output_data.size(); ++i) {
             output_data[i] = { out_re[i], out_im[i] };
@@ -77,7 +77,7 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_USM() {
                                            PrecisionType, PrecisionType>(
             descriptor, out_re.data(), out_im.data(), out_back_re.data(), out_back_im.data(),
             no_dependencies)
-            .wait();
+            .wait_and_throw();
 
         for (std::size_t i = 0; i < output_data.size(); ++i) {
             output_data[i] = { out_back_re[i], out_back_im[i] };

--- a/tests/unit_tests/dft/source/compute_tests.cpp
+++ b/tests/unit_tests/dft/source/compute_tests.cpp
@@ -50,12 +50,18 @@ class ComputeTests_real_real_out_of_place
 
 #define INSTANTIATE_TEST(PRECISION, DOMAIN, PLACE, LAYOUT, STORAGE)                              \
     TEST_P(ComputeTests##_##LAYOUT##PLACE, DOMAIN##_##PRECISION##_##PLACE##_##LAYOUT##STORAGE) { \
-        auto test =                                                                              \
-            DFT_Test<oneapi::mkl::dft::precision::PRECISION, oneapi::mkl::dft::domain::DOMAIN>{  \
-                std::get<0>(GetParam()), std::get<1>(GetParam()).sizes,                          \
-                std::get<1>(GetParam()).batches                                                  \
-            };                                                                                   \
-        EXPECT_TRUEORSKIP(test.test_##PLACE##_##LAYOUT##STORAGE());                              \
+        try {                                                                                    \
+            auto test =                                                                          \
+                DFT_Test<oneapi::mkl::dft::precision::PRECISION,                                 \
+                         oneapi::mkl::dft::domain::DOMAIN>{ std::get<0>(GetParam()),             \
+                                                            std::get<1>(GetParam()).sizes,       \
+                                                            std::get<1>(GetParam()).batches };   \
+            EXPECT_TRUE(test.test_##PLACE##_##LAYOUT##STORAGE());                                \
+        }                                                                                        \
+        catch (oneapi::mkl::unimplemented & e) {                                                 \
+            std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;           \
+            GTEST_SKIP();                                                                        \
+        }                                                                                        \
     }
 
 #define INSTANTIATE_TEST_DIMENSIONS_PRECISION_DOMAIN(PLACE, LAYOUT, STORAGE) \

--- a/tests/unit_tests/dft/source/compute_tests.cpp
+++ b/tests/unit_tests/dft/source/compute_tests.cpp
@@ -56,7 +56,7 @@ class ComputeTests_real_real_out_of_place
                          oneapi::mkl::dft::domain::DOMAIN>{ std::get<0>(GetParam()),             \
                                                             std::get<1>(GetParam()).sizes,       \
                                                             std::get<1>(GetParam()).batches };   \
-            EXPECT_TRUE(test.test_##PLACE##_##LAYOUT##STORAGE());                                \
+            EXPECT_TRUEORSKIP(test.test_##PLACE##_##LAYOUT##STORAGE());                          \
         }                                                                                        \
         catch (oneapi::mkl::unimplemented & e) {                                                 \
             std::cout << "Skipping test because: \"" << e.what() << "\"" << std::endl;           \


### PR DESCRIPTION
# Description

Since #288, MKLGPU now fails the REAL_REAL tests because the descriptor commit throws (due to not supporting REAL_REAL for COMPLEX_STORAGE). I've rearranged the tests so they always skip when something is not implemented.

To reproduce run the tests with the MKLGPU backend. The complex-to-complex `*real_real*` test will fail.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
