### PR TITLE
[MKL][CUBLAS] Restore pointer mode after calling USM dot

### DIFF
--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -911,7 +911,7 @@ inline sycl::event dot(const char *func_name, Func func, sycl::queue &queue, int
             cublasStatus_t err;
             CUBLAS_ERROR_FUNC_T_SYNC(func_name, func, err, handle, n, x_, incx, y_, incy, res_);
             if (result_on_device) {
-                cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
+                cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
             }
         });
     });


### PR DESCRIPTION
This properly restores the cuBLAS pointer mode after calling the USM version of dot. Before this fix, running the `DotUsm` test prior to `AxpyUsm` caused an illegal memory access in the latter test:

```
$ bin/test_main_blas_ct --gtest_filter='*DotUsmTests.RealSinglePrecision/Column_Major*:*AxpyUsmTests.RealSinglePrecision/Column_Major*'
...
[       OK ] DotUsmTestSuite/DotUsmTests.RealSinglePrecision/Column_Major_NVIDIA_GeForce_GTX_1650 (14 ms)
[----------] 1 test from DotUsmTestSuite/DotUsmTests (14 ms total)

[----------] 1 test from AxpyUsmTestSuite/AxpyUsmTests
[ RUN      ] AxpyUsmTestSuite/AxpyUsmTests.RealSinglePrecision/Column_Major_NVIDIA_GeForce_GTX_1650

UR CUDA ERROR:
	Value:           700
	Name:            CUDA_ERROR_ILLEGAL_ADDRESS
	Description:     an illegal memory access was encountered
	Function:        operator()
	Source Location: /home/pierre-andre/Projects/oneAPICore/build/dpcpp-cuda-release/_deps/unified-runtime-src/source/adapters/cuda/queue.cpp:225
Caught synchronous SYCL exception during AXPY:
Native API failed. Native API returns: -999 (Unknown PI error) -999 (Unknown PI error)
OpenCL status: sycl:1
relative error = 1.54731 absolute error = 0.528309 limit = 0.000161767
Difference in entry 0: DPC++ -0.186872 vs. Reference 0.341437
relative error = 1.28655 absolute error = 0.76502 limit = 0.000161767
Difference in entry 1: DPC++ -0.170389 vs. Reference 0.594631
relative error = 5.89641 absolute error = 0.301479 limit = 0.000161767
Difference in entry 2: DPC++ 0.250349 vs. Reference -0.0511292
...
```
Now both test suites pass cleanly for cuBLAS:

[blas_ct.log](https://github.com/oneapi-src/oneMKL/files/13227263/blas_ct.log)
[blas_rt.log](https://github.com/oneapi-src/oneMKL/files/13227264/blas_rt.log)

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests?  No, this crashes the unit test suite with default options.
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?