### PR TITLE
[LAPACK][rocSOLVER] Get rocSOLVER backend to build with SYCL2020 changes

### DIFF
--- a/src/lapack/backends/rocsolver/rocsolver_helper.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_helper.hpp
@@ -27,8 +27,8 @@
 #define _ROCSOLVER_HELPER_HPP_
 
 #include <CL/sycl.hpp>
-#include <rocblas.h>
-#include <rocsolver.h>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 #include <hip/hip_runtime.h>
 #include <complex>
 

--- a/src/lapack/backends/rocsolver/rocsolver_lapack.cpp
+++ b/src/lapack/backends/rocsolver/rocsolver_lapack.cpp
@@ -161,6 +161,7 @@ void getrf(const char *func_name, Func func, sycl::queue &queue, std::int64_t m,
     });
 
     // Copy from 32-bit buffer to 64-bit
+    queue.wait();
     queue.submit([&](sycl::handler &cgh) {
         auto ipiv32_acc = ipiv32.template get_access<sycl::access::mode::read>(cgh);
         auto ipiv_acc = ipiv.template get_access<sycl::access::mode::write>(cgh);
@@ -1286,6 +1287,7 @@ inline sycl::event getrf(const char *func_name, Func func, sycl::queue &queue, s
     });
 
     // Copy from 32-bit USM to 64-bit
+    queue.wait();
     auto done_casting = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(done);
         cgh.parallel_for(sycl::range<1>{ ipiv_size }, [=](sycl::id<1> index) {

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
@@ -57,7 +57,7 @@ public:
     // will be fixed when SYCL-2020 has been implemented for Pi backend.
     template <typename T, typename U>
     inline T get_mem(U acc) {
-        hipDeviceptr_t hipPtr = ih.get_native_mem<sycl::backend::hip>(acc);
+        hipDeviceptr_t hipPtr = ih.get_native_mem<sycl::backend::ext_oneapi_hip>(acc);
         return reinterpret_cast<T>(hipPtr);
     }
 };

--- a/src/lapack/backends/rocsolver/rocsolver_task.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_task.hpp
@@ -22,8 +22,8 @@
 #ifndef _MKL_LAPACK_ROCSOLVER_TASK_HPP_
 #define _MKL_LAPACK_ROCSOLVER_TASK_HPP_
 #include <hip/hip_runtime.h>
-#include <rocblas.h>
-#include <rocsolver.h>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 #include <complex>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
# Description

Allows oneMKL to build with rocSOLVER backend and fixes the crashing getrf tests. Now all tests pass.

Changes include:
backend::hip -> backend::ext_oneapi_hip
rocblas/rocsolver header locations
Wait on the queue before the integer array copy kernel in getrf (possibly a bug in the software stack as such a change was not necessary for cuSOLVER in #365)

Fixes #360 

# Checklist

## All Submissions
- [x] Do all unit tests pass locally? Attach a log.  [rocsolver.txt](https://github.com/oneapi-src/oneMKL/files/12757381/rocsolver.txt)
- [x] Have you formatted the code using clang-format?
