### PR TITLE
[mklcpu][mklgpu] enable SYCL API target for all Intel oneMKL domains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,8 @@ if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
   else()
     set(MKL_LINK static)
   endif()
+  # Enable SYCL API
+  set(DPCPP_COMPILER ON)
   # In case Intel oneMKL package doesn't include MKLConfig,
   # use MKLConfig from the repo
   find_package(MKL REQUIRED


### PR DESCRIPTION
# Description

This PR fixes build issue `Target "onemkl_<domain>_mklcpu" links to target "MKL::MKL_DPCPP" but the target was not found.`.

MKLConfig.cmake cannot identify that SYCL API is required in case Intel LLVM compiler is used to build the project. This PR enabled SYCL API before including Intel oneMKL cmake file.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally?
* Before
```
 -- CMAKE_BUILD_TYPE: None, set to Release by default
 -- CXX compiler: icpx was not found in PATH, using clang++ instead
 -- C compiler: icx was not found in PATH, using clang instead
 -- The CXX compiler identification is Clang 17.0.0
...
 -- Configuring done
 CMake Error at src/blas/backends/mklcpu/CMakeLists.txt:26 (add_library):
   Target "onemkl_blas_mklcpu" links to target "MKL::MKL_DPCPP" but the target
   was not found.  Perhaps a find_package() call is missing for an IMPORTED
   target, or an ALIAS target is missing?
```
* After the fix
```
 -- CMAKE_BUILD_TYPE: None, set to Release by default
 -- CXX compiler: icpx was not found in PATH, using clang++ instead
 -- C compiler: icx was not found in PATH, using clang instead
 -- The CXX compiler identification is Clang 17.0.0
...
 -- Configuring done
 -- Generating done
```
* Linux tests passed with Intel LLVM compiler
* On Windows I see some files failed to compile with Intel LLVM compiler: "clang-cl: note: diagnostic msg: Error generating preprocessed source(s)." To be investigated.

- [x] Have you formatted the code using clang-format? Yes
