### PR TITLE
[DFT] Fix strides for cuFFT

### DIFF
--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -144,19 +144,19 @@ public:
         const int bwd_dist = static_cast<int>(config_values.bwd_dist);
         std::array<int, max_supported_dims> inembed;
         if (rank == 2) {
-            inembed[1] = config_values.input_strides[1];
+            inembed[1] = config_values.input_strides[1] / istride;
         }
         else if (rank == 3) {
-            inembed[2] = config_values.input_strides[2];
-            inembed[1] = config_values.input_strides[1] / inembed[2];
+            inembed[2] = config_values.input_strides[2] / istride;
+            inembed[1] = (config_values.input_strides[1] / inembed[2]) / istride;
         }
         std::array<int, max_supported_dims> onembed;
         if (rank == 2) {
-            onembed[1] = config_values.output_strides[1];
+            onembed[1] = config_values.output_strides[1] / ostride;
         }
         else if (rank == 3) {
-            onembed[2] = config_values.output_strides[2];
-            onembed[1] = config_values.output_strides[1] / onembed[2];
+            onembed[2] = config_values.output_strides[2] / ostride;
+            onembed[1] = (config_values.output_strides[1] / onembed[2]) / ostride;
         }
 
         // When creating real-complex descriptions, the strides will always be wrong for one of the directions.


### PR DESCRIPTION
# Description

Fix `inembed` and `onembed` for non-default strides with the cuFFT backend. We don't have tests for this configuration at the moment. Adding proper tests is too much work at the moment so I suggest we merge the fix only for now.
We have a task to add this kind of tests in the future but it is unclear when we can start it.

Fixes https://github.com/oneapi-src/oneMKL/issues/341

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
