### PR TITLE
[DFT] Remove unneeded library from DFT CT tests

### DIFF
--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -29,9 +29,9 @@ namespace dft {
 namespace detail {
 
 // Compute the default strides. Modifies real_strides and complex_strides arguments.
-void compute_default_strides(const std::vector<std::int64_t>& dimensions,
-                             std::vector<std::int64_t>& input_strides,
-                             std::vector<std::int64_t>& output_strides) {
+inline void compute_default_strides(const std::vector<std::int64_t>& dimensions,
+                                    std::vector<std::int64_t>& input_strides,
+                                    std::vector<std::int64_t>& output_strides) {
     auto rank = dimensions.size();
     std::vector<std::int64_t> strides(rank + 1, 1);
     for (auto i = rank - 1; i > 0; --i) {

--- a/tests/unit_tests/dft/source/CMakeLists.txt
+++ b/tests/unit_tests/dft/source/CMakeLists.txt
@@ -50,12 +50,8 @@ target_include_directories(dft_source_ct
         )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
     add_sycl_to_target(TARGET dft_source_ct SOURCES ${DFT_SOURCES})
-    target_link_libraries(dft_source_ct PUBLIC onemkl)
 else ()
-    target_link_libraries(dft_source_ct PUBLIC
-            onemkl
-            ONEMKL::SYCL::SYCL
-            )
+    target_link_libraries(dft_source_ct PUBLIC ONEMKL::SYCL::SYCL)
 endif ()
 target_link_libraries(dft_source_ct PRIVATE onemkl_warnings)
 


### PR DESCRIPTION
# Description

Remove an unneeded library from the DFT CT tests. This was causing an issue when build with `BUILD_SHARED_LIBS=0`:
```
[16/18] Linking CXX executable bin/test_main_dft_ct
FAILED: bin/test_main_dft_ct tests/unit_tests/test_main_dft_ct[1]_tests.cmake /home/finlay/perf/oneMKL/build/tests/unit_tests/test_main_dft_ct[1]_tests.cmake 
: && /home/finlay/intel/oneapi/compiler/2023.1.0/linux/bin/icpx -O3 -DNDEBUG -fsycl tests/unit_tests/dft/source/CMakeFiles/dft_source_ct.dir/compute_tests.cpp.o tests/unit_tests/dft/source/CMakeFiles/dft_source_ct.dir/descriptor_tests.cpp.o tests/unit_tests/CMakeFiles/test_main_dft_ct.dir/main_test.cpp.o -o bin/test_main_dft_ct  lib/libgtest.a  lib/libgtest_main.a  -ldl  lib/libonemkl_dft_mklcpu.a  lib/libonemkl_dft_mklgpu.a  lib/libgtest.a  -fsycl  -fsycl-device-code-split=per_kernel  -Wl,-export-dynamic  /home/finlay/intel/oneapi/mkl/2023.1.0/lib/intel64/libmkl_sycl.a  -Wl,--start-group  /home/finlay/intel/oneapi/mkl/2023.1.0/lib/intel64/libmkl_intel_ilp64.a  /home/finlay/intel/oneapi/mkl/2023.1.0/lib/intel64/libmkl_sequential.a  /home/finlay/intel/oneapi/mkl/2023.1.0/lib/intel64/libmkl_core.a  -Wl,--end-group  -lm  -ldl  -lpthread  -lsycl  -lOpenCL  /home/finlay/intel/oneapi/compiler/2023.1.0/linux/lib/libsycl.so  -lonemkl && cd /home/finlay/perf/oneMKL/build/tests/unit_tests && /snap/cmake/1299/bin/cmake -D TEST_TARGET=test_main_dft_ct -D TEST_EXECUTABLE=/home/finlay/perf/oneMKL/build/bin/test_main_dft_ct -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/home/finlay/perf/oneMKL/build/tests/unit_tests -D TEST_EXTRA_ARGS= -D "TEST_PROPERTIES=BUILD_RPATH;/home/finlay/perf/oneMKL/build/lib;ENVIRONMENT;LD_LIBRARY_PATH=/home/finlay/perf/oneMKL/build/lib:/home/finlay/intel/oneapi/tbb/2021.9.0/env/../lib/intel64/gcc4.8:/home/finlay/intel/oneapi/mpi/2021.9.0//libfabric/lib:/home/finlay/intel/oneapi/mpi/2021.9.0//lib/release:/home/finlay/intel/oneapi/mpi/2021.9.0//lib:/home/finlay/intel/oneapi/mkl/2023.1.0/lib/intel64:/home/finlay/intel/oneapi/ipp/2021.8.0/lib/intel64:/home/finlay/intel/oneapi/debugger/2023.1.0/gdb/intel64/lib:/home/finlay/intel/oneapi/debugger/2023.1.0/libipt/intel64/lib:/home/finlay/intel/oneapi/debugger/2023.1.0/dep/lib:/home/finlay/intel/oneapi/compiler/2023.1.0/linux/lib:/home/finlay/intel/oneapi/compiler/2023.1.0/linux/lib/x64:/home/finlay/intel/oneapi/compiler/2023.1.0/linux/lib/oclfpga/host/linux64/lib:/home/finlay/intel/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin:/home/finlay/intel/oneapi/ccl/2021.9.0/lib/cpu_gpu_dpcpp" -D TEST_PREFIX=DFT/CT/ -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=test_main_dft_ct_TESTS -D CTEST_FILE=/home/finlay/perf/oneMKL/build/tests/unit_tests/test_main_dft_ct[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=30 -D TEST_XML_OUTPUT_DIR= -P /snap/cmake/1299/share/cmake-3.26/Modules/GoogleTestAddTests.cmake
/usr/bin/ld: cannot find -lonemkl
```

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you added relevant regression tests? - no relevant tests
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
