### PR TITLE
[BLAS:: SYCL-BLAS backend] Enable BLAS Level 3 Symm routine

### DIFF
--- a/src/blas/backends/syclblas/CMakeLists.txt
+++ b/src/blas/backends/syclblas/CMakeLists.txt
@@ -140,7 +140,7 @@ if (NOT sycl_blas_FOUND)
   FetchContent_Declare(
     sycl-blas
     GIT_REPOSITORY https://github.com/codeplaysoftware/sycl-blas
-    GIT_TAG        20bfe691be07c9a2a316715094a2441f30e497d7
+    GIT_TAG        master
   )
   FetchContent_MakeAvailable(sycl-blas)
   message(STATUS "Looking for sycl_blas - downloaded")

--- a/src/blas/backends/syclblas/syclblas_level3.cxx
+++ b/src/blas/backends/syclblas/syclblas_level3.cxx
@@ -39,7 +39,8 @@ void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo up
           std::int64_t m, std::int64_t n, real_t alpha, sycl::buffer<real_t, 1> &a,
           std::int64_t lda, sycl::buffer<real_t, 1> &b, std::int64_t ldb, real_t beta,
           sycl::buffer<real_t, 1> &c, std::int64_t ldc) {
-    throw unimplemented("blas", "symm", "");
+    CALL_SYCLBLAS_FN(::blas::_symm, queue, left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                     beta, c, ldc);
 }
 
 void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,


### PR DESCRIPTION
# Description

This PR enables the `symm` Level 3 operator in SYCL-BLAS backend for oneMKL.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
- [symm_test_ct.txt](https://github.com/oneapi-src/oneMKL/files/11465745/symm_test_ct.txt)
- The failures for double-precision functions on an iGPU that does not support double precision. In these cases, the backend `throws mkl::unsupported_device`, which results in a test failure.

- [x] Have you formatted the code using clang-format?