### PR TITLE
[SYCL-BLAS] fix SYCL-BLAS backend names in backend table

### DIFF
--- a/include/oneapi/mkl/detail/backends_table.hpp
+++ b/include/oneapi/mkl/detail/backends_table.hpp
@@ -53,7 +53,7 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
 #ifdef ENABLE_NETLIB_BACKEND
               LIB_NAME("blas_netlib"),
 #endif
-#ifdef ENABLE_SYCLBLAS_INTEL_CPU
+#ifdef ENABLE_SYCLBLAS_BACKEND_INTEL_CPU
               LIB_NAME("blas_syclblas"),
 #endif
           } },
@@ -62,7 +62,7 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
 #ifdef ENABLE_MKLGPU_BACKEND
               LIB_NAME("blas_mklgpu"),
 #endif
-#ifdef ENABLE_SYCLBLAS_INTEL_GPU
+#ifdef ENABLE_SYCLBLAS_BACKEND_INTEL_GPU
               LIB_NAME("blas_syclblas"),
 #endif
           } },
@@ -71,7 +71,7 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
 #ifdef ENABLE_ROCBLAS_BACKEND
               LIB_NAME("blas_rocblas"),
 #endif
-#ifdef ENABLE_SYCLBLAS_AMD_GPU
+#ifdef ENABLE_SYCLBLAS_BACKEND_AMD_GPU
               LIB_NAME("blas_syclblas"),
 #endif
           } },
@@ -80,7 +80,7 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
 #ifdef ENABLE_CUBLAS_BACKEND
               LIB_NAME("blas_cublas"),
 #endif
-#ifdef ENABLE_SYCLBLAS_NVIDIA_GPU
+#ifdef ENABLE_SYCLBLAS_BACKEND_NVIDIA_GPU
               LIB_NAME("blas_syclblas"),
 #endif
           } } } },


### PR DESCRIPTION
# Description

Fixes config/build for SYCL-BLAS to use correct `#define` names in backend table

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Log: [out.txt](https://github.com/oneapi-src/oneMKL/files/12029380/out.txt)
- [x] Have you formatted the code using clang-format?
