### PR TITLE
[BLAS][Netlib]Fix get pointer warnings

### DIFF
--- a/src/blas/backends/netlib/netlib_common.hpp
+++ b/src/blas/backends/netlib/netlib_common.hpp
@@ -32,11 +32,7 @@
 #include "oneapi/mkl/blas/detail/netlib/onemkl_blas_netlib.hpp"
 #include "oneapi/mkl/types.hpp"
 
-#if defined(__SYCL_COMPILER_VERSION) && __SYCL_COMPILER_VERSION <= 20230320
-#define GET_MULTI_PTR get_pointer()
-#else
 #define GET_MULTI_PTR template get_multi_ptr<sycl::access::decorated::yes>().get_raw()
-#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/blas/backends/netlib/netlib_common.hpp
+++ b/src/blas/backends/netlib/netlib_common.hpp
@@ -32,6 +32,12 @@
 #include "oneapi/mkl/blas/detail/netlib/onemkl_blas_netlib.hpp"
 #include "oneapi/mkl/types.hpp"
 
+#if defined(__SYCL_COMPILER_VERSION) && __SYCL_COMPILER_VERSION <= 20230320
+#define GET_MULTI_PTR get_pointer()
+#else
+#define GET_MULTI_PTR template get_multi_ptr<sycl::access::decorated::yes>().get_raw()
+#endif
+
 namespace oneapi {
 namespace mkl {
 namespace blas {

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -26,7 +26,7 @@ void asum(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_sasum>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_sasum((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_sasum((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
@@ -38,55 +38,55 @@ void asum(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t inc
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_dasum>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_dasum((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_dasum((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
 
-void asum(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, sycl::buffer<float, 1> &result) {
+void asum(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_scasum>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_scasum((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_scasum((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
 
-void asum(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, sycl::buffer<double, 1> &result) {
+void asum(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_dzasum>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_dzasum((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_dzasum((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
 
-void axpy(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x,
-          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy) {
+void axpy(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_saxpy>(cgh, [=]() {
-            ::cblas_saxpy((const int)n, (const float)alpha, accessor_x.get_pointer(),
-                          (const int)incx, accessor_y.get_pointer(), (const int)incy);
+            ::cblas_saxpy((const int)n, (const float)alpha, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void axpy(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x,
-          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy) {
+void axpy(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_daxpy>(cgh, [=]() {
-            ::cblas_daxpy((const int)n, (const double)alpha, accessor_x.get_pointer(),
-                          (const int)incx, accessor_y.get_pointer(), (const int)incy);
+            ::cblas_daxpy((const int)n, (const double)alpha, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -98,8 +98,8 @@ void axpy(sycl::queue &queue, int64_t n, std::complex<float> alpha,
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_caxpy>(cgh, [=]() {
-            ::cblas_caxpy((const int)n, (const void *)&alpha, accessor_x.get_pointer(),
-                          (const int)incx, accessor_y.get_pointer(), (const int)incy);
+            ::cblas_caxpy((const int)n, (const void *)&alpha, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -111,14 +111,14 @@ void axpy(sycl::queue &queue, int64_t n, std::complex<double> alpha,
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zaxpy>(cgh, [=]() {
-            ::cblas_zaxpy((const int)n, (const void *)&alpha, accessor_x.get_pointer(),
-                          (const int)incx, accessor_y.get_pointer(), (const int)incy);
+            ::cblas_zaxpy((const int)n, (const void *)&alpha, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void axpby(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x,
-           int64_t incx, float beta, sycl::buffer<float, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx,
+           float beta, sycl::buffer<float, 1> &y, int64_t incy) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -127,8 +127,8 @@ void axpby(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x
 #endif
 }
 
-void axpby(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x,
-           int64_t incx, double beta, sycl::buffer<double, 1> &y, int64_t incy) {
+void axpby(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx,
+           double beta, sycl::buffer<double, 1> &y, int64_t incy) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -165,8 +165,8 @@ void copy(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_scopy>(cgh, [=]() {
-            ::cblas_scopy((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_scopy((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -177,32 +177,32 @@ void copy(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dcopy>(cgh, [=]() {
-            ::cblas_dcopy((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_dcopy((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void copy(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+void copy(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ccopy>(cgh, [=]() {
-            ::cblas_ccopy((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_ccopy((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void copy(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+void copy(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zcopy>(cgh, [=]() {
-            ::cblas_zcopy((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_zcopy((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -215,8 +215,8 @@ void dot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_sdot>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_sdot((const int)n, accessor_x.get_pointer(), (const int)incx,
-                             accessor_y.get_pointer(), (const int)incy);
+                ::cblas_sdot((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                             accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -229,8 +229,8 @@ void dot(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_ddot>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_ddot((const int)n, accessor_x.get_pointer(), (const int)incx,
-                             accessor_y.get_pointer(), (const int)incy);
+                ::cblas_ddot((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                             accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -243,68 +243,68 @@ void dot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_dsdot>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_dsdot((const int)n, accessor_x.get_pointer(), (const int)incx,
-                              accessor_y.get_pointer(), (const int)incy);
+                ::cblas_dsdot((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                              accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void dotc(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+void dotc(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
           sycl::buffer<std::complex<float>, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cdotc>(cgh, [=]() {
-            ::cblas_cdotc_sub((const int)n, accessor_x.get_pointer(), (const int)incx,
-                              accessor_y.get_pointer(), (const int)incy,
-                              accessor_result.get_pointer());
+            ::cblas_cdotc_sub((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                              accessor_y.GET_MULTI_PTR, (const int)incy,
+                              accessor_result.GET_MULTI_PTR);
         });
     });
 }
 
-void dotc(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+void dotc(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
           sycl::buffer<std::complex<double>, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zdotc>(cgh, [=]() {
-            ::cblas_zdotc_sub((const int)n, accessor_x.get_pointer(), (const int)incx,
-                              accessor_y.get_pointer(), (const int)incy,
-                              accessor_result.get_pointer());
+            ::cblas_zdotc_sub((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                              accessor_y.GET_MULTI_PTR, (const int)incy,
+                              accessor_result.GET_MULTI_PTR);
         });
     });
 }
 
-void dotu(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
+void dotu(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy,
           sycl::buffer<std::complex<float>, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cdotu>(cgh, [=]() {
-            ::cblas_cdotu_sub((const int)n, accessor_x.get_pointer(), (const int)incx,
-                              accessor_y.get_pointer(), (const int)incy,
-                              accessor_result.get_pointer());
+            ::cblas_cdotu_sub((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                              accessor_y.GET_MULTI_PTR, (const int)incy,
+                              accessor_result.GET_MULTI_PTR);
         });
     });
 }
 
-void dotu(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
+void dotu(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy,
           sycl::buffer<std::complex<double>, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zdotu>(cgh, [=]() {
-            ::cblas_zdotu_sub((const int)n, accessor_x.get_pointer(), (const int)incx,
-                              accessor_y.get_pointer(), (const int)incy,
-                              accessor_result.get_pointer());
+            ::cblas_zdotu_sub((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                              accessor_y.GET_MULTI_PTR, (const int)incy,
+                              accessor_result.GET_MULTI_PTR);
         });
     });
 }
@@ -315,7 +315,7 @@ void iamin(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_isamin((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_isamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
@@ -326,29 +326,29 @@ void iamin(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t in
         auto accessor_x = x.template get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_idamin((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_idamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
 
-void iamin(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-           int64_t incx, sycl::buffer<int64_t, 1> &result) {
+void iamin(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_icamin((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_icamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
 
-void iamin(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-           int64_t incx, sycl::buffer<int64_t, 1> &result) {
+void iamin(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_izamin((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_izamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
@@ -359,7 +359,7 @@ void iamax(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_isamax((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_isamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
@@ -370,29 +370,29 @@ void iamax(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t in
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_idamax((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_idamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
 
-void iamax(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-           int64_t incx, sycl::buffer<int64_t, 1> &result) {
+void iamax(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_icamax((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_icamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
 
-void iamax(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-           int64_t incx, sycl::buffer<int64_t, 1> &result) {
+void iamax(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+           sycl::buffer<int64_t, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_izamax((int)n, accessor_x.get_pointer(), (int)incx);
+            accessor_result[0] = ::cblas_izamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
         });
     });
 }
@@ -404,7 +404,7 @@ void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_snrm2>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_snrm2((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_snrm2((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
@@ -416,31 +416,31 @@ void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t inc
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_dnrm2>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_dnrm2((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_dnrm2((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
 
-void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, sycl::buffer<float, 1> &result) {
+void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<float, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_scnrm2>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_scnrm2((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_scnrm2((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
 
-void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, sycl::buffer<double, 1> &result) {
+void nrm2(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<double, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_dznrm2>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_dznrm2((const int)n, accessor_x.get_pointer(), (const int)std::abs(incx));
+                ::cblas_dznrm2((const int)n, accessor_x.GET_MULTI_PTR, (const int)std::abs(incx));
         });
     });
 }
@@ -451,8 +451,8 @@ void rot(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_srot>(cgh, [=]() {
-            ::cblas_srot((const int)n, accessor_x.get_pointer(), (const int)incx,
-                         accessor_y.get_pointer(), (const int)incy, (const float)c, (const float)s);
+            ::cblas_srot((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_y.GET_MULTI_PTR, (const int)incy, (const float)c, (const float)s);
         });
     });
 }
@@ -463,35 +463,33 @@ void rot(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t incx
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_drot>(cgh, [=]() {
-            ::cblas_drot((const int)n, accessor_x.get_pointer(), (const int)incx,
-                         accessor_y.get_pointer(), (const int)incy, (const float)c, (const float)s);
+            ::cblas_drot((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_y.GET_MULTI_PTR, (const int)incy, (const float)c, (const float)s);
         });
     });
 }
 
-void rot(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-         int64_t incx, sycl::buffer<std::complex<float>, 1> &y, int64_t incy, float c,
-         float s) {
+void rot(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &y, int64_t incy, float c, float s) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_csrot>(cgh, [=]() {
-            ::cblas_csrot((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, (const float)c,
+            ::cblas_csrot((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, (const float)c,
                           (const float)s);
         });
     });
 }
 
-void rot(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-         int64_t incx, sycl::buffer<std::complex<double>, 1> &y, int64_t incy, double c,
-         double s) {
+void rot(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &y, int64_t incy, double c, double s) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zdrot>(cgh, [=]() {
-            ::cblas_zdrot((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, (const double)c,
+            ::cblas_zdrot((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, (const double)c,
                           (const double)s);
         });
     });
@@ -505,8 +503,8 @@ void rotg(sycl::queue &queue, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> 
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_s = s.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_srotg>(cgh, [=]() {
-            ::cblas_srotg(accessor_a.get_pointer(), accessor_b.get_pointer(),
-                          accessor_c.get_pointer(), accessor_s.get_pointer());
+            ::cblas_srotg(accessor_a.GET_MULTI_PTR, accessor_b.GET_MULTI_PTR,
+                          accessor_c.GET_MULTI_PTR, accessor_s.GET_MULTI_PTR);
         });
     });
 }
@@ -519,8 +517,8 @@ void rotg(sycl::queue &queue, sycl::buffer<double, 1> &a, sycl::buffer<double, 1
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_s = s.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_drotg>(cgh, [=]() {
-            ::cblas_drotg(accessor_a.get_pointer(), accessor_b.get_pointer(),
-                          accessor_c.get_pointer(), accessor_s.get_pointer());
+            ::cblas_drotg(accessor_a.GET_MULTI_PTR, accessor_b.GET_MULTI_PTR,
+                          accessor_c.GET_MULTI_PTR, accessor_s.GET_MULTI_PTR);
         });
     });
 }
@@ -534,8 +532,8 @@ void rotg(sycl::queue &queue, sycl::buffer<std::complex<float>, 1> &a,
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_s = s.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_crotg>(cgh, [=]() {
-            ::cblas_crotg(accessor_a.get_pointer(), accessor_b.get_pointer(),
-                          accessor_c.get_pointer(), accessor_s.get_pointer());
+            ::cblas_crotg(accessor_a.GET_MULTI_PTR, accessor_b.GET_MULTI_PTR,
+                          accessor_c.GET_MULTI_PTR, accessor_s.GET_MULTI_PTR);
         });
     });
 }
@@ -549,8 +547,8 @@ void rotg(sycl::queue &queue, sycl::buffer<std::complex<double>, 1> &a,
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_s = s.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zrotg>(cgh, [=]() {
-            ::cblas_zrotg(accessor_a.get_pointer(), accessor_b.get_pointer(),
-                          accessor_c.get_pointer(), accessor_s.get_pointer());
+            ::cblas_zrotg(accessor_a.GET_MULTI_PTR, accessor_b.GET_MULTI_PTR,
+                          accessor_c.GET_MULTI_PTR, accessor_s.GET_MULTI_PTR);
         });
     });
 }
@@ -562,8 +560,8 @@ void rotm(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_param = param.get_access<sycl::access::mode::read>(cgh);
         host_task<class netlib_srotm>(cgh, [=]() {
-            ::cblas_srotm((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_param.get_pointer());
+            ::cblas_srotm((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_param.GET_MULTI_PTR);
         });
     });
 }
@@ -575,8 +573,8 @@ void rotm(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t inc
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_param = param.get_access<sycl::access::mode::read>(cgh);
         host_task<class netlib_drotm>(cgh, [=]() {
-            ::cblas_drotm((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_param.get_pointer());
+            ::cblas_drotm((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_param.GET_MULTI_PTR);
         });
     });
 }
@@ -589,8 +587,8 @@ void rotmg(sycl::queue &queue, sycl::buffer<float, 1> &d1, sycl::buffer<float, 1
         auto accessor_x1 = x1.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_param = param.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_srotmg>(cgh, [=]() {
-            ::cblas_srotmg(accessor_d1.get_pointer(), accessor_d2.get_pointer(),
-                           accessor_x1.get_pointer(), (float)y1, accessor_param.get_pointer());
+            ::cblas_srotmg(accessor_d1.GET_MULTI_PTR, accessor_d2.GET_MULTI_PTR,
+                           accessor_x1.GET_MULTI_PTR, (float)y1, accessor_param.GET_MULTI_PTR);
         });
     });
 }
@@ -603,29 +601,27 @@ void rotmg(sycl::queue &queue, sycl::buffer<double, 1> &d1, sycl::buffer<double,
         auto accessor_x1 = x1.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_param = param.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_drotmg>(cgh, [=]() {
-            ::cblas_drotmg(accessor_d1.get_pointer(), accessor_d2.get_pointer(),
-                           accessor_x1.get_pointer(), (double)y1, accessor_param.get_pointer());
+            ::cblas_drotmg(accessor_d1.GET_MULTI_PTR, accessor_d2.GET_MULTI_PTR,
+                           accessor_x1.GET_MULTI_PTR, (double)y1, accessor_param.GET_MULTI_PTR);
         });
     });
 }
 
-void scal(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x,
-          int64_t incx) {
+void scal(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<float, 1> &x, int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_sscal>(cgh, [=]() {
-            ::cblas_sscal((const int)n, (const float)alpha, accessor_x.get_pointer(),
+            ::cblas_sscal((const int)n, (const float)alpha, accessor_x.GET_MULTI_PTR,
                           (const int)std::abs(incx));
         });
     });
 }
 
-void scal(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x,
-          int64_t incx) {
+void scal(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<double, 1> &x, int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dscal>(cgh, [=]() {
-            ::cblas_dscal((const int)n, (const double)alpha, accessor_x.get_pointer(),
+            ::cblas_dscal((const int)n, (const double)alpha, accessor_x.GET_MULTI_PTR,
                           (const int)std::abs(incx));
         });
     });
@@ -636,18 +632,18 @@ void scal(sycl::queue &queue, int64_t n, std::complex<float> alpha,
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cscal>(cgh, [=]() {
-            ::cblas_cscal((const int)n, (const void *)&alpha, accessor_x.get_pointer(),
+            ::cblas_cscal((const int)n, (const void *)&alpha, accessor_x.GET_MULTI_PTR,
                           (const int)std::abs(incx));
         });
     });
 }
 
-void scal(sycl::queue &queue, int64_t n, float alpha,
-          sycl::buffer<std::complex<float>, 1> &x, int64_t incx) {
+void scal(sycl::queue &queue, int64_t n, float alpha, sycl::buffer<std::complex<float>, 1> &x,
+          int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_csscal>(cgh, [=]() {
-            ::cblas_csscal((const int)n, (const float)alpha, accessor_x.get_pointer(),
+            ::cblas_csscal((const int)n, (const float)alpha, accessor_x.GET_MULTI_PTR,
                            (const int)std::abs(incx));
         });
     });
@@ -658,34 +654,33 @@ void scal(sycl::queue &queue, int64_t n, std::complex<double> alpha,
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zscal>(cgh, [=]() {
-            ::cblas_zscal((const int)n, (const void *)&alpha, accessor_x.get_pointer(),
+            ::cblas_zscal((const int)n, (const void *)&alpha, accessor_x.GET_MULTI_PTR,
                           (const int)std::abs(incx));
         });
     });
 }
 
-void scal(sycl::queue &queue, int64_t n, double alpha,
-          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+void scal(sycl::queue &queue, int64_t n, double alpha, sycl::buffer<std::complex<double>, 1> &x,
+          int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zdscal>(cgh, [=]() {
-            ::cblas_zdscal((const int)n, (const double)alpha, accessor_x.get_pointer(),
+            ::cblas_zdscal((const int)n, (const double)alpha, accessor_x.GET_MULTI_PTR,
                            (const int)std::abs(incx));
         });
     });
 }
 
-void sdsdot(sycl::queue &queue, int64_t n, float sb, sycl::buffer<float, 1> &x,
-            int64_t incx, sycl::buffer<float, 1> &y, int64_t incy,
-            sycl::buffer<float, 1> &result) {
+void sdsdot(sycl::queue &queue, int64_t n, float sb, sycl::buffer<float, 1> &x, int64_t incx,
+            sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &result) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_sdsdot>(cgh, [=]() {
             accessor_result[0] =
-                ::cblas_sdsdot((const int)n, (const float)sb, accessor_x.get_pointer(),
-                               (const int)incx, accessor_y.get_pointer(), (const int)incy);
+                ::cblas_sdsdot((const int)n, (const float)sb, accessor_x.GET_MULTI_PTR,
+                               (const int)incx, accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -696,8 +691,8 @@ void swap(sycl::queue &queue, int64_t n, sycl::buffer<float, 1> &x, int64_t incx
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_sswap>(cgh, [=]() {
-            ::cblas_sswap((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_sswap((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -708,32 +703,32 @@ void swap(sycl::queue &queue, int64_t n, sycl::buffer<double, 1> &x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dswap>(cgh, [=]() {
-            ::cblas_dswap((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_dswap((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void swap(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
+void swap(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<float>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cswap>(cgh, [=]() {
-            ::cblas_cswap((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_cswap((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void swap(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-          int64_t incx, sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+void swap(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &x, int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zswap>(cgh, [=]() {
-            ::cblas_zswap((const int)n, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy);
+            ::cblas_zswap((const int)n, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -741,7 +736,7 @@ void swap(sycl::queue &queue, int64_t n, sycl::buffer<std::complex<double>, 1> &
 // USM APIs
 
 sycl::event asum(sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -753,8 +748,8 @@ sycl::event asum(sycl::queue &queue, int64_t n, const float *x, int64_t incx, fl
     return done;
 }
 
-sycl::event asum(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const std::vector<sycl::event> &dependencies) {
+sycl::event asum(sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -767,7 +762,7 @@ sycl::event asum(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
 }
 
 sycl::event asum(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const std::vector<sycl::event> &dependencies) {
+                 float *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -780,7 +775,7 @@ sycl::event asum(sycl::queue &queue, int64_t n, const std::complex<float> *x, in
 }
 
 sycl::event asum(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const std::vector<sycl::event> &dependencies) {
+                 double *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -792,8 +787,8 @@ sycl::event asum(sycl::queue &queue, int64_t n, const std::complex<double> *x, i
     return done;
 }
 
-sycl::event axpy(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                     float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+sycl::event axpy(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -807,7 +802,7 @@ sycl::event axpy(sycl::queue &queue, int64_t n, float alpha, const float *x, int
 }
 
 sycl::event axpy(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
-                     double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -822,8 +817,8 @@ sycl::event axpy(sycl::queue &queue, int64_t n, double alpha, const double *x, i
 }
 
 sycl::event axpy(sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *x, int64_t incx, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -838,8 +833,8 @@ sycl::event axpy(sycl::queue &queue, int64_t n, std::complex<float> alpha,
 }
 
 sycl::event axpy(sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 const std::complex<double> *x, int64_t incx, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -854,8 +849,8 @@ sycl::event axpy(sycl::queue &queue, int64_t n, std::complex<double> alpha,
 }
 
 sycl::event axpby(sycl::queue &queue, int64_t n, float alpha, const float *x, int64_t incx,
-                      float beta, float *y, int64_t incy,
-                      const std::vector<sycl::event> &dependencies) {
+                  float beta, float *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -864,9 +859,9 @@ sycl::event axpby(sycl::queue &queue, int64_t n, float alpha, const float *x, in
 #endif
 }
 
-sycl::event axpby(sycl::queue &queue, int64_t n, double alpha, const double *x,
-                      int64_t incx, double beta, double *y, int64_t incy,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event axpby(sycl::queue &queue, int64_t n, double alpha, const double *x, int64_t incx,
+                  double beta, double *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -876,9 +871,9 @@ sycl::event axpby(sycl::queue &queue, int64_t n, double alpha, const double *x,
 }
 
 sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                      const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                      std::complex<float> *y, int64_t incy,
-                      const std::vector<sycl::event> &dependencies) {
+                  const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                  std::complex<float> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -888,9 +883,9 @@ sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<float> alpha,
 }
 
 sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                      const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                      std::complex<double> *y, int64_t incy,
-                      const std::vector<sycl::event> &dependencies) {
+                  const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                  std::complex<double> *y, int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "axpby", "for column_major layout");
 #endif
@@ -900,7 +895,7 @@ sycl::event axpby(sycl::queue &queue, int64_t n, std::complex<double> alpha,
 }
 
 sycl::event copy(sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -913,7 +908,7 @@ sycl::event copy(sycl::queue &queue, int64_t n, const float *x, int64_t incx, fl
 }
 
 sycl::event copy(sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -926,8 +921,8 @@ sycl::event copy(sycl::queue &queue, int64_t n, const double *x, int64_t incx, d
 }
 
 sycl::event copy(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -940,8 +935,8 @@ sycl::event copy(sycl::queue &queue, int64_t n, const std::complex<float> *x, in
 }
 
 sycl::event copy(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -954,7 +949,7 @@ sycl::event copy(sycl::queue &queue, int64_t n, const std::complex<double> *x, i
 }
 
 sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, float *result, const std::vector<sycl::event> &dependencies) {
+                int64_t incy, float *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -967,9 +962,8 @@ sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, con
     return done;
 }
 
-sycl::event dot(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                    const double *y, int64_t incy, double *result,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event dot(sycl::queue &queue, int64_t n, const double *x, int64_t incx, const double *y,
+                int64_t incy, double *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -983,8 +977,7 @@ sycl::event dot(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
 }
 
 sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, const float *y,
-                    int64_t incy, double *result,
-                    const std::vector<sycl::event> &dependencies) {
+                int64_t incy, double *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -998,8 +991,8 @@ sycl::event dot(sycl::queue &queue, int64_t n, const float *x, int64_t incx, con
 }
 
 sycl::event dotc(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1013,8 +1006,8 @@ sycl::event dotc(sycl::queue &queue, int64_t n, const std::complex<float> *x, in
 }
 
 sycl::event dotc(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1028,8 +1021,8 @@ sycl::event dotc(sycl::queue &queue, int64_t n, const std::complex<double> *x, i
 }
 
 sycl::event dotu(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     const std::complex<float> *y, int64_t incy, std::complex<float> *result,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *y, int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1043,8 +1036,8 @@ sycl::event dotu(sycl::queue &queue, int64_t n, const std::complex<float> *x, in
 }
 
 sycl::event dotu(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *result,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<double> *y, int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1057,8 +1050,8 @@ sycl::event dotu(sycl::queue &queue, int64_t n, const std::complex<double> *x, i
     return done;
 }
 
-sycl::event iamin(sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result, const std::vector<sycl::event> &dependencies) {
+sycl::event iamin(sycl::queue &queue, int64_t n, const float *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1070,8 +1063,8 @@ sycl::event iamin(sycl::queue &queue, int64_t n, const float *x, int64_t incx,
     return done;
 }
 
-sycl::event iamin(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result, const std::vector<sycl::event> &dependencies) {
+sycl::event iamin(sycl::queue &queue, int64_t n, const double *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1084,7 +1077,7 @@ sycl::event iamin(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
 }
 
 sycl::event iamin(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result, const std::vector<sycl::event> &dependencies) {
+                  int64_t *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1096,9 +1089,8 @@ sycl::event iamin(sycl::queue &queue, int64_t n, const std::complex<float> *x, i
     return done;
 }
 
-sycl::event iamin(sycl::queue &queue, int64_t n, const std::complex<double> *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event iamin(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                  int64_t *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1110,8 +1102,8 @@ sycl::event iamin(sycl::queue &queue, int64_t n, const std::complex<double> *x,
     return done;
 }
 
-sycl::event iamax(sycl::queue &queue, int64_t n, const float *x, int64_t incx,
-                      int64_t *result, const std::vector<sycl::event> &dependencies) {
+sycl::event iamax(sycl::queue &queue, int64_t n, const float *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1123,8 +1115,8 @@ sycl::event iamax(sycl::queue &queue, int64_t n, const float *x, int64_t incx,
     return done;
 }
 
-sycl::event iamax(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                      int64_t *result, const std::vector<sycl::event> &dependencies) {
+sycl::event iamax(sycl::queue &queue, int64_t n, const double *x, int64_t incx, int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1137,7 +1129,7 @@ sycl::event iamax(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
 }
 
 sycl::event iamax(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                      int64_t *result, const std::vector<sycl::event> &dependencies) {
+                  int64_t *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1149,9 +1141,8 @@ sycl::event iamax(sycl::queue &queue, int64_t n, const std::complex<float> *x, i
     return done;
 }
 
-sycl::event iamax(sycl::queue &queue, int64_t n, const std::complex<double> *x,
-                      int64_t incx, int64_t *result,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event iamax(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
+                  int64_t *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1164,7 +1155,7 @@ sycl::event iamax(sycl::queue &queue, int64_t n, const std::complex<double> *x,
 }
 
 sycl::event nrm2(sycl::queue &queue, int64_t n, const float *x, int64_t incx, float *result,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1176,8 +1167,8 @@ sycl::event nrm2(sycl::queue &queue, int64_t n, const float *x, int64_t incx, fl
     return done;
 }
 
-sycl::event nrm2(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
-                     double *result, const std::vector<sycl::event> &dependencies) {
+sycl::event nrm2(sycl::queue &queue, int64_t n, const double *x, int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1190,7 +1181,7 @@ sycl::event nrm2(sycl::queue &queue, int64_t n, const double *x, int64_t incx,
 }
 
 sycl::event nrm2(sycl::queue &queue, int64_t n, const std::complex<float> *x, int64_t incx,
-                     float *result, const std::vector<sycl::event> &dependencies) {
+                 float *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1203,7 +1194,7 @@ sycl::event nrm2(sycl::queue &queue, int64_t n, const std::complex<float> *x, in
 }
 
 sycl::event nrm2(sycl::queue &queue, int64_t n, const std::complex<double> *x, int64_t incx,
-                     double *result, const std::vector<sycl::event> &dependencies) {
+                 double *result, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1215,9 +1206,8 @@ sycl::event nrm2(sycl::queue &queue, int64_t n, const std::complex<double> *x, i
     return done;
 }
 
-sycl::event rot(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                    int64_t incy, float c, float s,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event rot(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y, int64_t incy,
+                float c, float s, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1231,9 +1221,8 @@ sycl::event rot(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
     return done;
 }
 
-sycl::event rot(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                    int64_t incy, double c, double s,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event rot(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y, int64_t incy,
+                double c, double s, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1248,8 +1237,8 @@ sycl::event rot(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *
 }
 
 sycl::event rot(sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
-                    std::complex<float> *y, int64_t incy, float c, float s,
-                    const std::vector<sycl::event> &dependencies) {
+                std::complex<float> *y, int64_t incy, float c, float s,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1264,8 +1253,8 @@ sycl::event rot(sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t i
 }
 
 sycl::event rot(sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
-                    std::complex<double> *y, int64_t incy, double c, double s,
-                    const std::vector<sycl::event> &dependencies) {
+                std::complex<double> *y, int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1280,7 +1269,7 @@ sycl::event rot(sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t 
 }
 
 sycl::event rotg(sycl::queue &queue, float *a, float *b, float *c, float *s,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1292,7 +1281,7 @@ sycl::event rotg(sycl::queue &queue, float *a, float *b, float *c, float *s,
 }
 
 sycl::event rotg(sycl::queue &queue, double *a, double *b, double *c, double *s,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1303,9 +1292,8 @@ sycl::event rotg(sycl::queue &queue, double *a, double *b, double *c, double *s,
     return done;
 }
 
-sycl::event rotg(sycl::queue &queue, std::complex<float> *a, std::complex<float> *b,
-                     float *c, std::complex<float> *s,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event rotg(sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
+                 std::complex<float> *s, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1316,9 +1304,8 @@ sycl::event rotg(sycl::queue &queue, std::complex<float> *a, std::complex<float>
     return done;
 }
 
-sycl::event rotg(sycl::queue &queue, std::complex<double> *a, std::complex<double> *b,
-                     double *c, std::complex<double> *s,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event rotg(sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
+                 std::complex<double> *s, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1329,8 +1316,8 @@ sycl::event rotg(sycl::queue &queue, std::complex<double> *a, std::complex<doubl
     return done;
 }
 
-sycl::event rotm(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, float *param, const std::vector<sycl::event> &dependencies) {
+sycl::event rotm(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y, int64_t incy,
+                 float *param, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1343,9 +1330,8 @@ sycl::event rotm(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y
     return done;
 }
 
-sycl::event rotm(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                     int64_t incy, double *param,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event rotm(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y, int64_t incy,
+                 double *param, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1358,8 +1344,8 @@ sycl::event rotm(sycl::queue &queue, int64_t n, double *x, int64_t incx, double 
     return done;
 }
 
-sycl::event rotmg(sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
-                      float *param, const std::vector<sycl::event> &dependencies) {
+sycl::event rotmg(sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1371,8 +1357,8 @@ sycl::event rotmg(sycl::queue &queue, float *d1, float *d2, float *x1, float y1,
     return done;
 }
 
-sycl::event rotmg(sycl::queue &queue, double *d1, double *d2, double *x1, double y1,
-                      double *param, const std::vector<sycl::event> &dependencies) {
+sycl::event rotmg(sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1385,7 +1371,7 @@ sycl::event rotmg(sycl::queue &queue, double *d1, double *d2, double *x1, double
 }
 
 sycl::event scal(sycl::queue &queue, int64_t n, float alpha, float *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1399,7 +1385,7 @@ sycl::event scal(sycl::queue &queue, int64_t n, float alpha, float *x, int64_t i
 }
 
 sycl::event scal(sycl::queue &queue, int64_t n, double alpha, double *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1412,9 +1398,8 @@ sycl::event scal(sycl::queue &queue, int64_t n, double alpha, double *x, int64_t
     return done;
 }
 
-sycl::event scal(sycl::queue &queue, int64_t n, std::complex<float> alpha,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event scal(sycl::queue &queue, int64_t n, std::complex<float> alpha, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1427,8 +1412,8 @@ sycl::event scal(sycl::queue &queue, int64_t n, std::complex<float> alpha,
     return done;
 }
 
-sycl::event scal(sycl::queue &queue, int64_t n, float alpha, std::complex<float> *x,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event scal(sycl::queue &queue, int64_t n, float alpha, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1441,9 +1426,8 @@ sycl::event scal(sycl::queue &queue, int64_t n, float alpha, std::complex<float>
     return done;
 }
 
-sycl::event scal(sycl::queue &queue, int64_t n, std::complex<double> alpha,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event scal(sycl::queue &queue, int64_t n, std::complex<double> alpha, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1456,8 +1440,8 @@ sycl::event scal(sycl::queue &queue, int64_t n, std::complex<double> alpha,
     return done;
 }
 
-sycl::event scal(sycl::queue &queue, int64_t n, double alpha, std::complex<double> *x,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event scal(sycl::queue &queue, int64_t n, double alpha, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1471,8 +1455,8 @@ sycl::event scal(sycl::queue &queue, int64_t n, double alpha, std::complex<doubl
 }
 
 sycl::event sdsdot(sycl::queue &queue, int64_t n, float sb, const float *x, int64_t incx,
-                       const float *y, int64_t incy, float *result,
-                       const std::vector<sycl::event> &dependencies) {
+                   const float *y, int64_t incy, float *result,
+                   const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1486,8 +1470,8 @@ sycl::event sdsdot(sycl::queue &queue, int64_t n, float sb, const float *x, int6
     return done;
 }
 
-sycl::event swap(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+sycl::event swap(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1499,8 +1483,8 @@ sycl::event swap(sycl::queue &queue, int64_t n, float *x, int64_t incx, float *y
     return done;
 }
 
-sycl::event swap(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+sycl::event swap(sycl::queue &queue, int64_t n, double *x, int64_t incx, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1513,8 +1497,8 @@ sycl::event swap(sycl::queue &queue, int64_t n, double *x, int64_t incx, double 
 }
 
 sycl::event swap(sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t incx,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1527,8 +1511,8 @@ sycl::event swap(sycl::queue &queue, int64_t n, std::complex<float> *x, int64_t 
 }
 
 sycl::event swap(sycl::queue &queue, int64_t n, std::complex<double> *x, int64_t incx,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/netlib/netlib_level2.cxx
+++ b/src/blas/backends/netlib/netlib_level2.cxx
@@ -29,8 +29,8 @@ void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
         host_task<class netlib_sgbmv>(cgh, [=]() {
             ::cblas_sgbmv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
                           (const int)kl, (const int)ku, (const float)alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
-                          (const int)incx, (const float)beta, accessor_y.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const float)beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
@@ -46,8 +46,8 @@ void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
         host_task<class netlib_dgbmv>(cgh, [=]() {
             ::cblas_dgbmv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
                           (const int)kl, (const int)ku, (const double)alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
-                          (const int)incx, (const double)beta, accessor_y.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const double)beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
@@ -64,8 +64,8 @@ void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
         host_task<class netlib_cgbmv>(cgh, [=]() {
             ::cblas_cgbmv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
                           (const int)kl, (const int)ku, (const void *)&alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
-                          (const int)incx, (const void *)&beta, accessor_y.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const void *)&beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
@@ -82,8 +82,8 @@ void gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
         host_task<class netlib_zgbmv>(cgh, [=]() {
             ::cblas_zgbmv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
                           (const int)kl, (const int)ku, (const void *)&alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
-                          (const int)incx, (const void *)&beta, accessor_y.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const void *)&beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
@@ -98,9 +98,9 @@ void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_sgemv>(cgh, [=]() {
             ::cblas_sgemv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
-                          (const float)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const float)beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const float)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const float)beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -114,9 +114,9 @@ void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alph
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dgemv>(cgh, [=]() {
             ::cblas_dgemv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
-                          (const double)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const double)beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const double)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const double)beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -131,9 +131,9 @@ void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, std::comple
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cgemv>(cgh, [=]() {
             ::cblas_cgemv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const void *)&beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const void *)&beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -148,9 +148,9 @@ void gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, std::comple
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zgemv>(cgh, [=]() {
             ::cblas_zgemv(MAJOR, convert_to_cblas_trans(trans), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const void *)&beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const void *)&beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -164,8 +164,8 @@ void ger(sycl::queue &queue, int64_t m, int64_t n, float alpha, sycl::buffer<flo
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_sger>(cgh, [=]() {
             ::cblas_sger(MAJOR, (const int)m, (const int)n, (const float)alpha,
-                         accessor_x.get_pointer(), (const int)incx, accessor_y.get_pointer(),
-                         (const int)incy, accessor_a.get_pointer(), (const int)lda);
+                         accessor_x.GET_MULTI_PTR, (const int)incx, accessor_y.GET_MULTI_PTR,
+                         (const int)incy, accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -179,8 +179,8 @@ void ger(sycl::queue &queue, int64_t m, int64_t n, double alpha, sycl::buffer<do
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dger>(cgh, [=]() {
             ::cblas_dger(MAJOR, (const int)m, (const int)n, (const double)alpha,
-                         accessor_x.get_pointer(), (const int)incx, accessor_y.get_pointer(),
-                         (const int)incy, accessor_a.get_pointer(), (const int)lda);
+                         accessor_x.GET_MULTI_PTR, (const int)incx, accessor_y.GET_MULTI_PTR,
+                         (const int)incy, accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -195,8 +195,8 @@ void gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cgerc>(cgh, [=]() {
             ::cblas_cgerc(MAJOR, (const int)m, (const int)n, (const void *)&alpha,
-                          accessor_x.get_pointer(), (const int)incx, accessor_y.get_pointer(),
-                          (const int)incy, accessor_a.get_pointer(), (const int)lda);
+                          accessor_x.GET_MULTI_PTR, (const int)incx, accessor_y.GET_MULTI_PTR,
+                          (const int)incy, accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -211,8 +211,8 @@ void gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zgerc>(cgh, [=]() {
             ::cblas_zgerc(MAJOR, (const int)m, (const int)n, (const void *)&alpha,
-                          accessor_x.get_pointer(), (const int)incx, accessor_y.get_pointer(),
-                          (const int)incy, accessor_a.get_pointer(), (const int)lda);
+                          accessor_x.GET_MULTI_PTR, (const int)incx, accessor_y.GET_MULTI_PTR,
+                          (const int)incy, accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -227,8 +227,8 @@ void geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cgeru>(cgh, [=]() {
             ::cblas_cgeru(MAJOR, (const int)m, (const int)n, (const void *)&alpha,
-                          accessor_x.get_pointer(), (const int)incx, accessor_y.get_pointer(),
-                          (const int)incy, accessor_a.get_pointer(), (const int)lda);
+                          accessor_x.GET_MULTI_PTR, (const int)incx, accessor_y.GET_MULTI_PTR,
+                          (const int)incy, accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -243,8 +243,8 @@ void geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zgeru>(cgh, [=]() {
             ::cblas_zgeru(MAJOR, (const int)m, (const int)n, (const void *)&alpha,
-                          accessor_x.get_pointer(), (const int)incx, accessor_y.get_pointer(),
-                          (const int)incy, accessor_a.get_pointer(), (const int)lda);
+                          accessor_x.GET_MULTI_PTR, (const int)incx, accessor_y.GET_MULTI_PTR,
+                          (const int)incy, accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -259,15 +259,15 @@ void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, std::compl
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_chbmv>(cgh, [=]() {
             ::cblas_chbmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n, (const int)k,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const void *)&beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const void *)&beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
-          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
           sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
@@ -276,9 +276,9 @@ void hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zhbmv>(cgh, [=]() {
             ::cblas_zhbmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n, (const int)k,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const void *)&beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const void *)&beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -293,9 +293,9 @@ void hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> a
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_chemv>(cgh, [=]() {
             ::cblas_chemv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const void *)&beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const void *)&beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -310,9 +310,9 @@ void hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> 
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zhemv>(cgh, [=]() {
             ::cblas_zhemv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const void *)&beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const void *)&beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -325,8 +325,8 @@ void her(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cher>(cgh, [=]() {
             ::cblas_cher(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const float)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_a.get_pointer(), (const int)lda);
+                         (const float)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -339,8 +339,8 @@ void her(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zher>(cgh, [=]() {
             ::cblas_zher(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const double)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_a.get_pointer(), (const int)lda);
+                         (const double)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
@@ -355,8 +355,8 @@ void her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> a
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cher2>(cgh, [=]() {
             ::cblas_cher2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_a.get_pointer(),
+                          (const void *)&alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_a.GET_MULTI_PTR,
                           (const int)lda);
         });
     });
@@ -372,8 +372,8 @@ void her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> 
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zher2>(cgh, [=]() {
             ::cblas_zher2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_a.get_pointer(),
+                          (const void *)&alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_a.GET_MULTI_PTR,
                           (const int)lda);
         });
     });
@@ -389,25 +389,25 @@ void hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> a
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_chpmv>(cgh, [=]() {
             ::cblas_chpmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_ap.get_pointer(), accessor_x.get_pointer(),
-                          (const int)incx, (const void *)&beta, accessor_y.get_pointer(),
+                          (const void *)&alpha, accessor_ap.GET_MULTI_PTR, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const void *)&beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
 }
 
 void hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
-          sycl::buffer<std::complex<double>, 1> &ap,
-          sycl::buffer<std::complex<double>, 1> &x, int64_t incx, std::complex<double> beta,
-          sycl::buffer<std::complex<double>, 1> &y, int64_t incy) {
+          sycl::buffer<std::complex<double>, 1> &ap, sycl::buffer<std::complex<double>, 1> &x,
+          int64_t incx, std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &y,
+          int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_ap = ap.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zhpmv>(cgh, [=]() {
             ::cblas_zhpmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_ap.get_pointer(), accessor_x.get_pointer(),
-                          (const int)incx, (const void *)&beta, accessor_y.get_pointer(),
+                          (const void *)&alpha, accessor_ap.GET_MULTI_PTR, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const void *)&beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
@@ -421,8 +421,8 @@ void hpr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_chpr>(cgh, [=]() {
             ::cblas_chpr(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const float)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_ap.get_pointer());
+                         (const float)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_ap.GET_MULTI_PTR);
         });
     });
 }
@@ -435,8 +435,8 @@ void hpr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zhpr>(cgh, [=]() {
             ::cblas_zhpr(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const double)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_ap.get_pointer());
+                         (const double)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_ap.GET_MULTI_PTR);
         });
     });
 }
@@ -451,8 +451,8 @@ void hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> a
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_chpr2>(cgh, [=]() {
             ::cblas_chpr2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_ap.get_pointer());
+                          (const void *)&alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_ap.GET_MULTI_PTR);
         });
     });
 }
@@ -467,8 +467,8 @@ void hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> 
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zhpr2>(cgh, [=]() {
             ::cblas_zhpr2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const void *)&alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_ap.get_pointer());
+                          (const void *)&alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_ap.GET_MULTI_PTR);
         });
     });
 }
@@ -482,9 +482,9 @@ void sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alph
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ssbmv>(cgh, [=]() {
             ::cblas_ssbmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n, (const int)k,
-                          (const float)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const float)beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const float)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const float)beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
@@ -498,187 +498,184 @@ void sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alp
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dsbmv>(cgh, [=]() {
             ::cblas_dsbmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n, (const int)k,
-                          (const double)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const double)beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const double)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const double)beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void spmv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          sycl::buffer<float, 1> &ap, sycl::buffer<float, 1> &x, int64_t incx, float beta,
-          sycl::buffer<float, 1> &y, int64_t incy) {
+void spmv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &ap,
+          sycl::buffer<float, 1> &x, int64_t incx, float beta, sycl::buffer<float, 1> &y,
+          int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_ap = ap.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_sspmv>(cgh, [=]() {
             ::cblas_sspmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const float)alpha, accessor_ap.get_pointer(), accessor_x.get_pointer(),
-                          (const int)incx, (const float)beta, accessor_y.get_pointer(),
+                          (const float)alpha, accessor_ap.GET_MULTI_PTR, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const float)beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
 }
 
 void spmv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          sycl::buffer<double, 1> &ap, sycl::buffer<double, 1> &x, int64_t incx,
-          double beta, sycl::buffer<double, 1> &y, int64_t incy) {
+          sycl::buffer<double, 1> &ap, sycl::buffer<double, 1> &x, int64_t incx, double beta,
+          sycl::buffer<double, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_ap = ap.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dspmv>(cgh, [=]() {
             ::cblas_dspmv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const double)alpha, accessor_ap.get_pointer(), accessor_x.get_pointer(),
-                          (const int)incx, (const double)beta, accessor_y.get_pointer(),
+                          (const double)alpha, accessor_ap.GET_MULTI_PTR, accessor_x.GET_MULTI_PTR,
+                          (const int)incx, (const double)beta, accessor_y.GET_MULTI_PTR,
                           (const int)incy);
         });
     });
 }
 
-void spr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-         sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &ap) {
+void spr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &ap) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_sspr>(cgh, [=]() {
             ::cblas_sspr(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const float)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_ap.get_pointer());
+                         (const float)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_ap.GET_MULTI_PTR);
         });
     });
 }
 
-void spr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-         sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &ap) {
+void spr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+         int64_t incx, sycl::buffer<double, 1> &ap) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dspr>(cgh, [=]() {
             ::cblas_dspr(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const double)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_ap.get_pointer());
+                         (const double)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_ap.GET_MULTI_PTR);
         });
     });
 }
 
-void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &y, int64_t incy,
-          sycl::buffer<float, 1> &ap) {
+void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &ap) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_sspr2>(cgh, [=]() {
             ::cblas_sspr2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const float)alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_ap.get_pointer());
+                          (const float)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_ap.GET_MULTI_PTR);
         });
     });
 }
 
-void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &y,
-          int64_t incy, sycl::buffer<double, 1> &ap) {
+void spr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &ap) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_ap = ap.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dspr2>(cgh, [=]() {
             ::cblas_dspr2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const double)alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_ap.get_pointer());
+                          (const double)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_ap.GET_MULTI_PTR);
         });
     });
 }
 
-void symv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &x, int64_t incx,
-          float beta, sycl::buffer<float, 1> &y, int64_t incy) {
+void symv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &a,
+          int64_t lda, sycl::buffer<float, 1> &x, int64_t incx, float beta,
+          sycl::buffer<float, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ssymv>(cgh, [=]() {
             ::cblas_ssymv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const float)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const float)beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const float)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const float)beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void symv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x, int64_t incx,
-          double beta, sycl::buffer<double, 1> &y, int64_t incy) {
+void symv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &a,
+          int64_t lda, sycl::buffer<double, 1> &x, int64_t incx, double beta,
+          sycl::buffer<double, 1> &y, int64_t incy) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dsymv>(cgh, [=]() {
             ::cblas_dsymv(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const double)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_x.get_pointer(), (const int)incx, (const double)beta,
-                          accessor_y.get_pointer(), (const int)incy);
+                          (const double)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_x.GET_MULTI_PTR, (const int)incx, (const double)beta,
+                          accessor_y.GET_MULTI_PTR, (const int)incy);
         });
     });
 }
 
-void syr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-         sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &a, int64_t lda) {
+void syr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+         int64_t incx, sycl::buffer<float, 1> &a, int64_t lda) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ssyr>(cgh, [=]() {
             ::cblas_ssyr(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const float)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_a.get_pointer(), (const int)lda);
+                         (const float)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
 
-void syr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-         sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &a,
-         int64_t lda) {
+void syr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+         int64_t incx, sycl::buffer<double, 1> &a, int64_t lda) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dsyr>(cgh, [=]() {
             ::cblas_dsyr(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                         (const double)alpha, accessor_x.get_pointer(), (const int)incx,
-                         accessor_a.get_pointer(), (const int)lda);
+                         (const double)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                         accessor_a.GET_MULTI_PTR, (const int)lda);
         });
     });
 }
 
-void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-          sycl::buffer<float, 1> &x, int64_t incx, sycl::buffer<float, 1> &y, int64_t incy,
-          sycl::buffer<float, 1> &a, int64_t lda) {
+void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, sycl::buffer<float, 1> &x,
+          int64_t incx, sycl::buffer<float, 1> &y, int64_t incy, sycl::buffer<float, 1> &a,
+          int64_t lda) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ssyr2>(cgh, [=]() {
             ::cblas_ssyr2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const float)alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_a.get_pointer(),
+                          (const float)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_a.GET_MULTI_PTR,
                           (const int)lda);
         });
     });
 }
 
-void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-          sycl::buffer<double, 1> &x, int64_t incx, sycl::buffer<double, 1> &y,
-          int64_t incy, sycl::buffer<double, 1> &a, int64_t lda) {
+void syr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, sycl::buffer<double, 1> &x,
+          int64_t incx, sycl::buffer<double, 1> &y, int64_t incy, sycl::buffer<double, 1> &a,
+          int64_t lda) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_y = y.get_access<sycl::access::mode::read>(cgh);
         auto accessor_a = a.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dsyr2>(cgh, [=]() {
             ::cblas_dsyr2(MAJOR, convert_to_cblas_uplo(upper_lower), (const int)n,
-                          (const double)alpha, accessor_x.get_pointer(), (const int)incx,
-                          accessor_y.get_pointer(), (const int)incy, accessor_a.get_pointer(),
+                          (const double)alpha, accessor_x.GET_MULTI_PTR, (const int)incx,
+                          accessor_y.GET_MULTI_PTR, (const int)incy, accessor_a.GET_MULTI_PTR,
                           (const int)lda);
         });
     });
@@ -693,7 +690,7 @@ void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_stbmv>(cgh, [=]() {
             ::cblas_stbmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -708,7 +705,7 @@ void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_dtbmv>(cgh, [=]() {
             ::cblas_dtbmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -723,7 +720,7 @@ void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_ctbmv>(cgh, [=]() {
             ::cblas_ctbmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -738,7 +735,7 @@ void tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_ztbmv>(cgh, [=]() {
             ::cblas_ztbmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -753,7 +750,7 @@ void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_stbsv>(cgh, [=]() {
             ::cblas_stbsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -768,7 +765,7 @@ void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_dtbsv>(cgh, [=]() {
             ::cblas_dtbsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -783,7 +780,7 @@ void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_ctbsv>(cgh, [=]() {
             ::cblas_ctbsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -798,7 +795,7 @@ void tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         host_task<class netlib_ztbsv>(cgh, [=]() {
             ::cblas_ztbsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           convert_to_cblas_diag(unit_diag), (const int)n, (const int)k,
-                          accessor_a.get_pointer(), (const int)lda, accessor_x.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_x.GET_MULTI_PTR,
                           (const int)incx);
         });
     });
@@ -811,8 +808,8 @@ void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_stpmv>(cgh, [=]() {
             ::cblas_stpmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -824,8 +821,8 @@ void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dtpmv>(cgh, [=]() {
             ::cblas_dtpmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -838,22 +835,22 @@ void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ctpmv>(cgh, [=]() {
             ::cblas_ctpmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
 
 void tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          sycl::buffer<std::complex<double>, 1> &ap,
-          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          sycl::buffer<std::complex<double>, 1> &ap, sycl::buffer<std::complex<double>, 1> &x,
+          int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_ap = ap.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ztpmv>(cgh, [=]() {
             ::cblas_ztpmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -865,8 +862,8 @@ void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_stpsv>(cgh, [=]() {
             ::cblas_stpsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -878,8 +875,8 @@ void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dtpsv>(cgh, [=]() {
             ::cblas_dtpsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -892,22 +889,22 @@ void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ctpsv>(cgh, [=]() {
             ::cblas_ctpsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
 
 void tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          sycl::buffer<std::complex<double>, 1> &ap,
-          sycl::buffer<std::complex<double>, 1> &x, int64_t incx) {
+          sycl::buffer<std::complex<double>, 1> &ap, sycl::buffer<std::complex<double>, 1> &x,
+          int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_ap = ap.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ztpsv>(cgh, [=]() {
             ::cblas_ztpsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.get_pointer(),
-                          accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_ap.GET_MULTI_PTR,
+                          accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -919,22 +916,21 @@ void trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_strmv>(cgh, [=]() {
             ::cblas_strmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_b.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_b.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
 
 void trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag, int64_t n,
-          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b,
-          int64_t incx) {
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b, int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dtrmv>(cgh, [=]() {
             ::cblas_dtrmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_b.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_b.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -947,8 +943,8 @@ void trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ctrmv>(cgh, [=]() {
             ::cblas_ctrmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_b.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_b.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -961,8 +957,8 @@ void trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ztrmv>(cgh, [=]() {
             ::cblas_ztrmv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_b.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_b.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -974,22 +970,21 @@ void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_strsv>(cgh, [=]() {
             ::cblas_strsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
 
 void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
-          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x,
-          int64_t incx) {
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &x, int64_t incx) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dtrsv>(cgh, [=]() {
             ::cblas_dtrsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -1002,8 +997,8 @@ void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ctrsv>(cgh, [=]() {
             ::cblas_ctrsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
@@ -1016,18 +1011,17 @@ void trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
         auto accessor_x = x.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ztrsv>(cgh, [=]() {
             ::cblas_ztrsv(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.get_pointer(),
-                          (const int)lda, accessor_x.get_pointer(), (const int)incx);
+                          convert_to_cblas_diag(unit_diag), (const int)n, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, accessor_x.GET_MULTI_PTR, (const int)incx);
         });
     });
 }
 
 // USM APIs
 
-sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, float alpha, const float *a, int64_t lda, const float *x,
-                     int64_t incx, float beta, float *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 float alpha, const float *a, int64_t lda, const float *x, int64_t incx, float beta,
+                 float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1042,10 +1036,10 @@ sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int6
     return done;
 }
 
-sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, double alpha, const double *a, int64_t lda, const double *x,
-                     int64_t incx, double beta, double *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 double alpha, const double *a, int64_t lda, const double *x, int64_t incx,
+                 double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1060,11 +1054,11 @@ sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int6
     return done;
 }
 
-sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1079,11 +1073,11 @@ sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int6
     return done;
 }
 
-sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl,
-                     int64_t ku, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *x, int64_t incx,
-                     std::complex<double> beta, std::complex<double> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int64_t kl, int64_t ku,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1099,8 +1093,8 @@ sycl::event gbmv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, int6
 }
 
 sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, float alpha,
-                     const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 const float *a, int64_t lda, const float *x, int64_t incx, float beta, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1116,8 +1110,8 @@ sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, floa
 }
 
 sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, double alpha,
-                     const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 const double *a, int64_t lda, const double *x, int64_t incx, double beta,
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1133,10 +1127,10 @@ sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n, doub
 }
 
 sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                     std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1152,10 +1146,10 @@ sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
 }
 
 sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1170,9 +1164,9 @@ sycl::event gemv(sycl::queue &queue, transpose trans, int64_t m, int64_t n,
     return done;
 }
 
-sycl::event ger(sycl::queue &queue, int64_t m, int64_t n, float alpha, const float *x,
-                    int64_t incx, const float *y, int64_t incy, float *a, int64_t lda,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event ger(sycl::queue &queue, int64_t m, int64_t n, float alpha, const float *x, int64_t incx,
+                const float *y, int64_t incy, float *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1187,8 +1181,8 @@ sycl::event ger(sycl::queue &queue, int64_t m, int64_t n, float alpha, const flo
 }
 
 sycl::event ger(sycl::queue &queue, int64_t m, int64_t n, double alpha, const double *x,
-                    int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
-                    const std::vector<sycl::event> &dependencies) {
+                int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1203,9 +1197,9 @@ sycl::event ger(sycl::queue &queue, int64_t m, int64_t n, double alpha, const do
 }
 
 sycl::event gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *a, int64_t lda,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1220,9 +1214,9 @@ sycl::event gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> a
 }
 
 sycl::event gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
-                     int64_t incy, std::complex<double> *a, int64_t lda,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1237,9 +1231,9 @@ sycl::event gerc(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> 
 }
 
 sycl::event geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *a, int64_t lda,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1254,9 +1248,9 @@ sycl::event geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<float> a
 }
 
 sycl::event geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
-                     int64_t incy, std::complex<double> *a, int64_t lda,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1271,10 +1265,10 @@ sycl::event geru(sycl::queue &queue, int64_t m, int64_t n, std::complex<double> 
 }
 
 sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
-                     std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
-                     const std::complex<float> *x, int64_t incx, std::complex<float> beta,
-                     std::complex<float> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *x, int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1290,10 +1284,10 @@ sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
 }
 
 sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *x, int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1309,9 +1303,9 @@ sycl::event hbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k,
 }
 
 sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
-                     int64_t incx, std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *a, int64_t lda, const std::complex<float> *x,
+                 int64_t incx, std::complex<float> beta, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1326,11 +1320,10 @@ sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<f
     return done;
 }
 
-sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, const std::complex<double> *x,
+                 int64_t incx, std::complex<double> beta, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1346,8 +1339,8 @@ sycl::event hemv(sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const std::complex<float> *x, int64_t incx, std::complex<float> *a, int64_t lda,
-                    const std::vector<sycl::event> &dependencies) {
+                const std::complex<float> *x, int64_t incx, std::complex<float> *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1362,8 +1355,8 @@ sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
 }
 
 sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const std::complex<double> *x, int64_t incx, std::complex<double> *a,
-                    int64_t lda, const std::vector<sycl::event> &dependencies) {
+                const std::complex<double> *x, int64_t incx, std::complex<double> *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1378,9 +1371,9 @@ sycl::event her(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
 }
 
 sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *a, int64_t lda,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1395,10 +1388,10 @@ sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<f
     return done;
 }
 
-sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *a,
-                     int64_t lda, const std::vector<sycl::event> &dependencies) {
+sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1414,9 +1407,9 @@ sycl::event her2(sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *ap, const std::complex<float> *x, int64_t incx,
-                     std::complex<float> beta, std::complex<float> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *ap, const std::complex<float> *x, int64_t incx,
+                 std::complex<float> beta, std::complex<float> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1431,11 +1424,10 @@ sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<f
     return done;
 }
 
-sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *ap,
-                     const std::complex<double> *x, int64_t incx, std::complex<double> beta,
-                     std::complex<double> *y, int64_t incy,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *ap, const std::complex<double> *x, int64_t incx,
+                 std::complex<double> beta, std::complex<double> *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1451,8 +1443,8 @@ sycl::event hpmv(sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const std::complex<float> *x, int64_t incx, std::complex<float> *ap,
-                    const std::vector<sycl::event> &dependencies) {
+                const std::complex<float> *x, int64_t incx, std::complex<float> *ap,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1467,8 +1459,8 @@ sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
 }
 
 sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const std::complex<double> *x, int64_t incx, std::complex<double> *ap,
-                    const std::vector<sycl::event> &dependencies) {
+                const std::complex<double> *x, int64_t incx, std::complex<double> *ap,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1483,9 +1475,9 @@ sycl::event hpr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
 }
 
 sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
-                     int64_t incy, std::complex<float> *ap,
-                     const std::vector<sycl::event> &dependencies) {
+                 const std::complex<float> *x, int64_t incx, const std::complex<float> *y,
+                 int64_t incy, std::complex<float> *ap,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1499,10 +1491,10 @@ sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<f
     return done;
 }
 
-sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n,
-                     std::complex<double> alpha, const std::complex<double> *x, int64_t incx,
-                     const std::complex<double> *y, int64_t incy, std::complex<double> *ap,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, int64_t incx, const std::complex<double> *y,
+                 int64_t incy, std::complex<double> *ap,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1517,8 +1509,8 @@ sycl::event hpr2(sycl::queue &queue, uplo upper_lower, int64_t n,
 }
 
 sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, float alpha,
-                     const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 const float *a, int64_t lda, const float *x, int64_t incx, float beta, float *y,
+                 int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1534,8 +1526,8 @@ sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, flo
 }
 
 sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, double alpha,
-                     const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+                 const double *a, int64_t lda, const double *x, int64_t incx, double beta,
+                 double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1550,9 +1542,9 @@ sycl::event sbmv(sycl::queue &queue, uplo upper_lower, int64_t n, int64_t k, dou
     return done;
 }
 
-sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *ap, const float *x, int64_t incx, float beta, float *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *ap,
+                 const float *x, int64_t incx, float beta, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1567,9 +1559,9 @@ sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
     return done;
 }
 
-sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *ap, const double *x, int64_t incx, double beta, double *y,
-                     int64_t incy, const std::vector<sycl::event> &dependencies) {
+sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *ap,
+                 const double *x, int64_t incx, double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1584,9 +1576,8 @@ sycl::event spmv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
     return done;
 }
 
-sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const float *x, int64_t incx, float *ap,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                int64_t incx, float *ap, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1600,9 +1591,8 @@ sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
     return done;
 }
 
-sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const double *x, int64_t incx, double *ap,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                int64_t incx, double *ap, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1616,9 +1606,9 @@ sycl::event spr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
     return done;
 }
 
-sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *x, int64_t incx, const float *y, int64_t incy, float *ap,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                 int64_t incx, const float *y, int64_t incy, float *ap,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1632,9 +1622,9 @@ sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
     return done;
 }
 
-sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *x, int64_t incx, const double *y, int64_t incy, double *ap,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                 int64_t incx, const double *y, int64_t incy, double *ap,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1648,9 +1638,9 @@ sycl::event spr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
     return done;
 }
 
-sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *a, int64_t lda, const float *x, int64_t incx, float beta,
-                     float *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *a,
+                 int64_t lda, const float *x, int64_t incx, float beta, float *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1665,9 +1655,9 @@ sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
     return done;
 }
 
-sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *a, int64_t lda, const double *x, int64_t incx, double beta,
-                     double *y, int64_t incy, const std::vector<sycl::event> &dependencies) {
+sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *a,
+                 int64_t lda, const double *x, int64_t incx, double beta, double *y, int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1682,9 +1672,8 @@ sycl::event symv(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
     return done;
 }
 
-sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                    const float *x, int64_t incx, float *a, int64_t lda,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                int64_t incx, float *a, int64_t lda, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1698,9 +1687,9 @@ sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
     return done;
 }
 
-sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                    const double *x, int64_t incx, double *a, int64_t lda,
-                    const std::vector<sycl::event> &dependencies) {
+sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                int64_t incx, double *a, int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1714,9 +1703,9 @@ sycl::event syr(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
     return done;
 }
 
-sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
-                     const float *x, int64_t incx, const float *y, int64_t incy, float *a,
-                     int64_t lda, const std::vector<sycl::event> &dependencies) {
+sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha, const float *x,
+                 int64_t incx, const float *y, int64_t incy, float *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1731,9 +1720,9 @@ sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, float alpha,
     return done;
 }
 
-sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
-                     const double *x, int64_t incx, const double *y, int64_t incy, double *a,
-                     int64_t lda, const std::vector<sycl::event> &dependencies) {
+sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha, const double *x,
+                 int64_t incx, const double *y, int64_t incy, double *a, int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1748,9 +1737,9 @@ sycl::event syr2(sycl::queue &queue, uplo upper_lower, int64_t n, double alpha,
     return done;
 }
 
-sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1765,9 +1754,9 @@ sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1782,10 +1771,9 @@ sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1800,10 +1788,9 @@ sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1818,9 +1805,9 @@ sycl::event tbmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1835,9 +1822,9 @@ sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1852,10 +1839,9 @@ sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<float> *a, int64_t lda,
-                     std::complex<float> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1870,10 +1856,9 @@ sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, int64_t k, const std::complex<double> *a, int64_t lda,
-                     std::complex<double> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 int64_t k, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
+                 int64_t incx, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1888,9 +1873,9 @@ sycl::event tbsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const float *ap, float *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const float *ap, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1904,9 +1889,9 @@ sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const double *ap, double *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const double *ap, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1920,9 +1905,9 @@ sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1936,9 +1921,9 @@ sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<double> *ap, std::complex<double> *x,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<double> *ap, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1952,9 +1937,9 @@ sycl::event tpmv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const float *ap, float *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const float *ap, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1968,9 +1953,9 @@ sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const double *ap, double *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const double *ap, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1984,9 +1969,9 @@ sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<float> *ap, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2000,9 +1985,9 @@ sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<double> *ap, std::complex<double> *x,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<double> *ap, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2016,9 +2001,9 @@ sycl::event tpsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
-                     int64_t n, const float *a, int64_t lda, float *b, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag, int64_t n,
+                 const float *a, int64_t lda, float *b, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2033,9 +2018,9 @@ sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag un
     return done;
 }
 
-sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
-                     int64_t n, const double *a, int64_t lda, double *b, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag, int64_t n,
+                 const double *a, int64_t lda, double *b, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2050,9 +2035,9 @@ sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag un
     return done;
 }
 
-sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
-                     int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *b,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag, int64_t n,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2067,9 +2052,9 @@ sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag un
     return done;
 }
 
-sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag,
-                     int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag unit_diag, int64_t n,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *b, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2084,9 +2069,9 @@ sycl::event trmv(sycl::queue &queue, uplo upper_lower, transpose transa, diag un
     return done;
 }
 
-sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const float *a, int64_t lda, float *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const float *a, int64_t lda, float *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2101,9 +2086,9 @@ sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const double *a, int64_t lda, double *x, int64_t incx,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const double *a, int64_t lda, double *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2118,9 +2103,9 @@ sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<float> *a, int64_t lda, std::complex<float> *x,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -2135,9 +2120,9 @@ sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag uni
     return done;
 }
 
-sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag,
-                     int64_t n, const std::complex<double> *a, int64_t lda, std::complex<double> *x,
-                     int64_t incx, const std::vector<sycl::event> &dependencies) {
+sycl::event trsv(sycl::queue &queue, uplo upper_lower, transpose trans, diag unit_diag, int64_t n,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *x, int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {

--- a/src/blas/backends/netlib/netlib_level3.cxx
+++ b/src/blas/backends/netlib/netlib_level3.cxx
@@ -19,10 +19,9 @@
 
 // Buffer APIs
 
-void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
-          sycl::buffer<float, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
-          int64_t ldc) {
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b,
+          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
@@ -30,17 +29,16 @@ void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int
         host_task<class netlib_sgemm>(cgh, [=]() {
             ::cblas_sgemm(MAJOR, convert_to_cblas_trans(transa), convert_to_cblas_trans(transb),
                           (const int)m, (const int)n, (const int)k, (const float)alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                          (const int)ldb, (const float)beta, accessor_c.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                          (const int)ldb, (const float)beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
 }
 
-void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
-          sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
-          int64_t ldc) {
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b,
+          int64_t ldb, double beta, sycl::buffer<double, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
@@ -48,17 +46,17 @@ void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int
         host_task<class netlib_dgemm>(cgh, [=]() {
             ::cblas_dgemm(MAJOR, convert_to_cblas_trans(transa), convert_to_cblas_trans(transb),
                           (const int)m, (const int)n, (const int)k, (const double)alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                          (const int)ldb, (const double)beta, accessor_c.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                          (const int)ldb, (const double)beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
 }
 
-void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
-          int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb,
-          std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
@@ -66,17 +64,17 @@ void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int
         host_task<class netlib_cgemm>(cgh, [=]() {
             ::cblas_cgemm(MAJOR, convert_to_cblas_trans(transa), convert_to_cblas_trans(transb),
                           (const int)m, (const int)n, (const int)k, (const void *)&alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                          (const int)ldb, (const void *)&beta, accessor_c.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                          (const int)ldb, (const void *)&beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
 }
 
-void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
-          int64_t lda, sycl::buffer<std::complex<double>, 1> &b, int64_t ldb,
-          std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
@@ -84,15 +82,15 @@ void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int
         host_task<class netlib_zgemm>(cgh, [=]() {
             ::cblas_zgemm(MAJOR, convert_to_cblas_trans(transa), convert_to_cblas_trans(transb),
                           (const int)m, (const int)n, (const int)k, (const void *)&alpha,
-                          accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                          (const int)ldb, (const void *)&beta, accessor_c.get_pointer(),
+                          accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                          (const int)ldb, (const void *)&beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
 }
 
-void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, sycl::half alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda,
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          sycl::half alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda,
           sycl::buffer<sycl::half, 1> &b, int64_t ldb, sycl::half beta,
           sycl::buffer<sycl::half, 1> &c, int64_t ldc) {
 #ifdef COLUMN_MAJOR
@@ -103,10 +101,9 @@ void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int
 #endif
 }
 
-void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda,
-          sycl::buffer<sycl::half, 1> &b, int64_t ldb, float beta,
-          sycl::buffer<float, 1> &c, int64_t ldc) {
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          float alpha, sycl::buffer<sycl::half, 1> &a, int64_t lda, sycl::buffer<sycl::half, 1> &b,
+          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -115,10 +112,9 @@ void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int
 #endif
 }
 
-void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
-          int64_t k, float alpha, sycl::buffer<bfloat16, 1> &a, int64_t lda,
-          sycl::buffer<bfloat16, 1> &b, int64_t ldb, float beta, sycl::buffer<float, 1> &c,
-          int64_t ldc) {
+void gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n, int64_t k,
+          float alpha, sycl::buffer<bfloat16, 1> &a, int64_t lda, sycl::buffer<bfloat16, 1> &b,
+          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -138,9 +134,9 @@ void hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int6
         host_task<class netlib_chemm>(cgh, [=]() {
             ::cblas_chemm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb, (const void *)&beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb, (const void *)&beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
@@ -156,38 +152,38 @@ void hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int6
         host_task<class netlib_zhemm>(cgh, [=]() {
             ::cblas_zhemm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb, (const void *)&beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb, (const void *)&beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
 
-void herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          float alpha, sycl::buffer<std::complex<float>, 1> &a, int64_t lda, float beta,
+void herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, float alpha,
+          sycl::buffer<std::complex<float>, 1> &a, int64_t lda, float beta,
           sycl::buffer<std::complex<float>, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_cherk>(cgh, [=]() {
             ::cblas_cherk(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          (const int)n, (const int)k, (const float)alpha, accessor_a.get_pointer(),
-                          (const int)lda, (const float)beta, accessor_c.get_pointer(),
+                          (const int)n, (const int)k, (const float)alpha, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, (const float)beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
 }
 
-void herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          double alpha, sycl::buffer<std::complex<double>, 1> &a, int64_t lda, double beta,
+void herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, double alpha,
+          sycl::buffer<std::complex<double>, 1> &a, int64_t lda, double beta,
           sycl::buffer<std::complex<double>, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_zherk>(cgh, [=]() {
             ::cblas_zherk(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          (const int)n, (const int)k, (const double)alpha, accessor_a.get_pointer(),
-                          (const int)lda, (const double)beta, accessor_c.get_pointer(),
+                          (const int)n, (const int)k, (const double)alpha, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, (const double)beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
@@ -204,8 +200,8 @@ void her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int
         host_task<class netlib_cher2k>(cgh, [=]() {
             ::cblas_cher2k(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                            (const int)n, (const int)k, (const void *)&alpha,
-                           accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                           (const int)ldb, (const float)beta, accessor_c.get_pointer(),
+                           accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                           (const int)ldb, (const float)beta, accessor_c.GET_MULTI_PTR,
                            (const int)ldc);
         });
     });
@@ -222,16 +218,16 @@ void her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int
         host_task<class netlib_zher2k>(cgh, [=]() {
             ::cblas_zher2k(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                            (const int)n, (const int)k, (const void *)&alpha,
-                           accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                           (const int)ldb, (const double)beta, accessor_c.get_pointer(),
+                           accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                           (const int)ldb, (const double)beta, accessor_c.GET_MULTI_PTR,
                            (const int)ldc);
         });
     });
 }
 
-void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b,
-          int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
+void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n, float alpha,
+          sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb,
+          float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
@@ -239,16 +235,16 @@ void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int6
         host_task<class netlib_ssymm>(cgh, [=]() {
             ::cblas_ssymm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), (const int)m, (const int)n,
-                          (const float)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb, (const float)beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          (const float)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb, (const float)beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
 
-void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
-          double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b,
-          int64_t ldb, double beta, sycl::buffer<double, 1> &c, int64_t ldc) {
+void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n, double alpha,
+          sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b, int64_t ldb,
+          double beta, sycl::buffer<double, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
@@ -256,9 +252,9 @@ void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int6
         host_task<class netlib_dsymm>(cgh, [=]() {
             ::cblas_dsymm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), (const int)m, (const int)n,
-                          (const double)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb, (const double)beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          (const double)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb, (const double)beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
@@ -274,9 +270,9 @@ void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int6
         host_task<class netlib_csymm>(cgh, [=]() {
             ::cblas_csymm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb, (const void *)&beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb, (const void *)&beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
@@ -292,38 +288,38 @@ void symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int6
         host_task<class netlib_zsymm>(cgh, [=]() {
             ::cblas_zsymm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb, (const void *)&beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb, (const void *)&beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
 
-void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          float alpha, sycl::buffer<float, 1> &a, int64_t lda, float beta,
-          sycl::buffer<float, 1> &c, int64_t ldc) {
+void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, float alpha,
+          sycl::buffer<float, 1> &a, int64_t lda, float beta, sycl::buffer<float, 1> &c,
+          int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ssyrk>(cgh, [=]() {
             ::cblas_ssyrk(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          (const int)n, (const int)k, (const float)alpha, accessor_a.get_pointer(),
-                          (const int)lda, (const float)beta, accessor_c.get_pointer(),
+                          (const int)n, (const int)k, (const float)alpha, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, (const float)beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
 }
 
-void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-          double alpha, sycl::buffer<double, 1> &a, int64_t lda, double beta,
-          sycl::buffer<double, 1> &c, int64_t ldc) {
+void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, double alpha,
+          sycl::buffer<double, 1> &a, int64_t lda, double beta, sycl::buffer<double, 1> &c,
+          int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_dsyrk>(cgh, [=]() {
             ::cblas_dsyrk(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                          (const int)n, (const int)k, (const double)alpha, accessor_a.get_pointer(),
-                          (const int)lda, (const double)beta, accessor_c.get_pointer(),
+                          (const int)n, (const int)k, (const double)alpha, accessor_a.GET_MULTI_PTR,
+                          (const int)lda, (const double)beta, accessor_c.GET_MULTI_PTR,
                           (const int)ldc);
         });
     });
@@ -338,8 +334,8 @@ void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int6
         host_task<class netlib_csyrk>(cgh, [=]() {
             ::cblas_csyrk(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           (const int)n, (const int)k, (const void *)&alpha,
-                          accessor_a.get_pointer(), (const int)lda, (const void *)&beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          accessor_a.GET_MULTI_PTR, (const int)lda, (const void *)&beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
@@ -353,32 +349,31 @@ void syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int6
         host_task<class netlib_zsyrk>(cgh, [=]() {
             ::cblas_zsyrk(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                           (const int)n, (const int)k, (const void *)&alpha,
-                          accessor_a.get_pointer(), (const int)lda, (const void *)&beta,
-                          accessor_c.get_pointer(), (const int)ldc);
+                          accessor_a.GET_MULTI_PTR, (const int)lda, (const void *)&beta,
+                          accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
 
-void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           float alpha, sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b,
-           int64_t ldb, float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
+void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k, float alpha,
+           sycl::buffer<float, 1> &a, int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb,
+           float beta, sycl::buffer<float, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
         auto accessor_c = c.get_access<sycl::access::mode::read_write>(cgh);
         host_task<class netlib_ssyr2k>(cgh, [=]() {
             ::cblas_ssyr2k(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
-                           (const int)n, (const int)k, (const float)alpha, accessor_a.get_pointer(),
-                           (const int)lda, accessor_b.get_pointer(), (const int)ldb,
-                           (const float)beta, accessor_c.get_pointer(), (const int)ldc);
+                           (const int)n, (const int)k, (const float)alpha, accessor_a.GET_MULTI_PTR,
+                           (const int)lda, accessor_b.GET_MULTI_PTR, (const int)ldb,
+                           (const float)beta, accessor_c.GET_MULTI_PTR, (const int)ldc);
         });
     });
 }
 
 void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
-           double alpha, sycl::buffer<double, 1> &a, int64_t lda,
-           sycl::buffer<double, 1> &b, int64_t ldb, double beta, sycl::buffer<double, 1> &c,
-           int64_t ldc) {
+           double alpha, sycl::buffer<double, 1> &a, int64_t lda, sycl::buffer<double, 1> &b,
+           int64_t ldb, double beta, sycl::buffer<double, 1> &c, int64_t ldc) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read>(cgh);
@@ -386,8 +381,8 @@ void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int
         host_task<class netlib_dsyr2k>(cgh, [=]() {
             ::cblas_dsyr2k(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                            (const int)n, (const int)k, (const double)alpha,
-                           accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                           (const int)ldb, (const double)beta, accessor_c.get_pointer(),
+                           accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                           (const int)ldb, (const double)beta, accessor_c.GET_MULTI_PTR,
                            (const int)ldc);
         });
     });
@@ -404,8 +399,8 @@ void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int
         host_task<class netlib_csyr2k>(cgh, [=]() {
             ::cblas_csyr2k(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                            (const int)n, (const int)k, (const void *)&alpha,
-                           accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                           (const int)ldb, (const void *)&beta, accessor_c.get_pointer(),
+                           accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                           (const int)ldb, (const void *)&beta, accessor_c.GET_MULTI_PTR,
                            (const int)ldc);
         });
     });
@@ -422,16 +417,16 @@ void syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int
         host_task<class netlib_zsyr2k>(cgh, [=]() {
             ::cblas_zsyr2k(MAJOR, convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(trans),
                            (const int)n, (const int)k, (const void *)&alpha,
-                           accessor_a.get_pointer(), (const int)lda, accessor_b.get_pointer(),
-                           (const int)ldb, (const void *)&beta, accessor_c.get_pointer(),
+                           accessor_a.GET_MULTI_PTR, (const int)lda, accessor_b.GET_MULTI_PTR,
+                           (const int)ldb, (const void *)&beta, accessor_c.GET_MULTI_PTR,
                            (const int)ldc);
         });
     });
 }
 
-void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a,
-          int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb) {
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
@@ -439,15 +434,15 @@ void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_strmm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const float)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const float)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
-void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a,
-          int64_t lda, sycl::buffer<double, 1> &b, int64_t ldb) {
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
@@ -455,16 +450,15 @@ void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_dtrmm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const double)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const double)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
-void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
@@ -472,14 +466,14 @@ void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_ctrmm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
-void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, std::complex<double> alpha,
           sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
           sycl::buffer<std::complex<double>, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
@@ -489,15 +483,15 @@ void trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_ztrmm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
-void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a,
-          int64_t lda, sycl::buffer<float, 1> &b, int64_t ldb) {
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, float alpha, sycl::buffer<float, 1> &a, int64_t lda,
+          sycl::buffer<float, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
@@ -505,15 +499,15 @@ void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_strsm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const float)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const float)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
-void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a,
-          int64_t lda, sycl::buffer<double, 1> &b, int64_t ldb) {
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, double alpha, sycl::buffer<double, 1> &a, int64_t lda,
+          sycl::buffer<double, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
@@ -521,16 +515,15 @@ void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_dtrsm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const double)alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const double)alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
-void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-          sycl::buffer<std::complex<float>, 1> &a, int64_t lda,
-          sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          int64_t lda, sycl::buffer<std::complex<float>, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
         auto accessor_a = a.get_access<sycl::access::mode::read>(cgh);
         auto accessor_b = b.get_access<sycl::access::mode::read_write>(cgh);
@@ -538,14 +531,14 @@ void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_ctrsm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
-void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-          diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa, diag unit_diag,
+          int64_t m, int64_t n, std::complex<double> alpha,
           sycl::buffer<std::complex<double>, 1> &a, int64_t lda,
           sycl::buffer<std::complex<double>, 1> &b, int64_t ldb) {
     queue.submit([&](sycl::handler &cgh) {
@@ -555,18 +548,17 @@ void trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose trans
             ::cblas_ztrsm(MAJOR, convert_to_cblas_side(left_right),
                           convert_to_cblas_uplo(upper_lower), convert_to_cblas_trans(transa),
                           convert_to_cblas_diag(unit_diag), (const int)m, (const int)n,
-                          (const void *)&alpha, accessor_a.get_pointer(), (const int)lda,
-                          accessor_b.get_pointer(), (const int)ldb);
+                          (const void *)&alpha, accessor_a.GET_MULTI_PTR, (const int)lda,
+                          accessor_b.GET_MULTI_PTR, (const int)ldb);
         });
     });
 }
 
 // USM APIs
 
-sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const float *a, int64_t lda, const float *b,
-                     int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, float alpha, const float *a, int64_t lda, const float *b, int64_t ldb,
+                 float beta, float *c, int64_t ldc, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -581,10 +573,10 @@ sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t
     return done;
 }
 
-sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, double alpha, const double *a, int64_t lda,
-                     const double *b, int64_t ldb, double beta, double *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, double alpha, const double *a, int64_t lda, const double *b,
+                 int64_t ldb, double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -599,11 +591,11 @@ sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t
     return done;
 }
 
-sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -619,11 +611,11 @@ sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t
     return done;
 }
 
-sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, const std::complex<double> *b,
-                     int64_t ldb, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -639,10 +631,10 @@ sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t
     return done;
 }
 
-sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda,
-                     const sycl::half *b, int64_t ldb, sycl::half beta, sycl::half *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, sycl::half alpha, const sycl::half *a, int64_t lda, const sycl::half *b,
+                 int64_t ldb, sycl::half beta, sycl::half *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -651,10 +643,10 @@ sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t
 #endif
 }
 
-sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const sycl::half *a, int64_t lda,
-                     const sycl::half *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, float alpha, const sycl::half *a, int64_t lda, const sycl::half *b,
+                 int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -663,10 +655,10 @@ sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t
 #endif
 }
 
-sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m,
-                     int64_t n, int64_t k, float alpha, const bfloat16 *a, int64_t lda,
-                     const bfloat16 *b, int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t m, int64_t n,
+                 int64_t k, float alpha, const bfloat16 *a, int64_t lda, const bfloat16 *b,
+                 int64_t ldb, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
 #ifdef COLUMN_MAJOR
     throw unimplemented("blas", "gemm", "for column_major layout");
 #endif
@@ -675,11 +667,11 @@ sycl::event gemm(sycl::queue &queue, transpose transa, transpose transb, int64_t
 #endif
 }
 
-sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -695,11 +687,11 @@ sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t 
     return done;
 }
 
-sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *b, int64_t ldb,
-                     std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -715,10 +707,10 @@ sycl::event hemm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t 
     return done;
 }
 
-sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, float alpha, const std::complex<float> *a, int64_t lda, float beta,
-                     std::complex<float> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 float alpha, const std::complex<float> *a, int64_t lda, float beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -733,10 +725,10 @@ sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t 
     return done;
 }
 
-sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, double alpha, const std::complex<double> *a, int64_t lda,
-                     double beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 double alpha, const std::complex<double> *a, int64_t lda, double beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -751,11 +743,10 @@ sycl::event herk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t 
     return done;
 }
 
-sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                      int64_t lda, const std::complex<float> *b, int64_t ldb, float beta,
-                      std::complex<float> *c, int64_t ldc,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                  const std::complex<float> *b, int64_t ldb, float beta, std::complex<float> *c,
+                  int64_t ldc, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -770,11 +761,10 @@ sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t
     return done;
 }
 
-sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                      int64_t lda, const std::complex<double> *b, int64_t ldb, double beta,
-                      std::complex<double> *c, int64_t ldc,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                  const std::complex<double> *b, int64_t ldb, double beta, std::complex<double> *c,
+                  int64_t ldc, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -789,10 +779,9 @@ sycl::event her2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t
     return done;
 }
 
-sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, float alpha, const float *a, int64_t lda, const float *b,
-                     int64_t ldb, float beta, float *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 float alpha, const float *a, int64_t lda, const float *b, int64_t ldb, float beta,
+                 float *c, int64_t ldc, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -808,10 +797,10 @@ sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t 
     return done;
 }
 
-sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, double alpha, const double *a, int64_t lda, const double *b,
-                     int64_t ldb, double beta, double *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 double alpha, const double *a, int64_t lda, const double *b, int64_t ldb,
+                 double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -827,11 +816,11 @@ sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t 
     return done;
 }
 
-sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, const std::complex<float> *b, int64_t ldb,
-                     std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                 std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -847,11 +836,11 @@ sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t 
     return done;
 }
 
-sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m,
-                     int64_t n, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, const std::complex<double> *b, int64_t ldb,
-                     std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t m, int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                 std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -867,9 +856,9 @@ sycl::event symm(sycl::queue &queue, side left_right, uplo upper_lower, int64_t 
     return done;
 }
 
-sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, float alpha, const float *a, int64_t lda, float beta, float *c,
-                     int64_t ldc, const std::vector<sycl::event> &dependencies) {
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 float alpha, const float *a, int64_t lda, float beta, float *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -884,9 +873,9 @@ sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t 
     return done;
 }
 
-sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, double alpha, const double *a, int64_t lda, double beta, double *c,
-                     int64_t ldc, const std::vector<sycl::event> &dependencies) {
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 double alpha, const double *a, int64_t lda, double beta, double *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -901,10 +890,10 @@ sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t 
     return done;
 }
 
-sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                     int64_t lda, std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                 std::complex<float> beta, std::complex<float> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -919,10 +908,10 @@ sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t 
     return done;
 }
 
-sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                     int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                     int64_t lda, std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                     const std::vector<sycl::event> &dependencies) {
+sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                 std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                 std::complex<double> beta, std::complex<double> *c, int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -937,10 +926,9 @@ sycl::event syrk(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t 
     return done;
 }
 
-sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, float alpha, const float *a, int64_t lda, const float *b,
-                      int64_t ldb, float beta, float *c, int64_t ldc,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  float alpha, const float *a, int64_t lda, const float *b, int64_t ldb, float beta,
+                  float *c, int64_t ldc, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -955,10 +943,10 @@ sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t
     return done;
 }
 
-sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, double alpha, const double *a, int64_t lda, const double *b,
-                      int64_t ldb, double beta, double *c, int64_t ldc,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  double alpha, const double *a, int64_t lda, const double *b, int64_t ldb,
+                  double beta, double *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -973,11 +961,11 @@ sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t
     return done;
 }
 
-sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<float> alpha, const std::complex<float> *a,
-                      int64_t lda, const std::complex<float> *b, int64_t ldb,
-                      std::complex<float> beta, std::complex<float> *c, int64_t ldc,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<float> alpha, const std::complex<float> *a, int64_t lda,
+                  const std::complex<float> *b, int64_t ldb, std::complex<float> beta,
+                  std::complex<float> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -992,11 +980,11 @@ sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t
     return done;
 }
 
-sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n,
-                      int64_t k, std::complex<double> alpha, const std::complex<double> *a,
-                      int64_t lda, const std::complex<double> *b, int64_t ldb,
-                      std::complex<double> beta, std::complex<double> *c, int64_t ldc,
-                      const std::vector<sycl::event> &dependencies) {
+sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t n, int64_t k,
+                  std::complex<double> alpha, const std::complex<double> *a, int64_t lda,
+                  const std::complex<double> *b, int64_t ldb, std::complex<double> beta,
+                  std::complex<double> *c, int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1012,8 +1000,8 @@ sycl::event syr2k(sycl::queue &queue, uplo upper_lower, transpose trans, int64_t
 }
 
 sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
+                 float *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1030,9 +1018,8 @@ sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpos
 }
 
 sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
-                     int64_t lda, double *b, int64_t ldb,
-                     const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
+                 double *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1049,9 +1036,9 @@ sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpos
 }
 
 sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1068,9 +1055,9 @@ sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpos
 }
 
 sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1087,8 +1074,8 @@ sycl::event trmm(sycl::queue &queue, side left_right, uplo upper_lower, transpos
 }
 
 sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
-                     float *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, float alpha, const float *a, int64_t lda,
+                 float *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1105,9 +1092,8 @@ sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpos
 }
 
 sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, double alpha, const double *a,
-                     int64_t lda, double *b, int64_t ldb,
-                     const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, double alpha, const double *a, int64_t lda,
+                 double *b, int64_t ldb, const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1124,9 +1110,9 @@ sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpos
 }
 
 sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
-                     const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
-                     const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, int64_t lda, std::complex<float> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
@@ -1143,9 +1129,9 @@ sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpos
 }
 
 sycl::event trsm(sycl::queue &queue, side left_right, uplo upper_lower, transpose transa,
-                     diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
-                     const std::complex<double> *a, int64_t lda, std::complex<double> *b,
-                     int64_t ldb, const std::vector<sycl::event> &dependencies) {
+                 diag unit_diag, int64_t m, int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, int64_t lda, std::complex<double> *b, int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
     auto done = queue.submit([&](sycl::handler &cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {


### PR DESCRIPTION
# Description
This PR is fixing deprecation warnings in BLAS-NETLIB backend with LLVM compiler. 

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? Tested with both dpcpp and llvm. 
[dpcpp_netlib.log](https://github.com/oneapi-src/oneMKL/files/12718805/dpcpp_netlib.log)
[llvm_netlib.log](https://github.com/oneapi-src/oneMKL/files/12718803/llvm_netlib.log)

- [X] Have you formatted the code using clang-format?

