### PR TITLE
[BLAS::portBLAS backend] Enabled omatadd operator

### DIFF
--- a/src/blas/backends/portblas/portblas_level3.cxx
+++ b/src/blas/backends/portblas/portblas_level3.cxx
@@ -173,7 +173,7 @@ void omatadd(sycl::queue &queue, transpose transa, transpose transb, std::int64_
              real_t alpha, sycl::buffer<real_t, 1> &a, std::int64_t lda, real_t beta,
              sycl::buffer<real_t, 1> &b, std::int64_t ldb, sycl::buffer<real_t, 1> &c,
              std::int64_t ldc) {
-    CALL_SYCLBLAS_FN(::blas::_omatadd, queue, transa, transb, m, n, alpha, a, lda, beta, b, ldb, c,
+    CALL_PORTBLAS_FN(::blas::_omatadd, queue, transa, transb, m, n, alpha, a, lda, beta, b, ldb, c,
                      ldc);
 }
 

--- a/src/blas/backends/portblas/portblas_level3.cxx
+++ b/src/blas/backends/portblas/portblas_level3.cxx
@@ -173,7 +173,8 @@ void omatadd(sycl::queue &queue, transpose transa, transpose transb, std::int64_
              real_t alpha, sycl::buffer<real_t, 1> &a, std::int64_t lda, real_t beta,
              sycl::buffer<real_t, 1> &b, std::int64_t ldb, sycl::buffer<real_t, 1> &c,
              std::int64_t ldc) {
-    throw unimplemented("blas", "omatadd", "");
+    CALL_SYCLBLAS_FN(::blas::_omatadd, queue, transa, transb, m, n, alpha, a, lda, beta, b, ldb, c,
+                     ldc);
 }
 
 void omatadd(sycl::queue &queue, transpose transa, transpose transb, std::int64_t m, std::int64_t n,


### PR DESCRIPTION
# Description

This PR enables:
- `Omatadd` - non complex type- Extension Level operator in SYCL-BLAS backend for oneMKL

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[test_omatadd_syclblas.txt](https://github.com/oneapi-src/oneMKL/files/12333076/test_omatadd_syclblas.txt)

- [x] Have you formatted the code using clang-format?


