### PR TITLE
[tests] skip DP tests on devices without DP support

### DIFF
--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -172,6 +172,8 @@ TEST_P(AxpyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha = 2.0;
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, alpha, 15));
@@ -192,6 +194,8 @@ TEST_P(AxpyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha = std::complex<double>(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  2, 3, alpha, 15));

--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -172,7 +172,7 @@ TEST_P(AxpyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha = 2.0;
     EXPECT_TRUEORSKIP(
@@ -194,7 +194,7 @@ TEST_P(AxpyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha = std::complex<double>(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
@@ -179,7 +179,7 @@ TEST_P(AxpyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha = 2.0;
     EXPECT_TRUEORSKIP(
@@ -201,7 +201,7 @@ TEST_P(AxpyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha = std::complex<double>(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
@@ -179,6 +179,8 @@ TEST_P(AxpyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha = 2.0;
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, alpha, 15));
@@ -199,6 +201,8 @@ TEST_P(AxpyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AxpyBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha = std::complex<double>(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  2, 3, alpha, 15));

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -259,7 +259,7 @@ TEST_P(AxpyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(AxpyBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -270,7 +270,7 @@ TEST_P(AxpyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AxpyBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -259,6 +259,8 @@ TEST_P(AxpyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(AxpyBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -268,6 +270,8 @@ TEST_P(AxpyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AxpyBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -164,7 +164,7 @@ TEST_P(CopyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 15));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 15));
@@ -181,7 +181,7 @@ TEST_P(CopyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 15));

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -164,6 +164,8 @@ TEST_P(CopyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 15));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 15));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1, 1, 15));
@@ -179,6 +181,8 @@ TEST_P(CopyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 15));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
@@ -174,7 +174,7 @@ TEST_P(CopyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha = 2.0;
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 15));
@@ -193,7 +193,7 @@ TEST_P(CopyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha = std::complex<double>(2.0, -0.5);
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
@@ -174,6 +174,8 @@ TEST_P(CopyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha = 2.0;
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 15));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 15));
@@ -191,6 +193,8 @@ TEST_P(CopyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(CopyBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha = std::complex<double>(2.0, -0.5);
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 15));

--- a/tests/unit_tests/blas/batch/copy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_usm.cpp
@@ -253,6 +253,8 @@ TEST_P(CopyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(CopyBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -262,6 +264,8 @@ TEST_P(CopyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(CopyBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/copy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_usm.cpp
@@ -253,7 +253,7 @@ TEST_P(CopyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(CopyBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -264,7 +264,7 @@ TEST_P(CopyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(CopyBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -195,7 +195,7 @@ TEST_P(DgmmBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::right, 2, 5));
@@ -227,7 +227,7 @@ TEST_P(DgmmBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::right, 2, 5));

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -195,6 +195,8 @@ TEST_P(DgmmBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::right, 2, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -225,6 +227,8 @@ TEST_P(DgmmBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::right, 2, 5));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -200,7 +200,7 @@ TEST_P(DgmmBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::right, 2, 5));
@@ -232,7 +232,7 @@ TEST_P(DgmmBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::right, 2, 5));

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -200,6 +200,8 @@ TEST_P(DgmmBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::right, 2, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -230,6 +232,8 @@ TEST_P(DgmmBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(DgmmBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::right, 2, 5));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -292,7 +292,7 @@ TEST_P(DgmmBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(DgmmBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -303,7 +303,7 @@ TEST_P(DgmmBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(DgmmBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -292,6 +292,8 @@ TEST_P(DgmmBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(DgmmBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -301,6 +303,8 @@ TEST_P(DgmmBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(DgmmBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -219,6 +219,8 @@ TEST_P(GemmBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -228,6 +230,8 @@ TEST_P(GemmBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -219,7 +219,7 @@ TEST_P(GemmBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -230,7 +230,7 @@ TEST_P(GemmBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -253,6 +253,8 @@ TEST_P(GemmBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -262,6 +264,8 @@ TEST_P(GemmBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -253,7 +253,7 @@ TEST_P(GemmBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -264,7 +264,7 @@ TEST_P(GemmBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -342,7 +342,7 @@ TEST_P(GemmBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -353,7 +353,7 @@ TEST_P(GemmBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -342,6 +342,8 @@ TEST_P(GemmBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -351,6 +353,8 @@ TEST_P(GemmBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -201,6 +201,8 @@ TEST_P(GemvBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1, 1, 5));
@@ -214,6 +216,8 @@ TEST_P(GemvBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5);
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 5);

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -201,7 +201,7 @@ TEST_P(GemvBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 5));
@@ -216,7 +216,7 @@ TEST_P(GemvBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5);

--- a/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
@@ -204,6 +204,8 @@ TEST_P(GemvBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1, 1, 5));
@@ -217,6 +219,8 @@ TEST_P(GemvBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5);
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 5);

--- a/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
@@ -204,7 +204,7 @@ TEST_P(GemvBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), -2, -3, 5));
@@ -219,7 +219,7 @@ TEST_P(GemvBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 2, 3, 5);

--- a/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
@@ -312,6 +312,8 @@ TEST_P(GemvBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemvBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -321,6 +323,8 @@ TEST_P(GemvBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
@@ -312,7 +312,7 @@ TEST_P(GemvBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemvBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -323,7 +323,7 @@ TEST_P(GemvBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
@@ -176,7 +176,7 @@ TEST_P(ImatcopyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -187,7 +187,7 @@ TEST_P(ImatcopyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
@@ -176,6 +176,8 @@ TEST_P(ImatcopyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -185,6 +187,8 @@ TEST_P(ImatcopyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
@@ -200,6 +200,8 @@ TEST_P(ImatcopyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -209,6 +211,8 @@ TEST_P(ImatcopyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
@@ -200,7 +200,7 @@ TEST_P(ImatcopyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -211,7 +211,7 @@ TEST_P(ImatcopyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/imatcopy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_usm.cpp
@@ -256,6 +256,8 @@ TEST_P(ImatcopyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -265,6 +267,8 @@ TEST_P(ImatcopyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/imatcopy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_usm.cpp
@@ -256,7 +256,7 @@ TEST_P(ImatcopyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -267,7 +267,7 @@ TEST_P(ImatcopyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
@@ -192,6 +192,8 @@ TEST_P(OmataddBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -201,6 +203,8 @@ TEST_P(OmataddBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
@@ -192,7 +192,7 @@ TEST_P(OmataddBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -203,7 +203,7 @@ TEST_P(OmataddBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/omatadd_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatadd_batch_stride_usm.cpp
@@ -225,7 +225,7 @@ TEST_P(OmataddBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -236,7 +236,7 @@ TEST_P(OmataddBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/omatadd_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatadd_batch_stride_usm.cpp
@@ -225,6 +225,8 @@ TEST_P(OmataddBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -234,6 +236,8 @@ TEST_P(OmataddBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
@@ -181,6 +181,8 @@ TEST_P(OmatcopyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -190,6 +192,8 @@ TEST_P(OmatcopyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
@@ -181,7 +181,7 @@ TEST_P(OmatcopyBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -192,7 +192,7 @@ TEST_P(OmatcopyBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/omatcopy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_stride_usm.cpp
@@ -212,6 +212,8 @@ TEST_P(OmatcopyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -221,6 +223,8 @@ TEST_P(OmatcopyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/omatcopy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_stride_usm.cpp
@@ -212,7 +212,7 @@ TEST_P(OmatcopyBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -223,7 +223,7 @@ TEST_P(OmatcopyBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/omatcopy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_usm.cpp
@@ -262,7 +262,7 @@ TEST_P(OmatcopyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -273,7 +273,7 @@ TEST_P(OmatcopyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/omatcopy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_usm.cpp
@@ -262,6 +262,8 @@ TEST_P(OmatcopyBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -271,6 +273,8 @@ TEST_P(OmatcopyBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -67,9 +67,9 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 
     upper_lower = (oneapi::mkl::uplo)(std::rand() % 2);
     if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-        trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
-                                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                                                : oneapi::mkl::transpose::conjtrans;
+        trans = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
+                : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                         : oneapi::mkl::transpose::conjtrans;
     }
     else {
         trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
@@ -201,7 +201,7 @@ TEST_P(SyrkBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -212,7 +212,7 @@ TEST_P(SyrkBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -67,9 +67,9 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 
     upper_lower = (oneapi::mkl::uplo)(std::rand() % 2);
     if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-        trans = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
-                : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                         : oneapi::mkl::transpose::conjtrans;
+        trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
+                                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                                                : oneapi::mkl::transpose::conjtrans;
     }
     else {
         trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -201,6 +201,8 @@ TEST_P(SyrkBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -210,6 +212,8 @@ TEST_P(SyrkBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -86,9 +86,9 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     beta = rand_scalar<fp>();
     upper_lower = (oneapi::mkl::uplo)(std::rand() % 2);
     if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-        trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
-                                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                                                : oneapi::mkl::transpose::conjtrans;
+        trans = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
+                : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                         : oneapi::mkl::transpose::conjtrans;
     }
     else {
         trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
@@ -229,7 +229,7 @@ TEST_P(SyrkBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -240,7 +240,7 @@ TEST_P(SyrkBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -229,6 +229,8 @@ TEST_P(SyrkBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -238,6 +240,8 @@ TEST_P(SyrkBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(SyrkBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -86,9 +86,9 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     beta = rand_scalar<fp>();
     upper_lower = (oneapi::mkl::uplo)(std::rand() % 2);
     if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-        trans = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
-                : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                         : oneapi::mkl::transpose::conjtrans;
+        trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
+                                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                                                : oneapi::mkl::transpose::conjtrans;
     }
     else {
         trans = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -106,9 +106,10 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
         beta[i] = rand_scalar<fp>();
         upper_lower[i] = (oneapi::mkl::uplo)(std::rand() % 2);
         if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-            trans[i] = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
-                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                                : oneapi::mkl::transpose::conjtrans;
+            trans[i] = (std::rand() % 2) == 0
+                           ? oneapi::mkl::transpose::nontrans
+                           : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                                    : oneapi::mkl::transpose::conjtrans;
         }
         else {
             trans[i] = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -308,6 +308,8 @@ TEST_P(SyrkBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(SyrkBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -317,6 +319,8 @@ TEST_P(SyrkBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(SyrkBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -106,10 +106,9 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
         beta[i] = rand_scalar<fp>();
         upper_lower[i] = (oneapi::mkl::uplo)(std::rand() % 2);
         if ((std::is_same<fp, float>::value) || (std::is_same<fp, double>::value)) {
-            trans[i] = (std::rand() % 2) == 0
-                           ? oneapi::mkl::transpose::nontrans
-                           : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
-                                                    : oneapi::mkl::transpose::conjtrans;
+            trans[i] = (std::rand() % 2) == 0   ? oneapi::mkl::transpose::nontrans
+                       : (std::rand() % 2) == 0 ? oneapi::mkl::transpose::trans
+                                                : oneapi::mkl::transpose::conjtrans;
         }
         else {
             trans[i] = (std::rand() % 2) == 0 ? oneapi::mkl::transpose::nontrans
@@ -308,7 +307,7 @@ TEST_P(SyrkBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(SyrkBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -319,7 +318,7 @@ TEST_P(SyrkBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(SyrkBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -206,6 +206,8 @@ TEST_P(TrsmBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -214,6 +216,8 @@ TEST_P(TrsmBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -206,7 +206,7 @@ TEST_P(TrsmBatchStrideTests, RealSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -216,7 +216,7 @@ TEST_P(TrsmBatchStrideTests, ComplexSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
@@ -208,6 +208,8 @@ TEST_P(TrsmBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -216,6 +218,8 @@ TEST_P(TrsmBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
@@ -208,7 +208,7 @@ TEST_P(TrsmBatchStrideUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -218,7 +218,7 @@ TEST_P(TrsmBatchStrideUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(TrsmBatchStrideUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
@@ -324,7 +324,7 @@ TEST_P(TrsmBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(TrsmBatchUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
@@ -335,7 +335,7 @@ TEST_P(TrsmBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(TrsmBatchUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));

--- a/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
@@ -324,6 +324,8 @@ TEST_P(TrsmBatchUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(TrsmBatchUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }
 
@@ -333,6 +335,8 @@ TEST_P(TrsmBatchUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(TrsmBatchUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 5));
 }

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -184,7 +184,7 @@ TEST_P(GemmtTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmtTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -300,7 +300,7 @@ TEST_P(GemmtTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmtTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0);
     std::complex<double> beta(3.0);

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -184,6 +184,8 @@ TEST_P(GemmtTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmtTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -298,6 +300,8 @@ TEST_P(GemmtTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmtTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0);
     std::complex<double> beta(3.0);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -184,6 +184,8 @@ TEST_P(GemmtUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmtUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -298,6 +300,8 @@ TEST_P(GemmtUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmtUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0);
     std::complex<double> beta(3.0);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -184,7 +184,7 @@ TEST_P(GemmtUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmtUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -300,7 +300,7 @@ TEST_P(GemmtUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmtUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0);
     std::complex<double> beta(3.0);

--- a/tests/unit_tests/blas/extensions/imatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy.cpp
@@ -169,7 +169,7 @@ TEST_P(ImatcopyTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -179,7 +179,7 @@ TEST_P(ImatcopyTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/extensions/imatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy.cpp
@@ -169,6 +169,8 @@ TEST_P(ImatcopyTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -177,6 +179,8 @@ TEST_P(ImatcopyTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
@@ -174,6 +174,8 @@ TEST_P(ImatcopyUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -182,6 +184,8 @@ TEST_P(ImatcopyUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
@@ -174,7 +174,7 @@ TEST_P(ImatcopyUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(ImatcopyUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -184,7 +184,7 @@ TEST_P(ImatcopyUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(ImatcopyUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/extensions/omatadd.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd.cpp
@@ -185,7 +185,7 @@ TEST_P(OmataddTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -195,7 +195,7 @@ TEST_P(OmataddTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/extensions/omatadd.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd.cpp
@@ -185,6 +185,8 @@ TEST_P(OmataddTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -193,6 +195,8 @@ TEST_P(OmataddTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/extensions/omatadd_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd_usm.cpp
@@ -189,7 +189,7 @@ TEST_P(OmataddUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -199,7 +199,7 @@ TEST_P(OmataddUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/extensions/omatadd_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd_usm.cpp
@@ -189,6 +189,8 @@ TEST_P(OmataddUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmataddUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -197,6 +199,8 @@ TEST_P(OmataddUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmataddUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/extensions/omatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy.cpp
@@ -178,7 +178,7 @@ TEST_P(OmatcopyTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -188,7 +188,7 @@ TEST_P(OmatcopyTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/extensions/omatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy.cpp
@@ -178,6 +178,8 @@ TEST_P(OmatcopyTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -186,6 +188,8 @@ TEST_P(OmatcopyTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
@@ -176,6 +176,8 @@ TEST_P(OmatcopyUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -184,6 +186,8 @@ TEST_P(OmatcopyUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
@@ -176,7 +176,7 @@ TEST_P(OmatcopyUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(OmatcopyUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
@@ -186,7 +186,7 @@ TEST_P(OmatcopyUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(OmatcopyUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -138,7 +138,7 @@ TEST_P(AsumTests, RealSinglePrecision) {
 }
 
 TEST_P(AsumTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (::test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
@@ -158,7 +158,7 @@ TEST_P(AsumTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AsumTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -138,6 +138,8 @@ TEST_P(AsumTests, RealSinglePrecision) {
 }
 
 TEST_P(AsumTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (::test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
@@ -156,6 +158,8 @@ TEST_P(AsumTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AsumTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -158,6 +158,8 @@ TEST_P(AsumUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(AsumUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (::test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
@@ -180,6 +182,8 @@ TEST_P(AsumUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AsumUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -158,7 +158,7 @@ TEST_P(AsumUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(AsumUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (::test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
@@ -182,7 +182,7 @@ TEST_P(AsumUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(AsumUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -144,6 +144,8 @@ TEST_P(AxpbyTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(
@@ -164,6 +166,8 @@ TEST_P(AxpbyTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -144,7 +144,7 @@ TEST_P(AxpbyTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -166,7 +166,7 @@ TEST_P(AxpbyTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level1/axpby_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpby_usm.cpp
@@ -147,7 +147,7 @@ TEST_P(AxpbyUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -169,7 +169,7 @@ TEST_P(AxpbyUsmTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level1/axpby_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpby_usm.cpp
@@ -147,6 +147,8 @@ TEST_P(AxpbyUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(
@@ -167,6 +169,8 @@ TEST_P(AxpbyUsmTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha, beta));
 }
 TEST_P(AxpbyUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -143,7 +143,7 @@ TEST_P(AxpyTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha));
 }
 TEST_P(AxpyTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
@@ -163,7 +163,7 @@ TEST_P(AxpyTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha));
 }
 TEST_P(AxpyTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -143,6 +143,8 @@ TEST_P(AxpyTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha));
 }
 TEST_P(AxpyTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, alpha));
@@ -161,6 +163,8 @@ TEST_P(AxpyTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha));
 }
 TEST_P(AxpyTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  1357, 2, 3, alpha));

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -146,6 +146,8 @@ TEST_P(AxpyUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha));
 }
 TEST_P(AxpyUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, alpha));
@@ -164,6 +166,8 @@ TEST_P(AxpyUsmTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha));
 }
 TEST_P(AxpyUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  1357, 2, 3, alpha));

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -146,7 +146,7 @@ TEST_P(AxpyUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2, alpha));
 }
 TEST_P(AxpyUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
@@ -166,7 +166,7 @@ TEST_P(AxpyUsmTests, ComplexSinglePrecision) {
                                                 1357, -3, -2, alpha));
 }
 TEST_P(AxpyUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -137,7 +137,7 @@ TEST_P(CopyTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
@@ -152,7 +152,7 @@ TEST_P(CopyTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -137,6 +137,8 @@ TEST_P(CopyTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
@@ -150,6 +152,8 @@ TEST_P(CopyTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -141,6 +141,8 @@ TEST_P(CopyUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
@@ -154,6 +156,8 @@ TEST_P(CopyUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -141,7 +141,7 @@ TEST_P(CopyUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
@@ -156,7 +156,7 @@ TEST_P(CopyUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(CopyUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -140,6 +140,8 @@ TEST_P(DotTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(
@@ -148,6 +150,7 @@ TEST_P(DotTests, RealDoublePrecision) {
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotTests, RealDoubleSinglePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -140,7 +140,7 @@ TEST_P(DotTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
@@ -150,7 +150,7 @@ TEST_P(DotTests, RealDoublePrecision) {
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotTests, RealDoubleSinglePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -156,6 +156,8 @@ TEST_P(DotUsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(
@@ -166,6 +168,7 @@ TEST_P(DotUsmTests, RealDoublePrecision) {
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotUsmTests, RealDoubleSinglePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -156,7 +156,7 @@ TEST_P(DotUsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
@@ -168,7 +168,7 @@ TEST_P(DotUsmTests, RealDoublePrecision) {
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2)));
 }
 TEST_P(DotUsmTests, RealDoubleSinglePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
     EXPECT_TRUEORSKIP(
         (test<float, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3)));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -143,7 +143,7 @@ TEST_P(DotcTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotcTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -143,6 +143,8 @@ TEST_P(DotcTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotcTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -148,7 +148,7 @@ TEST_P(DotcUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotcUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -148,6 +148,8 @@ TEST_P(DotcUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotcUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -143,6 +143,8 @@ TEST_P(DotuTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotuTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -143,7 +143,7 @@ TEST_P(DotuTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotuTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -147,7 +147,7 @@ TEST_P(DotuUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotuUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -147,6 +147,8 @@ TEST_P(DotuUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, -2));
 }
 TEST_P(DotuUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -135,7 +135,7 @@ TEST_P(IamaxTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
@@ -150,7 +150,7 @@ TEST_P(IamaxTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -135,6 +135,8 @@ TEST_P(IamaxTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
@@ -148,6 +150,8 @@ TEST_P(IamaxTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -152,7 +152,7 @@ TEST_P(IamaxUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
@@ -171,7 +171,7 @@ TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -152,6 +152,8 @@ TEST_P(IamaxUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
     EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(std::get<0>(GetParam()),
@@ -169,6 +171,8 @@ TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IamaxUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -135,6 +135,8 @@ TEST_P(IaminTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
@@ -148,6 +150,8 @@ TEST_P(IaminTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -135,7 +135,7 @@ TEST_P(IaminTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
@@ -150,7 +150,7 @@ TEST_P(IaminTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -152,7 +152,7 @@ TEST_P(IaminUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
@@ -171,7 +171,7 @@ TEST_P(IaminUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -152,6 +152,8 @@ TEST_P(IaminUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
     EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(std::get<0>(GetParam()),
@@ -169,6 +171,8 @@ TEST_P(IaminUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
 }
 TEST_P(IaminUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -138,7 +138,7 @@ TEST_P(Nrm2Tests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2Tests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
@@ -156,7 +156,7 @@ TEST_P(Nrm2Tests, ComplexSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2Tests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -138,6 +138,8 @@ TEST_P(Nrm2Tests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2Tests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
@@ -154,6 +156,8 @@ TEST_P(Nrm2Tests, ComplexSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2Tests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -156,7 +156,7 @@ TEST_P(Nrm2UsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2UsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
@@ -178,7 +178,7 @@ TEST_P(Nrm2UsmTests, ComplexSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2UsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -156,6 +156,8 @@ TEST_P(Nrm2UsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2UsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP(
@@ -176,6 +178,8 @@ TEST_P(Nrm2UsmTests, ComplexSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3)));
 }
 TEST_P(Nrm2UsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),
                                                           std::get<1>(GetParam()), 1357, 2)));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(std::get<0>(GetParam()),

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -149,6 +149,8 @@ TEST_P(RotTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double c(2.0);
     double s(-0.5);
     EXPECT_TRUEORSKIP(
@@ -169,6 +171,8 @@ TEST_P(RotTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double c = 2.0;
     double s = -0.5;
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -149,7 +149,7 @@ TEST_P(RotTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double c(2.0);
     double s(-0.5);
@@ -171,7 +171,7 @@ TEST_P(RotTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double c = 2.0;
     double s = -0.5;

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -150,7 +150,7 @@ TEST_P(RotUsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double c(2.0);
     double s(-0.5);
@@ -172,7 +172,7 @@ TEST_P(RotUsmTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double c = 2.0;
     double s = -0.5;

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -150,6 +150,8 @@ TEST_P(RotUsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double c(2.0);
     double s(-0.5);
     EXPECT_TRUEORSKIP(
@@ -170,6 +172,8 @@ TEST_P(RotUsmTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, c, s)));
 }
 TEST_P(RotUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double c = 2.0;
     double s = -0.5;
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -153,6 +153,8 @@ TEST_P(RotgTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP((test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
@@ -166,6 +168,8 @@ TEST_P(RotgTests, ComplexSinglePrecision) {
         (test<std::complex<float>, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -153,7 +153,7 @@ TEST_P(RotgTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP((test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
@@ -168,7 +168,7 @@ TEST_P(RotgTests, ComplexSinglePrecision) {
         (test<std::complex<float>, float>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -178,7 +178,7 @@ TEST_P(RotgUsmTests, RealSinglePrecision) {
         (test<float, float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
     EXPECT_TRUEORSKIP((test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
@@ -191,7 +191,7 @@ TEST_P(RotgUsmTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -178,6 +178,8 @@ TEST_P(RotgUsmTests, RealSinglePrecision) {
         (test<float, float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP((test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
     EXPECT_TRUEORSKIP((test<double, double, usm::alloc::device>(std::get<0>(GetParam()),
                                                                 std::get<1>(GetParam()))));
@@ -189,6 +191,8 @@ TEST_P(RotgUsmTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotgUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
     EXPECT_TRUEORSKIP((test<std::complex<double>, double, usm::alloc::device>(

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -170,7 +170,7 @@ TEST_P(RotmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, flag));
 }
 TEST_P(RotmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double flag(-1.0);
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -170,6 +170,8 @@ TEST_P(RotmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, flag));
 }
 TEST_P(RotmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double flag(-1.0);
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, flag));

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -171,6 +171,8 @@ TEST_P(RotmUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, flag));
 }
 TEST_P(RotmUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double flag(-1.0);
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, flag));

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -171,7 +171,7 @@ TEST_P(RotmUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, flag));
 }
 TEST_P(RotmUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double flag(-1.0);
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -194,7 +194,7 @@ TEST_P(RotmgTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 TEST_P(RotmgTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -194,6 +194,8 @@ TEST_P(RotmgTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 TEST_P(RotmgTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -221,6 +221,8 @@ TEST_P(RotmgUsmTests, RealSinglePrecision) {
         (test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotmgUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
     EXPECT_TRUEORSKIP(
         (test<double, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -221,7 +221,7 @@ TEST_P(RotmgUsmTests, RealSinglePrecision) {
         (test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()))));
 }
 TEST_P(RotmgUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -137,7 +137,7 @@ TEST_P(ScalTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
@@ -153,7 +153,7 @@ TEST_P(ScalTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP((test<std::complex<double>, std::complex<double>>(
@@ -169,7 +169,7 @@ TEST_P(ScalTests, ComplexRealSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalTests, ComplexRealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -137,6 +137,8 @@ TEST_P(ScalTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, alpha)));
@@ -151,6 +153,8 @@ TEST_P(ScalTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP((test<std::complex<double>, std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, alpha)));
@@ -165,6 +169,8 @@ TEST_P(ScalTests, ComplexRealSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalTests, ComplexRealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, alpha)));

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -144,7 +144,7 @@ TEST_P(ScalUsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
@@ -160,7 +160,7 @@ TEST_P(ScalUsmTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP((test<std::complex<double>, std::complex<double>>(
@@ -176,7 +176,7 @@ TEST_P(ScalUsmTests, ComplexRealSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalUsmTests, ComplexRealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -144,6 +144,8 @@ TEST_P(ScalUsmTests, RealSinglePrecision) {
         (test<float, float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         (test<double, double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, alpha)));
@@ -158,6 +160,8 @@ TEST_P(ScalUsmTests, ComplexSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP((test<std::complex<double>, std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, alpha)));
@@ -172,6 +176,8 @@ TEST_P(ScalUsmTests, ComplexRealSinglePrecision) {
                                                         std::get<1>(GetParam()), 1357, -3, alpha)));
 }
 TEST_P(ScalUsmTests, ComplexRealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, alpha)));

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -133,6 +133,7 @@ class SdsdotTests
         : public ::testing::TestWithParam<std::tuple<sycl::device *, oneapi::mkl::layout>> {};
 
 TEST_P(SdsdotTests, RealSinglePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, 2.0));

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -133,7 +133,7 @@ class SdsdotTests
         : public ::testing::TestWithParam<std::tuple<sycl::device *, oneapi::mkl::layout>> {};
 
 TEST_P(SdsdotTests, RealSinglePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, 2.0));

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -137,7 +137,7 @@ class SdsdotUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device *, oneapi::mkl::layout>> {};
 
 TEST_P(SdsdotUsmTests, RealSinglePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, 2.0));

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -137,6 +137,7 @@ class SdsdotUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device *, oneapi::mkl::layout>> {};
 
 TEST_P(SdsdotUsmTests, RealSinglePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3, 2.0));
     EXPECT_TRUEORSKIP(test(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1, 2.0));

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -140,6 +140,8 @@ TEST_P(SwapTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
@@ -153,6 +155,8 @@ TEST_P(SwapTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -140,7 +140,7 @@ TEST_P(SwapTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3));
@@ -155,7 +155,7 @@ TEST_P(SwapTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -143,6 +143,8 @@ TEST_P(SwapUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
@@ -156,6 +158,8 @@ TEST_P(SwapUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -143,7 +143,7 @@ TEST_P(SwapUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -2, -3));
@@ -158,7 +158,7 @@ TEST_P(SwapUsmTests, ComplexSinglePrecision) {
         test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1, 1));
 }
 TEST_P(SwapUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(
         test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2, 3));

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -167,6 +167,8 @@ TEST_P(GbmvTests, RealSinglePrecision) {
                                   42));
 }
 TEST_P(GbmvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -220,6 +222,8 @@ TEST_P(GbmvTests, ComplexSinglePrecision) {
                                                 alpha, beta, 1, 1, 42));
 }
 TEST_P(GbmvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -167,7 +167,7 @@ TEST_P(GbmvTests, RealSinglePrecision) {
                                   42));
 }
 TEST_P(GbmvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -222,7 +222,7 @@ TEST_P(GbmvTests, ComplexSinglePrecision) {
                                                 alpha, beta, 1, 1, 42));
 }
 TEST_P(GbmvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -170,6 +170,8 @@ TEST_P(GbmvUsmTests, RealSinglePrecision) {
                                   42));
 }
 TEST_P(GbmvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -223,6 +225,8 @@ TEST_P(GbmvUsmTests, ComplexSinglePrecision) {
                                                 alpha, beta, 1, 1, 42));
 }
 TEST_P(GbmvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -170,7 +170,7 @@ TEST_P(GbmvUsmTests, RealSinglePrecision) {
                                   42));
 }
 TEST_P(GbmvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -225,7 +225,7 @@ TEST_P(GbmvUsmTests, ComplexSinglePrecision) {
                                                 alpha, beta, 1, 1, 42));
 }
 TEST_P(GbmvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -158,6 +158,8 @@ TEST_P(GemvTests, RealSinglePrecision) {
                                   oneapi::mkl::transpose::trans, 25, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(GemvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -210,6 +212,8 @@ TEST_P(GemvTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -158,7 +158,7 @@ TEST_P(GemvTests, RealSinglePrecision) {
                                   oneapi::mkl::transpose::trans, 25, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(GemvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -212,7 +212,7 @@ TEST_P(GemvTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -164,6 +164,8 @@ TEST_P(GemvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::transpose::trans, 25, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(GemvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -214,6 +216,8 @@ TEST_P(GemvUsmTests, ComplexSinglePrecision) {
                                                 beta, 1, 1, 42));
 }
 TEST_P(GemvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -164,7 +164,7 @@ TEST_P(GemvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::transpose::trans, 25, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(GemvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -216,7 +216,7 @@ TEST_P(GemvUsmTests, ComplexSinglePrecision) {
                                                 beta, 1, 1, 42));
 }
 TEST_P(GemvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -148,6 +148,8 @@ TEST_P(GerTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GerTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 25, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -148,7 +148,7 @@ TEST_P(GerTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GerTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -151,7 +151,7 @@ TEST_P(GerUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GerUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -151,6 +151,8 @@ TEST_P(GerUsmTests, RealSinglePrecision) {
         test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GerUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 25, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -148,6 +148,8 @@ TEST_P(GercTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GercTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  25, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -148,7 +148,7 @@ TEST_P(GercTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GercTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -151,6 +151,8 @@ TEST_P(GercUsmTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GercUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  25, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -151,7 +151,7 @@ TEST_P(GercUsmTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GercUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -148,7 +148,7 @@ TEST_P(GeruTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GeruTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -148,6 +148,8 @@ TEST_P(GeruTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GeruTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  25, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -151,7 +151,7 @@ TEST_P(GeruUsmTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GeruUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -151,6 +151,8 @@ TEST_P(GeruUsmTests, ComplexSinglePrecision) {
                                                 25, 30, alpha, 1, 1, 42));
 }
 TEST_P(GeruUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  25, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -163,7 +163,7 @@ TEST_P(HbmvTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HbmvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -163,6 +163,8 @@ TEST_P(HbmvTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HbmvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -168,6 +168,8 @@ TEST_P(HbmvUsmTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HbmvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -168,7 +168,7 @@ TEST_P(HbmvUsmTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HbmvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -160,7 +160,7 @@ TEST_P(HemvTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HemvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -160,6 +160,8 @@ TEST_P(HemvTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HemvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -167,7 +167,7 @@ TEST_P(HemvUsmTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HemvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -167,6 +167,8 @@ TEST_P(HemvUsmTests, ComplexSinglePrecision) {
                                                 42));
 }
 TEST_P(HemvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -156,7 +156,7 @@ TEST_P(HerTests, ComplexSinglePrecision) {
                                           oneapi::mkl::uplo::upper, 30, alpha, 1, 42)));
 }
 TEST_P(HerTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -156,6 +156,8 @@ TEST_P(HerTests, ComplexSinglePrecision) {
                                           oneapi::mkl::uplo::upper, 30, alpha, 1, 42)));
 }
 TEST_P(HerTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -153,7 +153,7 @@ TEST_P(Her2Tests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Her2Tests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -153,6 +153,8 @@ TEST_P(Her2Tests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Her2Tests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::uplo::lower, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -160,7 +160,7 @@ TEST_P(Her2UsmTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Her2UsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -160,6 +160,8 @@ TEST_P(Her2UsmTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Her2UsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::uplo::lower, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -160,7 +160,7 @@ TEST_P(HerUsmTests, ComplexSinglePrecision) {
                                           oneapi::mkl::uplo::upper, 30, alpha, 1, 42)));
 }
 TEST_P(HerUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -160,6 +160,8 @@ TEST_P(HerUsmTests, ComplexSinglePrecision) {
                                           oneapi::mkl::uplo::upper, 30, alpha, 1, 42)));
 }
 TEST_P(HerUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(
         (test<std::complex<double>, double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -153,6 +153,8 @@ TEST_P(HpmvTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(HpmvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -153,7 +153,7 @@ TEST_P(HpmvTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(HpmvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -160,6 +160,8 @@ TEST_P(HpmvUsmTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(HpmvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -160,7 +160,7 @@ TEST_P(HpmvUsmTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(HpmvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -153,7 +153,7 @@ TEST_P(HprTests, ComplexSinglePrecision) {
 }
 
 TEST_P(HprTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -153,6 +153,8 @@ TEST_P(HprTests, ComplexSinglePrecision) {
 }
 
 TEST_P(HprTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower, 30, alpha, 2)));

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -152,7 +152,7 @@ TEST_P(Hpr2Tests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Hpr2Tests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -152,6 +152,8 @@ TEST_P(Hpr2Tests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Hpr2Tests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::uplo::lower, 30, alpha, 2, 3));

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -158,7 +158,7 @@ TEST_P(Hpr2UsmTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Hpr2UsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -158,6 +158,8 @@ TEST_P(Hpr2UsmTests, ComplexSinglePrecision) {
                                                 oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Hpr2UsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::uplo::lower, 30, alpha, 2, 3));

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -157,7 +157,7 @@ TEST_P(HprUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(HprUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -157,6 +157,8 @@ TEST_P(HprUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(HprUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower, 30, alpha, 2)));

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -155,7 +155,7 @@ TEST_P(SbmvTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, 5, alpha, beta, 1, 1, 42));
 }
 TEST_P(SbmvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -155,6 +155,8 @@ TEST_P(SbmvTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, 5, alpha, beta, 1, 1, 42));
 }
 TEST_P(SbmvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -161,7 +161,7 @@ TEST_P(SbmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, 5, alpha, beta, 1, 1, 42));
 }
 TEST_P(SbmvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -161,6 +161,8 @@ TEST_P(SbmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, 5, alpha, beta, 1, 1, 42));
 }
 TEST_P(SbmvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -153,7 +153,7 @@ TEST_P(SpmvTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(SpmvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -153,6 +153,8 @@ TEST_P(SpmvTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(SpmvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -160,7 +160,7 @@ TEST_P(SpmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(SpmvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -160,6 +160,8 @@ TEST_P(SpmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1));
 }
 TEST_P(SpmvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -149,7 +149,7 @@ TEST_P(SprTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1));
 }
 TEST_P(SprTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -149,6 +149,8 @@ TEST_P(SprTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1));
 }
 TEST_P(SprTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2));

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -152,6 +152,8 @@ TEST_P(Spr2Tests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Spr2Tests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2, 3));

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -152,7 +152,7 @@ TEST_P(Spr2Tests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Spr2Tests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -158,7 +158,7 @@ TEST_P(Spr2UsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Spr2UsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -158,6 +158,8 @@ TEST_P(Spr2UsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1));
 }
 TEST_P(Spr2UsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2, 3));

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -153,6 +153,8 @@ TEST_P(SprUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1));
 }
 TEST_P(SprUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2));

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -153,7 +153,7 @@ TEST_P(SprUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1));
 }
 TEST_P(SprUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -153,6 +153,8 @@ TEST_P(SymvTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(SymvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -153,7 +153,7 @@ TEST_P(SymvTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(SymvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -160,7 +160,7 @@ TEST_P(SymvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(SymvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -160,6 +160,8 @@ TEST_P(SymvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, beta, 1, 1, 42));
 }
 TEST_P(SymvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -149,6 +149,8 @@ TEST_P(SyrTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 42));
 }
 TEST_P(SyrTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2, 42));

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -149,7 +149,7 @@ TEST_P(SyrTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 42));
 }
 TEST_P(SyrTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -152,7 +152,7 @@ TEST_P(Syr2Tests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Syr2Tests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -152,6 +152,8 @@ TEST_P(Syr2Tests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Syr2Tests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -159,6 +159,8 @@ TEST_P(Syr2UsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Syr2UsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2, 3, 42));

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -159,7 +159,7 @@ TEST_P(Syr2UsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 1, 42));
 }
 TEST_P(Syr2UsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -153,6 +153,8 @@ TEST_P(SyrUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 42));
 }
 TEST_P(SyrUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, 30, alpha, 2, 42));

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -153,7 +153,7 @@ TEST_P(SyrUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::uplo::upper, 30, alpha, 1, 42));
 }
 TEST_P(SyrUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -163,7 +163,7 @@ TEST_P(TbmvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -229,7 +229,7 @@ TEST_P(TbmvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -163,6 +163,8 @@ TEST_P(TbmvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 5, 2, 42));
@@ -227,6 +229,8 @@ TEST_P(TbmvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 5, 2, 42));

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -171,7 +171,7 @@ TEST_P(TbmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -237,7 +237,7 @@ TEST_P(TbmvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -171,6 +171,8 @@ TEST_P(TbmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 5, 2, 42));
@@ -235,6 +237,8 @@ TEST_P(TbmvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbmvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 5, 2, 42));

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -163,6 +163,8 @@ TEST_P(TbsvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 5, 2, 42));
@@ -227,6 +229,8 @@ TEST_P(TbsvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 5, 2, 42));

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -163,7 +163,7 @@ TEST_P(TbsvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -229,7 +229,7 @@ TEST_P(TbsvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -171,7 +171,7 @@ TEST_P(TbsvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -237,7 +237,7 @@ TEST_P(TbsvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -171,6 +171,8 @@ TEST_P(TbsvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 5, 2, 42));
@@ -235,6 +237,8 @@ TEST_P(TbsvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 5, 2, 42));
 }
 TEST_P(TbsvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 5, 2, 42));

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -161,6 +161,8 @@ TEST_P(TpmvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2));
@@ -225,6 +227,8 @@ TEST_P(TpmvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2));

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -161,7 +161,7 @@ TEST_P(TpmvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -227,7 +227,7 @@ TEST_P(TpmvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -167,7 +167,7 @@ TEST_P(TpmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -233,7 +233,7 @@ TEST_P(TpmvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -167,6 +167,8 @@ TEST_P(TpmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2));
@@ -231,6 +233,8 @@ TEST_P(TpmvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpmvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2));

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -161,6 +161,8 @@ TEST_P(TpsvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2));
@@ -225,6 +227,8 @@ TEST_P(TpsvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2));

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -161,7 +161,7 @@ TEST_P(TpsvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -227,7 +227,7 @@ TEST_P(TpsvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -167,7 +167,7 @@ TEST_P(TpsvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -233,7 +233,7 @@ TEST_P(TpsvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -167,6 +167,8 @@ TEST_P(TpsvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2));
@@ -231,6 +233,8 @@ TEST_P(TpsvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2));
 }
 TEST_P(TpsvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2));

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -161,6 +161,8 @@ TEST_P(TrmvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2, 42));
@@ -225,6 +227,8 @@ TEST_P(TrmvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2, 42));

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -161,7 +161,7 @@ TEST_P(TrmvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -227,7 +227,7 @@ TEST_P(TrmvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -169,6 +169,8 @@ TEST_P(TrmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2, 42));
@@ -233,6 +235,8 @@ TEST_P(TrmvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2, 42));

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -169,7 +169,7 @@ TEST_P(TrmvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -235,7 +235,7 @@ TEST_P(TrmvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrmvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -161,7 +161,7 @@ TEST_P(TrsvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -227,7 +227,7 @@ TEST_P(TrsvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -161,6 +161,8 @@ TEST_P(TrsvTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2, 42));
@@ -225,6 +227,8 @@ TEST_P(TrsvTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2, 42));

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -169,6 +169,8 @@ TEST_P(TrsvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
                                    oneapi::mkl::diag::unit, 30, 2, 42));
@@ -233,6 +235,8 @@ TEST_P(TrsvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,
         oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::unit, 30, 2, 42));

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -169,7 +169,7 @@ TEST_P(TrsvUsmTests, RealSinglePrecision) {
                                   oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans,
@@ -235,7 +235,7 @@ TEST_P(TrsvUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, oneapi::mkl::diag::nonunit, 30, 2, 42));
 }
 TEST_P(TrsvUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(
         std::get<0>(GetParam()), std::get<1>(GetParam()), oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -220,7 +220,7 @@ TEST_P(GemmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -271,7 +271,7 @@ TEST_P(GemmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -220,6 +220,8 @@ TEST_P(GemmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP((test<double, double>(
@@ -269,6 +271,8 @@ TEST_P(GemmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP((test<std::complex<double>, std::complex<double>>(

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -219,6 +219,8 @@ TEST_P(GemmUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP((test<double, double>(
@@ -268,6 +270,8 @@ TEST_P(GemmUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP((test<std::complex<double>, std::complex<double>>(

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -219,7 +219,7 @@ TEST_P(GemmUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(GemmUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -270,7 +270,7 @@ TEST_P(GemmUsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(GemmUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -165,6 +165,8 @@ TEST_P(HemmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(HemmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -165,7 +165,7 @@ TEST_P(HemmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(HemmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -165,7 +165,7 @@ TEST_P(HemmUsmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(HemmUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -165,6 +165,8 @@ TEST_P(HemmUsmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(HemmUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -166,7 +166,7 @@ TEST_P(Her2kTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 102, 103, alpha, beta)));
 }
 TEST_P(Her2kTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     double beta(1.0);

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -166,6 +166,8 @@ TEST_P(Her2kTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 102, 103, alpha, beta)));
 }
 TEST_P(Her2kTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     double beta(1.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -167,6 +167,8 @@ TEST_P(Her2kUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 102, 103, alpha, beta)));
 }
 TEST_P(Her2kUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     double beta(1.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -167,7 +167,7 @@ TEST_P(Her2kUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 102, 103, alpha, beta)));
 }
 TEST_P(Her2kUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     double beta(1.0);

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -156,7 +156,7 @@ TEST_P(HerkTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 103, alpha, beta)));
 }
 TEST_P(HerkTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -156,6 +156,8 @@ TEST_P(HerkTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 103, alpha, beta)));
 }
 TEST_P(HerkTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -162,7 +162,7 @@ TEST_P(HerkUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 103, alpha, beta)));
 }
 TEST_P(HerkUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -162,6 +162,8 @@ TEST_P(HerkUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::conjtrans, 72, 27, 101, 103, alpha, beta)));
 }
 TEST_P(HerkUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP((test<std::complex<double>, double>(

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -165,6 +165,8 @@ TEST_P(SymmTests, RealSinglePrecision) {
                                   102, 103, alpha, beta));
 }
 TEST_P(SymmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -197,6 +199,8 @@ TEST_P(SymmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(SymmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -165,7 +165,7 @@ TEST_P(SymmTests, RealSinglePrecision) {
                                   102, 103, alpha, beta));
 }
 TEST_P(SymmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -199,7 +199,7 @@ TEST_P(SymmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(SymmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -165,6 +165,8 @@ TEST_P(SymmUsmTests, RealSinglePrecision) {
                                   102, 103, alpha, beta));
 }
 TEST_P(SymmUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -197,6 +199,8 @@ TEST_P(SymmUsmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(SymmUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -165,7 +165,7 @@ TEST_P(SymmUsmTests, RealSinglePrecision) {
                                   102, 103, alpha, beta));
 }
 TEST_P(SymmUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     double beta(3.0);
@@ -199,7 +199,7 @@ TEST_P(SymmUsmTests, ComplexSinglePrecision) {
                                                 72, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(SymmUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -161,6 +161,8 @@ TEST_P(Syr2kTests, RealSinglePrecision) {
                                   101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(3.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -193,6 +195,8 @@ TEST_P(Syr2kTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -161,7 +161,7 @@ TEST_P(Syr2kTests, RealSinglePrecision) {
                                   101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(3.0);
     double beta(3.0);
@@ -195,7 +195,7 @@ TEST_P(Syr2kTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -162,6 +162,8 @@ TEST_P(Syr2kUsmTests, RealSinglePrecision) {
                                   101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(3.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -194,6 +196,8 @@ TEST_P(Syr2kUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -162,7 +162,7 @@ TEST_P(Syr2kUsmTests, RealSinglePrecision) {
                                   101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(3.0);
     double beta(3.0);
@@ -196,7 +196,7 @@ TEST_P(Syr2kUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 102, 103, alpha, beta));
 }
 TEST_P(Syr2kUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -155,7 +155,7 @@ TEST_P(SyrkTests, RealSinglePrecision) {
                                   101, 103, alpha, beta));
 }
 TEST_P(SyrkTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(3.0);
     double beta(3.0);
@@ -189,7 +189,7 @@ TEST_P(SyrkTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 103, alpha, beta));
 }
 TEST_P(SyrkTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -155,6 +155,8 @@ TEST_P(SyrkTests, RealSinglePrecision) {
                                   101, 103, alpha, beta));
 }
 TEST_P(SyrkTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(3.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -187,6 +189,8 @@ TEST_P(SyrkTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 103, alpha, beta));
 }
 TEST_P(SyrkTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -160,6 +160,8 @@ TEST_P(SyrkUsmTests, RealSinglePrecision) {
                                   101, 103, alpha, beta));
 }
 TEST_P(SyrkUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(3.0);
     double beta(3.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -192,6 +194,8 @@ TEST_P(SyrkUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 103, alpha, beta));
 }
 TEST_P(SyrkUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -160,7 +160,7 @@ TEST_P(SyrkUsmTests, RealSinglePrecision) {
                                   101, 103, alpha, beta));
 }
 TEST_P(SyrkUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(3.0);
     double beta(3.0);
@@ -194,7 +194,7 @@ TEST_P(SyrkUsmTests, ComplexSinglePrecision) {
         oneapi::mkl::transpose::trans, 73, 27, 101, 103, alpha, beta));
 }
 TEST_P(SyrkUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(3.0, -0.5);
     std::complex<double> beta(3.0, -1.5);

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -192,6 +192,8 @@ TEST_P(TrmmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrmmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::left, oneapi::mkl::uplo::lower,
@@ -294,6 +296,8 @@ TEST_P(TrmmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrmmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::left, oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -192,7 +192,7 @@ TEST_P(TrmmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrmmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -296,7 +296,7 @@ TEST_P(TrmmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrmmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -194,7 +194,7 @@ TEST_P(TrmmUsmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrmmUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -298,7 +298,7 @@ TEST_P(TrmmUsmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrmmUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -194,6 +194,8 @@ TEST_P(TrmmUsmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrmmUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::left, oneapi::mkl::uplo::lower,
@@ -296,6 +298,8 @@ TEST_P(TrmmUsmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrmmUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::left, oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -216,6 +216,8 @@ TEST_P(TrsmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::left, oneapi::mkl::uplo::lower,
@@ -382,6 +384,8 @@ TEST_P(TrsmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::left, oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -216,7 +216,7 @@ TEST_P(TrsmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -384,7 +384,7 @@ TEST_P(TrsmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -219,6 +219,8 @@ TEST_P(TrsmUsmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrsmUsmTests, RealDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                    oneapi::mkl::side::left, oneapi::mkl::uplo::lower,
@@ -385,6 +387,8 @@ TEST_P(TrsmUsmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrsmUsmTests, ComplexDoublePrecision) {
+    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  oneapi::mkl::side::left, oneapi::mkl::uplo::lower,

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -219,7 +219,7 @@ TEST_P(TrsmUsmTests, RealSinglePrecision) {
                                   101, 102, alpha));
 }
 TEST_P(TrsmUsmTests, RealDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     double alpha(2.0);
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -387,7 +387,7 @@ TEST_P(TrsmUsmTests, ComplexSinglePrecision) {
         27, 101, 102, alpha));
 }
 TEST_P(TrsmUsmTests, ComplexDoublePrecision) {
-    if(std::get<0>(GetParam())->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     std::complex<double> alpha(2.0, -0.5);
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -53,6 +53,10 @@
             EXPECT_EQ(res, test_passed); \
     } while (0);
 
+#define CHECK_DOUBLE_ON_DEVICE(d)                                        \
+    if (d->get_info<sycl::info::device::double_fp_config>().size() == 0) \
+    GTEST_SKIP()
+
 #if defined(ENABLE_MKLCPU_BACKEND) || defined(ENABLE_NETLIB_BACKEND)
 #ifdef ENABLE_MKLCPU_BACKEND
 #define TEST_RUN_INTELCPU_SELECT_NO_ARGS(q, func) \

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -55,7 +55,7 @@
 
 #define CHECK_DOUBLE_ON_DEVICE(d)                                        \
     if (d->get_info<sycl::info::device::double_fp_config>().size() == 0) \
-    GTEST_SKIP()
+    GTEST_SKIP() << "Double precision is not supported on the device"
 
 #if defined(ENABLE_MKLCPU_BACKEND) || defined(ENABLE_NETLIB_BACKEND)
 #ifdef ENABLE_MKLCPU_BACKEND

--- a/tests/unit_tests/lapack/include/lapack_gtest_suite.hpp
+++ b/tests/unit_tests/lapack/include/lapack_gtest_suite.hpp
@@ -80,50 +80,50 @@ using ComplexDoublePrecisionUsm = std::complex<double>;
     DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE);                \
     INSTANTIATE_TEST_CLASS(SUITE, AccuracyUsm)
 
-#define DEFINE_TEST_ACCURACY_USM_REAL(SUITE)                                                       \
-    TEST_P(SUITE##AccuracyUsm, RealSinglePrecision) {                                              \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionUsm>, *GetParam()));     \
-    }                                                                                              \
-    TEST_P(SUITE##AccuracyUsm, RealDoublePrecision) {                                              \
-        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionUsm>, *GetParam()));     \
+#define DEFINE_TEST_ACCURACY_USM_REAL(SUITE)                                                   \
+    TEST_P(SUITE##AccuracyUsm, RealSinglePrecision) {                                          \
+        test_log::padding = "[          ] ";                                                   \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionUsm>, *GetParam())); \
+    }                                                                                          \
+    TEST_P(SUITE##AccuracyUsm, RealDoublePrecision) {                                          \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                    \
+        test_log::padding = "[          ] ";                                                   \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionUsm>, *GetParam())); \
     }
 
-#define DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE)                                                    \
-    TEST_P(SUITE##AccuracyUsm, ComplexSinglePrecision) {                                           \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexSinglePrecisionUsm>, *GetParam()));  \
-    }                                                                                              \
-    TEST_P(SUITE##AccuracyUsm, ComplexDoublePrecision) {                                           \
-        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexDoublePrecisionUsm>, *GetParam()));  \
+#define DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE)                                                   \
+    TEST_P(SUITE##AccuracyUsm, ComplexSinglePrecision) {                                          \
+        test_log::padding = "[          ] ";                                                      \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexSinglePrecisionUsm>, *GetParam())); \
+    }                                                                                             \
+    TEST_P(SUITE##AccuracyUsm, ComplexDoublePrecision) {                                          \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                       \
+        test_log::padding = "[          ] ";                                                      \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexDoublePrecisionUsm>, *GetParam())); \
     }
 
-#define DEFINE_TEST_ACCURACY_BUFFER_REAL(SUITE)                                                    \
-    TEST_P(SUITE##AccuracyBuffer, RealSinglePrecision) {                                           \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionBuffer>, *GetParam()));  \
-    }                                                                                              \
-    TEST_P(SUITE##AccuracyBuffer, RealDoublePrecision) {                                           \
-        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionBuffer>, *GetParam()));  \
+#define DEFINE_TEST_ACCURACY_BUFFER_REAL(SUITE)                                                   \
+    TEST_P(SUITE##AccuracyBuffer, RealSinglePrecision) {                                          \
+        test_log::padding = "[          ] ";                                                      \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionBuffer>, *GetParam())); \
+    }                                                                                             \
+    TEST_P(SUITE##AccuracyBuffer, RealDoublePrecision) {                                          \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                       \
+        test_log::padding = "[          ] ";                                                      \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionBuffer>, *GetParam())); \
     }
 
-#define DEFINE_TEST_ACCURACY_BUFFER_COMPLEX(SUITE)                                                 \
-    TEST_P(SUITE##AccuracyBuffer, ComplexSinglePrecision) {                                        \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(                                                                               \
-            accuracy_controller.run(::accuracy<ComplexSinglePrecisionBuffer>, *GetParam()));       \
-    }                                                                                              \
-    TEST_P(SUITE##AccuracyBuffer, ComplexDoublePrecision) {                                        \
-        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(                                                                               \
-            accuracy_controller.run(::accuracy<ComplexDoublePrecisionBuffer>, *GetParam()));       \
+#define DEFINE_TEST_ACCURACY_BUFFER_COMPLEX(SUITE)                                           \
+    TEST_P(SUITE##AccuracyBuffer, ComplexSinglePrecision) {                                  \
+        test_log::padding = "[          ] ";                                                 \
+        EXPECT_TRUE(                                                                         \
+            accuracy_controller.run(::accuracy<ComplexSinglePrecisionBuffer>, *GetParam())); \
+    }                                                                                        \
+    TEST_P(SUITE##AccuracyBuffer, ComplexDoublePrecision) {                                  \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                  \
+        test_log::padding = "[          ] ";                                                 \
+        EXPECT_TRUE(                                                                         \
+            accuracy_controller.run(::accuracy<ComplexDoublePrecisionBuffer>, *GetParam())); \
     }
 
 #define INSTANTIATE_GTEST_SUITE_DEPENDENCY(SUITE) \
@@ -142,28 +142,28 @@ using ComplexDoublePrecisionUsm = std::complex<double>;
     DEFINE_TEST_DEPENDENCY_COMPLEX(SUITE);                \
     INSTANTIATE_TEST_CLASS(SUITE, DependencyUsm);
 
-#define DEFINE_TEST_DEPENDENCY_REAL(SUITE)                                                         \
-    TEST_P(SUITE##DependencyUsm, RealSinglePrecision) {                                            \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(                                                                               \
-            dependency_controller.run(::usm_dependency<RealSinglePrecisionUsm>, *GetParam()));     \
-    }                                                                                              \
-    TEST_P(SUITE##DependencyUsm, RealDoublePrecision) {                                            \
-        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(                                                                               \
-            dependency_controller.run(::usm_dependency<RealDoublePrecisionUsm>, *GetParam()));     \
+#define DEFINE_TEST_DEPENDENCY_REAL(SUITE)                                                     \
+    TEST_P(SUITE##DependencyUsm, RealSinglePrecision) {                                        \
+        test_log::padding = "[          ] ";                                                   \
+        EXPECT_TRUE(                                                                           \
+            dependency_controller.run(::usm_dependency<RealSinglePrecisionUsm>, *GetParam())); \
+    }                                                                                          \
+    TEST_P(SUITE##DependencyUsm, RealDoublePrecision) {                                        \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                    \
+        test_log::padding = "[          ] ";                                                   \
+        EXPECT_TRUE(                                                                           \
+            dependency_controller.run(::usm_dependency<RealDoublePrecisionUsm>, *GetParam())); \
     }
 
-#define DEFINE_TEST_DEPENDENCY_COMPLEX(SUITE)                                                      \
-    TEST_P(SUITE##DependencyUsm, ComplexSinglePrecision) {                                         \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(                                                                               \
-            dependency_controller.run(::usm_dependency<ComplexSinglePrecisionUsm>, *GetParam()));  \
-    }                                                                                              \
-    TEST_P(SUITE##DependencyUsm, ComplexDoublePrecision) {                                         \
-        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
-        test_log::padding = "[          ] ";                                                       \
-        EXPECT_TRUE(                                                                               \
-            dependency_controller.run(::usm_dependency<ComplexDoublePrecisionUsm>, *GetParam()));  \
+#define DEFINE_TEST_DEPENDENCY_COMPLEX(SUITE)                                                     \
+    TEST_P(SUITE##DependencyUsm, ComplexSinglePrecision) {                                        \
+        test_log::padding = "[          ] ";                                                      \
+        EXPECT_TRUE(                                                                              \
+            dependency_controller.run(::usm_dependency<ComplexSinglePrecisionUsm>, *GetParam())); \
+    }                                                                                             \
+    TEST_P(SUITE##DependencyUsm, ComplexDoublePrecision) {                                        \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                       \
+        test_log::padding = "[          ] ";                                                      \
+        EXPECT_TRUE(                                                                              \
+            dependency_controller.run(::usm_dependency<ComplexDoublePrecisionUsm>, *GetParam())); \
     }\

--- a/tests/unit_tests/lapack/include/lapack_gtest_suite.hpp
+++ b/tests/unit_tests/lapack/include/lapack_gtest_suite.hpp
@@ -80,46 +80,50 @@ using ComplexDoublePrecisionUsm = std::complex<double>;
     DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE);                \
     INSTANTIATE_TEST_CLASS(SUITE, AccuracyUsm)
 
-#define DEFINE_TEST_ACCURACY_USM_REAL(SUITE)                                                   \
-    TEST_P(SUITE##AccuracyUsm, RealSinglePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionUsm>, *GetParam())); \
-    }                                                                                          \
-    TEST_P(SUITE##AccuracyUsm, RealDoublePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionUsm>, *GetParam())); \
+#define DEFINE_TEST_ACCURACY_USM_REAL(SUITE)                                                       \
+    TEST_P(SUITE##AccuracyUsm, RealSinglePrecision) {                                              \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionUsm>, *GetParam()));     \
+    }                                                                                              \
+    TEST_P(SUITE##AccuracyUsm, RealDoublePrecision) {                                              \
+        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionUsm>, *GetParam()));     \
     }
 
-#define DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE)                                                   \
-    TEST_P(SUITE##AccuracyUsm, ComplexSinglePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexSinglePrecisionUsm>, *GetParam())); \
-    }                                                                                             \
-    TEST_P(SUITE##AccuracyUsm, ComplexDoublePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexDoublePrecisionUsm>, *GetParam())); \
+#define DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE)                                                    \
+    TEST_P(SUITE##AccuracyUsm, ComplexSinglePrecision) {                                           \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexSinglePrecisionUsm>, *GetParam()));  \
+    }                                                                                              \
+    TEST_P(SUITE##AccuracyUsm, ComplexDoublePrecision) {                                           \
+        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexDoublePrecisionUsm>, *GetParam()));  \
     }
 
-#define DEFINE_TEST_ACCURACY_BUFFER_REAL(SUITE)                                                   \
-    TEST_P(SUITE##AccuracyBuffer, RealSinglePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionBuffer>, *GetParam())); \
-    }                                                                                             \
-    TEST_P(SUITE##AccuracyBuffer, RealDoublePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionBuffer>, *GetParam())); \
+#define DEFINE_TEST_ACCURACY_BUFFER_REAL(SUITE)                                                    \
+    TEST_P(SUITE##AccuracyBuffer, RealSinglePrecision) {                                           \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionBuffer>, *GetParam()));  \
+    }                                                                                              \
+    TEST_P(SUITE##AccuracyBuffer, RealDoublePrecision) {                                           \
+        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionBuffer>, *GetParam()));  \
     }
 
-#define DEFINE_TEST_ACCURACY_BUFFER_COMPLEX(SUITE)                                           \
-    TEST_P(SUITE##AccuracyBuffer, ComplexSinglePrecision) {                                  \
-        test_log::padding = "[          ] ";                                                 \
-        EXPECT_TRUE(                                                                         \
-            accuracy_controller.run(::accuracy<ComplexSinglePrecisionBuffer>, *GetParam())); \
-    }                                                                                        \
-    TEST_P(SUITE##AccuracyBuffer, ComplexDoublePrecision) {                                  \
-        test_log::padding = "[          ] ";                                                 \
-        EXPECT_TRUE(                                                                         \
-            accuracy_controller.run(::accuracy<ComplexDoublePrecisionBuffer>, *GetParam())); \
+#define DEFINE_TEST_ACCURACY_BUFFER_COMPLEX(SUITE)                                                 \
+    TEST_P(SUITE##AccuracyBuffer, ComplexSinglePrecision) {                                        \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(                                                                               \
+            accuracy_controller.run(::accuracy<ComplexSinglePrecisionBuffer>, *GetParam()));       \
+    }                                                                                              \
+    TEST_P(SUITE##AccuracyBuffer, ComplexDoublePrecision) {                                        \
+        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(                                                                               \
+            accuracy_controller.run(::accuracy<ComplexDoublePrecisionBuffer>, *GetParam()));       \
     }
 
 #define INSTANTIATE_GTEST_SUITE_DEPENDENCY(SUITE) \
@@ -138,26 +142,28 @@ using ComplexDoublePrecisionUsm = std::complex<double>;
     DEFINE_TEST_DEPENDENCY_COMPLEX(SUITE);                \
     INSTANTIATE_TEST_CLASS(SUITE, DependencyUsm);
 
-#define DEFINE_TEST_DEPENDENCY_REAL(SUITE)                                                     \
-    TEST_P(SUITE##DependencyUsm, RealSinglePrecision) {                                        \
-        test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(                                                                           \
-            dependency_controller.run(::usm_dependency<RealSinglePrecisionUsm>, *GetParam())); \
-    }                                                                                          \
-    TEST_P(SUITE##DependencyUsm, RealDoublePrecision) {                                        \
-        test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(                                                                           \
-            dependency_controller.run(::usm_dependency<RealDoublePrecisionUsm>, *GetParam())); \
+#define DEFINE_TEST_DEPENDENCY_REAL(SUITE)                                                         \
+    TEST_P(SUITE##DependencyUsm, RealSinglePrecision) {                                            \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(                                                                               \
+            dependency_controller.run(::usm_dependency<RealSinglePrecisionUsm>, *GetParam()));     \
+    }                                                                                              \
+    TEST_P(SUITE##DependencyUsm, RealDoublePrecision) {                                            \
+        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(                                                                               \
+            dependency_controller.run(::usm_dependency<RealDoublePrecisionUsm>, *GetParam()));     \
     }
 
-#define DEFINE_TEST_DEPENDENCY_COMPLEX(SUITE)                                                     \
-    TEST_P(SUITE##DependencyUsm, ComplexSinglePrecision) {                                        \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(                                                                              \
-            dependency_controller.run(::usm_dependency<ComplexSinglePrecisionUsm>, *GetParam())); \
-    }                                                                                             \
-    TEST_P(SUITE##DependencyUsm, ComplexDoublePrecision) {                                        \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(                                                                              \
-            dependency_controller.run(::usm_dependency<ComplexDoublePrecisionUsm>, *GetParam())); \
+#define DEFINE_TEST_DEPENDENCY_COMPLEX(SUITE)                                                      \
+    TEST_P(SUITE##DependencyUsm, ComplexSinglePrecision) {                                         \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(                                                                               \
+            dependency_controller.run(::usm_dependency<ComplexSinglePrecisionUsm>, *GetParam()));  \
+    }                                                                                              \
+    TEST_P(SUITE##DependencyUsm, ComplexDoublePrecision) {                                         \
+        if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP(); \
+        test_log::padding = "[          ] ";                                                       \
+        EXPECT_TRUE(                                                                               \
+            dependency_controller.run(::usm_dependency<ComplexDoublePrecisionUsm>, *GetParam()));  \
     }\

--- a/tests/unit_tests/rng/statistics_check/gaussian.cpp
+++ b/tests/unit_tests/rng/statistics_check/gaussian.cpp
@@ -43,6 +43,8 @@ TEST_P(GaussianIcdfTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianIcdfTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<
         statistics_test<oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
                         oneapi::mkl::rng::philox4x32x10>>
@@ -69,6 +71,8 @@ TEST_P(GaussianBoxmullerTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianBoxmullerTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>

--- a/tests/unit_tests/rng/statistics_check/gaussian.cpp
+++ b/tests/unit_tests/rng/statistics_check/gaussian.cpp
@@ -43,7 +43,7 @@ TEST_P(GaussianIcdfTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianIcdfTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<
         statistics_test<oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
@@ -71,7 +71,7 @@ TEST_P(GaussianBoxmullerTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianBoxmullerTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,

--- a/tests/unit_tests/rng/statistics_check/gaussian_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/gaussian_usm.cpp
@@ -43,7 +43,7 @@ TEST_P(GaussianIcdfUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianIcdfUsmTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
@@ -71,7 +71,7 @@ TEST_P(GaussianBoxmullerUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianBoxmullerUsmTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,

--- a/tests/unit_tests/rng/statistics_check/gaussian_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/gaussian_usm.cpp
@@ -43,6 +43,8 @@ TEST_P(GaussianIcdfUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianIcdfUsmTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::icdf>,
         oneapi::mkl::rng::philox4x32x10>>
@@ -69,6 +71,8 @@ TEST_P(GaussianBoxmullerUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(GaussianBoxmullerUsmTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::gaussian<double, oneapi::mkl::rng::gaussian_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>

--- a/tests/unit_tests/rng/statistics_check/lognormal.cpp
+++ b/tests/unit_tests/rng/statistics_check/lognormal.cpp
@@ -43,7 +43,7 @@ TEST_P(LognormalIcdfTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalIcdfTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
@@ -71,7 +71,7 @@ TEST_P(LognormalBoxmullerTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalBoxmullerTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,

--- a/tests/unit_tests/rng/statistics_check/lognormal.cpp
+++ b/tests/unit_tests/rng/statistics_check/lognormal.cpp
@@ -43,6 +43,8 @@ TEST_P(LognormalIcdfTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalIcdfTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
         oneapi::mkl::rng::philox4x32x10>>
@@ -69,6 +71,8 @@ TEST_P(LognormalBoxmullerTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalBoxmullerTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>

--- a/tests/unit_tests/rng/statistics_check/lognormal_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/lognormal_usm.cpp
@@ -43,7 +43,7 @@ TEST_P(LognormalIcdfUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalIcdfUsmTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
@@ -71,7 +71,7 @@ TEST_P(LognormalBoxmullerUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalBoxmullerUsmTest, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,

--- a/tests/unit_tests/rng/statistics_check/lognormal_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/lognormal_usm.cpp
@@ -43,6 +43,8 @@ TEST_P(LognormalIcdfUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalIcdfUsmTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::icdf>,
         oneapi::mkl::rng::philox4x32x10>>
@@ -69,6 +71,8 @@ TEST_P(LognormalBoxmullerUsmTest, RealSinglePrecision) {
 }
 
 TEST_P(LognormalBoxmullerUsmTest, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::lognormal<double, oneapi::mkl::rng::lognormal_method::box_muller2>,
         oneapi::mkl::rng::philox4x32x10>>

--- a/tests/unit_tests/rng/statistics_check/uniform.cpp
+++ b/tests/unit_tests/rng/statistics_check/uniform.cpp
@@ -43,6 +43,8 @@ TEST_P(UniformStdTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformStdTests, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
@@ -82,6 +84,8 @@ TEST_P(UniformAccurateTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformAccurateTests, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,
         oneapi::mkl::rng::philox4x32x10>>

--- a/tests/unit_tests/rng/statistics_check/uniform.cpp
+++ b/tests/unit_tests/rng/statistics_check/uniform.cpp
@@ -43,7 +43,7 @@ TEST_P(UniformStdTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformStdTests, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
@@ -84,7 +84,7 @@ TEST_P(UniformAccurateTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformAccurateTests, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,

--- a/tests/unit_tests/rng/statistics_check/uniform_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/uniform_usm.cpp
@@ -43,6 +43,8 @@ TEST_P(UniformStdUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformStdUsmTests, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
         oneapi::mkl::rng::philox4x32x10>>
@@ -82,6 +84,8 @@ TEST_P(UniformAccurateUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformAccurateUsmTests, RealDoublePrecision) {
+    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,
         oneapi::mkl::rng::philox4x32x10>>

--- a/tests/unit_tests/rng/statistics_check/uniform_usm.cpp
+++ b/tests/unit_tests/rng/statistics_check/uniform_usm.cpp
@@ -43,7 +43,7 @@ TEST_P(UniformStdUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformStdUsmTests, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::standard>,
@@ -84,7 +84,7 @@ TEST_P(UniformAccurateUsmTests, RealSinglePrecision) {
 }
 
 TEST_P(UniformAccurateUsmTests, RealDoublePrecision) {
-    if(GetParam()->get_info<sycl::info::device::double_fp_config>().size() == 0) GTEST_SKIP();
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
 
     rng_test<statistics_usm_test<
         oneapi::mkl::rng::uniform<double, oneapi::mkl::rng::uniform_method::accurate>,


### PR DESCRIPTION
# Description

PR adds double precision support check to unit tests for skipping double precision tests on devices that do not support it.

I've tested the changes on Intel Arc A770, all double precision tests are skipped as expected, all other tests are passed except for `GemmBatchUsm` for half precision (not related to the changes).

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
