### PR TITLE
[BLAS::SYCL-BLAS backend] Enable BLAS Level 2 Spr2 routine

### DIFF
--- a/src/blas/backends/syclblas/CMakeLists.txt
+++ b/src/blas/backends/syclblas/CMakeLists.txt
@@ -140,7 +140,7 @@ if (NOT sycl_blas_FOUND)
   FetchContent_Declare(
     sycl-blas
     GIT_REPOSITORY https://github.com/codeplaysoftware/sycl-blas
-    GIT_TAG        20bfe691be07c9a2a316715094a2441f30e497d7
+    GIT_TAG        master
   )
   FetchContent_MakeAvailable(sycl-blas)
   message(STATUS "Looking for sycl_blas - downloaded")

--- a/src/blas/backends/syclblas/syclblas_level2.cxx
+++ b/src/blas/backends/syclblas/syclblas_level2.cxx
@@ -153,7 +153,7 @@ void spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, real
 void spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, real_t alpha,
           sycl::buffer<real_t, 1> &x, std::int64_t incx, sycl::buffer<real_t, 1> &y,
           std::int64_t incy, sycl::buffer<real_t, 1> &a) {
-    throw unimplemented("blas", "spr2", "");
+    CALL_SYCLBLAS_FN(::blas::_spr2, queue, upper_lower, n, alpha, x, incx, y, incy, a);
 }
 
 void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,


### PR DESCRIPTION
# Description

This PR enables the `spr2` Level 2 operator in SYCL-BLAS backend for oneMKL.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
- [spr2_test_ct.txt](https://github.com/oneapi-src/oneMKL/files/11465719/spr2_test_ct.txt)
- The failures for double-precision functions on an iGPU that does not support double precision. In these cases, the backend `throws mkl::unsupported_device`, which results in a test failure.

- [x] Have you formatted the code using clang-format?