### PR TITLE
[CMake] Set SYCL_COMPILER for MKL and add MKLROOT in MKL search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
   endif()
   # Enable SYCL API
   set(DPCPP_COMPILER ON)
+  set(SYCL_COMPILER ON)
   # In case Intel oneMKL package doesn't include MKLConfig,
   # use MKLConfig from the repo
   find_package(MKL REQUIRED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
   find_package(MKL REQUIRED
           HINTS ${MKL_ROOT}/lib/cmake
                 ${MKL_ROOT}/lib/cmake/mkl
+                $ENV{MKLROOT}
                 ${PROJECT_SOURCE_DIR}/cmake/mkl)
 endif()
 


### PR DESCRIPTION
# Description

This PR updates the top `CMakeLists.txt`:
1. Set `SYCL_COMPILER` for the future oneMKL releases.
2. Add the environment variable `MKLROOT` in `MKLConfig.cmake` search paths. Note that the precedence is the command line option `-DMKL_ROOT`, the environment variable `MKLROOT`, then the copy in the repo.

# Checklist

## All Submissions

- Do all unit tests pass locally? N/A (Both SYCL and LLVM builds were successful. Build logs: [build_log_sycl_blas_lapack_rng_dft.txt](https://github.com/oneapi-src/oneMKL/files/12601224/build_log_sycl_blas_lapack_rng_dft.txt), [build_log_llvm_blas_lapack_rng.txt](https://github.com/oneapi-src/oneMKL/files/12601231/build_log_llvm_blas_lapack_rng.txt))
- Have you formatted the code using clang-format? N/A

# Tests
The expected output when using oneMKL 2023.0:
```
$ cmake .. -DTARGET_DOMAINS=rng -DMKL_ROOT=/nfs/site/proj/mkl/project/dainihsi/mkl_builds/__release_lnx_2023.0/mkl
...
-- TARGET_DOMAINS: rng
-- MKL_ARCH: intel64
-- MKL_LINK: dynamic
-- MKL_INTERFACE_FULL: intel_ilp64
-- MKL_THREADING: tbb_thread
-- MKL_MPI: None, set to ` intelmpi` by default
...
```

Before the changes, the environment variable `MKLROOT` was ignored, and the `MKLConfig.cmake` in the repo was used:
```
$ MKLROOT=/nfs/site/proj/mkl/project/dainihsi/mkl_builds/__release_lnx_2023.0/mkl cmake .. -DTARGET_DOMAINS=rng
...
-- TARGET_DOMAINS: rng
-- MKL_DPCPP_ARCH: intel64
-- MKL_ARCH: intel64
-- MKL_DPCPP_LINK: dynamic
-- MKL_LINK: dynamic
-- MKL_DPCPP_INTERFACE_FULL: intel_ilp64
-- MKL_INTERFACE_FULL: intel_ilp64
-- MKL_DPCPP_THREADING: tbb_thread
-- MKL_THREADING: tbb_thread
...
```

After the changes, the `MKLConfig.cmake` in `MKLROOT` was used:
```
$ MKLROOT=/nfs/site/proj/mkl/project/dainihsi/mkl_builds/__release_lnx_2023.0/mkl cmake .. -DTARGET_DOMAINS=rng
...
-- TARGET_DOMAINS: rng
-- MKL_ARCH: intel64
-- MKL_LINK: dynamic
-- MKL_INTERFACE_FULL: intel_ilp64
-- MKL_THREADING: tbb_thread
-- MKL_MPI: None, set to ` intelmpi` by default
...
```