### PR TITLE
[cmake] extend search path for sycl library and add error message

### DIFF
--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -27,7 +27,10 @@ check_cxx_compiler_flag("-fsycl" is_dpcpp)
 if(is_dpcpp)
   # Workaround for internal compiler error during linking if -fsycl is used
   get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
-  find_library(SYCL_LIBRARY NAMES sycl PATHS "${SYCL_BINARY_DIR}/../lib")
+  find_library(SYCL_LIBRARY NAMES sycl PATHS "${SYCL_BINARY_DIR}/../lib" "${SYCL_BINARY_DIR}/lib" ENV LIBRARY_PATH ENV PATH)
+  if(NOT SYCL_LIBRARY)
+    message(FATAL_ERROR "SYCL library is not found in ${SYCL_BINARY_DIR}/../lib, PATH, and LIBRARY_PATH")
+  endif()
 
   add_library(ONEMKL::SYCL::SYCL INTERFACE IMPORTED)
   if(UNIX)


### PR DESCRIPTION
# Description

Extend search path for SYCL runtime library in case of Intel LLVM opensource or Intel DPC++ compiler.

Fixes #322 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Builds/tests are successful except for problems with Windows build and Intel LLVM compiler, but it's not related, I see the same problem in develop branch.
- [x] Have you formatted the code using clang-format?

