### PR TITLE
[BLAS::portBLAS backend] Update gemm_batch and asum

### DIFF
--- a/src/blas/backends/portblas/portblas_batch.cxx
+++ b/src/blas/backends/portblas/portblas_batch.cxx
@@ -170,21 +170,8 @@ void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::
                 sycl::buffer<float, 1> &b, std::int64_t ldb, std::int64_t stride_b, float beta,
                 sycl::buffer<float, 1> &c, std::int64_t ldc, std::int64_t stride_c,
                 std::int64_t batch_size) {
-    // portBLAS's batched GEMM is for matrix strides equal to the size of the matrix only.
-    std::int64_t exp_stride_a =
-        (transa == transpose::nontrans) == is_column_major() ? lda * k : lda * m;
-    std::int64_t exp_stride_b =
-        (transb == transpose::nontrans) == is_column_major() ? ldb * n : ldb * k;
-    std::int64_t exp_stride_c = is_column_major() ? ldc * m : ldc * n;
-    if ((exp_stride_a == stride_a) && (exp_stride_b == stride_b) && (exp_stride_c == stride_c)) {
-        CALL_PORTBLAS_FN(::blas::_gemm_batched, queue, transa, transb, m, n, k, alpha, a, lda, b,
-                         ldb, beta, c, ldc, batch_size, ::blas::gemm_batch_type_t::strided);
-    }
-    else {
-        throw unimplemented("blas", "gemm_batch",
-                            " for strides not equal to the size of the"
-                            "input / output matrices");
-    }
+    CALL_PORTBLAS_FN(::blas::_gemm_strided_batched, queue, transa, transb, m, n, k, alpha, a, lda,
+                     stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
 }
 
 void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -193,21 +180,8 @@ void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::
                 sycl::buffer<double, 1> &b, std::int64_t ldb, std::int64_t stride_b, double beta,
                 sycl::buffer<double, 1> &c, std::int64_t ldc, std::int64_t stride_c,
                 std::int64_t batch_size) {
-    // portBLAS's batched GEMM is for matrix strides equal to the size of the matrix only.
-    std::int64_t exp_stride_a =
-        (transa == transpose::nontrans) == is_column_major() ? lda * k : lda * m;
-    std::int64_t exp_stride_b =
-        (transb == transpose::nontrans) == is_column_major() ? ldb * n : ldb * k;
-    std::int64_t exp_stride_c = is_column_major() ? ldc * m : ldc * n;
-    if ((exp_stride_a == stride_a) && (exp_stride_b == stride_b) && (exp_stride_c == stride_c)) {
-        CALL_PORTBLAS_FN(::blas::_gemm_batched, queue, transa, transb, m, n, k, alpha, a, lda, b,
-                         ldb, beta, c, ldc, batch_size, ::blas::gemm_batch_type_t::strided);
-    }
-    else {
-        throw unimplemented("blas", "gemm_batch",
-                            " for strides not equal to the size of the"
-                            "input / output matrices");
-    }
+    CALL_PORTBLAS_FN(::blas::_gemm_strided_batched, queue, transa, transb, m, n, k, alpha, a, lda,
+                     stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
 }
 
 void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,

--- a/src/blas/backends/portblas/portblas_level1.cxx
+++ b/src/blas/backends/portblas/portblas_level1.cxx
@@ -58,6 +58,12 @@ void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<real_t>,
 
 void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<real_t, 1> &x, std::int64_t incx,
           sycl::buffer<real_t, 1> &result) {
+    // portBLAS asum implementation requires that result is initialized to zero
+    // before performing the computation.
+    queue.submit([&](sycl::handler &cgh) {
+        auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
+        cgh.single_task([=]() { result_acc[0] = real_t(0); });
+    });
     CALL_PORTBLAS_FN(::blas::_asum, queue, n, x, incx, result);
 }
 


### PR DESCRIPTION
# Description

The api used to call the wrong `gemm_batch` implementation from portBLAS, this patch updates it calling the correct routine.
The `asum` operator available in portBLAS requires that result memory is initialized to zero before performing the routine. I updated the routine call accordingly. 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
asum test log: [asum_tests.txt](https://github.com/oneapi-src/oneMKL/files/12686744/asum_tests.txt)
gemm_batch log: [gemm_batch_stride_tests.txt](https://github.com/oneapi-src/oneMKL/files/12686751/gemm_batch_stride_tests.txt)

- [x] Have you formatted the code using clang-format?