### PR TITLE
[DFT] Fix MKLCPU const_cast for release DPC++

### DIFF
--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -156,7 +156,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_back_outofplace>(cgh, [=]() {
-            auto in_ptr = const_cast<input_type *>(in_acc.get_pointer());
+            auto in_ptr = const_cast<input_type *>(&in_acc.get_pointer()[0]);
             DFT_ERROR status =
                 DftiComputeBackward(desc_acc[detail::DIR::bwd], in_ptr, out_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
@@ -192,8 +192,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_ty
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_back_outofplace>(cgh, [=]() {
-            auto inre_ptr = const_cast<input_type *>(inre_acc.get_pointer());
-            auto inim_ptr = const_cast<input_type *>(inim_acc.get_pointer());
+            auto inre_ptr = const_cast<input_type *>(&inre_acc.get_pointer()[0]);
+            auto inim_ptr = const_cast<input_type *>(&inim_acc.get_pointer()[0]);
             DFT_ERROR status =
                 DftiComputeBackward(desc_acc[detail::DIR::bwd], inre_ptr, inim_ptr,
                                     outre_acc.get_pointer(), outim_acc.get_pointer());

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -157,7 +157,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_outofplace>(cgh, [=]() {
-            auto in_ptr = const_cast<input_type *>(in_acc.get_pointer());
+            auto in_ptr = const_cast<input_type *>(&in_acc.get_pointer()[0]);
             DFT_ERROR status =
                 DftiComputeForward(desc_acc[detail::DIR::fwd], in_ptr, out_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {
@@ -193,8 +193,8 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_typ
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_outofplace>(cgh, [=]() {
-            auto inre_ptr = const_cast<input_type *>(inre_acc.get_pointer());
-            auto inim_ptr = const_cast<input_type *>(inim_acc.get_pointer());
+            auto inre_ptr = const_cast<input_type *>(&inre_acc.get_pointer()[0]);
+            auto inim_ptr = const_cast<input_type *>(&inim_acc.get_pointer()[0]);
             DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], inre_ptr, inim_ptr,
                                                   outre_acc.get_pointer(), outim_acc.get_pointer());
             if (status != DFTI_NO_ERROR) {


### PR DESCRIPTION
# Description

* A previous commit introduces const_cast to fix changes to nightly LLVM
  * This break builds with the DPC++ release compiler
* This PR fixes the const casts.

Fixes https://github.com/oneapi-src/oneMKL/issues/355

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [N/A] Have you added relevant regression tests?
- [See issue] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
