### PR TITLE
[DFT] add backend_selector to compile-time dispatch compute_xxxward

### DIFF
--- a/examples/dft/compile_time_dispatching/CMakeLists.txt
+++ b/examples/dft/compile_time_dispatching/CMakeLists.txt
@@ -45,3 +45,4 @@ foreach(dfti_backend ${DFTI_CT_BACKENDS})
   # Register example as ctest
   add_test(NAME dft/EXAMPLE/CT/complex_fwd_buffer_${dfti_backend} COMMAND ${EXAMPLE_NAME})
 endforeach(dfti_backend)
+

--- a/examples/dft/compile_time_dispatching/CMakeLists.txt
+++ b/examples/dft/compile_time_dispatching/CMakeLists.txt
@@ -18,46 +18,30 @@
 #===============================================================================
 
 #Build object from all sources
-set(DFTI_CT_SOURCES "")
+set(DFTI_CT_BACKENDS "")
 
 if(ENABLE_MKLGPU_BACKEND)
-  list(APPEND DFTI_CT_SOURCES "complex_fwd_buffer_mklgpu")
+  list(APPEND DFTI_CT_BACKENDS "mklgpu")
 endif()
 
 if(ENABLE_MKLCPU_BACKEND)
-  list(APPEND DFTI_CT_SOURCES "complex_fwd_buffer_mklcpu")
+  list(APPEND DFTI_CT_BACKENDS "mklcpu")
 endif()
 
 include(WarningsUtils)
 
-foreach(dfti_ct_sources ${DFTI_CT_SOURCES})
-  # add executable and define include directories
-  # add dependencies and link libraries
-  # register example as ctest
- add_executable(example_${domain}_${dfti_ct_sources} ${dfti_ct_sources}.cpp)
-  target_include_directories(example_${domain}_${dfti_ct_sources}
+foreach(dfti_backend ${DFTI_CT_BACKENDS})
+  set(EXAMPLE_NAME example_dft_complex_fwd_buffer_${dfti_backend})
+  add_executable(${EXAMPLE_NAME} complex_fwd_buffer_${dfti_backend}.cpp)
+  target_include_directories(${EXAMPLE_NAME}
       PUBLIC ${PROJECT_SOURCE_DIR}/examples/include
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
   )
 
-  set(ONEMKL_LIBRARIES_${domain} "")
-  if(domain STREQUAL "dft")
-    if(dfti_ct_sources MATCHES "_mklcpu$")
-      add_dependencies(example_${domain}_${dfti_ct_sources} onemkl_${domain}_mklcpu)
-      list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklcpu)
-    endif()
-    if(dfti_ct_sources MATCHES "_mklgpu$")
-      add_dependencies(example_${domain}_${dfti_ct_sources} onemkl_${domain}_mklgpu)
-      list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklgpu)
-    endif() 
-  endif()
+  add_dependencies(${EXAMPLE_NAME} onemkl_dft_${dfti_backend})
+  target_link_libraries(${EXAMPLE_NAME} PRIVATE ONEMKL::SYCL::SYCL onemkl_dft_${dfti_backend})
 
-  target_link_libraries(example_${domain}_${dfti_ct_sources}
-      PUBLIC ${ONEMKL_LIBRARIES_${domain}}
-      ${ONEMKL_LIBRARIES_${domain}}
-      ONEMKL::SYCL::SYCL
-  )
   # Register example as ctest
- add_test(NAME ${domain}/EXAMPLE/CT/${dfti_ct_sources} COMMAND example_${domain}_${dfti_ct_sources})
-endforeach(dfti_ct_sources)
+  add_test(NAME dft/EXAMPLE/CT/complex_fwd_buffer_${dfti_backend} COMMAND ${EXAMPLE_NAME})
+endforeach(dfti_backend)

--- a/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklcpu.cpp
+++ b/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklcpu.cpp
@@ -64,14 +64,16 @@ void run_example(const sycl::device& cpu_device) {
                    static_cast<std::int64_t>(1));
 
     // 3. commit_descriptor (compile_time MKLCPU)
-    desc.commit(oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue });
+    auto selector = oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue };
+    desc.commit(selector);
 
     // 4. compute_forward / compute_backward (MKLCPU)
     {
         sycl::buffer<std::complex<double>> input_buffer(input_data.data(), sycl::range<1>(N));
         sycl::buffer<std::complex<double>> output_buffer(output_data.data(), sycl::range<1>(N));
         oneapi::mkl::dft::compute_forward<decltype(desc), std::complex<double>,
-                                          std::complex<double>>(desc, input_buffer, output_buffer);
+                                          std::complex<double>>(selector, desc, input_buffer,
+                                                                output_buffer);
     }
 }
 

--- a/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
+++ b/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
@@ -64,14 +64,15 @@ void run_example(const sycl::device& gpu_device) {
                    static_cast<std::int64_t>(1));
 
     // 3. commit_descriptor (compile_time MKLGPU)
-    desc.commit(oneapi::mkl::backend_selector<oneapi::mkl::backend::mklgpu>{ gpu_queue });
+    auto selector = oneapi::mkl::backend_selector<oneapi::mkl::backend::mklgpu>{ gpu_queue };
+    desc.commit(selector);
 
     // 4. compute_forward / compute_backward (MKLGPU)
     {
         sycl::buffer<std::complex<float>> input_buffer(input_data.data(), sycl::range<1>(N));
         sycl::buffer<std::complex<float>> output_buffer(output_data.data(), sycl::range<1>(N));
         oneapi::mkl::dft::compute_forward<decltype(desc), std::complex<float>, std::complex<float>>(
-            desc, input_buffer, output_buffer);
+            selector, desc, input_buffer, output_buffer);
     }
 }
 

--- a/include/oneapi/mkl/dft/backward.hpp
+++ b/include/oneapi/mkl/dft/backward.hpp
@@ -26,6 +26,66 @@
 #include <CL/sycl.hpp>
 #endif
 
+#include "oneapi/mkl/detail/backends.hpp"
+
+namespace oneapi::mkl {
+template <backend Backend>
+class backend_selector;
+}
+template <oneapi::mkl::backend Backend>
+using backend_selector = oneapi::mkl::backend_selector<Backend>;
+
+#define DECLARE_COMPTIME(BACKEND)                                                                       \
+    /*Buffer version*/ /*In-place transform*/                                                           \
+    template <typename descriptor_type, typename data_type>                                             \
+    void compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,                    \
+                          sycl::buffer<data_type, 1> &inout);                                           \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <typename descriptor_type, typename data_type>                                             \
+    void compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,                    \
+                          sycl::buffer<data_type, 1> &inout_re,                                         \
+                          sycl::buffer<data_type, 1> &inout_im);                                        \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    void compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,                    \
+                          sycl::buffer<input_type, 1> &in, sycl::buffer<output_type, 1> &out);          \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    void compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,                    \
+                          sycl::buffer<input_type, 1> &in_re, sycl::buffer<input_type, 1> &in_im,       \
+                          sycl::buffer<output_type, 1> &out_re,                                         \
+                          sycl::buffer<output_type, 1> &out_im);                                        \
+                                                                                                        \
+    /*USM version*/                                                                                     \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <typename descriptor_type, typename data_type>                                             \
+    sycl::event compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,             \
+                                 data_type *inout,                                                      \
+                                 const std::vector<sycl::event> &dependencies = {});                    \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <typename descriptor_type, typename data_type>                                             \
+    sycl::event compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,             \
+                                 data_type *inout_re, data_type *inout_im,                              \
+                                 const std::vector<sycl::event> &dependencies = {});                    \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    sycl::event compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,             \
+                                 input_type *in, output_type *out,                                      \
+                                 const std::vector<sycl::event> &dependencies = {});                    \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    sycl::event compute_backward(backend_selector<BACKEND> selector, descriptor_type &desc,             \
+                                 input_type *in_re, input_type *in_im, output_type *out_re,             \
+                                 output_type *out_im,                                                   \
+                                 const std::vector<sycl::event> &dependencies = {});
+
 namespace oneapi::mkl::dft {
 //Buffer version
 
@@ -71,6 +131,20 @@ template <typename descriptor_type, typename input_type, typename output_type>
 sycl::event compute_backward(descriptor_type &desc, input_type *in_re, input_type *in_im,
                              output_type *out_re, output_type *out_im,
                              const std::vector<sycl::event> &dependencies = {});
+
+#ifdef ENABLE_MKLGPU_BACKEND
+DECLARE_COMPTIME(backend::mklgpu)
+#endif
+
+#ifdef ENABLE_MKLCPU_BACKEND
+DECLARE_COMPTIME(backend::mklcpu)
+#endif
+
+#ifdef ENABLE_CUFFT_BACKEND
+DECLARE_COMPTIME(backend::cufft)
+#endif
 } // namespace oneapi::mkl::dft
+
+#undef DECLARE_COMPTIME
 
 #endif // _ONEMKL_DFT_BACKWARD_HPP_

--- a/include/oneapi/mkl/dft/forward.hpp
+++ b/include/oneapi/mkl/dft/forward.hpp
@@ -26,6 +26,66 @@
 #include <CL/sycl.hpp>
 #endif
 
+#include "oneapi/mkl/detail/backends.hpp"
+
+namespace oneapi::mkl {
+template <backend Backend>
+class backend_selector;
+}
+template <oneapi::mkl::backend Backend>
+using backend_selector = oneapi::mkl::backend_selector<Backend>;
+
+#define DECLARE_COMPTIME(BACKEND)                                                                       \
+    /*Buffer version*/                                                                                  \
+    /*In-place transform*/                                                                              \
+    template <typename descriptor_type, typename data_type>                                             \
+    void compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,                     \
+                         sycl::buffer<data_type, 1> &inout);                                            \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <typename descriptor_type, typename data_type>                                             \
+    void compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,                     \
+                         sycl::buffer<data_type, 1> &inout_re,                                          \
+                         sycl::buffer<data_type, 1> &inout_im);                                         \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    void compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,                     \
+                         sycl::buffer<input_type, 1> &in, sycl::buffer<output_type, 1> &out);           \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    void compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,                     \
+                         sycl::buffer<input_type, 1> &in_re, sycl::buffer<input_type, 1> &in_im,        \
+                         sycl::buffer<output_type, 1> &out_re,                                          \
+                         sycl::buffer<output_type, 1> &out_im);                                         \
+                                                                                                        \
+    /*USM version*/                                                                                     \
+    /*In-place transform*/                                                                              \
+    template <typename descriptor_type, typename data_type>                                             \
+    sycl::event compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,              \
+                                data_type *inout,                                                       \
+                                const std::vector<sycl::event> &dependencies = {});                     \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <typename descriptor_type, typename data_type>                                             \
+    sycl::event compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,              \
+                                data_type *inout_re, data_type *inout_im,                               \
+                                const std::vector<sycl::event> &dependencies = {});                     \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    sycl::event compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,              \
+                                input_type *in, output_type *out,                                       \
+                                const std::vector<sycl::event> &dependencies = {});                     \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <typename descriptor_type, typename input_type, typename output_type>                      \
+    sycl::event compute_forward(backend_selector<BACKEND> selector, descriptor_type &desc,              \
+                                input_type *in_re, input_type *in_im, output_type *out_re,              \
+                                output_type *out_im,                                                    \
+                                const std::vector<sycl::event> &dependencies = {});
+
 namespace oneapi::mkl::dft {
 
 //Buffer version
@@ -72,6 +132,20 @@ template <typename descriptor_type, typename input_type, typename output_type>
 sycl::event compute_forward(descriptor_type &desc, input_type *in_re, input_type *in_im,
                             output_type *out_re, output_type *out_im,
                             const std::vector<sycl::event> &dependencies = {});
+
+#ifdef ENABLE_MKLGPU_BACKEND
+DECLARE_COMPTIME(backend::mklgpu)
+#endif
+
+#ifdef ENABLE_MKLCPU_BACKEND
+DECLARE_COMPTIME(backend::mklcpu)
+#endif
+
+#ifdef ENABLE_CUFFT_BACKEND
+DECLARE_COMPTIME(backend::cufft)
+#endif
+
 } // namespace oneapi::mkl::dft
 
+#undef DECLARE_COMPTIME
 #endif // _ONEMKL_DFT_FORWARD_HPP_

--- a/src/dft/backends/cufft/CMakeLists.txt
+++ b/src/dft/backends/cufft/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ${MKL_LINK_SYCL})
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
-target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ})
+target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ} onemkl_dft)
 
 #Set oneMKL libraries as not transitive for dynamic
 if(BUILD_SHARED_LIBS)

--- a/src/dft/backends/mklcpu/CMakeLists.txt
+++ b/src/dft/backends/mklcpu/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
-target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ})
+target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ} onemkl_dft)
 
 #Set oneMKL libraries as not transitive for dynamic
 if(BUILD_SHARED_LIBS)

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -103,7 +103,7 @@ void commit_derived_impl<prec, dom>::commit(
                 }
             });
         })
-        .wait();
+        .wait_and_throw();
 }
 
 template <dft::detail::precision prec, dft::detail::domain dom>

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON
 )
-target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ})
+target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ} onemkl_dft)
 
 #Set oneMKL libraries as not transitive for dynamic
 if(BUILD_SHARED_LIBS)

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -29,9 +29,9 @@ namespace dft {
 namespace detail {
 
 // Compute the default strides. Modifies real_strides and complex_strides arguments.
-void compute_default_strides(const std::vector<std::int64_t>& dimensions,
-                             std::vector<std::int64_t>& input_strides,
-                             std::vector<std::int64_t>& output_strides) {
+inline void compute_default_strides(const std::vector<std::int64_t>& dimensions,
+                                    std::vector<std::int64_t>& input_strides,
+                                    std::vector<std::int64_t>& output_strides) {
     auto rank = dimensions.size();
     std::vector<std::int64_t> strides(rank + 1, 1);
     for (auto i = rank - 1; i > 0; --i) {

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -182,6 +182,9 @@ foreach(domain ${TARGET_DOMAINS})
       PROPERTIES TEST_PREFIX ${DOMAIN_PREFIX}/RT/
       DISCOVERY_TIMEOUT 30
     )
+
+    # ensure rt tests have up-to-date libs
+    add_dependencies(test_main_${domain}_rt ${ONEMKL_LIBRARIES_${domain}})
   endif()
 
   gtest_discover_tests(test_main_${domain}_ct

--- a/tests/unit_tests/dft/include/test_common.hpp
+++ b/tests/unit_tests/dft/include/test_common.hpp
@@ -162,6 +162,17 @@ void commit_descriptor(oneapi::mkl::dft::descriptor<precision, domain> &descript
 #endif
 }
 
+template <typename Func, typename... Args>
+void dispatch(sycl::queue queue, Func func, Args &&... args) {
+#ifdef CALL_RT_API
+    (void)queue;
+    func(std::forward<Args>(args)...);
+#else
+    // can't get return from this, so func must capture return values by reference in a lambda
+    TEST_RUN_CT_SELECT(queue, func, std::forward<Args>(args)...);
+#endif
+}
+
 // is it assumed that the unused elements of the array are ignored
 inline std::array<std::int64_t, 4> get_conjugate_even_complex_strides(
     const std::vector<std::int64_t> &sizes) {

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -431,8 +431,7 @@ inline void recommit_values(sycl::queue& sycl_queue) {
     std::vector<test_params> argument_groups{
         // not changeable
         // FORWARD_DOMAIN, PRECISION, DIMENSION, COMMIT_STATUS
-        { std::make_pair(config_param::NUMBER_OF_TRANSFORMS, std::int64_t{ 5 }),
-          std::make_pair(config_param::COMPLEX_STORAGE, config_value::COMPLEX_COMPLEX),
+        { std::make_pair(config_param::COMPLEX_STORAGE, config_value::COMPLEX_COMPLEX),
           std::make_pair(config_param::REAL_STORAGE, config_value::REAL_REAL),
           std::make_pair(config_param::CONJUGATE_EVEN_STORAGE, config_value::COMPLEX_COMPLEX) },
         { std::make_pair(config_param::PLACEMENT, config_value::NOT_INPLACE),
@@ -538,8 +537,12 @@ inline void swap_out_dead_queue(sycl::queue& sycl_queue) {
     auto inout = sycl::malloc_device<forward_type>(default_1d_lengths + 2, sycl_queue);
     sycl_queue.wait();
 
-    auto transform_event = oneapi::mkl::dft::compute_forward<decltype(descriptor), forward_type>(
-        descriptor, inout, std::vector<sycl::event>{});
+    sycl::event transform_event;
+    auto forward = [&transform_event](auto&&... params) {
+        transform_event =
+            oneapi::mkl::dft::compute_forward<decltype(descriptor), forward_type>(params...);
+    };
+    dispatch(sycl_queue, forward, descriptor, inout, std::vector<sycl::event>{});
     sycl_queue.wait();
 
     // after waiting on the second queue, the event should be completed

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -172,6 +172,7 @@
                 TEST_RUN_NVIDIAGPU_CUBLAS_SELECT(q, func, __VA_ARGS__);    \
                 TEST_RUN_NVIDIAGPU_CUSOLVER_SELECT(q, func, __VA_ARGS__);  \
                 TEST_RUN_NVIDIAGPU_CURAND_SELECT(q, func, __VA_ARGS__);    \
+                TEST_RUN_NVIDIAGPU_CUFFT_SELECT(q, func, __VA_ARGS__);     \
             }                                                              \
             else if (vendor_id == AMD_ID) {                                \
                 TEST_RUN_AMDGPU_ROCBLAS_SELECT(q, func, __VA_ARGS__);      \
@@ -253,12 +254,14 @@ static inline void *malloc_shared(size_t align, size_t size, sycl::device dev, s
 
 static inline void *malloc_device(size_t align, size_t size, sycl::device dev, sycl::context ctx) {
 #ifdef _WIN64
+    (void)align;
     return sycl::malloc_device(size, dev, ctx);
 #else
 #if defined(ENABLE_CUBLAS_BACKEND) || defined(ENABLE_ROCBLAS_BACKEND)
     return sycl::aligned_alloc_device(align, size, dev, ctx);
 #endif
 #if !defined(ENABLE_CUBLAS_BACKEND) && !defined(ENABLE_ROCBLAS_BACKEND)
+    (void)align;
     return sycl::malloc_device(size, dev, ctx);
 #endif
 #endif


### PR DESCRIPTION
# Description
Add a `backend_selector` argument to all the backend specific `compute_xxxward` functions. This is only there to give the function a unique signature, to avoid linking conflicts.

Fixes #309

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [x] Have you provided motivation for adding a new feature?
- [x] Have you added relevant tests?

## Bug fixes

- [x] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
