### PR TITLE
[cmake] replace missed FindMKL with MKLConfig

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -17,7 +17,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-install(FILES FindMKL.cmake
-              FindCompiler.cmake
+install(FILES FindCompiler.cmake
         DESTINATION "lib/cmake/${PROJECT_NAME}"
 )
+
+if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
+  install(FILES mkl/MKLConfig.cmake
+        DESTINATION "lib/cmake/${PROJECT_NAME}"
+  )
+endif()


### PR DESCRIPTION
# Description

PR replaces the missed FindMKL.cmake with MKLConfig.cmake after FindMKL.cmake removal in the installation step.
Also it slightly changes the logic by adding MKLConfig.cmake only in case Intel oneMKL backend (CPU or GPU) was enabled, because it's not needed for other backends.

Fixes install problem from #321 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally?
  * MKLConfig.cmake is installed in case of `ENABLE_MKLCPU_BACKEND=True`
```
$ cmake --install . --prefix /export/users/mkraynyu/oneMKL_install
...
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/cmake/oneMKL/oneMKLTargets.cmake
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/cmake/oneMKL/oneMKLTargets-release.cmake
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/cmake/oneMKL/oneMKLConfig.cmake
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/cmake/oneMKL/oneMKLConfigVersion.cmake
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/cmake/oneMKL/FindCompiler.cmake
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/cmake/oneMKL/MKLConfig.cmake
-- Installing: /export/users/mkraynyu/oneMKL_install/include/oneapi/mkl/detail/config.hpp
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/libonemkl.so.0
-- Installing: /export/users/mkraynyu/oneMKL_install/lib/libonemkl.so
...
```
  * MKLConfig.cmake is skipped in case Intel oneMKL backends are not enabled
```
$ cmake --install . --prefix /export/users/mkraynyu/oneMKL_install
...
-- Installing: /export/users/mkraynyu/lib/cmake/oneMKL/oneMKLTargets.cmake
-- Installing: /export/users/mkraynyu/lib/cmake/oneMKL/oneMKLTargets-release.cmake
-- Installing: /export/users/mkraynyu/lib/cmake/oneMKL/oneMKLConfig.cmake
-- Installing: /export/users/mkraynyu/lib/cmake/oneMKL/oneMKLConfigVersion.cmake
-- Installing: /export/users/mkraynyu/lib/cmake/oneMKL/FindCompiler.cmake
-- Installing: /export/users/mkraynyu/include/oneapi/mkl/detail/config.hpp
-- Installing: /export/users/mkraynyu/lib/libonemkl.so.0
-- Installing: /export/users/mkraynyu/lib/libonemkl.so
...
```
- [x] Have you formatted the code using clang-format?
