### PR TITLE
[BLAS::portBLAS backend] Add USM support for batch operators

### DIFF
--- a/src/blas/backends/portblas/portblas_batch.cxx
+++ b/src/blas/backends/portblas/portblas_batch.cxx
@@ -699,7 +699,9 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                        std::int64_t stride_b, float beta, float *c, std::int64_t ldc,
                        std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "gemm_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_gemm_strided_batched, queue, transa, transb, m, n, k, alpha, a,
+                         lda, stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size,
+                         dependencies);
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -709,7 +711,9 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                        std::int64_t stride_b, double beta, double *c, std::int64_t ldc,
                        std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "gemm_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_gemm_strided_batched, queue, transa, transb, m, n, k, alpha, a,
+                         lda, stride_a, b, ldb, stride_b, beta, c, ldc, stride_c, batch_size,
+                         dependencies);
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -821,7 +825,8 @@ sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "omatcopy_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_omatcopy_batch, queue, trans, m, n, alpha, a, lda, stride_a, b,
+                         ldb, stride_b, batch_size, dependencies);
 }
 
 sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -829,7 +834,8 @@ sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
                            const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "omatcopy_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_omatcopy_batch, queue, trans, m, n, alpha, a, lda, stride_a, b,
+                         ldb, stride_b, batch_size, dependencies);
 }
 
 sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -882,7 +888,9 @@ sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                           float beta, const float *b, std::int64_t ldb, std::int64_t stride_b,
                           float *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "omatadd_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_omatadd_batch, queue, transa, transb, m, n, alpha, a, lda,
+                         stride_a, beta, b, ldb, stride_b, c, ldc, stride_c, batch_size,
+                         dependencies);
 }
 
 sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -891,7 +899,9 @@ sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                           double beta, const double *b, std::int64_t ldb, std::int64_t stride_b,
                           double *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "omatadd_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_omatadd_batch, queue, transa, transb, m, n, alpha, a, lda,
+                         stride_a, beta, b, ldb, stride_b, c, ldc, stride_c, batch_size,
+                         dependencies);
 }
 
 sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,


### PR DESCRIPTION

# Description

This PR enables `gemmBatchStrided`, `omatadd_batch` and `omatcopy_batch` with USM support for portBLAS backend.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[gemmBatchStride_usm.txt](https://github.com/oneapi-src/oneMKL/files/13004440/gemmBatchStride_usm.txt)
[omataddBatchStride_usm.txt](https://github.com/oneapi-src/oneMKL/files/13004450/omataddBatchStride_usm.txt)
[omatcopyBatchStride_usm.txt](https://github.com/oneapi-src/oneMKL/files/13004467/omatcopyBatchStride_usm.txt)

- [x] Have you formatted the code using clang-format?
