### PR TITLE
[DFT] read only accessors return const reference with get_pointer()

### DIFF
--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -152,11 +152,12 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
+        auto in_acc = in.template get_access<sycl::access::mode::read>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_back_outofplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], in_acc.get_pointer(),
+            auto inPtr = const_cast<input_type*>(in_acc.get_pointer());
+            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], inPtr,
                                                    out_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
@@ -191,8 +192,9 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_back_outofplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeBackward(
-                desc_acc[detail::DIR::bwd], inre_acc.get_pointer(), inim_acc.get_pointer(),
+            auto inrePtr = const_cast<input_type*>(inre_acc.get_pointer());
+            auto inimPtr = const_cast<input_type*>(inim_acc.get_pointer());
+            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], inrePtr, inimPtr, 
                 outre_acc.get_pointer(), outim_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -186,8 +186,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto inre_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
-        auto inim_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
+        auto inre_acc = in_re.template get_access<sycl::access::mode::read>(cgh);
+        auto inim_acc = in_im.template get_access<sycl::access::mode::read>(cgh);
         auto outre_acc = out_re.template get_access<sycl::access::mode::write>(cgh);
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -156,8 +156,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_back_outofplace>(cgh, [=]() {
-            auto inPtr = const_cast<input_type*>(in_acc.get_pointer());
-            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], inPtr,
+            auto in_ptr = const_cast<input_type*>(in_acc.get_pointer());
+            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], in_ptr,
                                                    out_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
@@ -192,9 +192,9 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_back_outofplace>(cgh, [=]() {
-            auto inrePtr = const_cast<input_type*>(inre_acc.get_pointer());
-            auto inimPtr = const_cast<input_type*>(inim_acc.get_pointer());
-            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], inrePtr, inimPtr, 
+            auto inre_ptr = const_cast<input_type*>(inre_acc.get_pointer());
+            auto inim_ptr = const_cast<input_type*>(inim_acc.get_pointer());
+            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], inre_ptr, inim_ptr,
                 outre_acc.get_pointer(), outim_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -153,7 +153,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
-        auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
+        auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_back_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], in_acc.get_pointer(),
@@ -187,8 +187,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
         auto inre_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto inim_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
-        auto outre_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
-        auto outim_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
+        auto outre_acc = out_re.template get_access<sycl::access::mode::write>(cgh);
+        auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_back_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeBackward(

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -152,8 +152,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto in_acc = in.template get_access<sycl::access::mode::read>(cgh);
-        auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
+        auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
+        auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_back_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], in_acc.get_pointer(),
@@ -185,10 +185,10 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto inre_acc = in_re.template get_access<sycl::access::mode::read>(cgh);
-        auto inim_acc = in_im.template get_access<sycl::access::mode::read>(cgh);
-        auto outre_acc = out_re.template get_access<sycl::access::mode::write>(cgh);
-        auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
+        auto inre_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
+        auto inim_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
+        auto outre_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
+        auto outim_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_split_back_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeBackward(

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -154,7 +154,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
-        auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
+        auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], in_acc.get_pointer(),
@@ -188,8 +188,8 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
         auto inre_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto inim_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
-        auto outre_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
-        auto outim_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
+        auto outre_acc = out_re.template get_access<sycl::access::mode::write>(cgh);
+        auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd],

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -153,8 +153,8 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto in_acc = in.template get_access<sycl::access::mode::read>(cgh);
-        auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
+        auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
+        auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], in_acc.get_pointer(),
@@ -186,10 +186,10 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto inre_acc = in_re.template get_access<sycl::access::mode::read>(cgh);
-        auto inim_acc = in_im.template get_access<sycl::access::mode::read>(cgh);
-        auto outre_acc = out_re.template get_access<sycl::access::mode::write>(cgh);
-        auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
+        auto inre_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
+        auto inim_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
+        auto outre_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
+        auto outim_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_split_outofplace>(cgh, [=]() {
             DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd],

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -157,9 +157,9 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_outofplace>(cgh, [=]() {
-            auto inPtr = const_cast<input_type *>(in_acc.get_pointer());
+            auto in_ptr = const_cast<input_type *>(in_acc.get_pointer());
             DFT_ERROR status =
-                DftiComputeForward(desc_acc[detail::DIR::fwd], inPtr, out_acc.get_pointer());
+                DftiComputeForward(desc_acc[detail::DIR::fwd], in_ptr, out_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",
@@ -193,9 +193,9 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_outofplace>(cgh, [=]() {
-            auto inrePtr = const_cast<input_type *>(inre_acc.get_pointer());
-            auto inimPtr = const_cast<input_type *>(inim_acc.get_pointer());
-            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], inrePtr, inimPtr,
+            auto inre_ptr = const_cast<input_type *>(inre_acc.get_pointer());
+            auto inim_ptr = const_cast<input_type *>(inim_acc.get_pointer());
+            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], inre_ptr, inim_ptr,
                                                   outre_acc.get_pointer(), outim_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -153,12 +153,13 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
+        auto in_acc = in.template get_access<sycl::access::mode::read>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_outofplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], in_acc.get_pointer(),
-                                                  out_acc.get_pointer());
+            auto inPtr = const_cast<input_type *>(in_acc.get_pointer());
+            DFT_ERROR status =
+                DftiComputeForward(desc_acc[detail::DIR::fwd], inPtr, out_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",
@@ -186,14 +187,15 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
 
     cpu_queue.submit([&](sycl::handler &cgh) {
         auto desc_acc = mklcpu_desc_buffer.template get_access<sycl::access::mode::read>(cgh);
-        auto inre_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
-        auto inim_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
+        auto inre_acc = in_re.template get_access<sycl::access::mode::read>(cgh);
+        auto inim_acc = in_im.template get_access<sycl::access::mode::read>(cgh);
         auto outre_acc = out_re.template get_access<sycl::access::mode::write>(cgh);
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_outofplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd],
-                                                  inre_acc.get_pointer(), inim_acc.get_pointer(),
+            auto inrePtr = const_cast<input_type *>(inre_acc.get_pointer());
+            auto inimPtr = const_cast<input_type *>(inim_acc.get_pointer());
+            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], inrePtr, inimPtr,
                                                   outre_acc.get_pointer(), outim_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(


### PR DESCRIPTION
# Description
sycl 2020 spec states:
Member functions of accessor which return a reference to an element have been changed to return a const reference for read-only accessors. The get_pointer() member function has also been changed to return a const pointer for read-only accessors. The value_type and reference member types of accessor have been changed to be const types for read-only accessors.

This change is now apparent from the 20230616_nightly compiler , and in the first CEV testing we see build failures.
```
/export/users/mkltest/cache/mkl/develop/20230705_cev_nightly/__release_lnx/mkl/include/mkl_dfti.h:241:22: note: candidate function not viable: no known conversion from 'std::add_pointer_t<value_type>' (aka 'const float *') to 'void *' for 2nd argument
 241 | DFTI_EXTERN MKL_LONG DftiComputeForward(DFTI_DESCRIPTOR_HANDLE, void*, ...);
```
Fixes # (GitHub issue)

# Checklist
- [x] local build passes with and beyond 20230616_nightly compiler
- [x] local cpu tests pass

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [x] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
