### PR TITLE
[SPARSE] Add support for sparse MKLGPU backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,8 @@ if(ENABLE_MKLGPU_BACKEND
 	OR ENABLE_ROCFFT_BACKEND)
   list(APPEND DOMAINS_LIST "dft")
 endif()
-if(ENABLE_MKLCPU_BACKEND)
+if(ENABLE_MKLCPU_BACKEND
+        OR ENABLE_MKLGPU_BACKEND)
   list(APPEND DOMAINS_LIST "sparse_blas")
 endif()
 
@@ -207,8 +208,6 @@ endif()
 if(NOT TARGET_DOMAINS OR TARGET_DOMAINS STREQUAL "None")
   # Set to all by default
   set(TARGET_DOMAINS ${DOMAINS_LIST})
-  # Remove sparse_blas from the default until it is supported by MKLCPU and MKLGPU backends
-  list(REMOVE_ITEM TARGET_DOMAINS "sparse_blas")
 else()
   # Make sure the input was converted to list
   string(REPLACE " " ";" TARGET_DOMAINS ${TARGET_DOMAINS})

--- a/README.md
+++ b/README.md
@@ -150,9 +150,7 @@ Header-based and backend-independent Device API can be called within ```sycl ker
 
 ### Supported Configurations:
 
-Supported domains: BLAS, LAPACK, RNG, DFT
-
-Support for SPARSE_BLAS domain is in progress and disabled by default. Use it at your own risks.
+Supported domains: BLAS, LAPACK, RNG, DFT, SPARSE_BLAS
 
 #### Linux*
 
@@ -272,6 +270,18 @@ Support for SPARSE_BLAS domain is in progress and disabled by default. Use it at
         <tr>
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocFFT</td>
+            <td align="center">Dynamic, Static</td>
+            <td align="center">DPC++</td>
+        </tr>
+        <tr>
+            <td rowspan=2 align="center">SPARSE_BLAS</td>
+            <td align="center">Intel GPU</td>
+            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
+            <td align="center">Dynamic, Static</td>
+            <td align="center">DPC++</td>
+        </tr>
+        <tr>
+            <td align="center">x86 CPU</td>
             <td align="center">Dynamic, Static</td>
             <td align="center">DPC++</td>
         </tr>

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ oneAPI Math Kernel Library (oneMKL) Interfaces offers examples with the followin
 - rng: uniform_usm  
 - lapack: getrs_usm
 - dft: complex_fwd_buffer, real_fwd_usm
+- sparse_blas: sparse_gemv_usm
 
 Each routine has one run-time dispatching example and one compile-time dispatching example (which uses both mklcpu and cuda backends), located in `example/<$domain>/run_time_dispatching` and `example/<$domain>/compile_time_dispatching` subfolders, respectively.
 
@@ -16,7 +17,7 @@ The example executable naming convention follows `example_<$domain>_<$routine>_<
   or `example_<$domain>_<$routine>` for run-time dispatching examples. 
   E.g. `example_blas_gemm_usm_mklcpu_cublas `  `example_blas_gemm_usm`
 
-## Example outputs (blas, rng, lapack, dft)
+## Example outputs (blas, rng, lapack, dft, sparse_blas)
   
 ## blas
 
@@ -455,4 +456,118 @@ Device name is: AMD Radeon PRO W6800
 Running with single precision real data type:
 DFT example run_time dispatch
 DFT example ran OK
+```
+
+## sparse_blas
+
+Run-time dispatching examples with mklcpu backend
+```
+$ export SYCL_DEVICE_FILTER=cpu
+$ ./bin/example_sparse_blas_gemv_usm
+
+########################################################################
+# Sparse Matrix-Vector Multiply Example: 
+# 
+# y = alpha * op(A) * x + beta * y
+# 
+# where A is a sparse matrix in CSR format, x and y are dense vectors
+# and alpha, beta are floating point type precision scalars.
+# 
+# Using apis:
+#   sparse::gemv
+# 
+# Using single precision (float) data type
+# 
+# Device will be selected during runtime.
+# The environment variable SYCL_DEVICE_FILTER can be used to specify
+# SYCL device
+# 
+########################################################################
+
+Running Sparse BLAS GEMV USM example on CPU device.
+Device name is: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
+Running with single precision real data type:
+
+		sparse::gemv parameters:
+			transA = nontrans
+			nrows = 64
+			alpha = 1, beta = 0
+
+		 sparse::gemv example passed
+	Finished
+Sparse BLAS GEMV USM example ran OK.
+```
+
+Run-time dispatching examples with mklgpu backend
+```
+$ export SYCL_DEVICE_FILTER=gpu
+$ ./bin/example_sparse_blas_gemv_usm
+
+########################################################################
+# Sparse Matrix-Vector Multiply Example: 
+# 
+# y = alpha * op(A) * x + beta * y
+# 
+# where A is a sparse matrix in CSR format, x and y are dense vectors
+# and alpha, beta are floating point type precision scalars.
+# 
+# Using apis:
+#   sparse::gemv
+# 
+# Using single precision (float) data type
+# 
+# Device will be selected during runtime.
+# The environment variable SYCL_DEVICE_FILTER can be used to specify
+# SYCL device
+# 
+########################################################################
+
+Running Sparse BLAS GEMV USM example on GPU device.
+Device name is: Intel(R) HD Graphics 530 [0x1912]
+Running with single precision real data type:
+
+		sparse::gemv parameters:
+			transA = nontrans
+			nrows = 64
+			alpha = 1, beta = 0
+
+		 sparse::gemv example passed
+	Finished
+Sparse BLAS GEMV USM example ran OK.
+```
+
+Compile-time dispatching example with mklcpu backend
+```
+$ export SYCL_DEVICE_FILTER=cpu
+$ ./bin/example_sparse_blas_gemv_usm_mklcpu
+
+########################################################################
+# Sparse Matrix-Vector Multiply Example: 
+# 
+# y = alpha * op(A) * x + beta * y
+# 
+# where A is a sparse matrix in CSR format, x and y are dense vectors
+# and alpha, beta are floating point type precision scalars.
+# 
+# Using apis:
+#   sparse::gemv
+# 
+# Using single precision (float) data type
+# 
+# Running on Intel CPU device
+# 
+########################################################################
+
+Running Sparse BLAS GEMV USM example on CPU device.
+Device name is: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
+Running with single precision real data type:
+
+		sparse::gemv parameters:
+			transA = nontrans
+			nrows = 64
+			alpha = 1, beta = 0
+
+		 sparse::gemv example passed
+	Finished
+Sparse BLAS GEMV USM example ran OK.
 ```

--- a/examples/sparse_blas/run_time_dispatching/CMakeLists.txt
+++ b/examples/sparse_blas/run_time_dispatching/CMakeLists.txt
@@ -30,6 +30,9 @@ set(DEVICE_FILTERS "")
 if(ENABLE_MKLCPU_BACKEND)
   list(APPEND DEVICE_FILTERS "cpu")
 endif()
+if(ENABLE_MKLGPU_BACKEND)
+  list(APPEND DEVICE_FILTERS "gpu")
+endif()
 
 message(STATUS "SYCL_DEVICE_FILTER will be set to the following value(s): [${DEVICE_FILTERS}] for run-time dispatching examples")
 

--- a/include/oneapi/mkl/detail/backends_table.hpp
+++ b/include/oneapi/mkl/detail/backends_table.hpp
@@ -169,6 +169,12 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
 #ifdef ENABLE_MKLCPU_BACKEND
               LIB_NAME("sparse_blas_mklcpu")
 #endif
+          } },
+        { device::intelgpu,
+          {
+#ifdef ENABLE_MKLGPU_BACKEND
+              LIB_NAME("sparse_blas_mklgpu")
+#endif
           } } } },
 };
 

--- a/include/oneapi/mkl/sparse_blas/detail/mklgpu/onemkl_sparse_blas_mklgpu.hpp
+++ b/include/oneapi/mkl/sparse_blas/detail/mklgpu/onemkl_sparse_blas_mklgpu.hpp
@@ -17,24 +17,18 @@
 *
 **************************************************************************/
 
-#ifndef _ONEMKL_SPARSE_BLAS_HPP_
-#define _ONEMKL_SPARSE_BLAS_HPP_
+#ifndef _ONEMKL_SPARSE_BLAS_DETAIL_MKLGPU_ONEMKL_SPARSE_BLAS_MKLGPU_HPP_
+#define _ONEMKL_SPARSE_BLAS_DETAIL_MKLGPU_ONEMKL_SPARSE_BLAS_MKLGPU_HPP_
 
-#if __has_include(<sycl/sycl.hpp>)
-#include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include "oneapi/mkl/detail/export.hpp"
+#include "oneapi/mkl/sparse_blas/detail/helper_types.hpp"
 
-#include "oneapi/mkl/detail/config.hpp"
+namespace oneapi::mkl::sparse::mklgpu {
 
-#ifdef ENABLE_MKLCPU_BACKEND
-#include "sparse_blas/detail/mklcpu/sparse_blas_ct.hpp"
-#endif
-#ifdef ENABLE_MKLGPU_BACKEND
-#include "sparse_blas/detail/mklgpu/sparse_blas_ct.hpp"
-#endif
+namespace detail = oneapi::mkl::sparse::detail;
 
-#include "sparse_blas/detail/sparse_blas_rt.hpp"
+#include "oneapi/mkl/sparse_blas/detail/onemkl_sparse_blas_backends.hxx"
 
-#endif // _ONEMKL_SPARSE_BLAS_HPP_
+} // namespace oneapi::mkl::sparse::mklgpu
+
+#endif // _ONEMKL_SPARSE_BLAS_DETAIL_MKLGPU_ONEMKL_SPARSE_BLAS_MKLGPU_HPP_

--- a/include/oneapi/mkl/sparse_blas/detail/mklgpu/sparse_blas_ct.hpp
+++ b/include/oneapi/mkl/sparse_blas/detail/mklgpu/sparse_blas_ct.hpp
@@ -17,24 +17,25 @@
 *
 **************************************************************************/
 
-#ifndef _ONEMKL_SPARSE_BLAS_HPP_
-#define _ONEMKL_SPARSE_BLAS_HPP_
+#ifndef _ONEMKL_SPARSE_BLAS_DETAIL_MKLGPU_SPARSE_BLAS_CT_HPP_
+#define _ONEMKL_SPARSE_BLAS_DETAIL_MKLGPU_SPARSE_BLAS_CT_HPP_
 
-#if __has_include(<sycl/sycl.hpp>)
-#include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include "oneapi/mkl/sparse_blas/types.hpp"
+#include "oneapi/mkl/detail/backends.hpp"
+#include "oneapi/mkl/detail/backend_selector.hpp"
 
-#include "oneapi/mkl/detail/config.hpp"
+#include "onemkl_sparse_blas_mklgpu.hpp"
 
-#ifdef ENABLE_MKLCPU_BACKEND
-#include "sparse_blas/detail/mklcpu/sparse_blas_ct.hpp"
-#endif
-#ifdef ENABLE_MKLGPU_BACKEND
-#include "sparse_blas/detail/mklgpu/sparse_blas_ct.hpp"
-#endif
+namespace oneapi {
+namespace mkl {
+namespace sparse {
 
-#include "sparse_blas/detail/sparse_blas_rt.hpp"
+#define BACKEND mklgpu
+#include "oneapi/mkl/sparse_blas/detail/sparse_blas_ct.hxx"
+#undef BACKEND
 
-#endif // _ONEMKL_SPARSE_BLAS_HPP_
+} //namespace sparse
+} //namespace mkl
+} //namespace oneapi
+
+#endif // _ONEMKL_SPARSE_BLAS_DETAIL_MKLGPU_SPARSE_BLAS_CT_HPP_

--- a/src/sparse_blas/backends/CMakeLists.txt
+++ b/src/sparse_blas/backends/CMakeLists.txt
@@ -20,3 +20,7 @@
 if(ENABLE_MKLCPU_BACKEND)
   add_subdirectory(mklcpu)
 endif()
+
+if(ENABLE_MKLGPU_BACKEND)
+  add_subdirectory(mklgpu)
+endif()

--- a/src/sparse_blas/backends/mklcpu/CMakeLists.txt
+++ b/src/sparse_blas/backends/mklcpu/CMakeLists.txt
@@ -36,9 +36,6 @@ target_include_directories(${LIB_OBJ}
 )
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
-if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
-  add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})
-endif()
 
 if(TARGET MKL::MKL_SYCL::SPARSE)
   target_link_libraries(${LIB_OBJ}

--- a/src/sparse_blas/backends/mklgpu/CMakeLists.txt
+++ b/src/sparse_blas/backends/mklgpu/CMakeLists.txt
@@ -1,0 +1,83 @@
+#===============================================================================
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+#
+# SPDX-License-Identifier: Apache-2.0
+#===============================================================================
+
+set(LIB_NAME onemkl_sparse_blas_mklgpu)
+set(LIB_OBJ ${LIB_NAME}_obj)
+
+include(WarningsUtils)
+
+add_library(${LIB_NAME})
+add_library(${LIB_OBJ} OBJECT
+  mklgpu_basic.cpp
+  mklgpu_operations.cpp
+  $<$<BOOL:${BUILD_SHARED_LIBS}>: mklgpu_wrappers.cpp>
+)
+
+target_include_directories(${LIB_OBJ}
+  PRIVATE ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/src
+          ${CMAKE_BINARY_DIR}/bin
+)
+
+target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
+if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
+  add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})
+endif()
+
+if(TARGET MKL::MKL_SYCL::SPARSE)
+  target_link_libraries(${LIB_OBJ}
+    PUBLIC ONEMKL::SYCL::SYCL
+    PUBLIC MKL::MKL_SYCL::SPARSE
+    PRIVATE onemkl_warnings
+  )
+else()
+  target_link_libraries(${LIB_OBJ}
+    PUBLIC ONEMKL::SYCL::SYCL
+    PUBLIC MKL::MKL_DPCPP
+    PRIVATE onemkl_warnings
+  )
+endif()
+
+set_target_properties(${LIB_OBJ} PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+)
+target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ})
+
+#Set oneMKL libraries as not transitive for dynamic
+if(BUILD_SHARED_LIBS)
+  set_target_properties(${LIB_NAME} PROPERTIES
+    INTERFACE_LINK_LIBRARIES ONEMKL::SYCL::SYCL
+  )
+endif()
+
+# Add major version to the library
+set_target_properties(${LIB_NAME} PROPERTIES
+  SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+# Add dependencies rpath to the library
+list(APPEND CMAKE_BUILD_RPATH $<TARGET_FILE_DIR:${LIB_NAME}>)
+
+# Add the library to install package
+install(TARGETS ${LIB_OBJ} EXPORT oneMKLTargets)
+install(TARGETS ${LIB_NAME} EXPORT oneMKLTargets
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)

--- a/src/sparse_blas/backends/mklgpu/CMakeLists.txt
+++ b/src/sparse_blas/backends/mklgpu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
+          ${ONEMKL_GENERATED_INCLUDE_PATH}
 )
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})

--- a/src/sparse_blas/backends/mklgpu/CMakeLists.txt
+++ b/src/sparse_blas/backends/mklgpu/CMakeLists.txt
@@ -37,9 +37,6 @@ target_include_directories(${LIB_OBJ}
 )
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
-if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
-  add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})
-endif()
 
 if(TARGET MKL::MKL_SYCL::SPARSE)
   target_link_libraries(${LIB_OBJ}

--- a/src/sparse_blas/backends/mklgpu/mklgpu_basic.cpp
+++ b/src/sparse_blas/backends/mklgpu/mklgpu_basic.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright 2023 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "../mkl_common/mkl_helper.hpp"
+
+#include "oneapi/mkl/sparse_blas/detail/mklgpu/onemkl_sparse_blas_mklgpu.hpp"
+
+namespace oneapi::mkl::sparse::mklgpu {
+
+#include "../mkl_common/mkl_basic.cxx"
+
+} // namespace oneapi::mkl::sparse::mklgpu

--- a/src/sparse_blas/backends/mklgpu/mklgpu_operations.cpp
+++ b/src/sparse_blas/backends/mklgpu/mklgpu_operations.cpp
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright 2023 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "../mkl_common/mkl_helper.hpp"
+
+#include "oneapi/mkl/sparse_blas/detail/mklgpu/onemkl_sparse_blas_mklgpu.hpp"
+
+namespace oneapi::mkl::sparse::mklgpu {
+
+#include "../mkl_common/mkl_operations.cxx"
+
+} // namespace oneapi::mkl::sparse::mklgpu

--- a/src/sparse_blas/backends/mklgpu/mklgpu_wrappers.cpp
+++ b/src/sparse_blas/backends/mklgpu/mklgpu_wrappers.cpp
@@ -1,0 +1,32 @@
+/*******************************************************************************
+* Copyright 2023 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#include "oneapi/mkl/sparse_blas/types.hpp"
+
+#include "oneapi/mkl/sparse_blas/detail/mklgpu/onemkl_sparse_blas_mklgpu.hpp"
+
+#include "sparse_blas/function_table.hpp"
+
+#define WRAPPER_VERSION 1
+#define BACKEND         mklgpu
+
+extern "C" sparse_blas_function_table_t mkl_sparse_blas_table = {
+    WRAPPER_VERSION,
+#include "sparse_blas/backends/backend_wrappers.cxx"
+};

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -164,10 +164,13 @@ auto test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val, int &n
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
                                             transpose_val, oneapi::mkl::diag::unit, use_optimize),
                                num_passed, num_skipped);
-    // Test int64 indices
-    EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower,
-                                            transpose_val, nonunit, use_optimize),
-                               num_passed, num_skipped);
+    // Temporarily disable trsv using long indices on GPU
+    if (!dev->is_gpu()) {
+        // Test int64 indices
+        EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower,
+                                                transpose_val, nonunit, use_optimize),
+                                   num_passed, num_skipped);
+    }
     // Test lower without optimize_trsv
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false),

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_usm.cpp
@@ -185,10 +185,13 @@ void test_helper(sycl::device *dev, oneapi::mkl::transpose transpose_val, int &n
     EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, m, density_A_matrix, index_zero, lower,
                                             transpose_val, oneapi::mkl::diag::unit, use_optimize),
                                num_passed, num_skipped);
-    // Test int64 indices
-    EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower,
-                                            transpose_val, nonunit, use_optimize),
-                               num_passed, num_skipped);
+    // Temporarily disable trsv using long indices on GPU
+    if (!dev->is_gpu()) {
+        // Test int64 indices
+        EXPECT_TRUE_OR_FUTURE_SKIP(test<fpType>(dev, 15L, density_A_matrix, index_zero, lower,
+                                                transpose_val, nonunit, use_optimize),
+                                   num_passed, num_skipped);
+    }
     // Test lower without optimize_trsv
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test<fpType>(dev, m, density_A_matrix, index_zero, lower, transpose_val, nonunit, false),


### PR DESCRIPTION
# Description

Add support for sparse MKLGPU backend.
This enables the sparse_blas domain by default.

Depends on https://github.com/oneapi-src/oneMKL/pull/407

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## New features

- [x] Have you provided motivation for adding a new feature?
- [x] Have you added relevant tests?