### PR TITLE
[BLAS::portBLAS backend] Fix cmake issue with local portBLAS implementation

### DIFF
--- a/src/blas/backends/portblas/CMakeLists.txt
+++ b/src/blas/backends/portblas/CMakeLists.txt
@@ -145,8 +145,8 @@ if (NOT PORTBLAS_FOUND)
   FetchContent_MakeAvailable(portBLAS)
   message(STATUS "Looking for portBLAS - downloaded")
 
-  add_library(PORTBLAS::PORTBLAS INTERFACE IMPORTED)
-  target_include_directories(PORTBLAS::PORTBLAS
+  add_library(PORTBLAS::portblas INTERFACE IMPORTED)
+  target_include_directories(PORTBLAS::portblas
     INTERFACE ${FETCHCONTENT_BASE_DIR}/portblas-src/include
     INTERFACE ${FETCHCONTENT_BASE_DIR}/portblas-src/src
   )
@@ -155,7 +155,7 @@ else()
 endif()
 
 # This define is tuning portBLAS in header-only mode
-target_compile_definitions(PORTBLAS::PORTBLAS INTERFACE ${PORTBLAS_TUNING_TARGET})
+target_compile_definitions(PORTBLAS::portblas INTERFACE ${PORTBLAS_TUNING_TARGET})
 
 set(SOURCES
   portblas_level1_double.cpp portblas_level1_float.cpp
@@ -179,7 +179,7 @@ target_include_directories(${LIB_OBJ}
 )
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
-target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL PORTBLAS::PORTBLAS)
+target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL PORTBLAS::portblas)
 
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
# Description

Currently if compiling oneMKL using local portBLAS implementation using `-DPORTBLAS_DIR` will fail with the following:
```bash
-- Looking for dpc++
-- Performing Test is_dpcpp
-- Performing Test is_dpcpp - Success
-- Tuning portBLAS for Intel GPU devices
-- Looking for portBLAS
-- Looking for portBLAS - found
CMake Error at src/blas/backends/portblas/CMakeLists.txt:158 (target_compile_definitions):
  Cannot specify compile definitions for target "PORTBLAS::PORTBLAS" which is
  not built by this project.
```

The issue is caused by a mismatch in target between oneMKL cmake and portBLAS library cmake. 

This PR fix the issue allowing the usage of local portBLAS.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[fix_cmake_portblas.txt](https://github.com/oneapi-src/oneMKL/files/12662742/fix_cmake_portblas.txt)
The change doesn't modify oneMKL functionality, log attached for completeness.

- [x] Have you formatted the code using clang-format?
