### PR TITLE
[cmake] Add missing dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ENABLE_PORTBLAS_BACKEND_NVIDIA_GPU OFF CACHE INTERNAL "")
 set(ONEMKL_GENERATED_INCLUDE_PATH ${CMAKE_CURRENT_BINARY_DIR})
 
 # Build loader and backends for each domain
+add_custom_target(onemkl_backend_libs)
 foreach(domain ${TARGET_DOMAINS})
   add_subdirectory(${domain})
 endforeach()
@@ -51,6 +52,12 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/oneapi/mkl/detail/config.hpp"
 # Add recipe for onemkl loader library
 if(BUILD_SHARED_LIBS)
   add_library(onemkl SHARED)
+
+  # The loader library depends on all the backend libraries as it uses
+  # dlopen to load them at runtime.
+  # Use add_dependencies to ensure that all the backend libraries are
+  # (re-)built when compiling the loader or runtime binaries.
+  add_dependencies(onemkl onemkl_backend_libs)
 
   target_include_directories(onemkl
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/blas/backends/CMakeLists.txt
+++ b/src/blas/backends/CMakeLists.txt
@@ -17,6 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
+add_custom_target(onemkl_backend_libs_blas)
+add_dependencies(onemkl_backend_libs onemkl_backend_libs_blas)
+
 if(ENABLE_MKLCPU_BACKEND)
   add_subdirectory(mklcpu)
 endif()

--- a/src/blas/backends/cublas/CMakeLists.txt
+++ b/src/blas/backends/cublas/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES cublas_level1.cpp
                 $<$<BOOL:${BUILD_SHARED_LIBS}>: cublas_wrappers.cpp>)
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_blas ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/blas/backends/mklcpu/CMakeLists.txt
+++ b/src/blas/backends/mklcpu/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mklcpu_wrappers.cpp>)
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_blas ${LIB_NAME})
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})
 endif()

--- a/src/blas/backends/mklgpu/CMakeLists.txt
+++ b/src/blas/backends/mklgpu/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(${LIB_OBJ} OBJECT
   mklgpu_level1.cpp mklgpu_level2.cpp mklgpu_level3.cpp mklgpu_batch.cpp mklgpu_extensions.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mklgpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_blas ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/blas/backends/netlib/CMakeLists.txt
+++ b/src/blas/backends/netlib/CMakeLists.txt
@@ -29,7 +29,8 @@ set(SOURCES netlib_common.hpp
 )
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
-  
+add_dependencies(onemkl_backend_libs_blas ${LIB_NAME})
+
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})
 endif()

--- a/src/blas/backends/portblas/CMakeLists.txt
+++ b/src/blas/backends/portblas/CMakeLists.txt
@@ -175,6 +175,7 @@ set(SOURCES
   $<$<BOOL:${BUILD_SHARED_LIBS}>: portblas_wrappers.cpp>)
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_blas ${LIB_NAME})
 
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})

--- a/src/blas/backends/rocblas/CMakeLists.txt
+++ b/src/blas/backends/rocblas/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES rocblas_level1.cpp
                 $<$<BOOL:${BUILD_SHARED_LIBS}>: rocblas_wrappers.cpp>)
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_blas ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/dft/backends/CMakeLists.txt
+++ b/src/dft/backends/CMakeLists.txt
@@ -17,6 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
+add_custom_target(onemkl_backend_libs_dft)
+add_dependencies(onemkl_backend_libs onemkl_backend_libs_dft)
+
 if(ENABLE_MKLGPU_BACKEND)
   add_subdirectory(mklgpu)
 endif()

--- a/src/dft/backends/cufft/CMakeLists.txt
+++ b/src/dft/backends/cufft/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(${LIB_OBJ} OBJECT
   backward.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_cufft_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/dft/backends/mklcpu/CMakeLists.txt
+++ b/src/dft/backends/mklcpu/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(${LIB_OBJ} OBJECT
   backward.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_cpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(${LIB_OBJ} OBJECT
   backward.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_gpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/dft/backends/portfft/CMakeLists.txt
+++ b/src/dft/backends/portfft/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(${LIB_OBJ} OBJECT
   commit.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_portfft_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 find_package(portfft QUIET)
 if (NOT portfft_FOUND)

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(${LIB_OBJ} OBJECT
   backward.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_rocfft_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/lapack/backends/CMakeLists.txt
+++ b/src/lapack/backends/CMakeLists.txt
@@ -17,6 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
+add_custom_target(onemkl_backend_libs_lapack)
+add_dependencies(onemkl_backend_libs onemkl_backend_libs_lapack)
+
 if(ENABLE_MKLCPU_BACKEND)
   add_subdirectory(mklcpu)
 endif()

--- a/src/lapack/backends/cusolver/CMakeLists.txt
+++ b/src/lapack/backends/cusolver/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES     cusolver_lapack.cpp
                 $<$<BOOL:${BUILD_SHARED_LIBS}>: cusolver_wrappers.cpp>)
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_lapack ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/lapack/backends/mklcpu/CMakeLists.txt
+++ b/src/lapack/backends/mklcpu/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(${LIB_OBJ} OBJECT
   mkl_lapack.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: lapack_cpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_lapack ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/lapack/backends/mklgpu/CMakeLists.txt
+++ b/src/lapack/backends/mklgpu/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(${LIB_OBJ} OBJECT
   mkl_lapack.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: lapack_gpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_lapack ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/lapack/backends/rocsolver/CMakeLists.txt
+++ b/src/lapack/backends/rocsolver/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES rocsolver_lapack.cpp
           $<$<BOOL:${BUILD_SHARED_LIBS}>: rocsolver_wrappers.cpp>)
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_lapack ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/rng/backends/CMakeLists.txt
+++ b/src/rng/backends/CMakeLists.txt
@@ -17,6 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
+add_custom_target(onemkl_backend_libs_rng)
+add_dependencies(onemkl_backend_libs onemkl_backend_libs_rng)
+
 if(ENABLE_MKLCPU_BACKEND)
   add_subdirectory(mklcpu)
 endif()

--- a/src/rng/backends/curand/CMakeLists.txt
+++ b/src/rng/backends/curand/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SOURCES philox4x32x10.cpp
 
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_rng ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/rng/backends/mklcpu/CMakeLists.txt
+++ b/src/rng/backends/mklcpu/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES cpu_common.hpp
 
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_rng ${LIB_NAME})
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src

--- a/src/rng/backends/mklgpu/CMakeLists.txt
+++ b/src/rng/backends/mklgpu/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(${LIB_OBJ} OBJECT
   mrg32k3a.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_rng_gpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_rng ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/rng/backends/rocrand/CMakeLists.txt
+++ b/src/rng/backends/rocrand/CMakeLists.txt
@@ -61,6 +61,7 @@ set(SOURCES philox4x32x10.cpp mrg32k3a.cpp $<$<BOOL:${BUILD_SHARED_LIBS}>:
 
 add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT ${SOURCES})
+add_dependencies(onemkl_backend_libs_rng ${LIB_NAME})
 
 target_include_directories(
   ${LIB_OBJ} PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src

--- a/src/sparse_blas/backends/CMakeLists.txt
+++ b/src/sparse_blas/backends/CMakeLists.txt
@@ -17,6 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
+add_custom_target(onemkl_backend_libs_sparse_blas)
+add_dependencies(onemkl_backend_libs onemkl_backend_libs_sparse_blas)
+
 if(ENABLE_MKLCPU_BACKEND)
   add_subdirectory(mklcpu)
 endif()

--- a/src/sparse_blas/backends/mklcpu/CMakeLists.txt
+++ b/src/sparse_blas/backends/mklcpu/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${LIB_OBJ} OBJECT
   mklcpu_operations.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mklcpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_sparse_blas ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include

--- a/src/sparse_blas/backends/mklgpu/CMakeLists.txt
+++ b/src/sparse_blas/backends/mklgpu/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${LIB_OBJ} OBJECT
   mklgpu_operations.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mklgpu_wrappers.cpp>
 )
+add_dependencies(onemkl_backend_libs_sparse_blas ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include


### PR DESCRIPTION
# Description

The library `onemkl` does not depend on any of the libraries that it loads via `dlopen`. This means that a user can build the runtime tests or examples without (re-)building the libraries that will be loaded. This patchs fixes this issue. For example using the blas domain and MKLCPU backend:
```shell
### With the current develop branch:
$ cmake -Bbuild-blas-cpu -DTARGET_DOMAINS=blas -DENABLE_MKLGPU_BACKEND=OFF -DBUILD_FUNCTIONAL_TESTS=OFF .
$ cd build-blas-cpu && make example_blas_gemm_usm
# Only libonemkl.so and the example are built
$ LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ONEAPI_DEVICE_SELECTOR=*:cpu ./bin/example_blas_gemm_usm
[...]
libonemkl_blas_mklcpu.so: cannot open shared object file: No such file or directory
Caught std::exception during GEMM:
	oneMKL: Couldn\'t load selected backend

### With the fix using the same CMake command:
$ make example_blas_gemm_usm
# libonemkl_blas_mklcpu.so is built
$ LD_LIBRARY_PATH="lib:$LD_LIBRARY_PATH" ONEAPI_DEVICE_SELECTOR=*:cpu ./bin/example_blas_gemm_usm
[...]
BLAS GEMM USM example ran OK.
```
This affects all the domains and backends. Tested with CMake 1.13.5 and CMake 3.27.4.

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?