### PR TITLE
[BLAS][CUBLAS] Fixed host accesses for iamax and iamin operators in cublas backend

### DIFF
--- a/src/blas/backends/cublas/CMakeLists.txt
+++ b/src/blas/backends/cublas/CMakeLists.txt
@@ -37,6 +37,10 @@ target_include_directories(${LIB_OBJ}
           ${PROJECT_SOURCE_DIR}/src
 )
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
+target_compile_options(ONEMKL::SYCL::SYCL INTERFACE
+      -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda)
+target_link_options(ONEMKL::SYCL::SYCL INTERFACE
+      -fsycl-targets=nvptx64-nvidia-cuda)
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ONEMKL::cuBLAS::cuBLAS)
 target_compile_features(${LIB_OBJ} PUBLIC cxx_std_11)
 set_target_properties(${LIB_OBJ} PROPERTIES


### PR DESCRIPTION
# Description

This patch fixes the redundant host accesses for adjusting the output index for `iamax` and `iamin` operators in the `cublas` backend. The host accesses are now replaced by a simple SYCL kernel that performs the same index adjustment directly on the device.

Fixes #312 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? [cublas_iamax_iamin_fix.log](https://github.com/oneapi-src/oneMKL/files/12195371/cublas_iamax_iamin_fix.log)
- [x] Have you formatted the code using clang-format?
