### PR TITLE
[MKL][CUBLAS] Remove unnecessary call causing crashes in getNextComputeStream

### DIFF
--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -62,7 +62,6 @@ static inline void host_task_internal(H &cgh, sycl::queue queue, F f) {
     cgh.host_task([f, queue](sycl::interop_handle ih) {
         auto sc = CublasScopedContextHandler(queue, ih);
         f(sc);
-        sc.wait_stream(queue);
     });
 }
 #endif


### PR DESCRIPTION
All host tasks enqueued in the cuBLAS backend already call `CUBLAS_ERROR_FUNC_T_SYNC` before returning. This macro calls `cuStreamSynchronize`, which is all the synchronization needed.

The original call to `wait_stream` was resulting in a new stream being created and thus the wrong stream being waited on.

```
$ bin/test_main_blas_ct --gtest_filter='*DotUsmTests.RealSinglePrecision/Column_Major*:*AxpyUsmTests.RealSinglePrecision/Column_Major*'
Run this program with --terse_output to change the way it prints its output.
Note: Google Test filter = *DotUsmTests.RealSinglePrecision/Column_Major*:*AxpyUsmTests.RealSinglePrecision/Column_Major*
[==========] Running 2 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from DotUsmTestSuite/DotUsmTests
[ RUN      ] DotUsmTestSuite/DotUsmTests.RealSinglePrecision/Column_Major_NVIDIA_GeForce_GTX_1650
[       OK ] DotUsmTestSuite/DotUsmTests.RealSinglePrecision/Column_Major_NVIDIA_GeForce_GTX_1650 (13 ms)
[----------] 1 test from DotUsmTestSuite/DotUsmTests (13 ms total)

[----------] 1 test from AxpyUsmTestSuite/AxpyUsmTests
[ RUN      ] AxpyUsmTestSuite/AxpyUsmTests.RealSinglePrecision/Column_Major_NVIDIA_GeForce_GTX_1650

UR CUDA ERROR:
	Value:           700
	Name:            CUDA_ERROR_ILLEGAL_ADDRESS
	Description:     an illegal memory access was encountered
	Function:        getNextComputeStream
	Source Location: /home/pierre-andre/Projects/oneAPICore/build/dpcpp-cuda-release/_deps/unified-runtime-src/source/adapters/cuda/queue.cpp:45
```

This was tested on a GTX 1650 using CUDA 12.2 and 12.3, on Ubuntu 22.04.

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. No, -> test suites such as `bin/test_main_blas_ct` are aborted due to other (existing) errors.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests? No, this crashes the unit test suite with default options.
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
