### PR TITLE
[BLAS::portBLAS backend] Update nrm2 operator call routine

### DIFF
--- a/src/blas/backends/portblas/portblas_level1.cxx
+++ b/src/blas/backends/portblas/portblas_level1.cxx
@@ -238,8 +238,9 @@ sycl::event asum(sycl::queue &queue, std::int64_t n, const real_t *x, std::int64
     // before starting the computation.
     auto init_res_val = queue.submit(
         [&](sycl::handler &cgh) { cgh.single_task([=]() { result[0] = real_t(0); }); });
-    init_res_val.wait();
-    CALL_PORTBLAS_USM_FN(::blas::_asum, queue, n, x, incx, result, dependencies);
+    std::vector<sycl::event> new_dependencies = dependencies;
+    new_dependencies.push_back(init_res_val);
+    CALL_PORTBLAS_USM_FN(::blas::_asum, queue, n, x, incx, result, new_dependencies);
 }
 
 sycl::event axpy(sycl::queue &queue, std::int64_t n, real_t alpha, const real_t *x,

--- a/src/blas/backends/portblas/portblas_level1.cxx
+++ b/src/blas/backends/portblas/portblas_level1.cxx
@@ -309,8 +309,9 @@ sycl::event nrm2(sycl::queue &queue, std::int64_t n, const real_t *x, std::int64
     // before starting the computation.
     auto init_res_val = queue.submit(
         [&](sycl::handler &cgh) { cgh.single_task([=]() { result[0] = real_t(0); }); });
-    init_res_val.wait();
-    CALL_PORTBLAS_USM_FN(::blas::_nrm2, queue, n, x, incx, result, dependencies);
+    std::vector<sycl::event> new_dependencies = dependencies;
+    new_dependencies.push_back(init_res_val);
+    CALL_PORTBLAS_USM_FN(::blas::_nrm2, queue, n, x, incx, result, new_dependencies);
 }
 
 sycl::event rot(sycl::queue &queue, std::int64_t n, std::complex<real_t> *x, std::int64_t incx,


### PR DESCRIPTION
# Description

The nrm2 operator available in portBLAS requires that result memory is initialized to zero before performing the routine. I updated the routine call accordingly.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[nrm2.txt](https://github.com/oneapi-src/oneMKL/files/13002778/nrm2.txt)


- [x] Have you formatted the code using clang-format?

