### PR TITLE
[BLAS] --offload-arch required in both compilation and linking

### DIFF
--- a/src/blas/backends/syclblas/CMakeLists.txt
+++ b/src/blas/backends/syclblas/CMakeLists.txt
@@ -59,7 +59,7 @@ if(SYCLBLAS_TUNING_TARGET)
         -fsycl-targets=amdgcn-amd-amdhsa -fsycl-unnamed-lambda
       -Xsycl-target-backend --offload-arch=${HIP_TARGETS})
       target_link_options(ONEMKL::SYCL::SYCL INTERFACE
-        -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend)
+        -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=${HIP_TARGETS})
     else()
       message(WARNING "Compiler is not supported."
       " Unable to automatically set the required flags for the target '${SYCLBLAS_TUNING_TARGET}'."


### PR DESCRIPTION
# Description

Building SYCL-BLAS backend with AMD gpu support requires a slight tweak to config, since a different command-line argument is needed for both compilation and linking.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Log attached: [amd.txt](https://github.com/oneapi-src/oneMKL/files/12113659/amd.txt)

- [x] Have you formatted the code using clang-format?
