### PR TITLE
[LAPACK][rocSOLVER] Update rocSOLVER backend

### DIFF
--- a/src/lapack/backends/rocsolver/rocsolver_helper.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_helper.hpp
@@ -254,14 +254,15 @@ inline int get_rocsolver_devinfo(sycl::queue &queue, sycl::buffer<int> &devInfo)
 
 inline int get_rocsolver_devinfo(sycl::queue &queue, const int *devInfo) {
     int dev_info_;
-    queue.wait();
     queue.memcpy(&dev_info_, devInfo, sizeof(int));
+    queue.wait();
     return dev_info_;
 }
 
 template <typename DEVINFO_T>
 inline void lapack_info_check(sycl::queue &queue, DEVINFO_T devinfo, const char *func_name,
                               const char *cufunc_name) {
+    queue.wait();
     const int devinfo_ = get_rocsolver_devinfo(queue, devinfo);
     if (devinfo_ > 0)
         throw oneapi::mkl::lapack::computation_error(

--- a/src/lapack/backends/rocsolver/rocsolver_helper.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_helper.hpp
@@ -27,8 +27,8 @@
 #define _ROCSOLVER_HELPER_HPP_
 
 #include <CL/sycl.hpp>
-#include <rocblas.h>
-#include <rocsolver.h>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 #include <hip/hip_runtime.h>
 #include <complex>
 

--- a/src/lapack/backends/rocsolver/rocsolver_helper.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_helper.hpp
@@ -82,15 +82,7 @@ void overflow_check(Index index, Next... indices) {
 class rocsolver_error : virtual public std::runtime_error {
 protected:
     inline const char *rocsolver_error_map(rocblas_status error) {
-        switch (error) {
-            case rocblas_status_success: return "ROCBLAS_STATUS_SUCCESS";
-
-            case rocblas_status_invalid_value: return "ROCBLAS_STATUS_INVALID_VALUE";
-
-            case rocblas_status_internal_error: return "ROCBLAS_STATUS_INTERNAL_ERROR";
-
-            default: return "<unknown>";
-        }
+        return rocblas_status_to_string(error);
     }
 
     int error_number; ///< Error number
@@ -120,16 +112,7 @@ public:
 class hip_error : virtual public std::runtime_error {
 protected:
     inline const char *hip_error_map(hipError_t result) {
-        switch (result) {
-            case HIP_SUCCESS: return "HIP_SUCCESS";
-            case hipErrorNotInitialized: return "hipErrorNotInitialized";
-            case hipErrorInvalidContext: return "hipErrorInvalidContext";
-            case hipErrorInvalidDevice: return "hipErrorInvalidDevice";
-            case hipErrorInvalidValue: return "hipErrorInvalidValue";
-            case hipErrorMemoryAllocation: return "hipErrorMemoryAllocation";
-            case hipErrorLaunchOutOfResources: return "hipErrorLaunchOutOfResources";
-            default: return "<unknown>";
-        }
+        return hipGetErrorName(result);
     }
     int error_number; ///< error number
 public:

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
@@ -45,7 +45,6 @@ RocsolverScopedContextHandler::RocsolverScopedContextHandler(sycl::queue queue,
         : ih(ih),
           needToRecover_(false) {
     placedContext_ = new sycl::context(queue.get_context());
-    auto device = queue.get_device();
     auto desired = sycl::get_native<sycl::backend::ext_oneapi_hip>(*placedContext_);
     hipError_t err;
     HIP_ERROR_FUNC(hipCtxGetCurrent, err, &original_);

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
@@ -57,7 +57,11 @@ public:
     // will be fixed when SYCL-2020 has been implemented for Pi backend.
     template <typename T, typename U>
     inline T get_mem(U acc) {
+#ifdef SYCL_IMPLEMENTATION_ONEAPI
+        hipDeviceptr_t hipPtr = ih.get_native_mem<sycl::backend::ext_oneapi_hip>(acc);
+#else
         hipDeviceptr_t hipPtr = ih.get_native_mem<sycl::backend::hip>(acc);
+#endif
         return reinterpret_cast<T>(hipPtr);
     }
 };

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
@@ -57,11 +57,7 @@ public:
     // will be fixed when SYCL-2020 has been implemented for Pi backend.
     template <typename T, typename U>
     inline T get_mem(U acc) {
-#ifdef SYCL_IMPLEMENTATION_ONEAPI
         hipDeviceptr_t hipPtr = ih.get_native_mem<sycl::backend::ext_oneapi_hip>(acc);
-#else
-        hipDeviceptr_t hipPtr = ih.get_native_mem<sycl::backend::hip>(acc);
-#endif
         return reinterpret_cast<T>(hipPtr);
     }
 };

--- a/src/lapack/backends/rocsolver/rocsolver_task.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_task.hpp
@@ -22,8 +22,8 @@
 #ifndef _MKL_LAPACK_ROCSOLVER_TASK_HPP_
 #define _MKL_LAPACK_ROCSOLVER_TASK_HPP_
 #include <hip/hip_runtime.h>
-#include <rocblas.h>
-#include <rocsolver.h>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 #include <complex>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
# Description

This PR updates the rocSOLVER backend in order to fix the multiple race conditions seen in this backend, as well as some small cleaning and `ifdef` to support other sycl implementation modifications.

Here's the full list of modifications and what they fixed:

- [CLEANING]: The add of an `ifdef` to support the different names of the hip backend given by the different sycl implementations.
- [CLEANING]: Removal of all the `devInfo` logic in the library which calls HIP functions which do not accept and set `devInfo`.
- [RACE-CONDITION]: This PR https://github.com/intel/llvm/pull/11344 re-introduced the call to the extendedDeleter which fixes the segfault that was happening at the end of the `example_lapack_getrs_usm`
- [RACE-CONDITION]: The helper function `lapack_info_check` was not correctly waiting on the `sycl::queue` which created a race condition when reading `devInfo`. The wait has been moved to wait for all overloads, as well as the addition of another `wait` to let the `memcpy` finish.
- [RACE-CONDITION]: All `onemkl_rocsolver_host_task` now uses `ROCSOLVER_ERROR_FUNC_T_SYNC` to synchronize the `HIPStream`. (Similar to https://github.com/oneapi-src/oneMKL/pull/376)
- [RACE-CONDITION]: Added the explicit requirements for `parrallel_for` on `host_task` via `depends_on`.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

[example_lapack_getrs_usm.log.txt](https://github.com/oneapi-src/oneMKL/files/12801629/example_lapack_getrs_usm.log.txt)
[test_main_lapack_ct.log.txt](https://github.com/oneapi-src/oneMKL/files/12801630/test_main_lapack_ct.log.txt)
[test_main_lapack_rt.log.txt](https://github.com/oneapi-src/oneMKL/files/12801631/test_main_lapack_rt.log.txt)
