### PR TITLE
[DFT] Add descriptor move constructor and assignment

### DIFF
--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -52,6 +52,14 @@ public:
     // Syntax for d-dimensional DFT
     descriptor(std::vector<std::int64_t> dimensions);
 
+    // Copy operations are included in the oneAPI oneMKL specification, but not yet
+    // implemented here. If you need copies, please open an issue at
+    // https://github.com/oneapi-src/oneMKL/issues
+
+    descriptor(descriptor&&);
+
+    descriptor& operator=(descriptor&&);
+
     ~descriptor();
 
     void set_value(config_param param, ...);

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -159,6 +159,12 @@ descriptor<prec, dom>::descriptor(std::int64_t length)
         : descriptor<prec, dom>(std::vector<std::int64_t>{ length }) {}
 
 template <precision prec, domain dom>
+descriptor<prec, dom>::descriptor(descriptor<prec, dom>&& other) = default;
+
+template <precision prec, domain dom>
+descriptor<prec, dom>& descriptor<prec, dom>::operator=(descriptor<prec, dom>&&) = default;
+
+template <precision prec, domain dom>
 descriptor<prec, dom>::~descriptor() = default;
 
 template <precision prec, domain dom>

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -548,6 +548,39 @@ inline void swap_out_dead_queue(sycl::queue& sycl_queue) {
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
+static int test_move() {
+    using config_param = oneapi::mkl::dft::config_param;
+    // Use forward distance to test an element copied by value (ie. not on heap)
+    std::int64_t fwdDistanceRef(123);
+    // Use the DFT dimenensions to test heap allocated values.
+    {
+        // Move constructor
+        oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
+        descriptor.set_value(config_param::FWD_DISTANCE, fwdDistanceRef);
+        oneapi::mkl::dft::descriptor<precision, domain> descMoved{ std::move(descriptor) };
+        std::int64_t fwdDistance(0), dftLength(0);
+        descMoved.get_value(config_param::FWD_DISTANCE, &fwdDistance);
+        EXPECT_EQ(fwdDistance, fwdDistanceRef);
+        descMoved.get_value(config_param::LENGTHS, &dftLength);
+        EXPECT_EQ(default_1d_lengths, dftLength);
+    }
+    {
+        // Move assignment
+        oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };
+        descriptor.set_value(config_param::FWD_DISTANCE, fwdDistanceRef);
+        oneapi::mkl::dft::descriptor<precision, domain> descMoved{ default_1d_lengths };
+        descMoved = std::move(descriptor);
+        std::int64_t fwdDistance(0), dftLength(0);
+        descMoved.get_value(config_param::FWD_DISTANCE, &fwdDistance);
+        EXPECT_EQ(fwdDistance, fwdDistanceRef);
+        descMoved.get_value(config_param::LENGTHS, &dftLength);
+        EXPECT_EQ(default_1d_lengths, dftLength);
+    }
+
+    return !::testing::Test::HasFailure();
+}
+
+template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
 static int test_getter_setter() {
     set_and_get_lengths<precision, domain>();
     set_and_get_strides<precision, domain>();
@@ -575,6 +608,24 @@ int test_commit(sycl::device* dev) {
     swap_out_dead_queue<precision, domain>(sycl_queue);
 
     return !::testing::Test::HasFailure();
+}
+
+TEST(DescriptorTests, DescriptorMoveRealSingle) {
+    EXPECT_TRUE((test_move<oneapi::mkl::dft::precision::SINGLE, oneapi::mkl::dft::domain::REAL>()));
+}
+
+TEST(DescriptorTests, DescriptorMoveRealDouble) {
+    EXPECT_TRUE((test_move<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::REAL>()));
+}
+
+TEST(DescriptorTests, DescriptorMoveComplexSingle) {
+    EXPECT_TRUE(
+        (test_move<oneapi::mkl::dft::precision::SINGLE, oneapi::mkl::dft::domain::COMPLEX>()));
+}
+
+TEST(DescriptorTests, DescriptorMoveComplexDouble) {
+    EXPECT_TRUE(
+        (test_move<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::COMPLEX>()));
 }
 
 TEST(DescriptorTests, DescriptorTestsRealSingle) {

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -552,7 +552,7 @@ static int test_move() {
     using config_param = oneapi::mkl::dft::config_param;
     // Use forward distance to test an element copied by value (ie. not on heap)
     std::int64_t fwdDistanceRef(123);
-    // Use the DFT dimenensions to test heap allocated values.
+    // Use the DFT dimensions to test heap allocated values.
     {
         // Move constructor
         oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_1d_lengths };


### PR DESCRIPTION
# Description

This PR is paired with suggested changes to the oneMKL specification [here](https://github.com/oneapi-src/oneAPI-spec/pull/490) for adding move to the `dft::descriptor` class.

* Adds dft::descriptor move constructor
* Adds dft::descriptor move assignment
* Adds basic tests for both
* Notes that copy is not implemented

# Checklist

## All Submissions
- [x ] Do all unit tests pass locally? Attach a log.
[dftTestLog_20230710_1354.txt](https://github.com/oneapi-src/oneMKL/files/12002072/dftTestLog_20230710_1354.txt)
- [x ] Have you formatted the code using clang-format?

