### PR TITLE
[BLAS] Fix const pointer for netlib build with newer compilers

### DIFF
--- a/src/blas/backends/netlib/netlib_level1.cpp
+++ b/src/blas/backends/netlib/netlib_level1.cpp
@@ -185,7 +185,7 @@ void cblas_zdrot(const int n, std::complex<double> *zx, const int incx, std::com
     }
 }
 
-void cblas_crotg(std::complex<float> *ca, std::complex<float> *cb, float *c,
+void cblas_crotg(std::complex<float> *ca, const std::complex<float> *cb, float *c,
                  std::complex<float> *s) {
     if (std::abs(ca[0]) == 0) {
         c[0] = 0.0;
@@ -203,7 +203,7 @@ void cblas_crotg(std::complex<float> *ca, std::complex<float> *cb, float *c,
     }
 }
 
-void cblas_zrotg(std::complex<double> *ca, std::complex<double> *cb, double *c,
+void cblas_zrotg(std::complex<double> *ca, const std::complex<double> *cb, double *c,
                  std::complex<double> *s) {
     if (std::abs(ca[0]) == 0) {
         c[0] = 0.0;

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -549,7 +549,8 @@ void rotg(sycl::queue &queue, sycl::buffer<std::complex<double>, 1> &a,
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_s = s.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zrotg>(cgh, [=]() {
-            ::cblas_zrotg(accessor_a.get_pointer(), accessor_b.get_pointer(),
+            ::cblas_zrotg(accessor_a.get_pointer(),
+                          const_cast<std::complex<double>*>(accessor_b.get_pointer()),
                           accessor_c.get_pointer(), accessor_s.get_pointer());
         });
     });

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -549,8 +549,7 @@ void rotg(sycl::queue &queue, sycl::buffer<std::complex<double>, 1> &a,
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_s = s.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zrotg>(cgh, [=]() {
-            ::cblas_zrotg(accessor_a.get_pointer(),
-                          const_cast<std::complex<double>*>(accessor_b.get_pointer()),
+            ::cblas_zrotg(accessor_a.get_pointer(), accessor_b.get_pointer(),
                           accessor_c.get_pointer(), accessor_s.get_pointer());
         });
     });


### PR DESCRIPTION
# Description

In newer compilers, `buffer.get_pointer()` has different const behavior than in older compilers. This PR fixes the build for the Netlib backend for these newer compilers.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
