### PR TITLE
[RNG] Missing clang-format and deprecations fixes

### DIFF
--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -56,8 +56,8 @@ class kernel_name {};
 template <typename Engine, typename Distr>
 class kernel_name_usm {};
 
-template<typename T, sycl::access_mode AccMode>
-T* get_raw_ptr(sycl::accessor<T, 1, AccMode> acc) {
+template <typename T, sycl::access_mode AccMode>
+T *get_raw_ptr(sycl::accessor<T, 1, AccMode> acc) {
     return acc.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
 }
 

--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -56,6 +56,11 @@ class kernel_name {};
 template <typename Engine, typename Distr>
 class kernel_name_usm {};
 
+template<typename T, sycl::access_mode AccMode>
+T* get_raw_ptr(sycl::accessor<T, 1, AccMode> acc) {
+    return acc.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+}
+
 } // namespace mklcpu
 } // namespace rng
 } // namespace mkl

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -66,9 +66,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vsRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -80,9 +83,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vdRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -94,9 +100,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                viRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -108,9 +117,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vsRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -122,9 +134,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vdRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -136,9 +151,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vsRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -150,9 +168,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vdRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -164,9 +185,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vsRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -178,9 +202,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vdRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -192,10 +219,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vsRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -207,10 +236,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vdRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -222,10 +253,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vsRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -237,10 +270,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vdRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -252,9 +287,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.p());
+                viRngBernoulli(
+                    VSL_RNG_METHOD_BERNOULLI_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.p());
             });
         });
     }
@@ -266,10 +304,13 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr = acc_r.get_pointer();
-                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
+                std::uint32_t* r_ptr =
+                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                viRngBernoulli(
+                    VSL_RNG_METHOD_BERNOULLI_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
             });
         });
     }
@@ -281,9 +322,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.lambda());
+                viRngPoisson(
+                    VSL_RNG_METHOD_POISSON_POISNORM,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.lambda());
             });
         });
     }
@@ -295,10 +339,13 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr = acc_r.get_pointer();
-                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
+                std::uint32_t* r_ptr =
+                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                viRngPoisson(
+                    VSL_RNG_METHOD_POISSON_POISNORM,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
             });
         });
     }
@@ -310,9 +357,11 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD,
-                                 static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                                 acc_r.get_pointer());
+                viRngUniformBits(
+                    VSL_RNG_METHOD_UNIFORMBITS_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw());
             });
         });
     }

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -66,12 +66,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -83,12 +80,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -100,12 +94,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                viRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -117,12 +108,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -134,12 +122,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -151,12 +136,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -168,12 +150,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -185,12 +164,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -202,12 +178,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -219,12 +192,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -236,12 +207,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -253,12 +222,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -270,12 +237,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -287,12 +252,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngBernoulli(
-                    VSL_RNG_METHOD_BERNOULLI_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.p());
+                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.p());
             });
         });
     }
@@ -304,13 +266,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr =
-                    get_raw_ptr(acc_r);
-                viRngBernoulli(
-                    VSL_RNG_METHOD_BERNOULLI_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
+                std::uint32_t* r_ptr = get_raw_ptr(acc_r);
+                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
             });
         });
     }
@@ -322,12 +281,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngPoisson(
-                    VSL_RNG_METHOD_POISSON_POISNORM,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.lambda());
+                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.lambda());
             });
         });
     }
@@ -339,13 +295,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr =
-                    get_raw_ptr(acc_r);
-                viRngPoisson(
-                    VSL_RNG_METHOD_POISSON_POISNORM,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
+                std::uint32_t* r_ptr = get_raw_ptr(acc_r);
+                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
             });
         });
     }
@@ -357,11 +310,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniformBits(
-                    VSL_RNG_METHOD_UNIFORMBITS_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r));
+                viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD,
+                                 static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                                 get_raw_ptr(acc_r));
             });
         });
     }

--- a/src/rng/backends/mklcpu/mrg32k3a.cpp
+++ b/src/rng/backends/mklcpu/mrg32k3a.cpp
@@ -69,8 +69,8 @@ public:
                 vsRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -86,8 +86,8 @@ public:
                 vdRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -103,8 +103,8 @@ public:
                 viRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -120,8 +120,8 @@ public:
                 vsRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -137,8 +137,8 @@ public:
                 vdRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -154,8 +154,8 @@ public:
                 vsRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -171,8 +171,8 @@ public:
                 vdRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -188,8 +188,8 @@ public:
                 vsRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -205,8 +205,8 @@ public:
                 vdRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -222,8 +222,8 @@ public:
                 vsRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -239,8 +239,8 @@ public:
                 vdRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -256,8 +256,8 @@ public:
                 vsRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -273,8 +273,8 @@ public:
                 vdRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -290,8 +290,8 @@ public:
                 viRngBernoulli(
                     VSL_RNG_METHOD_BERNOULLI_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.p());
             });
         });
@@ -305,11 +305,11 @@ public:
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 std::uint32_t* r_ptr =
-                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                    get_raw_ptr(acc_r);
                 viRngBernoulli(
                     VSL_RNG_METHOD_BERNOULLI_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                        get_raw_ptr(acc_stream)),
                     n, reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
             });
         });
@@ -325,8 +325,8 @@ public:
                 viRngPoisson(
                     VSL_RNG_METHOD_POISSON_POISNORM,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.lambda());
             });
         });
@@ -340,11 +340,11 @@ public:
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<mrg32k3a_impl, decltype(distr)>>(cgh, [=]() {
                 std::uint32_t* r_ptr =
-                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                    get_raw_ptr(acc_r);
                 viRngPoisson(
                     VSL_RNG_METHOD_POISSON_POISNORM,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                        get_raw_ptr(acc_stream)),
                     n, reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
             });
         });
@@ -360,8 +360,8 @@ public:
                 viRngUniformBits(
                     VSL_RNG_METHOD_UNIFORMBITS_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw());
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r));
             });
         });
     }

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -68,9 +68,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vsRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -82,9 +85,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vdRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -96,9 +102,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                viRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -110,9 +119,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vsRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -124,9 +136,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.a(), distr.b());
+                vdRngUniform(
+                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.a(), distr.b());
             });
         });
     }
@@ -138,9 +153,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vsRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -152,9 +170,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vdRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -166,9 +187,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vsRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -180,9 +204,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                              static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                              acc_r.get_pointer(), distr.mean(), distr.stddev());
+                vdRngGaussian(
+                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.mean(), distr.stddev());
             });
         });
     }
@@ -194,10 +221,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vsRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -209,10 +238,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vdRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -224,10 +255,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vsRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -239,10 +272,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.m(), distr.s(), distr.displ(),
-                               distr.scale());
+                vdRngLognormal(
+                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
     }
@@ -254,9 +289,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               acc_r.get_pointer(), distr.p());
+                viRngBernoulli(
+                    VSL_RNG_METHOD_BERNOULLI_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.p());
             });
         });
     }
@@ -268,10 +306,13 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr = acc_r.get_pointer();
-                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
-                               static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                               reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
+                std::uint32_t* r_ptr =
+                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                viRngBernoulli(
+                    VSL_RNG_METHOD_BERNOULLI_ICDF,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
             });
         });
     }
@@ -283,9 +324,12 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             acc_r.get_pointer(), distr.lambda());
+                viRngPoisson(
+                    VSL_RNG_METHOD_POISSON_POISNORM,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                    distr.lambda());
             });
         });
     }
@@ -297,10 +341,13 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr = acc_r.get_pointer();
-                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
-                             static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                             reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
+                std::uint32_t* r_ptr =
+                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                viRngPoisson(
+                    VSL_RNG_METHOD_POISSON_POISNORM,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
             });
         });
     }
@@ -312,9 +359,11 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD,
-                                 static_cast<VSLStreamStatePtr>(acc_stream.get_pointer()), n,
-                                 acc_r.get_pointer());
+                viRngUniformBits(
+                    VSL_RNG_METHOD_UNIFORMBITS_STD,
+                    static_cast<VSLStreamStatePtr>(
+                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw());
             });
         });
     }

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -68,12 +68,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -85,12 +82,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -102,12 +96,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                viRngUniform(VSL_RNG_METHOD_UNIFORM_STD,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -119,12 +110,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vsRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -136,12 +124,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngUniform(
-                    VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.a(), distr.b());
+                vdRngUniform(VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.a(), distr.b());
             });
         });
     }
@@ -153,12 +138,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -170,12 +152,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -187,12 +166,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vsRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -204,12 +180,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngGaussian(
-                    VSL_RNG_METHOD_GAUSSIAN_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.mean(), distr.stddev());
+                vdRngGaussian(VSL_RNG_METHOD_GAUSSIAN_ICDF,
+                              static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                              get_raw_ptr(acc_r), distr.mean(), distr.stddev());
             });
         });
     }
@@ -221,12 +194,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -238,12 +209,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -255,12 +224,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vsRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vsRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -272,12 +239,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                vdRngLognormal(
-                    VSL_RNG_METHOD_LOGNORMAL_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.m(), distr.s(), distr.displ(), distr.scale());
+                vdRngLognormal(VSL_RNG_METHOD_LOGNORMAL_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.m(), distr.s(), distr.displ(),
+                               distr.scale());
             });
         });
     }
@@ -289,12 +254,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngBernoulli(
-                    VSL_RNG_METHOD_BERNOULLI_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.p());
+                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               get_raw_ptr(acc_r), distr.p());
             });
         });
     }
@@ -306,13 +268,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr =
-                    get_raw_ptr(acc_r);
-                viRngBernoulli(
-                    VSL_RNG_METHOD_BERNOULLI_ICDF,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
+                std::uint32_t* r_ptr = get_raw_ptr(acc_r);
+                viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF,
+                               static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                               reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
             });
         });
     }
@@ -324,12 +283,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngPoisson(
-                    VSL_RNG_METHOD_POISSON_POISNORM,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r),
-                    distr.lambda());
+                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             get_raw_ptr(acc_r), distr.lambda());
             });
         });
     }
@@ -341,13 +297,10 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                std::uint32_t* r_ptr =
-                    get_raw_ptr(acc_r);
-                viRngPoisson(
-                    VSL_RNG_METHOD_POISSON_POISNORM,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
+                std::uint32_t* r_ptr = get_raw_ptr(acc_r);
+                viRngPoisson(VSL_RNG_METHOD_POISSON_POISNORM,
+                             static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                             reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
             });
         });
     }
@@ -359,11 +312,9 @@ public:
             auto acc_stream = stream_buf.get_access<sycl::access::mode::read_write>(cgh);
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
-                viRngUniformBits(
-                    VSL_RNG_METHOD_UNIFORMBITS_STD,
-                    static_cast<VSLStreamStatePtr>(
-                        get_raw_ptr(acc_stream)),
-                    n, get_raw_ptr(acc_r));
+                viRngUniformBits(VSL_RNG_METHOD_UNIFORMBITS_STD,
+                                 static_cast<VSLStreamStatePtr>(get_raw_ptr(acc_stream)), n,
+                                 get_raw_ptr(acc_r));
             });
         });
     }

--- a/src/rng/backends/mklcpu/philox4x32x10.cpp
+++ b/src/rng/backends/mklcpu/philox4x32x10.cpp
@@ -71,8 +71,8 @@ public:
                 vsRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -88,8 +88,8 @@ public:
                 vdRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -105,8 +105,8 @@ public:
                 viRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -122,8 +122,8 @@ public:
                 vsRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -139,8 +139,8 @@ public:
                 vdRngUniform(
                     VSL_RNG_METHOD_UNIFORM_STD_ACCURATE,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.a(), distr.b());
             });
         });
@@ -156,8 +156,8 @@ public:
                 vsRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -173,8 +173,8 @@ public:
                 vdRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -190,8 +190,8 @@ public:
                 vsRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -207,8 +207,8 @@ public:
                 vdRngGaussian(
                     VSL_RNG_METHOD_GAUSSIAN_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.mean(), distr.stddev());
             });
         });
@@ -224,8 +224,8 @@ public:
                 vsRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -241,8 +241,8 @@ public:
                 vdRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_BOXMULLER2,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -258,8 +258,8 @@ public:
                 vsRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -275,8 +275,8 @@ public:
                 vdRngLognormal(
                     VSL_RNG_METHOD_LOGNORMAL_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.m(), distr.s(), distr.displ(), distr.scale());
             });
         });
@@ -292,8 +292,8 @@ public:
                 viRngBernoulli(
                     VSL_RNG_METHOD_BERNOULLI_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.p());
             });
         });
@@ -307,11 +307,11 @@ public:
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 std::uint32_t* r_ptr =
-                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                    get_raw_ptr(acc_r);
                 viRngBernoulli(
                     VSL_RNG_METHOD_BERNOULLI_ICDF,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                        get_raw_ptr(acc_stream)),
                     n, reinterpret_cast<std::int32_t*>(r_ptr), distr.p());
             });
         });
@@ -327,8 +327,8 @@ public:
                 viRngPoisson(
                     VSL_RNG_METHOD_POISSON_POISNORM,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw(),
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r),
                     distr.lambda());
             });
         });
@@ -342,11 +342,11 @@ public:
             auto acc_r = r.get_access<sycl::access::mode::read_write>(cgh);
             host_task<kernel_name<philox4x32x10_impl, decltype(distr)>>(cgh, [=]() {
                 std::uint32_t* r_ptr =
-                    acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+                    get_raw_ptr(acc_r);
                 viRngPoisson(
                     VSL_RNG_METHOD_POISSON_POISNORM,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
+                        get_raw_ptr(acc_stream)),
                     n, reinterpret_cast<std::int32_t*>(r_ptr), distr.lambda());
             });
         });
@@ -362,8 +362,8 @@ public:
                 viRngUniformBits(
                     VSL_RNG_METHOD_UNIFORMBITS_STD,
                     static_cast<VSLStreamStatePtr>(
-                        acc_stream.template get_multi_ptr<sycl::access::decorated::no>().get_raw()),
-                    n, acc_r.template get_multi_ptr<sycl::access::decorated::no>().get_raw());
+                        get_raw_ptr(acc_stream)),
+                    n, get_raw_ptr(acc_r));
             });
         });
     }

--- a/src/rng/backends/rocrand/rocrand_helper.hpp
+++ b/src/rng/backends/rocrand/rocrand_helper.hpp
@@ -315,10 +315,10 @@ public:
     }
 };
 
-#define HIP_ERROR_FUNC(name, err, ...)                                        \
-    err = name(__VA_ARGS__);                                                  \
-    if (err != HIP_SUCCESS) {                                                 \
-        throw rocm_error(std::string(#name) + std::string(" : "), err);       \
+#define HIP_ERROR_FUNC(name, err, ...)                                  \
+    err = name(__VA_ARGS__);                                            \
+    if (err != HIP_SUCCESS) {                                           \
+        throw rocm_error(std::string(#name) + std::string(" : "), err); \
     }
 
 #define ROCRAND_CALL(func, status, ...)                                       \

--- a/tests/unit_tests/rng/include/engines_api_tests.hpp
+++ b/tests/unit_tests/rng/include/engines_api_tests.hpp
@@ -63,6 +63,7 @@ public:
             oneapi::mkl::rng::generate(distr, engine2, N_GEN, r2_buffer);
             oneapi::mkl::rng::generate(distr, engine3, N_GEN, r3_buffer);
             oneapi::mkl::rng::generate(distr, engine4, N_GEN, r4_buffer);
+            QUEUE_WAIT(queue);
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;
@@ -118,6 +119,7 @@ public:
                 oneapi::mkl::rng::generate(distr, engine3, N_GEN, r2_buffer);
                 oneapi::mkl::rng::generate(distr, engine4, N_GEN, r3_buffer);
             }
+            QUEUE_WAIT(queue);
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -123,9 +123,9 @@ protected:
 };
 
 #ifdef CALL_RT_API
-#define QUEUE_WAIT(q)   q.wait()
+#define QUEUE_WAIT(q) q.wait()
 #else
-#define QUEUE_WAIT(q)   q.get_queue().wait()
+#define QUEUE_WAIT(q) q.get_queue().wait()
 #endif
 
 #endif // _RNG_TEST_COMMON_HPP__

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -122,4 +122,10 @@ protected:
     Test test_;
 };
 
+#ifdef CALL_RT_API
+#define QUEUE_WAIT(q)   q.wait()
+#else
+#define QUEUE_WAIT(q)   q.get_queue().wait()
+#endif
+
 #endif // _RNG_TEST_COMMON_HPP__

--- a/tests/unit_tests/rng/include/skip_ahead_test.hpp
+++ b/tests/unit_tests/rng/include/skip_ahead_test.hpp
@@ -67,6 +67,7 @@ public:
             for (int i = 0; i < N_ENGINES; i++) {
                 oneapi::mkl::rng::generate(distr, *(engines[i]), N_PORTION, r_buffers[i]);
             }
+            QUEUE_WAIT(queue);
 
             // Clear memory
             for (int i = 0; i < N_ENGINES; i++) {
@@ -118,6 +119,7 @@ public:
 
             oneapi::mkl::rng::generate(distr, engine1, N_GEN, r1_buffer);
             oneapi::mkl::rng::generate(distr, engine2, N_GEN, r2_buffer);
+            QUEUE_WAIT(queue);
         }
         catch (const oneapi::mkl::unimplemented& e) {
             status = test_skipped;

--- a/tests/unit_tests/rng/include/statistics_check_test.hpp
+++ b/tests/unit_tests/rng/include/statistics_check_test.hpp
@@ -63,6 +63,7 @@ public:
             Engine engine(queue, SEED);
             Distr distr(args...);
             oneapi::mkl::rng::generate(distr, engine, n_gen, r_buffer);
+            QUEUE_WAIT(queue);
         }
         catch (sycl::exception const& e) {
             std::cout << "Caught synchronous SYCL exception during generation:\n"


### PR DESCRIPTION
- remove deprecated accessor::get_pointer()
- clang-format for rocrand_helpers.hpp
- add explicit sync for tests

Test log: 
[tests_log.txt](https://github.com/oneapi-src/oneMKL/files/13428710/tests_log.txt) - Philox4x32x10 fails for skip_ahead_ex is expected
