### PR TITLE
[SPARSE] Add support for sparse TRSV with MKLCPU backend

### DIFF
--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -51,9 +51,8 @@ sycl::event optimize_trsv(sycl::queue& queue, uplo uplo_val, transpose transpose
                           detail::matrix_handle* handle,
                           const std::vector<sycl::event>& dependencies) {
     if (transpose_val != transpose::nontrans) {
-      throw mkl::unimplemented(
-                    "sparse_blas/backends/mkl", __FUNCTION__,
-                    "Transposed or conjugate trsv is not supported");
+        throw mkl::unimplemented("sparse_blas/backends/mkl", __FUNCTION__,
+                                 "Transposed or conjugate trsv is not supported");
     }
     return oneapi::mkl::sparse::optimize_trsv(queue, uplo_val, transpose_val, diag_val,
                                               detail::get_handle(handle), dependencies);
@@ -83,9 +82,8 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>> trsv(sycl::queue& queue, upl
                                                          sycl::buffer<fpType, 1>& x,
                                                          sycl::buffer<fpType, 1>& y) {
     if (transpose_val != transpose::nontrans) {
-      throw mkl::unimplemented(
-                    "sparse_blas/backends/mkl", __FUNCTION__,
-                    "Transposed or conjugate trsv is not supported");
+        throw mkl::unimplemented("sparse_blas/backends/mkl", __FUNCTION__,
+                                 "Transposed or conjugate trsv is not supported");
     }
     oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
                               detail::get_handle(A_handle), x, y);
@@ -97,9 +95,8 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> trsv(
     detail::matrix_handle* A_handle, const fpType* x, fpType* y,
     const std::vector<sycl::event>& dependencies) {
     if (transpose_val != transpose::nontrans) {
-      throw mkl::unimplemented(
-                    "sparse_blas/backends/mkl", __FUNCTION__,
-                    "Transposed or conjugate trsv is not supported");
+        throw mkl::unimplemented("sparse_blas/backends/mkl", __FUNCTION__,
+                                 "Transposed or conjugate trsv is not supported");
     }
     // TODO: Remove const_cast in future oneMKL release
     return oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,

--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -47,11 +47,11 @@ sycl::event optimize_gemv(sycl::queue& queue, transpose transpose_val,
                                               dependencies);
 }
 
-sycl::event optimize_trsv(sycl::queue& queue, uplo uplo_val, transpose transpose_val,
-                          diag diag_val, detail::matrix_handle* handle,
+sycl::event optimize_trsv(sycl::queue& queue, uplo uplo_val, transpose transpose_val, diag diag_val,
+                          detail::matrix_handle* handle,
                           const std::vector<sycl::event>& dependencies) {
-    return oneapi::mkl::sparse::optimize_trsv(queue, uplo_val, transpose_val, diag_val, detail::get_handle(handle),
-                                              dependencies);
+    return oneapi::mkl::sparse::optimize_trsv(queue, uplo_val, transpose_val, diag_val,
+                                              detail::get_handle(handle), dependencies);
 }
 
 template <typename fpType>
@@ -73,12 +73,12 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> gemv(
 
 template <typename fpType>
 std::enable_if_t<detail::is_fp_supported_v<fpType>> trsv(sycl::queue& queue, uplo uplo_val,
-                                                         transpose transpose_val,
-                                                         diag diag_val,
+                                                         transpose transpose_val, diag diag_val,
                                                          detail::matrix_handle* A_handle,
                                                          sycl::buffer<fpType, 1>& x,
                                                          sycl::buffer<fpType, 1>& y) {
-    oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val, detail::get_handle(A_handle), x, y);
+    oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
+                              detail::get_handle(A_handle), x, y);
 }
 
 template <typename fpType>

--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -50,6 +50,11 @@ sycl::event optimize_gemv(sycl::queue& queue, transpose transpose_val,
 sycl::event optimize_trsv(sycl::queue& queue, uplo uplo_val, transpose transpose_val, diag diag_val,
                           detail::matrix_handle* handle,
                           const std::vector<sycl::event>& dependencies) {
+    if (transpose_val != transpose::nontrans) {
+      throw mkl::unimplemented(
+                    "sparse_blas/backends/mkl", __FUNCTION__,
+                    "Transposed or conjugate trsv is not supported");
+    }
     return oneapi::mkl::sparse::optimize_trsv(queue, uplo_val, transpose_val, diag_val,
                                               detail::get_handle(handle), dependencies);
 }
@@ -77,6 +82,11 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>> trsv(sycl::queue& queue, upl
                                                          detail::matrix_handle* A_handle,
                                                          sycl::buffer<fpType, 1>& x,
                                                          sycl::buffer<fpType, 1>& y) {
+    if (transpose_val != transpose::nontrans) {
+      throw mkl::unimplemented(
+                    "sparse_blas/backends/mkl", __FUNCTION__,
+                    "Transposed or conjugate trsv is not supported");
+    }
     oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
                               detail::get_handle(A_handle), x, y);
 }
@@ -86,6 +96,11 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> trsv(
     sycl::queue& queue, uplo uplo_val, transpose transpose_val, diag diag_val,
     detail::matrix_handle* A_handle, const fpType* x, fpType* y,
     const std::vector<sycl::event>& dependencies) {
+    if (transpose_val != transpose::nontrans) {
+      throw mkl::unimplemented(
+                    "sparse_blas/backends/mkl", __FUNCTION__,
+                    "Transposed or conjugate trsv is not supported");
+    }
     // TODO: Remove const_cast in future oneMKL release
     return oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
                                      detail::get_handle(A_handle), const_cast<fpType*>(x), y,

--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -86,7 +86,7 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> trsv(
     sycl::queue& queue, uplo uplo_val, transpose transpose_val, diag diag_val,
     detail::matrix_handle* A_handle, const fpType* x, fpType* y,
     const std::vector<sycl::event>& dependencies) {
-    // TODO: Remove const_cast with 2024.1 oneMKL release
+    // TODO: Remove const_cast in future oneMKL release
     return oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
                                      detail::get_handle(A_handle), const_cast<fpType*>(x), y,
                                      dependencies);

--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -50,6 +50,7 @@ sycl::event optimize_gemv(sycl::queue& queue, transpose transpose_val,
 sycl::event optimize_trsv(sycl::queue& queue, uplo uplo_val, transpose transpose_val, diag diag_val,
                           detail::matrix_handle* handle,
                           const std::vector<sycl::event>& dependencies) {
+    // TODO: Remove this if condition once Intel oneMKL adds support for trans/conjtrans to optimize_trsv
     if (transpose_val != transpose::nontrans) {
         throw mkl::unimplemented("sparse_blas/backends/mkl", __FUNCTION__,
                                  "Transposed or conjugate trsv is not supported");
@@ -81,6 +82,7 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>> trsv(sycl::queue& queue, upl
                                                          detail::matrix_handle* A_handle,
                                                          sycl::buffer<fpType, 1>& x,
                                                          sycl::buffer<fpType, 1>& y) {
+    // TODO: Remove this if condition once Intel oneMKL adds support for trans/conjtrans to trsv
     if (transpose_val != transpose::nontrans) {
         throw mkl::unimplemented("sparse_blas/backends/mkl", __FUNCTION__,
                                  "Transposed or conjugate trsv is not supported");
@@ -94,6 +96,7 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> trsv(
     sycl::queue& queue, uplo uplo_val, transpose transpose_val, diag diag_val,
     detail::matrix_handle* A_handle, const fpType* x, fpType* y,
     const std::vector<sycl::event>& dependencies) {
+    // TODO: Remove this if condition once Intel oneMKL adds support for trans/conjtrans to trsv
     if (transpose_val != transpose::nontrans) {
         throw mkl::unimplemented("sparse_blas/backends/mkl", __FUNCTION__,
                                  "Transposed or conjugate trsv is not supported");

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -53,6 +53,17 @@
             EXPECT_EQ(res, test_passed); \
     } while (0);
 
+// GTEST_SKIP stops the execution of the program.
+// This macro lets a test use multiple EXPECT_TRUE_OR_FUTURE_SKIP and mark a test as skipped only once at the end.
+#define EXPECT_TRUE_OR_FUTURE_SKIP(a, skip) \
+    do {                                    \
+        int res = a;                        \
+        if (res == test_skipped)            \
+            skip = true;                    \
+        else                                \
+            EXPECT_EQ(res, test_passed);    \
+    } while (0);
+
 #define CHECK_DOUBLE_ON_DEVICE(d)                                        \
     if (d->get_info<sycl::info::device::double_fp_config>().size() == 0) \
     GTEST_SKIP() << "Double precision is not supported on the device"

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -55,13 +55,15 @@
 
 // GTEST_SKIP stops the execution of the program.
 // This macro lets a test use multiple EXPECT_TRUE_OR_FUTURE_SKIP and mark a test as skipped only once at the end.
-#define EXPECT_TRUE_OR_FUTURE_SKIP(a, skip) \
-    do {                                    \
-        int res = a;                        \
-        if (res == test_skipped)            \
-            skip = true;                    \
-        else                                \
-            EXPECT_EQ(res, test_passed);    \
+#define EXPECT_TRUE_OR_FUTURE_SKIP(a, num_passed, num_skipped) \
+    do {                                                       \
+        int res = a;                                           \
+        if (res == test_skipped)                               \
+            ++num_skipped;                                     \
+        else {                                                 \
+            ++num_passed;                                      \
+            EXPECT_EQ(res, test_passed);                       \
+        }                                                      \
     } while (0);
 
 #define CHECK_DOUBLE_ON_DEVICE(d)                                        \

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -44,6 +44,9 @@
 #define test_passed  1
 #define test_skipped 2
 
+// Note GTEST_SKIP may not print the associated message when using ctest.
+// However, running a test binary with the flag `--terse-output` will print them.
+
 #define EXPECT_TRUEORSKIP(a)             \
     do {                                 \
         int res = a;                     \

--- a/tests/unit_tests/sparse_blas/include/sparse_reference.hpp
+++ b/tests/unit_tests/sparse_blas/include/sparse_reference.hpp
@@ -154,7 +154,8 @@ auto dense_transpose_if_needed(const fpType *x, std::size_t outer_size, std::siz
 template <typename fpType, typename intType>
 std::vector<fpType> sparse_to_dense(const intType *ia, const intType *ja, const fpType *a,
                                     std::size_t a_nrows, std::size_t a_ncols, intType a_ind,
-                                    oneapi::mkl::transpose transpose_val, oneapi::mkl::diag diag_val) {
+                                    oneapi::mkl::transpose transpose_val,
+                                    oneapi::mkl::diag diag_val) {
     std::vector<fpType> dense_a(a_nrows * a_ncols, fpType(0));
     for (std::size_t row = 0; row < a_nrows; row++) {
         for (intType i = ia[row] - a_ind; i < ia[row + 1] - a_ind; i++) {
@@ -173,9 +174,9 @@ std::vector<fpType> sparse_to_dense(const intType *ia, const intType *ja, const 
         }
     }
     if (diag_val == oneapi::mkl::diag::unit) {
-      for (std::size_t i = 0; i < a_nrows; ++i) {
-        dense_a[i * a_ncols + i] = set_fp_value<fpType>()(1.f, 0.f);
-      }
+        for (std::size_t i = 0; i < a_nrows; ++i) {
+            dense_a[i * a_ncols + i] = set_fp_value<fpType>()(1.f, 0.f);
+        }
     }
     return dense_a;
 }
@@ -268,7 +269,8 @@ void prepare_reference_gemm_data(const intType *ia, const intType *ja, const fpT
 template <typename fpType, typename intType>
 void prepare_reference_trsv_data(const intType *ia, const intType *ja, const fpType *a, intType m,
                                  intType a_ind, oneapi::mkl::uplo uplo_val,
-                                 oneapi::mkl::transpose opA, oneapi::mkl::diag diag_val, const fpType *x, fpType *y_ref) {
+                                 oneapi::mkl::transpose opA, oneapi::mkl::diag diag_val,
+                                 const fpType *x, fpType *y_ref) {
     std::size_t mu = static_cast<std::size_t>(m);
     auto dense_a = sparse_to_dense(ia, ja, a, mu, mu, a_ind, opA, diag_val);
 
@@ -279,7 +281,8 @@ void prepare_reference_trsv_data(const intType *ia, const intType *ja, const fpT
     //
     // Compute each element of the reference one after the other starting from 0 (resp. the end) for a lower (resp. upper) triangular matrix.
     // A matrix is considered lowered if it is lower and not transposed or upper and transposed.
-    const bool is_lower = (uplo_val == oneapi::mkl::uplo::lower) == (opA == oneapi::mkl::transpose::nontrans);
+    const bool is_lower =
+        (uplo_val == oneapi::mkl::uplo::lower) == (opA == oneapi::mkl::transpose::nontrans);
     for (std::size_t row = 0; row < mu; row++) {
         std::size_t uplo_row = is_lower ? row : (mu - 1 - row);
         fpType rhs = x[uplo_row];

--- a/tests/unit_tests/sparse_blas/include/sparse_reference.hpp
+++ b/tests/unit_tests/sparse_blas/include/sparse_reference.hpp
@@ -26,6 +26,8 @@
 
 #include "oneapi/mkl.hpp"
 
+#include "test_common.hpp"
+
 template <typename T>
 inline T conjugate(T) {
     static_assert(false, "Unsupported type");
@@ -147,6 +149,37 @@ auto dense_transpose_if_needed(const fpType *x, std::size_t outer_size, std::siz
     return opx;
 }
 
+/// Return the dense matrix A in row major layout.
+/// Diagonal values are overwritten with 1s if diag_val is unit.
+template <typename fpType, typename intType>
+std::vector<fpType> sparse_to_dense(const intType *ia, const intType *ja, const fpType *a,
+                                    std::size_t a_nrows, std::size_t a_ncols, intType a_ind,
+                                    oneapi::mkl::transpose transpose_val, oneapi::mkl::diag diag_val) {
+    std::vector<fpType> dense_a(a_nrows * a_ncols, fpType(0));
+    for (std::size_t row = 0; row < a_nrows; row++) {
+        for (intType i = ia[row] - a_ind; i < ia[row + 1] - a_ind; i++) {
+            std::size_t iu = static_cast<std::size_t>(i);
+            std::size_t col = static_cast<std::size_t>(ja[iu] - a_ind);
+            std::size_t dense_a_idx = transpose_val != oneapi::mkl::transpose::nontrans
+                                          ? col * a_nrows + row
+                                          : row * a_ncols + col;
+            fpType val = a[iu];
+            if constexpr (complex_info<fpType>::is_complex) {
+                if (transpose_val == oneapi::mkl::transpose::conjtrans) {
+                    val = std::conj(val);
+                }
+            }
+            dense_a[dense_a_idx] = val;
+        }
+    }
+    if (diag_val == oneapi::mkl::diag::unit) {
+      for (std::size_t i = 0; i < a_nrows; ++i) {
+        dense_a[i * a_ncols + i] = set_fp_value<fpType>()(1.f, 0.f);
+      }
+    }
+    return dense_a;
+}
+
 template <typename fpType, typename intType>
 void prepare_reference_gemv_data(const intType *ia, const intType *ja, const fpType *a,
                                  intType a_nrows, intType a_ncols, intType a_nnz, intType a_ind,
@@ -229,6 +262,32 @@ void prepare_reference_gemm_data(const intType *ia, const intType *ja, const fpT
                 c = alpha * tmp + beta * c;
             }
         }
+    }
+}
+
+template <typename fpType, typename intType>
+void prepare_reference_trsv_data(const intType *ia, const intType *ja, const fpType *a, intType m,
+                                 intType a_ind, oneapi::mkl::uplo uplo_val,
+                                 oneapi::mkl::transpose opA, oneapi::mkl::diag diag_val, const fpType *x, fpType *y_ref) {
+    std::size_t mu = static_cast<std::size_t>(m);
+    auto dense_a = sparse_to_dense(ia, ja, a, mu, mu, a_ind, opA, diag_val);
+
+    //
+    // do TRSV operation
+    //
+    //  y_ref <- op(A)^-1 * x
+    //
+    // Compute each element of the reference one after the other starting from 0 (resp. the end) for a lower (resp. upper) triangular matrix.
+    // A matrix is considered lowered if it is lower and not transposed or upper and transposed.
+    const bool is_lower = (uplo_val == oneapi::mkl::uplo::lower) == (opA == oneapi::mkl::transpose::nontrans);
+    for (std::size_t row = 0; row < mu; row++) {
+        std::size_t uplo_row = is_lower ? row : (mu - 1 - row);
+        fpType rhs = x[uplo_row];
+        for (std::size_t col = 0; col < row; col++) {
+            std::size_t uplo_col = is_lower ? col : (mu - 1 - col);
+            rhs -= dense_a[uplo_row * mu + uplo_col] * y_ref[uplo_col];
+        }
+        y_ref[uplo_row] = rhs / dense_a[uplo_row * mu + uplo_row];
     }
 }
 

--- a/tests/unit_tests/sparse_blas/include/test_common.hpp
+++ b/tests/unit_tests/sparse_blas/include/test_common.hpp
@@ -20,9 +20,11 @@
 #ifndef _TEST_COMMON_HPP__
 #define _TEST_COMMON_HPP__
 
+#include <complex>
 #include <iostream>
 #include <memory>
 #include <limits>
+#include <vector>
 
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>

--- a/tests/unit_tests/sparse_blas/include/test_common.hpp
+++ b/tests/unit_tests/sparse_blas/include/test_common.hpp
@@ -105,7 +105,7 @@ struct set_fp_value<std::complex<scalarType>> {
 template <typename fpType>
 struct rand_scalar {
     inline fpType operator()(double min, double max) {
-        return (fpType(std::rand()) / fpType(RAND_MAX)) * fpType(max - min) - fpType(min);
+        return (fpType(std::rand()) / fpType(RAND_MAX)) * fpType(max - min) + fpType(min);
     }
 };
 
@@ -166,8 +166,18 @@ intType generate_random_matrix(const intType nrows, const intType ncols, const d
     for (intType i = 0; i < nrows; i++) {
         ia.push_back(nnz + indexing); // ending index of row_i.
         for (intType j = 0; j < ncols; j++) {
-            if ((require_diagonal && i == j) || (rand_density(0.0, 1.0) < density_val)) {
-                a.push_back(rand_data(-0.5, 0.5));
+            const bool is_diag = require_diagonal && i == j;
+            if (is_diag || (rand_density(0.0, 1.0) <= density_val)) {
+                fpType val;
+                if (is_diag) {
+                    // Guarantee an amplitude >= 0.1
+                    fpType sign = (std::rand() % 2) * 2 - 1;
+                    val = rand_data(0.1, 0.5) * sign;
+                }
+                else {
+                    val = rand_data(-0.5, 0.5);
+                }
+                a.push_back(val);
                 ja.push_back(j + indexing);
                 nnz++;
             }

--- a/tests/unit_tests/sparse_blas/source/CMakeLists.txt
+++ b/tests/unit_tests/sparse_blas/source/CMakeLists.txt
@@ -22,6 +22,8 @@ set(SPBLAS_SOURCES
   "sparse_gemm_usm.cpp"
   "sparse_gemv_buffer.cpp"
   "sparse_gemv_usm.cpp"
+  "sparse_trsv_buffer.cpp"
+  "sparse_trsv_usm.cpp"
 )
 
 include(WarningsUtils)

--- a/tests/unit_tests/sparse_blas/source/sparse_gemm_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemm_buffer.cpp
@@ -138,7 +138,7 @@ class SparseGemmBufferTests : public ::testing::TestWithParam<sycl::device *> {}
  * @param transpose_B Transpose value for the B matrix
  */
 template <typename fpType>
-void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
+bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
                  oneapi::mkl::transpose transpose_B) {
     double density_A_matrix = 0.8;
     fpType fp_zero = set_fp_value<fpType>()(0.f, 0.f);
@@ -151,58 +151,80 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
     bool no_opt_1_input = false;
     bool opt_2_inputs = true;
 
+    bool skip = false;
     // Basic test
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test index_base 1
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix,
-                           oneapi::mkl::index_base::one, col_major, transpose_A, transpose_B,
-                           fp_one, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, oneapi::mkl::index_base::one,
+             col_major, transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input,
+             opt_2_inputs),
+        skip);
     // Test non-default alpha
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, set_fp_value<fpType>()(2.f, 1.5f), fp_zero,
-                           ldb, ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, set_fp_value<fpType>()(2.f, 1.5f), fp_zero, ldb, ldc, no_opt_1_input,
+             opt_2_inputs),
+        skip);
     // Test non-default beta
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, set_fp_value<fpType>()(3.2f, 1.f), ldb,
-                           ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, set_fp_value<fpType>()(3.2f, 1.f), ldb, ldc, no_opt_1_input,
+             opt_2_inputs),
+        skip);
     // Test 0 alpha
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_zero, fp_one, ldb, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_zero, fp_one, ldb, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test 0 alpha and beta
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_zero, fp_zero, ldb, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_zero, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test non-default ldb
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb + 5, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb + 5, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test non-default ldc
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc + 6, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc + 6, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test row major layout
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero,
-                           oneapi::mkl::layout::row_major, transpose_A, transpose_B, fp_one,
-                           fp_zero, ncols_C, ncols_C, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero,
+             oneapi::mkl::layout::row_major, transpose_A, transpose_B, fp_one, fp_zero, ncols_C,
+             ncols_C, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test int64 indices
     long long_nrows_A = 27, long_ncols_A = 13, long_ncols_C = 6;
     long long_ldb = transpose_A == oneapi::mkl::transpose::nontrans ? long_ncols_A : long_nrows_A;
     long long_ldc = transpose_A == oneapi::mkl::transpose::nontrans ? long_nrows_A : long_ncols_A;
-    EXPECT_TRUEORSKIP(test(dev, long_nrows_A, long_ncols_A, long_ncols_C, density_A_matrix,
-                           index_zero, col_major, transpose_A, transpose_B, fp_one, fp_zero,
-                           long_ldb, long_ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, long_nrows_A, long_ncols_A, long_ncols_C, density_A_matrix,
+                                    index_zero, col_major, transpose_A, transpose_B, fp_one,
+                                    fp_zero, long_ldb, long_ldc, no_opt_1_input, opt_2_inputs),
+                               skip);
     // Use optimize_gemm with only the sparse gemm input
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, true, false));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, true, false),
+        skip);
     // Use the 2 optimize_gemm versions
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, true, true));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, true, true),
+        skip);
     // Do not use optimize_gemm
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, false, false));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, false, false),
+        skip);
+    return skip;
 }
 
 /**
@@ -213,39 +235,57 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
  * @param dev Device to test
  */
 template <typename fpType>
-void test_helper_transpose(sycl::device *dev) {
+bool test_helper_transpose(sycl::device *dev) {
     std::vector<oneapi::mkl::transpose> transpose_vals{ oneapi::mkl::transpose::nontrans,
                                                         oneapi::mkl::transpose::trans };
     if (complex_info<fpType>::is_complex) {
         transpose_vals.push_back(oneapi::mkl::transpose::conjtrans);
     }
+    bool skip = false;
     for (auto transpose_A : transpose_vals) {
         for (auto transpose_B : transpose_vals) {
-            test_helper<fpType>(dev, transpose_A, transpose_B);
+            skip |= test_helper<fpType>(dev, transpose_A, transpose_B);
         }
     }
+    return skip;
 }
 
 TEST_P(SparseGemmBufferTests, RealSinglePrecision) {
     using fpType = float;
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemmBufferTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemmBufferTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemmBufferTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(SparseGemmBufferTestSuite, SparseGemmBufferTests,

--- a/tests/unit_tests/sparse_blas/source/sparse_gemm_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemm_buffer.cpp
@@ -17,11 +17,8 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-#include <algorithm>
 #include <complex>
-#include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <vector>
 
 #if __has_include(<sycl/sycl.hpp>)

--- a/tests/unit_tests/sparse_blas/source/sparse_gemm_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemm_usm.cpp
@@ -17,11 +17,8 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-#include <algorithm>
 #include <complex>
-#include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <vector>
 
 #if __has_include(<sycl/sycl.hpp>)

--- a/tests/unit_tests/sparse_blas/source/sparse_gemm_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemm_usm.cpp
@@ -164,10 +164,12 @@ class SparseGemmUsmTests : public ::testing::TestWithParam<sycl::device *> {};
  * @param dev Device to test
  * @param transpose_A Transpose value for the A matrix
  * @param transpose_B Transpose value for the B matrix
+ * @param num_passed Increase the number of configurations passed
+ * @param num_skipped Increase the number of configurations skipped
  */
 template <typename fpType>
-bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
-                 oneapi::mkl::transpose transpose_B) {
+void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
+                 oneapi::mkl::transpose transpose_B, int &num_passed, int &num_skipped) {
     double density_A_matrix = 0.8;
     fpType fp_zero = set_fp_value<fpType>()(0.f, 0.f);
     fpType fp_one = set_fp_value<fpType>()(1.f, 0.f);
@@ -179,56 +181,55 @@ bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
     bool no_opt_1_input = false;
     bool opt_2_inputs = true;
 
-    bool skip = false;
     // Basic test
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test index_base 1
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, oneapi::mkl::index_base::one,
              col_major, transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input,
              opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test non-default alpha
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, set_fp_value<fpType>()(2.f, 1.5f), fp_zero, ldb, ldc, no_opt_1_input,
              opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test non-default beta
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_one, set_fp_value<fpType>()(3.2f, 1.f), ldb, ldc, no_opt_1_input,
              opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test 0 alpha
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_zero, fp_one, ldb, ldc, no_opt_1_input, opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test 0 alpha and beta
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_zero, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test non-default ldb
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_one, fp_zero, ldb + 5, ldc, no_opt_1_input, opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test non-default ldc
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_one, fp_zero, ldb, ldc + 6, no_opt_1_input, opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test row major layout
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero,
              oneapi::mkl::layout::row_major, transpose_A, transpose_B, fp_one, fp_zero, ncols_C,
              ncols_C, no_opt_1_input, opt_2_inputs),
-        skip);
+        num_passed, num_skipped);
     // Test int64 indices
     long long_nrows_A = 27, long_ncols_A = 13, long_ncols_C = 6;
     long long_ldb = transpose_A == oneapi::mkl::transpose::nontrans ? long_ncols_A : long_nrows_A;
@@ -236,23 +237,22 @@ bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
     EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, long_nrows_A, long_ncols_A, long_ncols_C, density_A_matrix,
                                     index_zero, col_major, transpose_A, transpose_B, fp_one,
                                     fp_zero, long_ldb, long_ldc, no_opt_1_input, opt_2_inputs),
-                               skip);
+                               num_passed, num_skipped);
     // Use optimize_gemm with only the sparse gemm input
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_one, fp_zero, ldb, ldc, true, false),
-        skip);
+        num_passed, num_skipped);
     // Use the 2 optimize_gemm versions
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_one, fp_zero, ldb, ldc, true, true),
-        skip);
+        num_passed, num_skipped);
     // Do not use optimize_gemm
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
              transpose_B, fp_one, fp_zero, ldb, ldc, false, false),
-        skip);
-    return skip;
+        num_passed, num_skipped);
 }
 
 /**
@@ -261,58 +261,66 @@ bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
  * 
  * @tparam fpType Complex or scalar, single or double precision type
  * @param dev Device to test
+ * @param num_passed Increase the number of configurations passed
+ * @param num_skipped Increase the number of configurations skipped
  */
 template <typename fpType>
-bool test_helper_transpose(sycl::device *dev) {
+auto test_helper_transpose(sycl::device *dev, int &num_passed, int &num_skipped) {
     std::vector<oneapi::mkl::transpose> transpose_vals{ oneapi::mkl::transpose::nontrans,
                                                         oneapi::mkl::transpose::trans };
     if (complex_info<fpType>::is_complex) {
         transpose_vals.push_back(oneapi::mkl::transpose::conjtrans);
     }
-    bool skip = false;
     for (auto transpose_A : transpose_vals) {
         for (auto transpose_B : transpose_vals) {
-            skip |= test_helper<fpType>(dev, transpose_A, transpose_B);
+            test_helper<fpType>(dev, transpose_A, transpose_B, num_passed, num_skipped);
         }
     }
-    return skip;
 }
 
 TEST_P(SparseGemmUsmTests, RealSinglePrecision) {
     using fpType = float;
-    bool skip = test_helper_transpose<fpType>(GetParam());
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper_transpose<fpType>(GetParam(), num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseGemmUsmTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = test_helper_transpose<fpType>(GetParam());
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper_transpose<fpType>(GetParam(), num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseGemmUsmTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    bool skip = test_helper_transpose<fpType>(GetParam());
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper_transpose<fpType>(GetParam(), num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseGemmUsmTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = test_helper_transpose<fpType>(GetParam());
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper_transpose<fpType>(GetParam(), num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_gemm_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemm_usm.cpp
@@ -166,7 +166,7 @@ class SparseGemmUsmTests : public ::testing::TestWithParam<sycl::device *> {};
  * @param transpose_B Transpose value for the B matrix
  */
 template <typename fpType>
-void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
+bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
                  oneapi::mkl::transpose transpose_B) {
     double density_A_matrix = 0.8;
     fpType fp_zero = set_fp_value<fpType>()(0.f, 0.f);
@@ -179,58 +179,80 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
     bool no_opt_1_input = false;
     bool opt_2_inputs = true;
 
+    bool skip = false;
     // Basic test
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test index_base 1
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix,
-                           oneapi::mkl::index_base::one, col_major, transpose_A, transpose_B,
-                           fp_one, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, oneapi::mkl::index_base::one,
+             col_major, transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, no_opt_1_input,
+             opt_2_inputs),
+        skip);
     // Test non-default alpha
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, set_fp_value<fpType>()(2.f, 1.5f), fp_zero,
-                           ldb, ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, set_fp_value<fpType>()(2.f, 1.5f), fp_zero, ldb, ldc, no_opt_1_input,
+             opt_2_inputs),
+        skip);
     // Test non-default beta
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, set_fp_value<fpType>()(3.2f, 1.f), ldb,
-                           ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, set_fp_value<fpType>()(3.2f, 1.f), ldb, ldc, no_opt_1_input,
+             opt_2_inputs),
+        skip);
     // Test 0 alpha
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_zero, fp_one, ldb, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_zero, fp_one, ldb, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test 0 alpha and beta
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_zero, fp_zero, ldb, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_zero, fp_zero, ldb, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test non-default ldb
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb + 5, ldc, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb + 5, ldc, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test non-default ldc
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc + 6, no_opt_1_input,
-                           opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc + 6, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test row major layout
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero,
-                           oneapi::mkl::layout::row_major, transpose_A, transpose_B, fp_one,
-                           fp_zero, ncols_C, ncols_C, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero,
+             oneapi::mkl::layout::row_major, transpose_A, transpose_B, fp_one, fp_zero, ncols_C,
+             ncols_C, no_opt_1_input, opt_2_inputs),
+        skip);
     // Test int64 indices
     long long_nrows_A = 27, long_ncols_A = 13, long_ncols_C = 6;
     long long_ldb = transpose_A == oneapi::mkl::transpose::nontrans ? long_ncols_A : long_nrows_A;
     long long_ldc = transpose_A == oneapi::mkl::transpose::nontrans ? long_nrows_A : long_ncols_A;
-    EXPECT_TRUEORSKIP(test(dev, long_nrows_A, long_ncols_A, long_ncols_C, density_A_matrix,
-                           index_zero, col_major, transpose_A, transpose_B, fp_one, fp_zero,
-                           long_ldb, long_ldc, no_opt_1_input, opt_2_inputs));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, long_nrows_A, long_ncols_A, long_ncols_C, density_A_matrix,
+                                    index_zero, col_major, transpose_A, transpose_B, fp_one,
+                                    fp_zero, long_ldb, long_ldc, no_opt_1_input, opt_2_inputs),
+                               skip);
     // Use optimize_gemm with only the sparse gemm input
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, true, false));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, true, false),
+        skip);
     // Use the 2 optimize_gemm versions
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, true, true));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, true, true),
+        skip);
     // Do not use optimize_gemm
-    EXPECT_TRUEORSKIP(test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major,
-                           transpose_A, transpose_B, fp_one, fp_zero, ldb, ldc, false, false));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, nrows_A, ncols_A, ncols_C, density_A_matrix, index_zero, col_major, transpose_A,
+             transpose_B, fp_one, fp_zero, ldb, ldc, false, false),
+        skip);
+    return skip;
 }
 
 /**
@@ -241,39 +263,57 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_A,
  * @param dev Device to test
  */
 template <typename fpType>
-void test_helper_transpose(sycl::device *dev) {
+bool test_helper_transpose(sycl::device *dev) {
     std::vector<oneapi::mkl::transpose> transpose_vals{ oneapi::mkl::transpose::nontrans,
                                                         oneapi::mkl::transpose::trans };
     if (complex_info<fpType>::is_complex) {
         transpose_vals.push_back(oneapi::mkl::transpose::conjtrans);
     }
+    bool skip = false;
     for (auto transpose_A : transpose_vals) {
         for (auto transpose_B : transpose_vals) {
-            test_helper<fpType>(dev, transpose_A, transpose_B);
+            skip |= test_helper<fpType>(dev, transpose_A, transpose_B);
         }
     }
+    return skip;
 }
 
 TEST_P(SparseGemmUsmTests, RealSinglePrecision) {
     using fpType = float;
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemmUsmTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemmUsmTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemmUsmTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper_transpose<fpType>(GetParam());
+    bool skip = test_helper_transpose<fpType>(GetParam());
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(SparseGemmUsmTestSuite, SparseGemmUsmTests, testing::ValuesIn(devices),

--- a/tests/unit_tests/sparse_blas/source/sparse_gemv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemv_buffer.cpp
@@ -17,11 +17,8 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-#include <algorithm>
 #include <complex>
-#include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <vector>
 
 #if __has_include(<sycl/sycl.hpp>)

--- a/tests/unit_tests/sparse_blas/source/sparse_gemv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemv_buffer.cpp
@@ -128,65 +128,94 @@ class SparseGemvBufferTests : public ::testing::TestWithParam<sycl::device *> {}
  * @param transpose_val Transpose value for the input matrix
  */
 template <typename fpType>
-void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
+bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     double density_A_matrix = 0.8;
     fpType fp_zero = set_fp_value<fpType>()(0.f, 0.f);
     fpType fp_one = set_fp_value<fpType>()(1.f, 0.f);
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     bool use_optimize = true;
 
+    bool skip = false;
     // Basic test
-    EXPECT_TRUEORSKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one, fp_zero,
-                           use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one, fp_zero, use_optimize),
+        skip);
     // Test index_base 1
-    EXPECT_TRUEORSKIP(test(dev, 4, 6, density_A_matrix, oneapi::mkl::index_base::one, transpose_val,
-                           fp_one, fp_zero, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, oneapi::mkl::index_base::one,
+                                    transpose_val, fp_one, fp_zero, use_optimize),
+                               skip);
     // Test non-default alpha
-    EXPECT_TRUEORSKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val,
-                           set_fp_value<fpType>()(2.f, 1.5f), fp_zero, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val,
+                                    set_fp_value<fpType>()(2.f, 1.5f), fp_zero, use_optimize),
+                               skip);
     // Test non-default beta
-    EXPECT_TRUEORSKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one,
-                           set_fp_value<fpType>()(3.2f, 1.f), use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one,
+                                    set_fp_value<fpType>()(3.2f, 1.f), use_optimize),
+                               skip);
     // Test 0 alpha
-    EXPECT_TRUEORSKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_zero, fp_one,
-                           use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_zero, fp_one, use_optimize),
+        skip);
     // Test 0 alpha and beta
-    EXPECT_TRUEORSKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_zero, fp_zero,
-                           use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_zero,
+                                    fp_zero, use_optimize),
+                               skip);
     // Test int64 indices
-    EXPECT_TRUEORSKIP(test(dev, 27L, 13L, density_A_matrix, index_zero, transpose_val, fp_one,
-                           fp_one, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 27L, 13L, density_A_matrix, index_zero, transpose_val,
+                                    fp_one, fp_one, use_optimize),
+                               skip);
     // Test without optimize_gemv
-    EXPECT_TRUEORSKIP(
-        test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one, fp_zero, false));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one, fp_zero, false), skip);
+    return skip;
 }
 
 TEST_P(SparseGemvBufferTests, RealSinglePrecision) {
     using fpType = float;
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemvBufferTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemvBufferTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseGemvBufferTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(SparseGemvBufferTestSuite, SparseGemvBufferTests,

--- a/tests/unit_tests/sparse_blas/source/sparse_gemv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemv_usm.cpp
@@ -152,95 +152,101 @@ class SparseGemvUsmTests : public ::testing::TestWithParam<sycl::device *> {};
  * @tparam fpType Complex or scalar, single or double precision type
  * @param dev Device to test
  * @param transpose_val Transpose value for the input matrix
+ * @param num_passed Increase the number of configurations passed
+ * @param num_skipped Increase the number of configurations skipped
  */
 template <typename fpType>
-bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
+void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val, int &num_passed,
+                 int &num_skipped) {
     double density_A_matrix = 0.8;
     fpType fp_zero = set_fp_value<fpType>()(0.f, 0.f);
     fpType fp_one = set_fp_value<fpType>()(1.f, 0.f);
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     bool use_optimize = true;
 
-    bool skip = false;
     // Basic test
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one, fp_zero, use_optimize),
-        skip);
+        num_passed, num_skipped);
     // Test index_base 1
     EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, oneapi::mkl::index_base::one,
                                     transpose_val, fp_one, fp_zero, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test non-default alpha
     EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val,
                                     set_fp_value<fpType>()(2.f, 1.5f), fp_zero, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test non-default beta
     EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one,
                                     set_fp_value<fpType>()(3.2f, 1.f), use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test 0 alpha
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_zero, fp_one, use_optimize),
-        skip);
+        num_passed, num_skipped);
     // Test 0 alpha and beta
     EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_zero,
                                     fp_zero, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test int64 indices
     EXPECT_TRUE_OR_FUTURE_SKIP(test(dev, 27L, 13L, density_A_matrix, index_zero, transpose_val,
                                     fp_one, fp_one, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test without optimize_gemv
     EXPECT_TRUE_OR_FUTURE_SKIP(
-        test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one, fp_zero, false), skip);
-    return skip;
+        test(dev, 4, 6, density_A_matrix, index_zero, transpose_val, fp_one, fp_zero, false),
+        num_passed, num_skipped);
 }
 
 TEST_P(SparseGemvUsmTests, RealSinglePrecision) {
     using fpType = float;
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseGemvUsmTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseGemvUsmTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseGemvUsmTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_gemv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemv_usm.cpp
@@ -17,11 +17,8 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-#include <algorithm>
 #include <complex>
-#include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <vector>
 
 #if __has_include(<sycl/sycl.hpp>)

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -134,9 +134,12 @@ class SparseTrsvBufferTests : public ::testing::TestWithParam<sycl::device *> {}
  * @tparam fpType Complex or scalar, single or double precision type
  * @param dev Device to test
  * @param transpose_val Transpose value for the input matrix
+ * @param num_passed Increase the number of configurations passed
+ * @param num_skipped Increase the number of configurations skipped
  */
 template <typename fpType>
-bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
+auto test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val, int &num_passed,
+                 int &num_skipped) {
     double density_A_matrix = 0.144;
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
@@ -144,85 +147,87 @@ bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     int m = 277;
     bool use_optimize = true;
 
-    bool skip = false;
     // Basic test
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
                                             transpose_val, nonunit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test index_base 1
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, oneapi::mkl::index_base::one,
                                             lower, transpose_val, nonunit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test upper triangular matrix
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
                      nonunit, use_optimize),
-        skip);
+        num_passed, num_skipped);
     // Test unit diagonal matrix
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
                                             transpose_val, oneapi::mkl::diag::unit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test int64 indices
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower,
                                             transpose_val, nonunit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test lower without optimize_trsv
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false),
-        skip);
+        num_passed, num_skipped);
     // Test upper without optimize_trsv
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
                      nonunit, false),
-        skip);
-    return skip;
+        num_passed, num_skipped);
 }
 
 TEST_P(SparseTrsvBufferTests, RealSinglePrecision) {
     using fpType = float;
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseTrsvBufferTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseTrsvBufferTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseTrsvBufferTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -137,11 +137,11 @@ class SparseTrsvBufferTests : public ::testing::TestWithParam<sycl::device *> {}
  */
 template <typename fpType>
 void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
-    double density_A_matrix = 0.8;
+    double density_A_matrix = 0.144;
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
     oneapi::mkl::diag nonunit = oneapi::mkl::diag::nonunit;
-    int m = 5;
+    int m = 277;
     bool use_optimize = true;
 
     // Basic test

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -73,7 +73,6 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
     // Shuffle ordering of column indices/values to test sortedness
     shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
 
-    // TODO(Romain): Use buffer
     auto ia_buf = make_buffer(ia_host);
     auto ja_buf = make_buffer(ja_host);
     auto a_buf = make_buffer(a_host);

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -1,0 +1,191 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include <algorithm>
+#include <complex>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "oneapi/mkl.hpp"
+#include "oneapi/mkl/detail/config.hpp"
+#include "sparse_reference.hpp"
+#include "test_common.hpp"
+#include "test_helper.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<sycl::device *> devices;
+
+namespace {
+
+template <typename fpType, typename intType>
+int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::index_base index,
+         oneapi::mkl::uplo uplo_val, oneapi::mkl::transpose transpose_val,
+         oneapi::mkl::diag diag_val) {
+    sycl::queue main_queue(*dev, exception_handler_t());
+
+    intType int_index = (index == oneapi::mkl::index_base::zero) ? 0 : 1;
+    const std::size_t mu = static_cast<std::size_t>(m);
+
+    // Input matrix in CSR format
+    std::vector<intType> ia_host, ja_host;
+    std::vector<fpType> a_host;
+    // Always require values to be present in the diagonal of the sparse matrix.
+    // The values set in the matrix don't need to be 1s even if diag_val is unit.
+    const bool require_diagonal = true;
+    intType nnz = generate_random_matrix<fpType, intType>(
+        m, m, density_A_matrix, int_index, ia_host, ja_host, a_host, require_diagonal);
+
+    // Input dense vector.
+    // The input `x` is initialized to random values on host and device.
+    std::vector<fpType> x_host;
+    rand_vector(x_host, mu);
+
+    // Output and reference dense vectors.
+    // They are both initialized with a dummy value to catch more errors.
+    std::vector<fpType> y_host(mu, -2.0f);
+    std::vector<fpType> y_ref_host(y_host);
+
+    // Shuffle ordering of column indices/values to test sortedness
+    shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
+
+    // TODO(Romain): Use buffer
+    auto ia_buf = make_buffer(ia_host);
+    auto ja_buf = make_buffer(ja_host);
+    auto a_buf = make_buffer(a_host);
+    auto x_buf = make_buffer(x_host);
+    auto y_buf = make_buffer(y_host);
+
+    sycl::event ev_release;
+    oneapi::mkl::sparse::matrix_handle_t handle = nullptr;
+    try {
+        CALL_RT_OR_CT(oneapi::mkl::sparse::init_matrix_handle, main_queue, &handle);
+
+        CALL_RT_OR_CT(oneapi::mkl::sparse::set_csr_data, main_queue, handle, m, m, nnz, index,
+                      ia_buf, ja_buf, a_buf);
+
+        CALL_RT_OR_CT(oneapi::mkl::sparse::optimize_trsv, main_queue, uplo_val, transpose_val,
+                      diag_val, handle);
+
+        CALL_RT_OR_CT(oneapi::mkl::sparse::trsv, main_queue, uplo_val, transpose_val, diag_val,
+                      handle, x_buf, y_buf);
+
+        CALL_RT_OR_CT(ev_release = oneapi::mkl::sparse::release_matrix_handle, main_queue, &handle);
+    }
+    catch (const sycl::exception &e) {
+        std::cout << "Caught synchronous SYCL exception during sparse TRSV:\n"
+                  << e.what() << std::endl;
+        print_error_code(e);
+        return 0;
+    }
+    catch (const oneapi::mkl::unimplemented &e) {
+        wait_and_free(main_queue, &handle);
+        return test_skipped;
+    }
+    catch (const std::runtime_error &error) {
+        std::cout << "Error raised during execution of sparse TRSV:\n" << error.what() << std::endl;
+        return 0;
+    }
+
+    // Compute reference.
+    prepare_reference_trsv_data(ia_host.data(), ja_host.data(), a_host.data(), m, int_index,
+                                uplo_val, transpose_val, diag_val, x_host.data(),
+                                y_ref_host.data());
+
+    // Compare the results of reference implementation and DPC++ implementation.
+    auto y_acc = y_buf.template get_host_access(sycl::read_only);
+    bool valid = check_equal_vector(y_acc, y_ref_host);
+
+    ev_release.wait_and_throw();
+    return static_cast<int>(valid);
+}
+
+class SparseTrsvBufferTests : public ::testing::TestWithParam<sycl::device *> {};
+
+/**
+ * Helper function to run tests in different configuration.
+ *
+ * @tparam fpType Complex or scalar, single or double precision type
+ * @param dev Device to test
+ * @param transpose_val Transpose value for the input matrix
+ */
+template <typename fpType>
+void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
+    double density_A_matrix = 0.8;
+    oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
+    oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
+    oneapi::mkl::diag nonunit = oneapi::mkl::diag::nonunit;
+    int m = 5;
+    // Basic test
+    EXPECT_TRUEORSKIP(
+        test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit));
+    // Test index_base 1
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, oneapi::mkl::index_base::one, lower,
+                                   transpose_val, nonunit));
+    // Test upper triangular matrix
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper,
+                                   transpose_val, nonunit));
+    // Test unit diagonal matrix
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                   oneapi::mkl::diag::unit));
+    // Test int64 indices
+    EXPECT_TRUEORSKIP(
+        test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val, nonunit));
+}
+
+TEST_P(SparseTrsvBufferTests, RealSinglePrecision) {
+    using fpType = float;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+}
+
+TEST_P(SparseTrsvBufferTests, RealDoublePrecision) {
+    using fpType = double;
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+}
+
+TEST_P(SparseTrsvBufferTests, ComplexSinglePrecision) {
+    using fpType = std::complex<float>;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+}
+
+TEST_P(SparseTrsvBufferTests, ComplexDoublePrecision) {
+    using fpType = std::complex<double>;
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+}
+
+INSTANTIATE_TEST_SUITE_P(SparseTrsvBufferTestSuite, SparseTrsvBufferTests,
+                         testing::ValuesIn(devices), ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -159,8 +159,11 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     // Test int64 indices
     EXPECT_TRUEORSKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val,
                                    nonunit, use_optimize));
-    // Test without optimize_trsv
+    // Test lower without optimize_trsv
     EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                    nonunit, false));
+    // Test upper without optimize_trsv
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
                                     nonunit, false));
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -70,8 +70,8 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
     // Intel oneMKL does not support unsorted data if
     // `sparse::optimize_trsv()` is not called first.
     if (use_optimize) {
-      // Shuffle ordering of column indices/values to test sortedness
-      shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
+        // Shuffle ordering of column indices/values to test sortedness
+        shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
     }
 
     auto ia_buf = make_buffer(ia_host);

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -17,11 +17,8 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-#include <algorithm>
 #include <complex>
-#include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <vector>
 
 #if __has_include(<sycl/sycl.hpp>)

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -159,9 +159,9 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     EXPECT_TRUEORSKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val,
                                    nonunit, use_optimize));
     if (!dev->is_cpu()) {
-      // Test without optimize_trsv
-      EXPECT_TRUEORSKIP(
-          test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false));
+        // Test without optimize_trsv
+        EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                       nonunit, false));
     }
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -67,8 +67,12 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
     std::vector<fpType> y_host(mu, -2.0f);
     std::vector<fpType> y_ref_host(y_host);
 
-    // Shuffle ordering of column indices/values to test sortedness
-    shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
+    // Intel oneMKL does not support unsorted data if
+    // `sparse::optimize_trsv()` is not called first.
+    if (use_optimize) {
+      // Shuffle ordering of column indices/values to test sortedness
+      shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
+    }
 
     auto ia_buf = make_buffer(ia_host);
     auto ja_buf = make_buffer(ja_host);
@@ -155,11 +159,9 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     // Test int64 indices
     EXPECT_TRUEORSKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val,
                                    nonunit, use_optimize));
-    if (!dev->is_cpu()) {
-        // Test without optimize_trsv
-        EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
-                                       nonunit, false));
-    }
+    // Test without optimize_trsv
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                    nonunit, false));
 }
 
 TEST_P(SparseTrsvBufferTests, RealSinglePrecision) {

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -68,8 +68,8 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
     // Intel oneMKL does not support unsorted data if
     // `sparse::optimize_trsv()` is not called first.
     if (use_optimize) {
-      // Shuffle ordering of column indices/values to test sortedness
-      shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
+        // Shuffle ordering of column indices/values to test sortedness
+        shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
     }
 
     auto ia_usm_uptr = malloc_device_uptr<intType>(main_queue, ia_host.size());

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -139,7 +139,8 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
 
     // Compute reference.
     prepare_reference_trsv_data(ia_host.data(), ja_host.data(), a_host.data(), m, int_index,
-                                uplo_val, transpose_val, diag_val, x_host.data(), y_ref_host.data());
+                                uplo_val, transpose_val, diag_val, x_host.data(),
+                                y_ref_host.data());
 
     // Compare the results of reference implementation and DPC++ implementation.
     ev_copy.wait_and_throw();
@@ -183,9 +184,9 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     EXPECT_TRUEORSKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val,
                                    nonunit, use_optimize));
     if (!dev->is_cpu()) {
-      // Test without optimize_trsv
-      EXPECT_TRUEORSKIP(
-          test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false));
+        // Test without optimize_trsv
+        EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                       nonunit, false));
     }
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -184,8 +184,11 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     // Test int64 indices
     EXPECT_TRUEORSKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val,
                                    nonunit, use_optimize));
-    // Test without optimize_trsv
+    // Test lower without optimize_trsv
     EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                    nonunit, false));
+    // Test upper without optimize_trsv
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
                                     nonunit, false));
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -162,11 +162,11 @@ class SparseTrsvUsmTests : public ::testing::TestWithParam<sycl::device *> {};
  */
 template <typename fpType>
 void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
-    double density_A_matrix = 0.8;
+    double density_A_matrix = 0.144;
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
     oneapi::mkl::diag nonunit = oneapi::mkl::diag::nonunit;
-    int m = 5;
+    int m = 277;
     bool use_optimize = true;
 
     // Basic test

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -1,0 +1,214 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include <algorithm>
+#include <complex>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "oneapi/mkl.hpp"
+#include "oneapi/mkl/detail/config.hpp"
+#include "sparse_reference.hpp"
+#include "test_common.hpp"
+#include "test_helper.hpp"
+
+#include <gtest/gtest.h>
+
+extern std::vector<sycl::device *> devices;
+
+namespace {
+
+template <typename fpType, typename intType>
+int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::index_base index,
+         oneapi::mkl::uplo uplo_val, oneapi::mkl::transpose transpose_val,
+         oneapi::mkl::diag diag_val) {
+    sycl::queue main_queue(*dev, exception_handler_t());
+
+    intType int_index = (index == oneapi::mkl::index_base::zero) ? 0 : 1;
+    const std::size_t mu = static_cast<std::size_t>(m);
+
+    // Input matrix in CSR format
+    std::vector<intType> ia_host, ja_host;
+    std::vector<fpType> a_host;
+    // Always require values to be present in the diagonal of the sparse matrix.
+    // The values set in the matrix don't need to be 1s even if diag_val is unit.
+    const bool require_diagonal = true;
+    intType nnz = generate_random_matrix<fpType, intType>(
+        m, m, density_A_matrix, int_index, ia_host, ja_host, a_host, require_diagonal);
+
+    // Input dense vector.
+    // The input `x` is initialized to random values on host and device.
+    std::vector<fpType> x_host;
+    rand_vector(x_host, mu);
+
+    // Output and reference dense vectors.
+    // They are both initialized with a dummy value to catch more errors.
+    std::vector<fpType> y_host(mu, -2.0f);
+    std::vector<fpType> y_ref_host(y_host);
+
+    // Shuffle ordering of column indices/values to test sortedness
+    shuffle_data(ia_host.data(), ja_host.data(), a_host.data(), mu);
+
+    auto ia_usm_uptr = malloc_device_uptr<intType>(main_queue, ia_host.size());
+    auto ja_usm_uptr = malloc_device_uptr<intType>(main_queue, ja_host.size());
+    auto a_usm_uptr = malloc_device_uptr<fpType>(main_queue, a_host.size());
+    auto x_usm_uptr = malloc_device_uptr<fpType>(main_queue, x_host.size());
+    auto y_usm_uptr = malloc_device_uptr<fpType>(main_queue, y_host.size());
+
+    intType *ia_usm = ia_usm_uptr.get();
+    intType *ja_usm = ja_usm_uptr.get();
+    fpType *a_usm = a_usm_uptr.get();
+    fpType *x_usm = x_usm_uptr.get();
+    fpType *y_usm = y_usm_uptr.get();
+
+    std::vector<sycl::event> mat_dependencies;
+    std::vector<sycl::event> trsv_dependencies;
+    // Copy host to device
+    mat_dependencies.push_back(
+        main_queue.memcpy(ia_usm, ia_host.data(), ia_host.size() * sizeof(intType)));
+    mat_dependencies.push_back(
+        main_queue.memcpy(ja_usm, ja_host.data(), ja_host.size() * sizeof(intType)));
+    mat_dependencies.push_back(
+        main_queue.memcpy(a_usm, a_host.data(), a_host.size() * sizeof(fpType)));
+    trsv_dependencies.push_back(
+        main_queue.memcpy(x_usm, x_host.data(), x_host.size() * sizeof(fpType)));
+    trsv_dependencies.push_back(
+        main_queue.memcpy(y_usm, y_host.data(), y_host.size() * sizeof(fpType)));
+
+    sycl::event ev_copy, ev_release;
+    oneapi::mkl::sparse::matrix_handle_t handle = nullptr;
+    try {
+        sycl::event ev_set, ev_opt, ev_trsv;
+        CALL_RT_OR_CT(oneapi::mkl::sparse::init_matrix_handle, main_queue, &handle);
+
+        CALL_RT_OR_CT(ev_set = oneapi::mkl::sparse::set_csr_data, main_queue, handle, m, m, nnz,
+                      index, ia_usm, ja_usm, a_usm, mat_dependencies);
+
+        CALL_RT_OR_CT(ev_opt = oneapi::mkl::sparse::optimize_trsv, main_queue, uplo_val,
+                      transpose_val, diag_val, handle, { ev_set });
+
+        trsv_dependencies.push_back(ev_opt);
+        CALL_RT_OR_CT(ev_trsv = oneapi::mkl::sparse::trsv, main_queue, uplo_val, transpose_val,
+                      diag_val, handle, x_usm, y_usm, trsv_dependencies);
+
+        CALL_RT_OR_CT(ev_release = oneapi::mkl::sparse::release_matrix_handle, main_queue, &handle,
+                      { ev_trsv });
+
+        ev_copy = main_queue.memcpy(y_host.data(), y_usm, y_host.size() * sizeof(fpType), ev_trsv);
+    }
+    catch (const sycl::exception &e) {
+        std::cout << "Caught synchronous SYCL exception during sparse TRSV:\n"
+                  << e.what() << std::endl;
+        print_error_code(e);
+        return 0;
+    }
+    catch (const oneapi::mkl::unimplemented &e) {
+        wait_and_free(main_queue, &handle);
+        return test_skipped;
+    }
+    catch (const std::runtime_error &error) {
+        std::cout << "Error raised during execution of sparse TRSV:\n" << error.what() << std::endl;
+        return 0;
+    }
+
+    // Compute reference.
+    prepare_reference_trsv_data(ia_host.data(), ja_host.data(), a_host.data(), m, int_index,
+                                uplo_val, transpose_val, diag_val, x_host.data(), y_ref_host.data());
+
+    // Compare the results of reference implementation and DPC++ implementation.
+    ev_copy.wait_and_throw();
+    bool valid = check_equal_vector(y_host, y_ref_host);
+
+    ev_release.wait_and_throw();
+    return static_cast<int>(valid);
+}
+
+class SparseTrsvUsmTests : public ::testing::TestWithParam<sycl::device *> {};
+
+/**
+ * Helper function to run tests in different configuration.
+ *
+ * @tparam fpType Complex or scalar, single or double precision type
+ * @param dev Device to test
+ * @param transpose_val Transpose value for the input matrix
+ */
+template <typename fpType>
+void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
+    double density_A_matrix = 0.8;
+    oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
+    oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
+    oneapi::mkl::diag nonunit = oneapi::mkl::diag::nonunit;
+    int m = 5;
+    // Basic test
+    EXPECT_TRUEORSKIP(
+        test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit));
+    // Test index_base 1
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, oneapi::mkl::index_base::one, lower,
+                                   transpose_val, nonunit));
+    // Test upper triangular matrix
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper,
+                                   transpose_val, nonunit));
+    // Test unit diagonal matrix
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                   oneapi::mkl::diag::unit));
+    // Test int64 indices
+    EXPECT_TRUEORSKIP(
+        test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val, nonunit));
+}
+
+TEST_P(SparseTrsvUsmTests, RealSinglePrecision) {
+    using fpType = float;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+}
+
+TEST_P(SparseTrsvUsmTests, RealDoublePrecision) {
+    using fpType = double;
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+}
+
+TEST_P(SparseTrsvUsmTests, ComplexSinglePrecision) {
+    using fpType = std::complex<float>;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+}
+
+TEST_P(SparseTrsvUsmTests, ComplexDoublePrecision) {
+    using fpType = std::complex<double>;
+    CHECK_DOUBLE_ON_DEVICE(GetParam());
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+}
+
+INSTANTIATE_TEST_SUITE_P(SparseTrsvUsmTestSuite, SparseTrsvUsmTests, testing::ValuesIn(devices),
+                         ::DeviceNamePrint());
+
+} // anonymous namespace

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -159,7 +159,8 @@ class SparseTrsvUsmTests : public ::testing::TestWithParam<sycl::device *> {};
  * @param transpose_val Transpose value for the input matrix
  */
 template <typename fpType>
-bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
+void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val, int &num_passed,
+                 int &num_skipped) {
     double density_A_matrix = 0.144;
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
@@ -167,85 +168,87 @@ bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     int m = 277;
     bool use_optimize = true;
 
-    bool skip = false;
     // Basic test
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
                                             transpose_val, nonunit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test index_base 1
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, oneapi::mkl::index_base::one,
                                             lower, transpose_val, nonunit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test upper triangular matrix
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
                      nonunit, use_optimize),
-        skip);
+        num_passed, num_skipped);
     // Test unit diagonal matrix
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
                                             transpose_val, oneapi::mkl::diag::unit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test int64 indices
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower,
                                             transpose_val, nonunit, use_optimize),
-                               skip);
+                               num_passed, num_skipped);
     // Test lower without optimize_trsv
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false),
-        skip);
+        num_passed, num_skipped);
     // Test upper without optimize_trsv
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
                      nonunit, false),
-        skip);
-    return skip;
+        num_passed, num_skipped);
 }
 
 TEST_P(SparseTrsvUsmTests, RealSinglePrecision) {
     using fpType = float;
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseTrsvUsmTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseTrsvUsmTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 
 TEST_P(SparseTrsvUsmTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    bool skip = false;
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
-    if (skip) {
+    int num_passed = 0, num_skipped = 0;
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans, num_passed, num_skipped);
+    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans, num_passed, num_skipped);
+    if (num_skipped > 0) {
         // Mark that some tests were skipped
-        GTEST_SKIP();
+        GTEST_SKIP() << "Passed: " << num_passed << ", Skipped: " << num_skipped
+                     << " configurations." << std::endl;
     }
 }
 

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -17,11 +17,8 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-#include <algorithm>
 #include <complex>
-#include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <vector>
 
 #if __has_include(<sycl/sycl.hpp>)

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -161,7 +161,7 @@ class SparseTrsvUsmTests : public ::testing::TestWithParam<sycl::device *> {};
  * @param transpose_val Transpose value for the input matrix
  */
 template <typename fpType>
-void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
+bool test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     double density_A_matrix = 0.144;
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
@@ -169,55 +169,86 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     int m = 277;
     bool use_optimize = true;
 
+    bool skip = false;
     // Basic test
-    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
-                                   nonunit, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
+                                            transpose_val, nonunit, use_optimize),
+                               skip);
     // Test index_base 1
-    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, oneapi::mkl::index_base::one, lower,
-                                   transpose_val, nonunit, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, oneapi::mkl::index_base::one,
+                                            lower, transpose_val, nonunit, use_optimize),
+                               skip);
     // Test upper triangular matrix
-    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper,
-                                   transpose_val, nonunit, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
+                     nonunit, use_optimize),
+        skip);
     // Test unit diagonal matrix
-    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
-                                   oneapi::mkl::diag::unit, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
+                                            transpose_val, oneapi::mkl::diag::unit, use_optimize),
+                               skip);
     // Test int64 indices
-    EXPECT_TRUEORSKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val,
-                                   nonunit, use_optimize));
+    EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower,
+                                            transpose_val, nonunit, use_optimize),
+                               skip);
     // Test lower without optimize_trsv
-    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
-                                    nonunit, false));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false),
+        skip);
     // Test upper without optimize_trsv
-    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
-                                    nonunit, false));
+    EXPECT_TRUE_OR_FUTURE_SKIP(
+        test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper, transpose_val,
+                     nonunit, false),
+        skip);
+    return skip;
 }
 
 TEST_P(SparseTrsvUsmTests, RealSinglePrecision) {
     using fpType = float;
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseTrsvUsmTests, RealDoublePrecision) {
     using fpType = double;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseTrsvUsmTests, ComplexSinglePrecision) {
     using fpType = std::complex<float>;
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 TEST_P(SparseTrsvUsmTests, ComplexDoublePrecision) {
     using fpType = std::complex<double>;
     CHECK_DOUBLE_ON_DEVICE(GetParam());
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
-    test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    bool skip = false;
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::nontrans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::trans);
+    skip |= test_helper<fpType>(GetParam(), oneapi::mkl::transpose::conjtrans);
+    if (skip) {
+        // Mark that some tests were skipped
+        GTEST_SKIP();
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(SparseTrsvUsmTestSuite, SparseTrsvUsmTests, testing::ValuesIn(devices),

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -51,9 +51,7 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
     // Input matrix in CSR format
     std::vector<intType> ia_host, ja_host;
     std::vector<fpType> a_host;
-    // Always require values to be present in the diagonal of the sparse matrix.
-    // The values set in the matrix don't need to be 1s even if diag_val is unit.
-    const bool require_diagonal = true;
+    const bool require_diagonal = diag_val == oneapi::mkl::diag::nonunit;
     intType nnz = generate_random_matrix<fpType, intType>(
         m, m, density_A_matrix, int_index, ia_host, ja_host, a_host, require_diagonal);
 

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -45,7 +45,7 @@ namespace {
 template <typename fpType, typename intType>
 int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::index_base index,
          oneapi::mkl::uplo uplo_val, oneapi::mkl::transpose transpose_val,
-         oneapi::mkl::diag diag_val) {
+         oneapi::mkl::diag diag_val, bool use_optimize) {
     sycl::queue main_queue(*dev, exception_handler_t());
 
     intType int_index = (index == oneapi::mkl::index_base::zero) ? 0 : 1;
@@ -102,23 +102,25 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
     sycl::event ev_copy, ev_release;
     oneapi::mkl::sparse::matrix_handle_t handle = nullptr;
     try {
-        sycl::event ev_set, ev_opt, ev_trsv;
+        sycl::event event;
         CALL_RT_OR_CT(oneapi::mkl::sparse::init_matrix_handle, main_queue, &handle);
 
-        CALL_RT_OR_CT(ev_set = oneapi::mkl::sparse::set_csr_data, main_queue, handle, m, m, nnz,
+        CALL_RT_OR_CT(event = oneapi::mkl::sparse::set_csr_data, main_queue, handle, m, m, nnz,
                       index, ia_usm, ja_usm, a_usm, mat_dependencies);
 
-        CALL_RT_OR_CT(ev_opt = oneapi::mkl::sparse::optimize_trsv, main_queue, uplo_val,
-                      transpose_val, diag_val, handle, { ev_set });
+        if (use_optimize) {
+            CALL_RT_OR_CT(event = oneapi::mkl::sparse::optimize_trsv, main_queue, uplo_val,
+                          transpose_val, diag_val, handle, { event });
+        }
 
-        trsv_dependencies.push_back(ev_opt);
-        CALL_RT_OR_CT(ev_trsv = oneapi::mkl::sparse::trsv, main_queue, uplo_val, transpose_val,
+        trsv_dependencies.push_back(event);
+        CALL_RT_OR_CT(event = oneapi::mkl::sparse::trsv, main_queue, uplo_val, transpose_val,
                       diag_val, handle, x_usm, y_usm, trsv_dependencies);
 
         CALL_RT_OR_CT(ev_release = oneapi::mkl::sparse::release_matrix_handle, main_queue, &handle,
-                      { ev_trsv });
+                      { event });
 
-        ev_copy = main_queue.memcpy(y_host.data(), y_usm, y_host.size() * sizeof(fpType), ev_trsv);
+        ev_copy = main_queue.memcpy(y_host.data(), y_usm, y_host.size() * sizeof(fpType), event);
     }
     catch (const sycl::exception &e) {
         std::cout << "Caught synchronous SYCL exception during sparse TRSV:\n"
@@ -163,21 +165,28 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val) {
     oneapi::mkl::uplo lower = oneapi::mkl::uplo::lower;
     oneapi::mkl::diag nonunit = oneapi::mkl::diag::nonunit;
     int m = 5;
+    bool use_optimize = true;
+
     // Basic test
-    EXPECT_TRUEORSKIP(
-        test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit));
+    EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
+                                   nonunit, use_optimize));
     // Test index_base 1
     EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, oneapi::mkl::index_base::one, lower,
-                                   transpose_val, nonunit));
+                                   transpose_val, nonunit, use_optimize));
     // Test upper triangular matrix
     EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, oneapi::mkl::uplo::upper,
-                                   transpose_val, nonunit));
+                                   transpose_val, nonunit, use_optimize));
     // Test unit diagonal matrix
     EXPECT_TRUEORSKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val,
-                                   oneapi::mkl::diag::unit));
+                                   oneapi::mkl::diag::unit, use_optimize));
     // Test int64 indices
-    EXPECT_TRUEORSKIP(
-        test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val, nonunit));
+    EXPECT_TRUEORSKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower, transpose_val,
+                                   nonunit, use_optimize));
+    if (!dev->is_cpu()) {
+      // Test without optimize_trsv
+      EXPECT_TRUEORSKIP(
+          test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false));
+    }
 }
 
 TEST_P(SparseTrsvUsmTests, RealSinglePrecision) {


### PR DESCRIPTION
# Description

Add support for sparse TRSV using MKLCPU.
Relies on https://github.com/oneapi-src/oneMKL/pull/403

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New features

- [x] Have you provided motivation for adding a new feature?
- [x] Have you added relevant tests?