### PR TITLE
[DFT] Remove invalid descriptor configuration for MKLCPU

### DIFF
--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -431,8 +431,7 @@ inline void recommit_values(sycl::queue& sycl_queue) {
     std::vector<test_params> argument_groups{
         // not changeable
         // FORWARD_DOMAIN, PRECISION, DIMENSION, COMMIT_STATUS
-        { std::make_pair(config_param::NUMBER_OF_TRANSFORMS, std::int64_t{ 5 }),
-          std::make_pair(config_param::COMPLEX_STORAGE, config_value::COMPLEX_COMPLEX),
+        { std::make_pair(config_param::COMPLEX_STORAGE, config_value::COMPLEX_COMPLEX),
           std::make_pair(config_param::REAL_STORAGE, config_value::REAL_REAL),
           std::make_pair(config_param::CONJUGATE_EVEN_STORAGE, config_value::COMPLEX_COMPLEX) },
         { std::make_pair(config_param::PLACEMENT, config_value::NOT_INPLACE),

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -266,6 +266,7 @@ static inline void *malloc_shared(size_t align, size_t size, sycl::device dev, s
 }
 
 static inline void *malloc_device(size_t align, size_t size, sycl::device dev, sycl::context ctx) {
+    (void)align;
 #ifdef _WIN64
     return sycl::malloc_device(size, dev, ctx);
 #else


### PR DESCRIPTION
# Description

The modified test would previously throw this error when run with the MKLCPU backend:
```
terminate called after throwing an instance of 'oneapi::mkl::exception'
  what():  oneMKL: dft/backends/mklcpu/commit: DftiCommitDescriptor failed with status : Intel MKL DFTI ERROR: Inconsistent configuration parameters, Intel MKL DFTI ERROR: Inconsistent configuration parameters
Aborted (core dumped)
```

I believe this is because `NUMBER_OF_TRANSFORMS` was set without setting the `FORWARD|BACKWARD_DISTANCE`.
This configuration checking must have been added in a more recent release, which is why it wasn't a problem before now.

I also fixed a warning for an unused variable coming from `malloc_device`. 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. [mklcpu_run.log](https://github.com/oneapi-src/oneMKL/files/11907888/mklcpu_run.log)
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you added relevant regression tests? - N/A
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
