### PR TITLE
[BLAS][ROCBLAS] Fixed host accesses for iamax and iamin operators in rocblas backend

### DIFF
--- a/src/blas/backends/rocblas/CMakeLists.txt
+++ b/src/blas/backends/rocblas/CMakeLists.txt
@@ -39,6 +39,12 @@ target_include_directories(${LIB_OBJ}
           ${PROJECT_BINARY_DIR}/bin
 )
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
+target_compile_options(ONEMKL::SYCL::SYCL INTERFACE
+    -fsycl-targets=amdgcn-amd-amdhsa -fsycl-unnamed-lambda
+    -Xsycl-target-backend --offload-arch=${HIP_TARGETS})
+target_link_options(ONEMKL::SYCL::SYCL INTERFACE
+    -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend 
+    --offload-arch=${HIP_TARGETS})
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ONEMKL::rocBLAS::rocBLAS)
 target_compile_features(${LIB_OBJ} PUBLIC cxx_std_17)
 set_target_properties(${LIB_OBJ} PROPERTIES

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -478,10 +478,13 @@ inline void iamax(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &
             rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
-    // This requires to bring the data to host, copy it, and return it back to
-    // the device
-    result.template get_access<sycl::access::mode::write>()[0] = std::max(
-        (int64_t)int_res_buff.template get_access<sycl::access::mode::read>()[0] - 1, int64_t{ 0 });
+
+    queue.submit([&](sycl::handler &cgh) {
+        auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::read>(cgh);
+        auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
+        cgh.single_task(
+            [=]() { result_acc[0] = std::max((int64_t)int_res_acc[0] - 1, (int64_t)0); });
+    });
 }
 
 #define IAMAX_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
@@ -563,8 +566,13 @@ inline void iamin(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &
             rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
-    result.template get_access<sycl::access::mode::write>()[0] = std::max(
-        (int64_t)int_res_buff.template get_access<sycl::access::mode::read>()[0] - 1, int64_t{ 0 });
+
+    queue.submit([&](sycl::handler &cgh) {
+        auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::read>(cgh);
+        auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
+        cgh.single_task(
+            [=]() { result_acc[0] = std::max((int64_t)int_res_acc[0] - 1, (int64_t)0); });
+    });
 }
 
 #define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \


### PR DESCRIPTION
# Description
This patch fixes the redundant host accesses for adjusting the output index for `iamax` and `iamin` operators in the `rocblas` backend. The host accesses are now replaced by a simple SYCL kernel that performs the same index adjustment directly on the device.

Fixes https://github.com/oneapi-src/oneMKL/issues/312

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
[rocblas_iamax_iamin_fix.log](https://github.com/oneapi-src/oneMKL/files/12228910/rocblas_iamax_iamin_fix.log)

- [x] Have you formatted the code using clang-format?