### PR TITLE
[RNG][rocRAND] Update rocRAND backend

### DIFF
--- a/src/rng/backends/rocrand/mrg32k3a.cpp
+++ b/src/rng/backends/rocrand/mrg32k3a.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (C) 2022 Heidelberg University, Engineering Mathematics and Computing Lab (EMCL) 
  * and Computing Centre (URZ)
- * cuRAND back-end Copyright (c) 2021, The Regents of the University of
+ * rocRAND back-end Copyright (c) 2021, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject to receipt
  * of any required approvals from the U.S. Dept. of Energy). All rights
  * reserved.
@@ -88,7 +88,9 @@ namespace rocrand {
 class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:
     mrg32k3a_impl(sycl::queue queue, std::uint32_t seed)
-            : oneapi::mkl::rng::detail::engine_impl(queue) {
+            : oneapi::mkl::rng::detail::engine_impl(queue),
+              seed_(seed),
+              offset_(0) {
         rocrand_status status;
         ROCRAND_CALL(rocrand_create_generator, status, &engine_, ROCRAND_RNG_PSEUDO_MRG32K3A);
         ROCRAND_CALL(rocrand_set_seed, status, engine_, (unsigned long long)seed);
@@ -97,12 +99,19 @@ public:
     mrg32k3a_impl(sycl::queue queue, std::initializer_list<std::uint32_t> seed)
             : oneapi::mkl::rng::detail::engine_impl(queue) {
         throw oneapi::mkl::unimplemented("rng", "mrg32ka engine",
-                                         "multi-seed unsupported by cuRAND backend");
+                                         "multi-seed unsupported by rocRAND backend");
     }
 
-    mrg32k3a_impl(const mrg32k3a_impl* other) : oneapi::mkl::rng::detail::engine_impl(*other) {
-        throw oneapi::mkl::unimplemented("rng", "mrg32ka engine",
-                                         "copy construction unsupported by cuRAND backend");
+    mrg32k3a_impl(const mrg32k3a_impl* other)
+            : oneapi::mkl::rng::detail::engine_impl(*other),
+              seed_(other->seed_),
+              offset_(other->offset_) {
+        rocrand_status status;
+        ROCRAND_CALL(rocrand_create_generator, status, &engine_, ROCRAND_RNG_PSEUDO_MRG32K3A);
+        ROCRAND_CALL(rocrand_set_seed, status, engine_, (unsigned long long)seed_);
+
+        // Allign this->engine_'s offset state with other->engine_'s offset
+        skip_ahead(offset_);
     }
 
     // Buffers API
@@ -119,6 +128,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -134,6 +146,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -150,6 +165,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         range_transform_int<std::int32_t>(queue_, distr.a(), distr.b(), n, ib, r);
     }
 
@@ -165,6 +183,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -180,6 +201,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -196,6 +220,8 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(const oneapi::mkl::rng::gaussian<
@@ -211,22 +237,42 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        queue_
+            .submit([&](sycl::handler& cgh) {
+                auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
+                onemkl_rocrand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
+                    rocrand_status status;
+                    ROCRAND_CALL(rocrand_generate_normal, status, engine_, r_ptr, n, distr.mean(),
+                                 distr.stddev());
+                });
+            })
+            .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        queue_
+            .submit([&](sycl::handler& cgh) {
+                auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
+                onemkl_rocrand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
+                    rocrand_status status;
+                    ROCRAND_CALL(rocrand_generate_normal_double, status, engine_, r_ptr, n,
+                                 distr.mean(), distr.stddev());
+                });
+            })
+            .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(const oneapi::mkl::rng::lognormal<
@@ -242,6 +288,8 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(const oneapi::mkl::rng::lognormal<
@@ -257,50 +305,88 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, sycl::buffer<float, 1>& r) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        queue_
+            .submit([&](sycl::handler& cgh) {
+                auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
+                onemkl_rocrand_host_task(cgh, acc, engine_, [=](float* r_ptr) {
+                    rocrand_status status;
+                    ROCRAND_CALL(rocrand_generate_log_normal, status, engine_, r_ptr, n, distr.m(),
+                                 distr.s());
+                });
+            })
+            .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, sycl::buffer<double, 1>& r) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        queue_
+            .submit([&](sycl::handler& cgh) {
+                auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
+                onemkl_rocrand_host_task(cgh, acc, engine_, [=](double* r_ptr) {
+                    rocrand_status status;
+                    ROCRAND_CALL(rocrand_generate_log_normal_double, status, engine_, r_ptr, n,
+                                 distr.m(), distr.s());
+                });
+            })
+            .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
                           std::int64_t n, sycl::buffer<std::int32_t, 1>& r) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+            "Bernoulli distribution method unsupported by rocRAND backend");
     }
 
     virtual void generate(const bernoulli<std::uint32_t, bernoulli_method::icdf>& distr,
                           std::int64_t n, sycl::buffer<std::uint32_t, 1>& r) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+            "Bernoulli distribution method unsupported by rocRAND backend");
     }
 
     virtual void generate(const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr,
                           std::int64_t n, sycl::buffer<std::int32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        queue_
+            .submit([&](sycl::handler& cgh) {
+                auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
+                onemkl_rocrand_host_task(cgh, acc, engine_, [=](std::int32_t* r_ptr) {
+                    rocrand_status status;
+                    ROCRAND_CALL(rocrand_generate_poisson, status, engine_, (std::uint32_t*)r_ptr,
+                                 n, distr.lambda());
+                });
+            })
+            .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr,
                           std::int64_t n, sycl::buffer<std::uint32_t, 1>& r) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+        queue_
+            .submit([&](sycl::handler& cgh) {
+                auto acc = r.get_access<sycl::access::mode::read_write>(cgh);
+                onemkl_rocrand_host_task(cgh, acc, engine_, [=](std::uint32_t* r_ptr) {
+                    rocrand_status status;
+                    ROCRAND_CALL(rocrand_generate_poisson, status, engine_, r_ptr, n,
+                                 distr.lambda());
+                });
+            })
+            .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     virtual void generate(const bits<std::uint32_t>& distr, std::int64_t n,
@@ -314,6 +400,8 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
     }
 
     // USM APIs
@@ -330,6 +418,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         return range_transform_fp<float>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -345,6 +436,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         return range_transform_fp<double>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -362,6 +456,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         return range_transform_int(queue_, distr.a(), distr.b(), n, ib, r);
     }
 
@@ -377,6 +474,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         return range_transform_fp_accurate<float>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -392,6 +492,9 @@ public:
                 });
             })
             .wait_and_throw();
+
+        increment_internal_offset(n);
+
         return range_transform_fp_accurate<double>(queue_, distr.a(), distr.b(), n, r);
     }
 
@@ -400,13 +503,17 @@ public:
             distr,
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
-        return queue_.submit([&](sycl::handler& cgh) {
+        auto event = queue_.submit([&](sycl::handler& cgh) {
             onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 rocrand_status status;
                 ROCRAND_CALL(rocrand_generate_normal, status, engine_, r, n, distr.mean(),
                              distr.stddev());
             });
         });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
@@ -414,31 +521,51 @@ public:
             distr,
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
-        return queue_.submit([&](sycl::handler& cgh) {
+        auto event = queue_.submit([&](sycl::handler& cgh) {
             onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 rocrand_status status;
                 ROCRAND_CALL(rocrand_generate_normal_double, status, engine_, r, n, distr.mean(),
                              distr.stddev());
             });
         });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
         const oneapi::mkl::rng::gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
-        return sycl::event{};
+        sycl::event::wait_and_throw(dependencies);
+        auto event = queue_.submit([&](sycl::handler& cgh) {
+            onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
+                rocrand_status status;
+                ROCRAND_CALL(rocrand_generate_normal, status, engine_, r, n, distr.mean(),
+                             distr.stddev());
+            });
+        });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
         const oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>& distr,
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
-        return sycl::event{};
+        sycl::event::wait_and_throw(dependencies);
+        auto event = queue_.submit([&](sycl::handler& cgh) {
+            onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
+                rocrand_status status;
+                ROCRAND_CALL(rocrand_generate_normal_double, status, engine_, r, n, distr.mean(),
+                             distr.stddev());
+            });
+        });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
@@ -446,13 +573,17 @@ public:
             distr,
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
-        return queue_.submit([&](sycl::handler& cgh) {
+        auto event = queue_.submit([&](sycl::handler& cgh) {
             onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 rocrand_status status;
                 ROCRAND_CALL(rocrand_generate_log_normal, status, engine_, r, n, distr.m(),
                              distr.s());
             });
         });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
@@ -460,31 +591,51 @@ public:
             distr,
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
-        return queue_.submit([&](sycl::handler& cgh) {
+        auto event = queue_.submit([&](sycl::handler& cgh) {
             onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 rocrand_status status;
                 ROCRAND_CALL(rocrand_generate_log_normal_double, status, engine_, r, n, distr.m(),
                              distr.s());
             });
         });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
         const oneapi::mkl::rng::lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, float* r, const std::vector<sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
-        return sycl::event{};
+        sycl::event::wait_and_throw(dependencies);
+        auto event = queue_.submit([&](sycl::handler& cgh) {
+            onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
+                rocrand_status status;
+                ROCRAND_CALL(rocrand_generate_log_normal, status, engine_, r, n, distr.m(),
+                             distr.s());
+            });
+        });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
         const oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>& distr,
         std::int64_t n, double* r, const std::vector<sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
-        return sycl::event{};
+        sycl::event::wait_and_throw(dependencies);
+        auto event = queue_.submit([&](sycl::handler& cgh) {
+            onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
+                rocrand_status status;
+                ROCRAND_CALL(rocrand_generate_log_normal_double, status, engine_, r, n, distr.m(),
+                             distr.s());
+            });
+        });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(const bernoulli<std::int32_t, bernoulli_method::icdf>& distr,
@@ -492,7 +643,7 @@ public:
                                  const std::vector<sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+            "Bernoulli distribution method unsupported by rocRAND backend");
         return sycl::event{};
     }
 
@@ -501,37 +652,57 @@ public:
                                  const std::vector<sycl::event>& dependencies) override {
         throw oneapi::mkl::unimplemented(
             "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
+            "Bernoulli distribution method unsupported by rocRAND backend");
         return sycl::event{};
     }
 
     virtual sycl::event generate(
         const poisson<std::int32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
         std::int32_t* r, const std::vector<sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
-        return sycl::event{};
+        sycl::event::wait_and_throw(dependencies);
+        auto event = queue_.submit([&](sycl::handler& cgh) {
+            onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
+                rocrand_status status;
+                ROCRAND_CALL(rocrand_generate_poisson, status, engine_, (std::uint32_t*)r, n,
+                             distr.lambda());
+            });
+        });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(
         const poisson<std::uint32_t, poisson_method::gaussian_icdf_based>& distr, std::int64_t n,
         std::uint32_t* r, const std::vector<sycl::event>& dependencies) override {
-        throw oneapi::mkl::unimplemented(
-            "rng", "mrg32ka engine",
-            "ICDF method not used for pseudorandom generators in cuRAND backend");
-        return sycl::event{};
+        sycl::event::wait_and_throw(dependencies);
+
+        auto event = queue_.submit([&](sycl::handler& cgh) {
+            onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
+                rocrand_status status;
+                ROCRAND_CALL(rocrand_generate_poisson, status, engine_, r, n, distr.lambda());
+            });
+        });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual sycl::event generate(const bits<std::uint32_t>& distr, std::int64_t n, std::uint32_t* r,
                                  const std::vector<sycl::event>& dependencies) override {
         sycl::event::wait_and_throw(dependencies);
-        return queue_.submit([&](sycl::handler& cgh) {
+        auto event = queue_.submit([&](sycl::handler& cgh) {
             onemkl_rocrand_host_task(cgh, engine_, [=](sycl::interop_handle ih) {
                 rocrand_status status;
                 ROCRAND_CALL(rocrand_generate, status, engine_, r, n);
             });
         });
+
+        increment_internal_offset(n);
+
+        return event;
     }
 
     virtual oneapi::mkl::rng::detail::engine_impl* copy_state() override {
@@ -545,11 +716,11 @@ public:
 
     virtual void skip_ahead(std::initializer_list<std::uint64_t> num_to_skip) override {
         throw oneapi::mkl::unimplemented("rng", "skip_ahead",
-                                         "initializer list unsupported by cuRAND backend");
+                                         "initializer list unsupported by rocRAND backend");
     }
 
     virtual void leapfrog(std::uint64_t idx, std::uint64_t stride) override {
-        throw oneapi::mkl::unimplemented("rng", "leapfrog", "unsupported by cuRAND backend");
+        throw oneapi::mkl::unimplemented("rng", "leapfrog", "unsupported by rocRAND backend");
     }
 
     virtual ~mrg32k3a_impl() override {
@@ -559,8 +730,13 @@ public:
 private:
     rocrand_generator engine_;
     std::uint32_t seed_;
+    std::uint64_t offset_;
+
+    void increment_internal_offset(std::uint64_t n) {
+        offset_ += n;
+    }
 };
-#else // cuRAND backend is currently not supported on Windows
+#else // rocRAND backend is currently not supported on Windows
 class mrg32k3a_impl : public oneapi::mkl::rng::detail::engine_impl {
 public:
     mrg32k3a_impl(sycl::queue queue, std::uint32_t seed)

--- a/src/rng/backends/rocrand/rocrand_helper.hpp
+++ b/src/rng/backends/rocrand/rocrand_helper.hpp
@@ -315,10 +315,10 @@ public:
     }
 };
 
-#define HIP_ERROR_FUNC(name, err, ...)                                 \
-    err = name(__VA_ARGS__);                                           \
-    if (err != HIP_SUCCESS) {                                          \
-        throw hip_error(std::string(#name) + std::string(" : "), err); \
+#define HIP_ERROR_FUNC(name, err, ...)                                        \
+    err = name(__VA_ARGS__);                                                  \
+    if (err != HIP_SUCCESS) {                                                 \
+        throw rocm_error(std::string(#name) + std::string(" : "), err);       \
     }
 
 #define ROCRAND_CALL(func, status, ...)                                       \

--- a/src/rng/backends/rocrand/rocrand_task.hpp
+++ b/src/rng/backends/rocrand/rocrand_task.hpp
@@ -43,6 +43,9 @@ static inline void host_task_internal(H &cgh, A acc, E e, F f) {
         auto r_ptr = reinterpret_cast<typename A::value_type *>(
             ih.get_native_mem<sycl::backend::ext_oneapi_hip>(acc));
         f(r_ptr);
+
+        hipError_t err;
+        HIP_ERROR_FUNC(hipStreamSynchronize, err, stream);
     });
 }
 
@@ -53,6 +56,9 @@ static inline void host_task_internal(H &cgh, E e, F f) {
         auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
         ROCRAND_CALL(rocrand_set_stream, status, e, stream);
         f(ih);
+
+        hipError_t err;
+        HIP_ERROR_FUNC(hipStreamSynchronize, err, stream);
     });
 }
 #endif


### PR DESCRIPTION
# Description

This PR updates the rocRAND backend's distribution functions which used to be unimplemented.

The following distribution functions have been implemented for the `philo` and `mrg` generators, for both API (Buffer and USM):

- `gaussian<float, oneapi::mkl::rng::gaussian_method::icdf>`
- `gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>`
- `lognormal<float, oneapi::mkl::rng::lognormal_method::icdf>`
- `lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>`
- `poisson<std::int32_t, poisson_method::gaussian_icdf_based>`
- `poisson<std::uint32_t, poisson_method::gaussian_icdf_based>`

While updating these functions, a race condition has also been fixed, which makes the `gaussian` distribution functions pass again. The reason for the race condition was due to the asynchronous `host_task` which launched asynchronouss rocRAND computation. The stream created for that computation was not synchronized.

Similar issues raised on cuBLAS: https://github.com/oneapi-src/oneMKL/issues/175#issuecomment-1072290446

Furthermore, the copy constructor has also been implemented and a `seed_` and an `offset_` member has been introduced to the `philo_impl` and `mrg_impl` to be able to track and set the same `seed`, and also align the `offset` of the engines if the `* other` already generated values.

Finally, the constructor for `philo` and `mrg`, and the function `skip_ahead` which takes a `std::initializer_list` are still marked as unimplemented due to rocRAND not supporting `std::initializer_list`.
Also, the `bernoulli` distribution function is still marked as unimplemented due to rocRAND not supporting this distribution method.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

[example_rng_uniform_usm.log.txt](https://github.com/oneapi-src/oneMKL/files/12514300/example_rng_uniform_usm.log.txt)
[test_main_rng_ct.log.txt](https://github.com/oneapi-src/oneMKL/files/12514301/test_main_rng_ct.log.txt)
[test_main_rng_rt.log.txt](https://github.com/oneapi-src/oneMKL/files/12514302/test_main_rng_rt.log.txt)
