### PR TITLE
[DFT] Add cuFFT linking for cmake < 3.17

### DIFF
--- a/src/dft/backends/cufft/CMakeLists.txt
+++ b/src/dft/backends/cufft/CMakeLists.txt
@@ -20,7 +20,6 @@
 set(LIB_NAME onemkl_dft_cufft)
 set(LIB_OBJ ${LIB_NAME}_obj)
 
-find_package(CUDAToolkit REQUIRED)
 
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
@@ -41,7 +40,14 @@ target_include_directories(${LIB_OBJ}
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT} ${MKL_COPT})
 
-target_link_libraries(${LIB_OBJ} PRIVATE CUDA::cufft CUDA::cuda_driver)
+if (${CMAKE_VERSION} VERSION_LESS "3.17.0")
+  find_package(CUDA REQUIRED)
+  target_include_directories(${LIB_OBJ} PRIVATE ${CUDA_INCLUDE_DIRS})
+  target_link_libraries(${LIB_OBJ} PRIVATE cuda ${CUDA_CUFFT_LIBRARIES})
+else()
+  find_package(CUDAToolkit REQUIRED)
+  target_link_libraries(${LIB_OBJ} PRIVATE CUDA::cufft CUDA::cuda_driver)
+endif()
 
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ${MKL_LINK_SYCL})
 


### PR DESCRIPTION
# Description
The current cmake minimum version is 3.13, but the cuFFT backend is using [FindCUDAToolkit](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html) to link with cuFFT (introduced in cmake 3.17). I've added linking using the deprecated [FindCUDA](https://cmake.org/cmake/help/latest/module/FindCUDA.html).

To reproduce, build with the cuFFT backend with a cmake version < 3.17 (see #321). 

Fixes #321

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
