### PR TITLE
[DFT] Implement external workspace according to draft spec

### DIFF
--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -139,7 +139,7 @@ public:
      * @param function_name The function name to user in generated exceptions.
     */
     template <typename... ArgTs>
-    inline void compute_call_throw(const char *function_name) {
+    void compute_call_throw(const char *function_name) {
         external_workspace_helper_.template compute_call_throw<ArgTs...>(function_name);
     }
 
@@ -148,8 +148,23 @@ public:
      * @param function_name The function name to user in generated exceptions.
      * @param cgh The command group handler to associate the accessor with.
     */
-    inline void get_workspace_buffer_access_if_rqd(const char *function_name, sycl::handler &cgh) {
-        external_workspace_helper_.get_workspace_buffer_access_if_rqd(function_name, cgh);
+    void add_buffer_dependency_if_rqd(const char *function_name, sycl::handler &cgh) {
+        external_workspace_helper_.add_buffer_dependency_if_rqd(function_name, cgh);
+    }
+
+    /** If WORKSPACE_EXTERNAL is set, depend on the last USM workspace event added via set_last_usm_workspace_event.
+     * @param cgh The command group handler to associate the accessor with.
+    */
+    void depend_on_last_usm_workspace_event_if_rqd(sycl::handler &cgh) {
+        external_workspace_helper_.depend_on_last_usm_workspace_event(cgh);
+    }
+
+    /** If WORKSPACE_EXTERNAL is set, store the given event internally to allow it to be depended upon by
+     * subsequent calls to depend_on_last_usm_workspace_event.
+     * @param sycl_event The last usage of the USM workspace.
+    */
+    void set_last_usm_workspace_event(sycl::event &sycl_event) {
+        external_workspace_helper_.set_last_usm_workspace_event(sycl_event);
     }
 
 protected:

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -149,7 +149,7 @@ public:
      * @param cgh The command group handler to associate the accessor with.
     */
     void add_buffer_workspace_dependency_if_rqd(const char *function_name, sycl::handler &cgh) {
-        external_workspace_helper_.add_buffer_workspace_dependency_if_rqd(function_name, cgh);
+        external_workspace_helper_.add_buffer_dependency_if_rqd(function_name, cgh);
     }
 
     /** If WORKSPACE_EXTERNAL is set, depend on the last USM workspace event added via set_last_usm_workspace_event.

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -84,6 +84,9 @@ public:
     // set_workspace should be overrided for any backend that enables external workspaces.
     // If these are overrided, get_workspace_external_bytes_impl must also be overrided.
     // For backends that do not support external workspaces, these functions do not need to be overrided.
+    // When not overrided, external workspace support is faked: an external workspace can be set, 
+    // and errors will be generated according to the specificiation, 
+    // but the required workspace size will always be zero, and any given workspace will not actually be used.
     virtual void set_workspace(scalar_type *usm_workspace) {
         external_workspace_helper_.set_workspace_throw(*this, usm_workspace);
     };

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -148,8 +148,8 @@ public:
      * @param function_name The function name to user in generated exceptions.
      * @param cgh The command group handler to associate the accessor with.
     */
-    void add_buffer_dependency_if_rqd(const char *function_name, sycl::handler &cgh) {
-        external_workspace_helper_.add_buffer_dependency_if_rqd(function_name, cgh);
+    void add_buffer_workspace_dependency_if_rqd(const char *function_name, sycl::handler &cgh) {
+        external_workspace_helper_.add_buffer_workspace_dependency_if_rqd(function_name, cgh);
     }
 
     /** If WORKSPACE_EXTERNAL is set, depend on the last USM workspace event added via set_last_usm_workspace_event.

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -156,15 +156,15 @@ public:
      * @param cgh The command group handler to associate the accessor with.
     */
     void depend_on_last_usm_workspace_event_if_rqd(sycl::handler &cgh) {
-        external_workspace_helper_.depend_on_last_usm_workspace_event(cgh);
+        external_workspace_helper_.depend_on_last_usm_workspace_event_if_rqd(cgh);
     }
 
     /** If WORKSPACE_EXTERNAL is set, store the given event internally to allow it to be depended upon by
      * subsequent calls to depend_on_last_usm_workspace_event.
      * @param sycl_event The last usage of the USM workspace.
     */
-    void set_last_usm_workspace_event(sycl::event &sycl_event) {
-        external_workspace_helper_.set_last_usm_workspace_event(sycl_event);
+    void set_last_usm_workspace_event_if_rqd(sycl::event &sycl_event) {
+        external_workspace_helper_.set_last_usm_workspace_event_if_rqd(sycl_event);
     }
 
 protected:

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -81,9 +81,9 @@ public:
         return external_workspace_helper_.get_rqd_workspace_bytes(*this);
     };
 
-    // Set workspace by be overrided for any backend that actually uses the workspace.
+    // set_workspace should be overrided for any backend that enables external workspaces.
     // If these are overrided, get_workspace_external_bytes_impl must also be overrided.
-    // For backends that do not support external workspace, these functions do not need to be overrided.
+    // For backends that do not support external workspaces, these functions do not need to be overrided.
     virtual void set_workspace(scalar_type *usm_workspace) {
         external_workspace_helper_.set_workspace_throw(*this, usm_workspace);
     };

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -81,11 +81,11 @@ public:
         return external_workspace_helper_.get_rqd_workspace_bytes(*this);
     };
 
-    // set_workspace should be overrided for any backend that enables external workspaces.
-    // If these are overrided, get_workspace_external_bytes_impl must also be overrided.
-    // For backends that do not support external workspaces, these functions do not need to be overrided.
-    // When not overrided, external workspace support is faked: an external workspace can be set, 
-    // and errors will be generated according to the specificiation, 
+    // set_workspace should be overridden for any backend that enables external workspaces.
+    // If these are overridden, get_workspace_external_bytes_impl must also be overridden.
+    // For backends that do not support external workspaces, these functions do not need to be overridden.
+    // When not overridden, external workspace support is faked: an external workspace can be set,
+    // and errors will be generated according to the specificiation,
     // but the required workspace size will always be zero, and any given workspace will not actually be used.
     virtual void set_workspace(scalar_type *usm_workspace) {
         external_workspace_helper_.set_workspace_throw(*this, usm_workspace);

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -95,9 +95,9 @@ public:
         return values_;
     };
 
-    void set_workspace(scalar_type* usmWorkspace);
+    void set_workspace(scalar_type* usm_workspace);
 
-    void set_workspace(sycl::buffer<scalar_type>& bufferWorkspace);
+    void set_workspace(sycl::buffer<scalar_type>& buffer_workspace);
 
 private:
     // Has a value when the descriptor is committed.

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -45,6 +45,9 @@ inline commit_impl<prec, dom>* get_commit(descriptor<prec, dom>& desc);
 
 template <precision prec, domain dom>
 class descriptor {
+private:
+    using scalar_type = typename descriptor_info<descriptor>::scalar_type;
+
 public:
     // Syntax for 1-dimensional DFT
     descriptor(std::int64_t length);
@@ -91,6 +94,10 @@ public:
     const dft_values<prec, dom>& get_values() const noexcept {
         return values_;
     };
+
+    void set_workspace(scalar_type* usmWorkspace);
+
+    void set_workspace(sycl::buffer<scalar_type>& bufferWorkspace);
 
 private:
     // Has a value when the descriptor is committed.

--- a/include/oneapi/mkl/dft/detail/external_workspace_helper.hpp
+++ b/include/oneapi/mkl/dft/detail/external_workspace_helper.hpp
@@ -77,13 +77,6 @@ public:
         *this = external_workspace_helper(ext_workspace_rqd);
     }
 
-    /** Reset. May be required for changing descriptor settings before recommitting. Assumes no change
-     *  in workspace setting.
-    */
-    inline void reset() {
-        *this = external_workspace_helper(m_ext_workspace_rqd);
-    }
-
     /** Get the required workspace bytes for the backend's external workspace.
      *  @param committed_desc The backend's native descriptor.
     */

--- a/include/oneapi/mkl/dft/detail/external_workspace_helper.hpp
+++ b/include/oneapi/mkl/dft/detail/external_workspace_helper.hpp
@@ -1,0 +1,185 @@
+/*******************************************************************************
+* Copyright Codeplay Software Ltd
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _ONEMKL_DFT_EXTERNAL_WORKSPACE_HELPER_HPP_
+#define _ONEMKL_DFT_EXTERNAL_WORKSPACE_HELPER_HPP_
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "oneapi/mkl/detail/export.hpp"
+#include "oneapi/mkl/dft/detail/types_impl.hpp"
+#include "oneapi/mkl/dft/detail/commit_impl.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace dft {
+namespace detail {
+
+template <precision prec, domain dom>
+class external_workspace_helper {
+public:
+    using commit_impl_t = commit_impl<prec, dom>;
+    using scalar_t = typename commit_impl_t::scalar_type;
+
+private:
+    // Enum to represent whatever the workspace was set as.
+    enum class ext_workspace_type {
+        not_set,
+        usm,
+        buffer,
+    };
+
+    // Is an external workspace required?
+    bool m_ext_workspace_rqd;
+
+    // Set workspace type, with optional workspaces.
+    ext_workspace_type m_workspace_type;
+
+    // Minimum size of workspace in bytes. -1 indicates not set.
+    std::int64_t m_workspace_bytes_rqd;
+
+    std::optional<sycl::buffer<scalar_t>> m_workspace_buffer;
+
+public:
+    /** Constructor.
+     *  @param ext_workspace_rqd True if WORKSPACE_PLACEMENT is set to WORKSPACE_EXTERNAL.
+     *  @param backend_rqd_bytes_fn The function to call to obtain the backend's required workspace size.
+    */
+    inline constexpr external_workspace_helper(bool ext_workspace_rqd)
+            : m_ext_workspace_rqd(ext_workspace_rqd),
+              m_workspace_type(ext_workspace_type::not_set),
+              m_workspace_bytes_rqd(-1) {}
+
+    /** Reset. May be required for changing descriptor settings before recommitting.
+     *  @param ext_workspace_rqd True if WORKSPACE_PLACEMENT is set to WORKSPACE_EXTERNAL.
+    */
+    inline void reset(bool ext_workspace_rqd) {
+        *this = external_workspace_helper(ext_workspace_rqd);
+    }
+
+    /** Reset. May be required for changing descriptor settings before recommitting. Assumes no change
+     *  in workspace setting.
+    */
+    inline void reset() {
+        *this = external_workspace_helper(m_ext_workspace_rqd);
+    }
+
+    /** Get the required workspace bytes for the backend's external workspace.
+     *  @param committed_desc The backend's native descriptor.
+    */
+    inline std::int64_t get_rqd_workspace_bytes(commit_impl_t& committed_desc) {
+        if (m_workspace_bytes_rqd == -1) {
+            m_workspace_bytes_rqd = committed_desc.get_workspace_external_bytes_impl();
+        }
+        return m_workspace_bytes_rqd;
+    }
+
+    /** Throw according to spec for setting the workspace. USM version.
+     *  @param committed_desc The backend's native descriptor.
+     *  @param usm_workspace A USM allocation for the workspace. Assumed to be sufficeintly large.
+    */
+    inline void set_workspace_throw(commit_impl_t& committed_desc, scalar_t* usm_workspace) {
+        if (get_rqd_workspace_bytes(committed_desc) > 0 && usm_workspace == nullptr) {
+            throw mkl::invalid_argument("DFT", "set_workspace",
+                                        "Provided workspace is too small (nullptr)");
+            return;
+        }
+        m_ext_workspace_rqd = true;
+        m_workspace_type = ext_workspace_type::usm;
+    }
+
+    /** Throw according to spec for setting the workspace. Buffer version.
+     *  @param committed_desc The backend's native descriptor.
+     *  @param buffer_workspace A buffer for the workspace
+    */
+    inline void set_workspace_throw(commit_impl_t& committed_desc,
+                                    sycl::buffer<scalar_t>& buffer_workspace) {
+        if (static_cast<std::size_t>(get_rqd_workspace_bytes(committed_desc)) / sizeof(scalar_t) >
+            buffer_workspace.size()) {
+            throw mkl::invalid_argument("DFT", "set_workspace", "Provided workspace is too small");
+            return;
+        }
+        if (buffer_workspace.is_sub_buffer()) {
+            throw mkl::invalid_argument("DFT", "set_workspace",
+                                        "Cannot use sub-buffers for workspace");
+            return;
+        }
+        m_ext_workspace_rqd = true;
+        m_workspace_type = ext_workspace_type::buffer;
+        m_workspace_buffer = buffer_workspace;
+    }
+
+    template <typename FirstArgT, typename... ArgTs>
+    inline void compute_call_throw(const char* function_name) const {
+        constexpr bool is_pointer = std::is_pointer_v<std::remove_reference_t<FirstArgT>>;
+        if constexpr (is_pointer) {
+            usm_compute_call_throw(function_name);
+        }
+        else {
+            buffer_compute_call_throw(function_name);
+        }
+    }
+
+    inline void get_workspace_buffer_access_if_rqd(const char* function_name, sycl::handler& cgh) {
+        if (m_ext_workspace_rqd) {
+            if (m_workspace_buffer) {
+                if (m_workspace_buffer->size()) {
+                    m_workspace_buffer->template get_access<sycl::access::mode::read_write>(cgh);
+                }
+                return;
+            }
+            throw mkl::invalid_argument(
+                "DFT", function_name,
+                "Buffer external workspace must be used with buffer compute calls");
+        }
+    }
+
+private:
+    /** When a compute function using USM arguments is called, throw an exception if an incorrect workspace has been set.
+     *  @param function_name The name of the function to use in the error.
+    */
+    inline void usm_compute_call_throw(const char* function_name) const {
+        if (m_ext_workspace_rqd && m_workspace_type != ext_workspace_type::usm) {
+            throw mkl::invalid_argument(
+                "DFT", function_name, "USM external workspace must be used with usm compute calls");
+        }
+    }
+
+    /** When a compute function using buffer arguments is called, throw an exception if an incorrect workspace has been set.
+     *  @param function_name The name of the function to use in the error.
+    */
+    inline void buffer_compute_call_throw(const char* function_name) const {
+        if (m_ext_workspace_rqd && m_workspace_type != ext_workspace_type::buffer) {
+            throw mkl::invalid_argument(
+                "DFT", function_name,
+                "Buffer external workspace must be used with buffer compute calls");
+        }
+    }
+};
+
+} // namespace detail
+} // namespace dft
+} // namespace mkl
+} // namespace oneapi
+
+#endif //_ONEMKL_DFT_EXTERNAL_WORKSPACE_HELPER_HPP_

--- a/include/oneapi/mkl/dft/detail/external_workspace_helper.hpp
+++ b/include/oneapi/mkl/dft/detail/external_workspace_helper.hpp
@@ -147,7 +147,7 @@ public:
     /** If WORKSPACE_EXTERNAL is set, depend on the last USM workspace event added via set_last_usm_workspace_event.
      * @param cgh The command group handler to associate the accessor with.
     */
-    inline void depend_on_last_usm_workspace_event_if_rqd(sycl::handler& cgh) {
+    void depend_on_last_usm_workspace_event_if_rqd(sycl::handler& cgh) {
         if (m_ext_workspace_rqd) {
             cgh.depends_on(m_usm_workspace_last_dependency);
         }
@@ -157,7 +157,7 @@ public:
      * subsequent calls to depend_on_last_usm_workspace_event.
      * @param sycl_event The last usage of the USM workspace.
     */
-    void set_last_usm_workspace_event(sycl::event& sycl_event) {
+    void set_last_usm_workspace_event_if_rqd(sycl::event& sycl_event) {
         if (m_ext_workspace_rqd) {
             m_usm_workspace_last_dependency = sycl_event;
         }

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -137,6 +137,8 @@ enum class config_param {
     BWD_DISTANCE,
 
     WORKSPACE,
+    WORKSPACE_PLACEMENT,
+    WORKSPACE_EXTERNAL_BYTES,
     ORDERING,
     TRANSPOSE,
     PACKED_FORMAT,
@@ -169,7 +171,11 @@ enum class config_value {
     NONE,
 
     // for config_param::PACKED_FORMAT for storing conjugate-even finite sequence in real containers
-    CCE_FORMAT
+    CCE_FORMAT,
+
+    // For config_param::WORKSPACE_PLACEMENT
+    WORKSPACE_AUTOMATIC,
+    WORKSPACE_EXTERNAL
 };
 
 template <precision prec, domain dom>
@@ -190,6 +196,7 @@ public:
     config_value real_storage;
     config_value conj_even_storage;
     config_value workspace;
+    config_value workspace_placement;
     config_value ordering;
     bool transpose;
     config_value packed_format;

--- a/src/dft/backends/backend_compute_signature.cxx
+++ b/src/dft/backends/backend_compute_signature.cxx
@@ -24,37 +24,45 @@ This file should be included for each backend, with <BACKEND> defined to match
 the namespace of the backend's implementation.
 */
 
-using scalar_type = typename dft::detail::commit_impl<prec, dom>::scalar_type;
 using fwd_type = typename dft::detail::commit_impl<prec, dom>::fwd_type;
 using bwd_type = typename dft::detail::commit_impl<prec, dom>::bwd_type;
 using descriptor_type = typename dft::detail::descriptor<prec, dom>;
 
 // forward inplace COMPLEX_COMPLEX
 void forward_ip_cc(descriptor_type& desc, sycl::buffer<fwd_type, 1>& inout) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<fwd_type, 1>>(
+        "compute_forward");
     oneapi::mkl::dft::BACKEND::compute_forward(desc, inout);
 }
 sycl::event forward_ip_cc(descriptor_type& desc, fwd_type* inout,
                           const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<fwd_type*>("compute_forward");
     return oneapi::mkl::dft::BACKEND::compute_forward(desc, inout, dependencies);
 }
 
 // forward inplace REAL_REAL
 void forward_ip_rr(descriptor_type& desc, sycl::buffer<scalar_type, 1>& inout_re,
                    sycl::buffer<scalar_type, 1>& inout_im) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<scalar_type, 1>>(
+        "compute_forward");
     oneapi::mkl::dft::BACKEND::compute_forward(desc, inout_re, inout_im);
 }
 sycl::event forward_ip_rr(descriptor_type& desc, scalar_type* inout_re, scalar_type* inout_im,
                           const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<scalar_type*>("compute_forward");
     return oneapi::mkl::dft::BACKEND::compute_forward(desc, inout_re, inout_im, dependencies);
 }
 
 // forward out-of-place COMPLEX_COMPLEX
 void forward_op_cc(descriptor_type& desc, sycl::buffer<fwd_type, 1>& in,
                    sycl::buffer<bwd_type, 1>& out) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<fwd_type, 1>>(
+        "compute_forward");
     oneapi::mkl::dft::BACKEND::compute_forward<descriptor_type>(desc, in, out);
 }
 sycl::event forward_op_cc(descriptor_type& desc, fwd_type* in, bwd_type* out,
                           const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<fwd_type*>("compute_forward");
     return oneapi::mkl::dft::BACKEND::compute_forward<descriptor_type>(desc, in, out, dependencies);
 }
 
@@ -62,41 +70,53 @@ sycl::event forward_op_cc(descriptor_type& desc, fwd_type* in, bwd_type* out,
 void forward_op_rr(descriptor_type& desc, sycl::buffer<scalar_type, 1>& in_re,
                    sycl::buffer<scalar_type, 1>& in_im, sycl::buffer<scalar_type, 1>& out_re,
                    sycl::buffer<scalar_type, 1>& out_im) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<scalar_type, 1>>(
+        "compute_forward");
     oneapi::mkl::dft::BACKEND::compute_forward(desc, in_re, in_im, out_re, out_im);
 }
 sycl::event forward_op_rr(descriptor_type& desc, scalar_type* in_re, scalar_type* in_im,
                           scalar_type* out_re, scalar_type* out_im,
                           const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<scalar_type*>("compute_forward");
     return oneapi::mkl::dft::BACKEND::compute_forward(desc, in_re, in_im, out_re, out_im,
                                                       dependencies);
 }
 
 // backward inplace COMPLEX_COMPLEX
 void backward_ip_cc(descriptor_type& desc, sycl::buffer<fwd_type, 1>& inout) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<fwd_type, 1>>(
+        "compute_backward");
     oneapi::mkl::dft::BACKEND::compute_backward(desc, inout);
 }
 sycl::event backward_ip_cc(descriptor_type& desc, fwd_type* inout,
                            const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<fwd_type*>("compute_backward");
     return oneapi::mkl::dft::BACKEND::compute_backward(desc, inout, dependencies);
 }
 
 // backward inplace REAL_REAL
 void backward_ip_rr(descriptor_type& desc, sycl::buffer<scalar_type, 1>& inout_re,
                     sycl::buffer<scalar_type, 1>& inout_im) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<scalar_type, 1>>(
+        "compute_backward");
     oneapi::mkl::dft::BACKEND::compute_backward(desc, inout_re, inout_im);
 }
 sycl::event backward_ip_rr(descriptor_type& desc, scalar_type* inout_re, scalar_type* inout_im,
                            const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<scalar_type*>("compute_backward");
     return oneapi::mkl::dft::BACKEND::compute_backward(desc, inout_re, inout_im, dependencies);
 }
 
 // backward out-of-place COMPLEX_COMPLEX
 void backward_op_cc(descriptor_type& desc, sycl::buffer<bwd_type, 1>& in,
                     sycl::buffer<fwd_type, 1>& out) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<bwd_type, 1>>(
+        "compute_backward");
     oneapi::mkl::dft::BACKEND::compute_backward(desc, in, out);
 }
 sycl::event backward_op_cc(descriptor_type& desc, bwd_type* in, fwd_type* out,
                            const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<bwd_type*>("compute_backward");
     return oneapi::mkl::dft::BACKEND::compute_backward(desc, in, out, dependencies);
 }
 
@@ -104,11 +124,14 @@ sycl::event backward_op_cc(descriptor_type& desc, bwd_type* in, fwd_type* out,
 void backward_op_rr(descriptor_type& desc, sycl::buffer<scalar_type, 1>& in_re,
                     sycl::buffer<scalar_type, 1>& in_im, sycl::buffer<scalar_type, 1>& out_re,
                     sycl::buffer<scalar_type, 1>& out_im) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<sycl::buffer<scalar_type, 1>>(
+        "compute_backward");
     oneapi::mkl::dft::BACKEND::compute_backward(desc, in_re, in_im, out_re, out_im);
 }
 sycl::event backward_op_rr(descriptor_type& desc, scalar_type* in_re, scalar_type* in_im,
                            scalar_type* out_re, scalar_type* out_im,
                            const std::vector<sycl::event>& dependencies) override {
+    dft::detail::get_commit(desc)->template compute_call_throw<scalar_type*>("compute_backward");
     return oneapi::mkl::dft::BACKEND::compute_backward(desc, in_re, in_im, out_re, out_im,
                                                        dependencies);
 }

--- a/src/dft/backends/cufft/backward.cpp
+++ b/src/dft/backends/cufft/backward.cpp
@@ -69,7 +69,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_backward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -115,7 +115,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_backward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);

--- a/src/dft/backends/cufft/backward.cpp
+++ b/src/dft/backends/cufft/backward.cpp
@@ -178,7 +178,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, fwd<descriptor
                 func_name, stream, plan, inout + offsets[0], inout + offsets[1]);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -224,7 +224,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, bwd<descriptor
                 func_name, stream, plan, in + offsets[0], out + offsets[1]);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 

--- a/src/dft/backends/cufft/backward.cpp
+++ b/src/dft/backends/cufft/backward.cpp
@@ -69,6 +69,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -114,6 +115,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);

--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -94,6 +94,9 @@ public:
 
     void commit(const dft::detail::dft_values<prec, dom>& config_values) override {
         // this could be a recommit
+        this->external_workspace_helper_.reset(
+            config_values.workspace_placement ==
+            oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
         clean_plans();
 
         if (config_values.fwd_scale != 1.0 || config_values.bwd_scale != 1.0) {

--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -44,15 +44,20 @@ namespace detail {
 template <dft::precision prec, dft::domain dom>
 class cufft_commit final : public dft::detail::commit_impl<prec, dom> {
 private:
+    using scalar_type = typename dft::detail::commit_impl<prec, dom>::scalar_type;
+
     // For real to complex transforms, the "type" arg also encodes the direction (e.g. CUFFT_R2C vs CUFFT_C2R) in the plan so we must have one for each direction.
     // We also need this because oneMKL uses a directionless "FWD_DISTANCE" and "BWD_DISTANCE" while cuFFT uses a directional "idist" and "odist".
     // plans[0] is forward, plans[1] is backward
     std::array<std::optional<cufftHandle>, 2> plans = { std::nullopt, std::nullopt };
     std::array<std::int64_t, 2> offsets;
+    // For using a buffer external workspace, the buffer object itself needs to be kept between compute calls such that accessors can be used.
+    std::optional<sycl::buffer<scalar_type, 1>> buffer_workspace;
 
 public:
     cufft_commit(sycl::queue& queue, const dft::detail::dft_values<prec, dom>& config_values)
-            : oneapi::mkl::dft::detail::commit_impl<prec, dom>(queue, backend::cufft) {
+            : oneapi::mkl::dft::detail::commit_impl<prec, dom>(queue, backend::cufft,
+                                                               config_values) {
         if constexpr (prec == dft::detail::precision::DOUBLE) {
             if (!queue.get_device().has(sycl::aspect::fp64)) {
                 throw mkl::exception("DFT", "commit", "Device does not support double precision.");
@@ -266,17 +271,22 @@ public:
 
         if (valid_forward) {
             cufftHandle fwd_plan;
-            auto res = cufftPlanMany(&fwd_plan, // plan
-                                     rank, // rank
-                                     n_copy.data(), // n
-                                     inembed.data(), // inembed
-                                     istride, // istride
-                                     fwd_dist, // idist
-                                     onembed.data(), // onembed
-                                     ostride, // ostride
-                                     bwd_dist, // odist
-                                     fwd_type, // type
-                                     batch // batch
+            auto res = cufftCreate(&fwd_plan);
+            if (res != CUFFT_SUCCESS) {
+                throw mkl::exception("dft/backends/cufft", __FUNCTION__, "cufftCreate failed.");
+            }
+            apply_external_workspace_setting(fwd_plan, config_values.workspace_placement);
+            res = cufftPlanMany(&fwd_plan, // plan
+                                rank, // rank
+                                n_copy.data(), // n
+                                inembed.data(), // inembed
+                                istride, // istride
+                                fwd_dist, // idist
+                                onembed.data(), // onembed
+                                ostride, // ostride
+                                bwd_dist, // odist
+                                fwd_type, // type
+                                batch // batch
             );
 
             if (res != CUFFT_SUCCESS) {
@@ -289,19 +299,23 @@ public:
 
         if (valid_backward) {
             cufftHandle bwd_plan;
-
+            auto res = cufftCreate(&bwd_plan);
+            if (res != CUFFT_SUCCESS) {
+                throw mkl::exception("dft/backends/cufft", __FUNCTION__, "cufftCreate failed.");
+            }
+            apply_external_workspace_setting(bwd_plan, config_values.workspace_placement);
             // flip fwd_distance and bwd_distance because cuFFt uses input distance and output distance.
-            auto res = cufftPlanMany(&bwd_plan, // plan
-                                     rank, // rank
-                                     n_copy.data(), // n
-                                     inembed.data(), // inembed
-                                     istride, // istride
-                                     bwd_dist, // idist
-                                     onembed.data(), // onembed
-                                     ostride, // ostride
-                                     fwd_dist, // odist
-                                     bwd_type, // type
-                                     batch // batch
+            res = cufftPlanMany(&bwd_plan, // plan
+                                rank, // rank
+                                n_copy.data(), // n
+                                inembed.data(), // inembed
+                                istride, // istride
+                                bwd_dist, // idist
+                                onembed.data(), // onembed
+                                ostride, // ostride
+                                fwd_dist, // odist
+                                bwd_type, // type
+                                batch // batch
             );
             if (res != CUFFT_SUCCESS) {
                 throw mkl::exception("dft/backends/cufft", __FUNCTION__,
@@ -315,6 +329,17 @@ public:
         clean_plans();
     }
 
+    static void apply_external_workspace_setting(cufftHandle& handle,
+                                                 const config_value& workspace_setting) {
+        if (workspace_setting == config_value::WORKSPACE_EXTERNAL) {
+            auto res = cufftSetAutoAllocation(handle, 0);
+            if (res != CUFFT_SUCCESS) {
+                throw mkl::exception("dft/backends/cufft", "commit",
+                                     "cufftSetAutoAllocation(plan, 0) failed.");
+            }
+        }
+    }
+
     void* get_handle() noexcept override {
         return plans.data();
     }
@@ -322,6 +347,76 @@ public:
     std::array<std::int64_t, 2> get_offsets() noexcept {
         return offsets;
     }
+
+    virtual void set_workspace(scalar_type* usmWorkspace) override {
+        this->external_workspace_helper_.set_workspace_throw(*this, usmWorkspace);
+        if (plans[0]) {
+            cufftSetWorkArea(*plans[0], usmWorkspace);
+        }
+        if (plans[1]) {
+            cufftSetWorkArea(*plans[1],
+                             usmWorkspace + get_plan0_workspace_size_bytes() / sizeof(scalar_type));
+        }
+    }
+
+    void set_buffer_workspace(cufftHandle plan, sycl::buffer<scalar_type>& bufferWorkspace,
+                              std::size_t range, std::size_t offset) {
+        this->get_queue().submit([&](sycl::handler& cgh) {
+            auto workspace_acc =
+                bufferWorkspace.template get_access<sycl::access::mode::read_write>(cgh, range,
+                                                                                    offset);
+            cgh.host_task([=](sycl::interop_handle ih) {
+                auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
+                auto result = cufftSetStream(plan, stream);
+                if (result != CUFFT_SUCCESS) {
+                    throw oneapi::mkl::exception(
+                        "dft/backends/cufft", "set_workspace",
+                        "cufftSetStream returned " + std::to_string(result));
+                }
+                auto workspace_native = reinterpret_cast<scalar_type*>(
+                    ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(workspace_acc));
+                cufftSetWorkArea(plan, workspace_native);
+            });
+        });
+        this->get_queue().wait_and_throw();
+    }
+
+    virtual void set_workspace(sycl::buffer<scalar_type>& bufferWorkspace) override {
+        this->external_workspace_helper_.set_workspace_throw(*this, bufferWorkspace);
+        std::size_t plan0_count =
+            static_cast<std::size_t>(get_plan0_workspace_size_bytes()) / sizeof(scalar_type);
+        std::size_t total_workspace_count =
+            static_cast<std::size_t>(this->get_workspace_external_bytes()) / sizeof(scalar_type);
+        std::size_t plan1_count = total_workspace_count - plan0_count;
+        buffer_workspace = bufferWorkspace;
+        if (plans[0]) {
+            set_buffer_workspace(*plans[0], bufferWorkspace, plan0_count, 0);
+        }
+        if (plans[1]) {
+            set_buffer_workspace(*plans[1], bufferWorkspace, plan1_count, plan0_count);
+        }
+    }
+
+    std::int64_t get_plan_workspace_size_bytes(cufftHandle handle) {
+        std::size_t size = 0;
+        cufftGetSize(*plans[0], &size);
+        std::int64_t padded_size = static_cast<int64_t>(size);
+        return padded_size;
+    }
+
+    // Separate workspaces are needed for the forward and backward plans. Because the plans[1]'s workspace is offset
+    // by the size of plans[0]'s workspace, we need to be able to get plans[0]'s size individually.
+    std::int64_t get_plan0_workspace_size_bytes() {
+        if (!plans[0]) {
+            return 0;
+        }
+        return get_plan_workspace_size_bytes(*plans[0]);
+    }
+
+    virtual std::int64_t get_workspace_external_bytes_impl() override {
+        std::int64_t size = plans[1] ? get_plan_workspace_size_bytes(*plans[1]) : 0;
+        return size + get_plan0_workspace_size_bytes();
+    };
 
 #define BACKEND cufft
 #include "../backend_compute_signature.cxx"

--- a/src/dft/backends/cufft/forward.cpp
+++ b/src/dft/backends/cufft/forward.cpp
@@ -72,7 +72,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -117,7 +117,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);

--- a/src/dft/backends/cufft/forward.cpp
+++ b/src/dft/backends/cufft/forward.cpp
@@ -72,7 +72,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
+        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -117,7 +117,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
+        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -169,8 +169,9 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
         offsets[1] *= 2; // offset is supplied in complex but we offset scalar pointer
     }
 
-    return queue.submit([&](sycl::handler &cgh) {
+    sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(dependencies);
+        commit->depend_on_last_usm_workspace_event_if_rqd(cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -179,6 +180,8 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
                 func_name, stream, plan, inout + offsets[0], inout + offsets[1]);
         });
     });
+    commit->set_last_usm_workspace_event(sycl_event);
+    return sycl_event;
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
@@ -212,8 +215,9 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
         }
     }
 
-    return queue.submit([&](sycl::handler &cgh) {
+    sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(dependencies);
+        commit->depend_on_last_usm_workspace_event_if_rqd(cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -222,6 +226,8 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
                 func_name, stream, plan, in + offsets[0], out + offsets[1]);
         });
     });
+    commit->set_last_usm_workspace_event(sycl_event);
+    return sycl_event;
 }
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format

--- a/src/dft/backends/cufft/forward.cpp
+++ b/src/dft/backends/cufft/forward.cpp
@@ -180,7 +180,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
                 func_name, stream, plan, inout + offsets[0], inout + offsets[1]);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -226,7 +226,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
                 func_name, stream, plan, in + offsets[0], out + offsets[1]);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 

--- a/src/dft/backends/cufft/forward.cpp
+++ b/src/dft/backends/cufft/forward.cpp
@@ -72,6 +72,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
@@ -116,6 +117,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -79,9 +79,10 @@ commit_derived_impl<prec, dom>::~commit_derived_impl() {
 template <dft::detail::precision prec, dft::detail::domain dom>
 void commit_derived_impl<prec, dom>::commit(
     const dft::detail::dft_values<prec, dom>& config_values) {
-    this->external_workspace_helper_.reset(
-        config_values.workspace_placement ==
-        oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
+    this->external_workspace_helper_ =
+        oneapi::mkl::dft::detail::external_workspace_helper<prec, dom>(
+            config_values.workspace_placement ==
+            oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
     set_value(bidirection_handle.data(), config_values);
 
     this->get_queue()

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -45,7 +45,7 @@ namespace detail {
 template <dft::detail::precision prec, dft::detail::domain dom>
 commit_derived_impl<prec, dom>::commit_derived_impl(
     sycl::queue queue, const dft::detail::dft_values<prec, dom>& config_values)
-        : oneapi::mkl::dft::detail::commit_impl<prec, dom>(queue, backend::mklcpu) {
+        : oneapi::mkl::dft::detail::commit_impl<prec, dom>(queue, backend::mklcpu, config_values) {
     // create the descriptor once for the lifetime of the descriptor class
     DFT_ERROR status[2] = { DFTI_BAD_DESCRIPTOR, DFTI_BAD_DESCRIPTOR };
 

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -79,6 +79,9 @@ commit_derived_impl<prec, dom>::~commit_derived_impl() {
 template <dft::detail::precision prec, dft::detail::domain dom>
 void commit_derived_impl<prec, dom>::commit(
     const dft::detail::dft_values<prec, dom>& config_values) {
+    this->external_workspace_helper_.reset(
+        config_values.workspace_placement ==
+        oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
     set_value(bidirection_handle.data(), config_values);
 
     this->get_queue()

--- a/src/dft/backends/mklcpu/commit_derived_impl.hpp
+++ b/src/dft/backends/mklcpu/commit_derived_impl.hpp
@@ -39,6 +39,7 @@ enum DIR { fwd = 0, bwd = 1 };
 template <dft::detail::precision prec, dft::detail::domain dom>
 class commit_derived_impl final : public dft::detail::commit_impl<prec, dom> {
 private:
+    using scalar_type = typename dft::detail::commit_impl<prec, dom>::scalar_type;
     static constexpr DFTI_CONFIG_VALUE mklcpu_prec = to_mklcpu(prec);
     static constexpr DFTI_CONFIG_VALUE mklcpu_dom = to_mklcpu(dom);
     using mklcpu_desc_t = DFTI_DESCRIPTOR_HANDLE;

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -54,10 +54,12 @@ private:
     static constexpr dft::precision mklgpu_prec = to_mklgpu(prec);
     static constexpr dft::domain mklgpu_dom = to_mklgpu(dom);
     using mklgpu_descriptor_t = dft::descriptor<mklgpu_prec, mklgpu_dom>;
+    using scalar_type = typename dft::detail::commit_impl<prec, dom>::scalar_type;
 
 public:
     mklgpu_commit(sycl::queue queue, const dft::detail::dft_values<prec, dom>& config_values)
-            : oneapi::mkl::dft::detail::commit_impl<prec, dom>(queue, backend::mklgpu),
+            : oneapi::mkl::dft::detail::commit_impl<prec, dom>(queue, backend::mklgpu,
+                                                               config_values),
               handle(config_values.dimensions) {
         // MKLGPU does not throw an informative exception for the following:
         if constexpr (prec == dft::detail::precision::DOUBLE) {
@@ -84,6 +86,16 @@ public:
     }
 
     ~mklgpu_commit() override = default;
+
+    virtual void set_workspace(scalar_type* usmWorkspace) override {
+        this->external_workspace_helper_.set_workspace_throw(*this, usmWorkspace);
+        handle.set_workspace(usmWorkspace);
+    }
+
+    virtual void set_workspace(sycl::buffer<scalar_type>& bufferWorkspace) override {
+        this->external_workspace_helper_.set_workspace_throw(*this, bufferWorkspace);
+        handle.set_workspace(bufferWorkspace);
+    }
 
 #define BACKEND mklgpu
 #include "../backend_compute_signature.cxx"
@@ -122,7 +134,12 @@ private:
         desc.set_value(backend_param::OUTPUT_STRIDES, config.output_strides.data());
         desc.set_value(backend_param::FWD_DISTANCE, config.fwd_dist);
         desc.set_value(backend_param::BWD_DISTANCE, config.bwd_dist);
-        // Setting the workspace causes an FFT_INVALID_DESCRIPTOR.
+        if (config.workspace_placement == dft::detail::config_value::WORKSPACE_EXTERNAL) {
+            // Setting WORKSPACE_INTERNAL (default) causes FFT_INVALID_DESCRIPTOR.
+            desc.set_value(backend_param::WORKSPACE,
+                           to_mklgpu_config_value<onemkl_param::WORKSPACE_PLACEMENT>(
+                               config.workspace_placement));
+        }
         // Setting the ordering causes an FFT_INVALID_DESCRIPTOR. Check that default is used:
         if (config.ordering != dft::detail::config_value::ORDERED) {
             throw mkl::invalid_argument("dft/backends/mklgpu", "commit",
@@ -133,6 +150,13 @@ private:
             throw mkl::invalid_argument("dft/backends/mklgpu", "commit",
                                         "MKLGPU only supports non-transposed.");
         }
+    }
+
+    // This is called by the workspace_helper, and is not part of the user API.
+    virtual std::int64_t get_workspace_external_bytes_impl() override {
+        std::size_t workspaceSize = 0;
+        handle.get_value(dft::config_param::WORKSPACE_BYTES, &workspaceSize);
+        return static_cast<std::int64_t>(workspaceSize);
     }
 };
 } // namespace detail

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -71,6 +71,9 @@ public:
     }
 
     virtual void commit(const dft::detail::dft_values<prec, dom>& config_values) override {
+        this->external_workspace_helper_.reset(
+            config_values.workspace_placement ==
+            oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
         set_value(handle, config_values);
         try {
             handle.commit(this->get_queue());

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -71,9 +71,10 @@ public:
     }
 
     virtual void commit(const dft::detail::dft_values<prec, dom>& config_values) override {
-        this->external_workspace_helper_.reset(
-            config_values.workspace_placement ==
-            oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
+        this->external_workspace_helper_ =
+            oneapi::mkl::dft::detail::external_workspace_helper<prec, dom>(
+                config_values.workspace_placement ==
+                oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
         set_value(handle, config_values);
         try {
             handle.commit(this->get_queue());

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -91,14 +91,14 @@ public:
 
     ~mklgpu_commit() override = default;
 
-    virtual void set_workspace(scalar_type* usmWorkspace) override {
-        this->external_workspace_helper_.set_workspace_throw(*this, usmWorkspace);
-        handle.set_workspace(usmWorkspace);
+    virtual void set_workspace(scalar_type* usm_workspace) override {
+        this->external_workspace_helper_.set_workspace_throw(*this, usm_workspace);
+        handle.set_workspace(usm_workspace);
     }
 
-    virtual void set_workspace(sycl::buffer<scalar_type>& bufferWorkspace) override {
-        this->external_workspace_helper_.set_workspace_throw(*this, bufferWorkspace);
-        handle.set_workspace(bufferWorkspace);
+    virtual void set_workspace(sycl::buffer<scalar_type>& buffer_workspace) override {
+        this->external_workspace_helper_.set_workspace_throw(*this, buffer_workspace);
+        handle.set_workspace(buffer_workspace);
     }
 
 #define BACKEND mklgpu

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -74,6 +74,8 @@ inline constexpr dft::config_param to_mklgpu(dft::detail::config_param param) {
         case iparam::ORDERING: return oparam::ORDERING;
         case iparam::TRANSPOSE: return oparam::TRANSPOSE;
         case iparam::PACKED_FORMAT: return oparam::PACKED_FORMAT;
+        case iparam::WORKSPACE_PLACEMENT: return oparam::WORKSPACE; // Same as WORKSPACE
+        case iparam::WORKSPACE_EXTERNAL_BYTES: return oparam::WORKSPACE_BYTES;
         case iparam::COMMIT_STATUS: return oparam::COMMIT_STATUS;
         default:
             throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
@@ -141,6 +143,31 @@ inline constexpr int to_mklgpu<dft::detail::config_param::PACKED_FORMAT>(
         throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
                                     "Invalid config value for packed format.");
         return 0;
+    }
+}
+
+/** Convert a config_value to the backend's native value. Throw on invalid input.
+ * @tparam Param The config param the value is for.
+ * @param value The config value to convert.
+**/
+template <dft::detail::config_param Param>
+inline constexpr dft::config_value to_mklgpu_config_value(dft::detail::config_value value);
+
+template <>
+inline constexpr dft::config_value
+to_mklgpu_config_value<dft::detail::config_param::WORKSPACE_PLACEMENT>(
+    dft::detail::config_value value) {
+    if (value == dft::detail::config_value::WORKSPACE_AUTOMATIC) {
+        // NB: dft::config_value != dft::detail::config_value
+        return dft::config_value::WORKSPACE_INTERNAL;
+    }
+    else if (value == dft::detail::config_value::WORKSPACE_EXTERNAL) {
+        return dft::config_value::WORKSPACE_EXTERNAL;
+    }
+    else {
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for workspace placement.");
+        return dft::config_value::WORKSPACE_INTERNAL;
     }
 }
 } // namespace detail

--- a/src/dft/backends/rocfft/backward.cpp
+++ b/src/dft/backends/rocfft/backward.cpp
@@ -247,7 +247,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, fwd<descriptor
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -281,7 +281,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, scalar<descrip
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -315,7 +315,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, bwd<descriptor
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -347,7 +347,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, scalar<descrip
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 

--- a/src/dft/backends/rocfft/backward.cpp
+++ b/src/dft/backends/rocfft/backward.cpp
@@ -76,6 +76,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -110,6 +111,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto inout_re_acc = inout_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto inout_im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -144,6 +146,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_backward(desc, in, out)";
@@ -179,6 +182,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         auto in_im_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_re_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_im_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_backward(desc, in_re, in_im, out_re, out_im)";

--- a/src/dft/backends/rocfft/backward.cpp
+++ b/src/dft/backends/rocfft/backward.cpp
@@ -76,7 +76,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_backward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -111,7 +111,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto inout_re_acc = inout_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto inout_im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_backward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -146,7 +146,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_backward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_backward(desc, in, out)";
@@ -182,7 +182,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         auto in_im_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_re_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_im_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_backward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_backward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_backward(desc, in_re, in_im, out_re, out_im)";

--- a/src/dft/backends/rocfft/commit.cpp
+++ b/src/dft/backends/rocfft/commit.cpp
@@ -137,6 +137,9 @@ public:
 
     void commit(const dft::detail::dft_values<prec, dom>& config_values) override {
         // this could be a recommit
+        this->external_workspace_helper_.reset(
+            config_values.workspace_placement ==
+            oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
         clean_plans();
 
         const rocfft_result_placement placement =

--- a/src/dft/backends/rocfft/commit.cpp
+++ b/src/dft/backends/rocfft/commit.cpp
@@ -137,9 +137,10 @@ public:
 
     void commit(const dft::detail::dft_values<prec, dom>& config_values) override {
         // this could be a recommit
-        this->external_workspace_helper_.reset(
-            config_values.workspace_placement ==
-            oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
+        this->external_workspace_helper_ =
+            oneapi::mkl::dft::detail::external_workspace_helper<prec, dom>(
+                config_values.workspace_placement ==
+                oneapi::mkl::dft::detail::config_value::WORKSPACE_EXTERNAL);
         clean_plans();
 
         const rocfft_result_placement placement =

--- a/src/dft/backends/rocfft/forward.cpp
+++ b/src/dft/backends/rocfft/forward.cpp
@@ -79,7 +79,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
+        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -114,7 +114,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto inout_re_acc = inout_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto inout_im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
+        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -148,7 +148,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
+        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_forward(desc, in, out)";
@@ -184,7 +184,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         auto in_im_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_re_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_im_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
+        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_forward(desc, in_re, in_im, out_re, out_im)";
@@ -237,8 +237,9 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
     }
     inout += offsets[0];
 
-    return queue.submit([&](sycl::handler &cgh) {
+    sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(deps);
+        commit->depend_on_last_usm_workspace_event_if_rqd(cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -248,6 +249,8 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
             detail::sync_checked(func_name, stream);
         });
     });
+    commit->set_last_usm_workspace_event(sycl_event);
+    return sycl_event;
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
@@ -268,8 +271,9 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
             "rocFFT requires input and output offsets (first value in strides) to be equal for in-place transforms!");
     }
 
-    return queue.submit([&](sycl::handler &cgh) {
+    sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(deps);
+        commit->depend_on_last_usm_workspace_event_if_rqd(cgh);
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
 
@@ -278,6 +282,8 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
             detail::sync_checked(func_name, stream);
         });
     });
+    commit->set_last_usm_workspace_event(sycl_event);
+    return sycl_event;
 }
 
 //Out-of-place transform
@@ -296,8 +302,9 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
     in += offsets[0];
     out += offsets[1];
 
-    return queue.submit([&](sycl::handler &cgh) {
+    sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(deps);
+        commit->depend_on_last_usm_workspace_event_if_rqd(cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_forward(desc, in, out, deps)";
@@ -309,6 +316,8 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
             detail::sync_checked(func_name, stream);
         });
     });
+    commit->set_last_usm_workspace_event(sycl_event);
+    return sycl_event;
 }
 
 //Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
@@ -324,8 +333,9 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
     auto info = detail::get_fwd_info(commit);
     auto offsets = detail::get_offsets(commit);
 
-    return queue.submit([&](sycl::handler &cgh) {
+    sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(deps);
+        commit->depend_on_last_usm_workspace_event_if_rqd(cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name =
@@ -338,6 +348,8 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
             detail::sync_checked(func_name, stream);
         });
     });
+    commit->set_last_usm_workspace_event(sycl_event);
+    return sycl_event;
 }
 
 // Template function instantiations

--- a/src/dft/backends/rocfft/forward.cpp
+++ b/src/dft/backends/rocfft/forward.cpp
@@ -249,7 +249,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -282,7 +282,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -316,7 +316,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 
@@ -348,7 +348,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
             detail::sync_checked(func_name, stream);
         });
     });
-    commit->set_last_usm_workspace_event(sycl_event);
+    commit->set_last_usm_workspace_event_if_rqd(sycl_event);
     return sycl_event;
 }
 

--- a/src/dft/backends/rocfft/forward.cpp
+++ b/src/dft/backends/rocfft/forward.cpp
@@ -79,7 +79,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -114,7 +114,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto inout_re_acc = inout_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto inout_im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -148,7 +148,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_forward(desc, in, out)";
@@ -184,7 +184,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         auto in_im_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_re_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_im_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
-        commit->add_buffer_dependency_if_rqd("compute_forward", cgh);
+        commit->add_buffer_workspace_dependency_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_forward(desc, in_re, in_im, out_re, out_im)";

--- a/src/dft/backends/rocfft/forward.cpp
+++ b/src/dft/backends/rocfft/forward.cpp
@@ -79,6 +79,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
 
     queue.submit([&](sycl::handler &cgh) {
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -113,6 +114,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
     queue.submit([&](sycl::handler &cgh) {
         auto inout_re_acc = inout_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto inout_im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, info);
@@ -146,6 +148,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_acc = out.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_forward(desc, in, out)";
@@ -181,6 +184,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         auto in_im_acc = in_im.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_re_acc = out_re.template get_access<sycl::access::mode::read_write>(cgh);
         auto out_im_acc = out_im.template get_access<sycl::access::mode::read_write>(cgh);
+        commit->get_workspace_buffer_access_if_rqd("compute_forward", cgh);
 
         cgh.host_task([=](sycl::interop_handle ih) {
             const std::string func_name = "compute_forward(desc, in_re, in_im, out_re, out_im)";

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -247,9 +247,9 @@ void descriptor<prec, dom>::get_value(config_param param, ...) const {
 }
 
 template <precision prec, domain dom>
-void descriptor<prec, dom>::set_workspace(scalar_type* usmWorkspace) {
+void descriptor<prec, dom>::set_workspace(scalar_type* usm_workspace) {
     if (pimpl_) {
-        return pimpl_->set_workspace(usmWorkspace);
+        return pimpl_->set_workspace(usm_workspace);
     }
     else {
         throw mkl::uninitialized("DFT", "set_workspace",
@@ -258,9 +258,9 @@ void descriptor<prec, dom>::set_workspace(scalar_type* usmWorkspace) {
 }
 
 template <precision prec, domain dom>
-void descriptor<prec, dom>::set_workspace(sycl::buffer<scalar_type>& bufferWorkspace) {
+void descriptor<prec, dom>::set_workspace(sycl::buffer<scalar_type>& buffer_workspace) {
     if (pimpl_) {
-        return pimpl_->set_workspace(bufferWorkspace);
+        return pimpl_->set_workspace(buffer_workspace);
     }
     else {
         throw mkl::uninitialized("DFT", "set_workspace",

--- a/src/dft/descriptor_config_helper.hpp
+++ b/src/dft/descriptor_config_helper.hpp
@@ -78,6 +78,8 @@ PARAM_TYPE_HELPER(config_param::OUTPUT_STRIDES, std::int64_t*)
 PARAM_TYPE_HELPER(config_param::FWD_DISTANCE, std::int64_t)
 PARAM_TYPE_HELPER(config_param::BWD_DISTANCE, std::int64_t)
 PARAM_TYPE_HELPER(config_param::WORKSPACE, config_value)
+PARAM_TYPE_HELPER(config_param::WORKSPACE_PLACEMENT, config_value)
+PARAM_TYPE_HELPER(config_param::WORKSPACE_EXTERNAL_BYTES, std::int64_t)
 PARAM_TYPE_HELPER(config_param::ORDERING, config_value)
 PARAM_TYPE_HELPER(config_param::TRANSPOSE, bool)
 PARAM_TYPE_HELPER(config_param::PACKED_FORMAT, config_value)
@@ -182,6 +184,19 @@ void set_value(dft_values<prec, dom>& vals,
         else {
             throw mkl::invalid_argument("DFT", "set_value", "Workspace must be allow or avoid.");
         }
+    }
+    else if constexpr (Param == config_param::WORKSPACE_PLACEMENT) {
+        if (set_val == config_value::WORKSPACE_AUTOMATIC ||
+            set_val == config_value::WORKSPACE_EXTERNAL) {
+            vals.workspace_placement = set_val;
+        }
+        else {
+            throw mkl::invalid_argument(
+                "DFT", "set_value", "Workspace must be WORKSPACE_AUTOMATIC or WORKSPACE_EXTERNAL.");
+        }
+    }
+    else if constexpr (Param == config_param::WORKSPACE_EXTERNAL_BYTES) {
+        throw mkl::invalid_argument("DFT", "set_value", "Read-only parameter.");
     }
     else if constexpr (Param == config_param::ORDERING) {
         if (set_val == config_value::ORDERED || set_val == config_value::BACKWARD_SCRAMBLED) {

--- a/tests/unit_tests/dft/include/parseval_check.hpp
+++ b/tests/unit_tests/dft/include/parseval_check.hpp
@@ -1,0 +1,81 @@
+/***************************************************************************
+*  Copyright (C) Codeplay Software Limited
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  For your convenience, a copy of the License has been included in this
+*  repository.
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+**************************************************************************/
+
+#ifndef ONEMKL_PARSEVAL_CHECK_HPP
+#define ONEMKL_PARSEVAL_CHECK_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <vector>
+#include <numeric>
+
+#include "test_common.hpp"
+
+/** Use Parseval's theorem to verify the output of DFT. This does not guarantee that the output
+ * of the DFT is correct, and is only a sanity check.
+ * 
+ * Check Sum(|in[i]|^2) == Sum(|out[i]|^2).
+ * 
+ * @tparam TypeFwd Forward domain type
+ * @tparam TypeBwd Backward domain type
+ * @param dft_len DFT size
+ * @param in forward domain data
+ * @param out bwd domain data
+ * @param rescale_forward A value to multiply the in data by.
+*/
+template <typename TypeFwd, typename TypeBwd>
+bool parseval_check(std::size_t dft_len, const TypeFwd* in, TypeBwd* out,
+                    TypeFwd rescale_forward = 1) {
+    static_assert(is_complex<TypeBwd>());
+    bool complex_forward = is_complex<TypeFwd>();
+    auto bwd_len = complex_forward ? dft_len : dft_len / 2 + 1;
+
+    float in_sum{ 0 };
+    float out_sum{ 0 };
+    for (std::size_t i{ 0 }; i < dft_len; ++i) {
+        in_sum += static_cast<float>(std::abs(in[i] * rescale_forward) *
+                                     std::abs(in[i] * rescale_forward));
+    }
+    if (complex_forward) {
+        for (std::size_t i{ 0 }; i < bwd_len; ++i) {
+            out_sum += static_cast<float>(std::abs(out[i]) * std::abs(out[i]));
+        }
+    }
+    else {
+        for (std::size_t i{ 0 }; i < bwd_len - 1; ++i) {
+            out_sum += static_cast<float>(std::abs(out[i]) * std::abs(out[i]));
+        }
+        out_sum *= 2;
+        out_sum += static_cast<float>(std::abs(out[bwd_len - 1]) * std::abs(out[bwd_len - 1]));
+    }
+    out_sum /= static_cast<float>(dft_len);
+    auto max_norm_ref = *std::max_element(
+        in, in + dft_len, [](const auto& a, const auto& b) { return std::abs(a) < std::abs(b); });
+    // Heuristic for the average-case error margins
+    auto abs_error_margin = 10 * std::abs(max_norm_ref) * std::log2(static_cast<float>(dft_len));
+    if (std::abs(in_sum - out_sum) > abs_error_margin) {
+        std::cout << "Failed check with Parseval's theorem: Fwd sum = " << in_sum
+                  << ", Bwd sum = " << out_sum << " (tol = " << abs_error_margin << ")"
+                  << std::endl;
+        return false;
+    }
+    return true;
+}
+#endif // ONEMKL_PARSEVAL_CHECK_HPP

--- a/tests/unit_tests/dft/source/CMakeLists.txt
+++ b/tests/unit_tests/dft/source/CMakeLists.txt
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-set(DFT_SOURCES "compute_tests.cpp" "descriptor_tests.cpp")
+set(DFT_SOURCES "compute_tests.cpp" "descriptor_tests.cpp" "workspace_external_tests.cpp")
 
 include(WarningsUtils)
 

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -344,6 +344,23 @@ static void set_and_get_values() {
         descriptor.get_value(oneapi::mkl::dft::config_param::PACKED_FORMAT, &value);
         EXPECT_EQ(oneapi::mkl::dft::config_value::CCE_FORMAT, value);
     }
+
+    {
+        oneapi::mkl::dft::config_value value{
+            oneapi::mkl::dft::config_value::COMMITTED
+        }; // Initialize with invalid value
+        descriptor.get_value(oneapi::mkl::dft::config_param::WORKSPACE_PLACEMENT, &value);
+        EXPECT_EQ(oneapi::mkl::dft::config_value::WORKSPACE_AUTOMATIC, value);
+
+        descriptor.set_value(oneapi::mkl::dft::config_param::WORKSPACE_PLACEMENT,
+                             oneapi::mkl::dft::config_value::WORKSPACE_EXTERNAL);
+
+        value = oneapi::mkl::dft::config_value::COMMITTED; // Initialize with invalid value
+        descriptor.get_value(oneapi::mkl::dft::config_param::WORKSPACE_PLACEMENT, &value);
+        EXPECT_EQ(oneapi::mkl::dft::config_value::WORKSPACE_EXTERNAL, value);
+        descriptor.set_value(oneapi::mkl::dft::config_param::WORKSPACE_PLACEMENT,
+                             oneapi::mkl::dft::config_value::WORKSPACE_AUTOMATIC);
+    }
 }
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>

--- a/tests/unit_tests/dft/source/workspace_external_tests.cpp
+++ b/tests/unit_tests/dft/source/workspace_external_tests.cpp
@@ -1,0 +1,320 @@
+/***************************************************************************
+*  Copyright (C) Codeplay Software Limited
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  For your convenience, a copy of the License has been included in this
+*  repository.
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+**************************************************************************/
+
+#include <iostream>
+#include <vector>
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "test_helper.hpp"
+#include "test_common.hpp"
+#include "parseval_check.hpp"
+#include <gtest/gtest.h>
+
+extern std::vector<sycl::device*> devices;
+
+class WorkspaceExternalTests : public ::testing::TestWithParam<sycl::device*> {};
+
+template <oneapi::mkl::dft::precision prec, oneapi::mkl::dft::domain dom>
+int test_workspace_external_usm_impl(std::size_t dftSize, sycl::device* dev) {
+    using namespace oneapi::mkl::dft;
+    using scalar_t = std::conditional_t<prec == precision::DOUBLE, double, float>;
+    using forward_t = std::conditional_t<dom == domain::COMPLEX, std::complex<scalar_t>, scalar_t>;
+    using backward_t = std::complex<scalar_t>;
+
+    sycl::queue sycl_queue(*dev);
+    if (prec == precision::DOUBLE && !sycl_queue.get_device().has(sycl::aspect::fp64)) {
+        return test_skipped;
+    }
+    descriptor<prec, dom> desc(static_cast<std::int64_t>(dftSize));
+
+    desc.set_value(config_param::WORKSPACE_PLACEMENT, config_value::WORKSPACE_EXTERNAL);
+    desc.set_value(config_param::PLACEMENT, config_value::NOT_INPLACE);
+    commit_descriptor(desc, sycl_queue);
+    std::int64_t workspaceBytes = -1;
+    desc.get_value(config_param::WORKSPACE_EXTERNAL_BYTES, &workspaceBytes);
+    if (workspaceBytes < 0) {
+        return ::testing::Test::HasFailure();
+    }
+    scalar_t* workspace = sycl::malloc_device<scalar_t>(
+        static_cast<std::size_t>(workspaceBytes) / sizeof(scalar_t), sycl_queue);
+    desc.set_workspace(workspace);
+    // Generate data
+    std::vector<forward_t> hostFwd(static_cast<std::size_t>(dftSize));
+    std::size_t bwdSize = dom == domain::COMPLEX ? dftSize : dftSize / 2 + 1;
+    std::vector<backward_t> hostBwd(bwdSize);
+    rand_vector(hostFwd, dftSize);
+
+    // Allocate enough memory that we don't have to worry about the domain.
+    forward_t* deviceFwd = sycl::malloc_device<forward_t>(dftSize, sycl_queue);
+    backward_t* deviceBwd = sycl::malloc_device<backward_t>(bwdSize, sycl_queue);
+    sycl_queue.copy(hostFwd.data(), deviceFwd, dftSize);
+    sycl_queue.wait_and_throw();
+
+    compute_forward<decltype(desc), forward_t, backward_t>(desc, deviceFwd, deviceBwd);
+    sycl_queue.wait_and_throw();
+
+    sycl_queue.copy(deviceBwd, hostBwd.data(), bwdSize);
+    sycl_queue.wait_and_throw();
+
+    // To see external workspaces, larger sizes of DFT may be needed. Using the reference DFT with larger sizes is slow,
+    // so use Parseval's theorum as a sanity check instead.
+    bool sanityCheckPasses = parseval_check(dftSize, hostFwd.data(), hostBwd.data());
+
+    if (sanityCheckPasses) {
+        sycl_queue.copy(hostFwd.data(), deviceFwd, dftSize);
+        sycl_queue.wait_and_throw();
+        compute_backward<decltype(desc), backward_t, forward_t>(desc, deviceBwd, deviceFwd);
+        sycl_queue.wait_and_throw();
+        sycl_queue.copy(deviceFwd, hostFwd.data(), dftSize);
+        sycl_queue.wait_and_throw();
+        forward_t rescale =
+            static_cast<forward_t>(1) / static_cast<forward_t>(static_cast<scalar_t>(dftSize));
+        sanityCheckPasses = parseval_check(dftSize, hostFwd.data(), hostBwd.data(), rescale);
+    }
+
+    sycl::free(deviceFwd, sycl_queue);
+    sycl::free(deviceBwd, sycl_queue);
+    sycl::free(workspace, sycl_queue);
+    return sanityCheckPasses ? !::testing::Test::HasFailure() : ::testing::Test::HasFailure();
+    ;
+}
+
+template <oneapi::mkl::dft::precision prec, oneapi::mkl::dft::domain dom>
+int test_workspace_external_buffer_impl(std::size_t dftSize, sycl::device* dev) {
+    using namespace oneapi::mkl::dft;
+    using scalar_t = std::conditional_t<prec == precision::DOUBLE, double, float>;
+    using forward_t = std::conditional_t<dom == domain::COMPLEX, std::complex<scalar_t>, scalar_t>;
+    using backward_t = std::complex<scalar_t>;
+
+    sycl::queue sycl_queue(*dev);
+    if (prec == precision::DOUBLE && !sycl_queue.get_device().has(sycl::aspect::fp64)) {
+        return test_skipped;
+    }
+    descriptor<prec, dom> desc(static_cast<std::int64_t>(dftSize));
+
+    desc.set_value(config_param::WORKSPACE_PLACEMENT, config_value::WORKSPACE_EXTERNAL);
+    desc.set_value(config_param::PLACEMENT, config_value::NOT_INPLACE);
+    commit_descriptor(desc, sycl_queue);
+    std::int64_t workspaceBytes = -1;
+    desc.get_value(config_param::WORKSPACE_EXTERNAL_BYTES, &workspaceBytes);
+    if (workspaceBytes < 0) {
+        return ::testing::Test::HasFailure();
+    }
+    sycl::buffer<scalar_t> workspace(static_cast<std::size_t>(workspaceBytes) / sizeof(scalar_t));
+    desc.set_workspace(workspace);
+    // Generate data
+    std::vector<forward_t> hostFwd(static_cast<std::size_t>(dftSize));
+    std::size_t bwdSize = dom == domain::COMPLEX ? dftSize : dftSize / 2 + 1; // TODO: Check this!
+    std::vector<backward_t> hostBwd(bwdSize);
+    rand_vector(hostFwd, dftSize);
+    auto hostFwdCpy = hostFwd; // Some backends modify the input data (rocFFT).
+
+    {
+        sycl::buffer<forward_t> bufFwd(hostFwd);
+        sycl::buffer<backward_t> bufBwd(hostBwd);
+        compute_forward<decltype(desc), forward_t, backward_t>(desc, bufFwd, bufBwd);
+    }
+
+    // To see external workspaces, larger sizes of DFT may be needed. Using the reference DFT with larger sizes is slow,
+    // so use Parseval's theorum as a sanity check instead.
+    bool sanityCheckPasses = parseval_check(dftSize, hostFwdCpy.data(), hostBwd.data());
+
+    if (sanityCheckPasses) {
+        auto hostBwdCpy = hostBwd;
+        {
+            sycl::buffer<forward_t> bufFwd(hostFwd);
+            sycl::buffer<backward_t> bufBwd(hostBwd);
+            compute_backward<decltype(desc), backward_t, forward_t>(desc, bufBwd, bufFwd);
+            sycl_queue.wait_and_throw();
+        }
+        forward_t rescale =
+            static_cast<forward_t>(1) / static_cast<forward_t>(static_cast<scalar_t>(dftSize));
+        sanityCheckPasses = parseval_check(dftSize, hostFwd.data(), hostBwdCpy.data(), rescale);
+    }
+
+    return sanityCheckPasses ? !::testing::Test::HasFailure() : ::testing::Test::HasFailure();
+    ;
+}
+
+template <oneapi::mkl::dft::precision prec, oneapi::mkl::dft::domain dom>
+void test_workspace_external_usm(sycl::device* dev) {
+    EXPECT_TRUEORSKIP((test_workspace_external_usm_impl<prec, dom>(2, dev)));
+    EXPECT_TRUEORSKIP((test_workspace_external_usm_impl<prec, dom>(1024 * 3 * 5 * 7 * 16, dev)));
+}
+
+template <oneapi::mkl::dft::precision prec, oneapi::mkl::dft::domain dom>
+void test_workspace_external_buffer(sycl::device* dev) {
+    EXPECT_TRUEORSKIP((test_workspace_external_buffer_impl<prec, dom>(2, dev)));
+    EXPECT_TRUEORSKIP((test_workspace_external_buffer_impl<prec, dom>(1024 * 3 * 5 * 7 * 16, dev)));
+}
+
+TEST_P(WorkspaceExternalTests, TestWorkspaceExternalSingleUsm) {
+    using precision = oneapi::mkl::dft::precision;
+    using domain = oneapi::mkl::dft::domain;
+    test_workspace_external_usm<precision::SINGLE, domain::REAL>(GetParam());
+    test_workspace_external_usm<precision::SINGLE, domain::COMPLEX>(GetParam());
+}
+
+TEST_P(WorkspaceExternalTests, TestWorkspaceExternalDoubleUsm) {
+    using precision = oneapi::mkl::dft::precision;
+    using domain = oneapi::mkl::dft::domain;
+    test_workspace_external_usm<precision::DOUBLE, domain::REAL>(GetParam());
+    test_workspace_external_usm<precision::DOUBLE, domain::COMPLEX>(GetParam());
+}
+
+TEST_P(WorkspaceExternalTests, TestWorkspaceExternalSingleBuffer) {
+    using precision = oneapi::mkl::dft::precision;
+    using domain = oneapi::mkl::dft::domain;
+    test_workspace_external_buffer<precision::SINGLE, domain::REAL>(GetParam());
+    test_workspace_external_buffer<precision::SINGLE, domain::COMPLEX>(GetParam());
+}
+
+TEST_P(WorkspaceExternalTests, TestWorkspaceExternalDoubleBuffer) {
+    using precision = oneapi::mkl::dft::precision;
+    using domain = oneapi::mkl::dft::domain;
+    test_workspace_external_buffer<precision::DOUBLE, domain::REAL>(GetParam());
+    test_workspace_external_buffer<precision::DOUBLE, domain::COMPLEX>(GetParam());
+}
+
+/// A test where set_workspace is called when an external workspace is not set.
+TEST_P(WorkspaceExternalTests, SetWorkspaceOnWorkspaceAutomatic) {
+    using namespace oneapi::mkl::dft;
+    sycl::queue sycl_queue(*GetParam());
+    const int dftLen = 1024 * 3 * 5 * 7 * 16; // A size likely to require an external workspace.
+    float* fftDataUsm = sycl::malloc_device<float>(dftLen * 2, sycl_queue);
+    sycl::buffer<float> fftDataBuf(dftLen * 2);
+    descriptor<precision::SINGLE, domain::COMPLEX> descUsm(dftLen), descBuf(dftLen);
+    // WORKSPACE_EXTERNAL is NOT set.
+    commit_descriptor(descUsm, sycl_queue);
+    commit_descriptor(descBuf, sycl_queue);
+    std::int64_t workspaceBytes = 0;
+    descUsm.get_value(config_param::WORKSPACE_EXTERNAL_BYTES, &workspaceBytes);
+
+    // No workspace set yet: all of the following should work.
+    compute_forward(descUsm, fftDataUsm);
+    compute_forward(descBuf, fftDataBuf);
+    compute_backward(descUsm, fftDataUsm);
+    compute_backward(descBuf, fftDataBuf);
+    compute_forward(descUsm, fftDataBuf);
+    compute_forward(descBuf, fftDataUsm);
+    compute_backward(descUsm, fftDataBuf);
+    compute_backward(descBuf, fftDataUsm);
+    sycl_queue.wait_and_throw();
+
+    // Set workspace
+    float* usmWorkspace = sycl::malloc_device<float>(
+        static_cast<std::size_t>(workspaceBytes) / sizeof(float), sycl_queue);
+    sycl::buffer<float> bufferWorkspace(static_cast<std::size_t>(workspaceBytes) / sizeof(float));
+    descUsm.set_workspace(usmWorkspace);
+    descBuf.set_workspace(bufferWorkspace);
+
+    // Should work:
+    compute_forward(descUsm, fftDataUsm);
+    sycl_queue.wait_and_throw();
+    compute_forward(descBuf, fftDataBuf);
+    sycl_queue.wait_and_throw();
+    compute_backward(descUsm, fftDataUsm);
+    sycl_queue.wait_and_throw();
+    compute_backward(descBuf, fftDataBuf);
+    sycl_queue.wait_and_throw();
+
+    // Should not work:
+    EXPECT_THROW(compute_forward(descUsm, fftDataBuf), oneapi::mkl::invalid_argument);
+    EXPECT_THROW(compute_forward(descBuf, fftDataUsm), oneapi::mkl::invalid_argument);
+    EXPECT_THROW(compute_backward(descUsm, fftDataBuf), oneapi::mkl::invalid_argument);
+    EXPECT_THROW(compute_backward(descBuf, fftDataUsm), oneapi::mkl::invalid_argument);
+    sycl_queue.wait_and_throw();
+
+    // Free any allocations:
+    sycl::free(usmWorkspace, sycl_queue);
+    sycl::free(fftDataUsm, sycl_queue);
+}
+
+/// Test that the implementation throws as expected.
+TEST_P(WorkspaceExternalTests, ThrowOnBadCalls) {
+    using namespace oneapi::mkl::dft;
+    sycl::queue sycl_queue(*GetParam());
+    const int dftLen = 1024 * 3 * 5 * 7 * 16; // A size likely to require an external workspace.
+    float* fftDataUsm = sycl::malloc_device<float>(dftLen * 2, sycl_queue);
+    sycl::buffer<float> fftDataBuf(dftLen * 2);
+    descriptor<precision::SINGLE, domain::COMPLEX> descUsm(dftLen), descBuf(dftLen);
+    descUsm.set_value(config_param::WORKSPACE_PLACEMENT, config_value::WORKSPACE_EXTERNAL);
+    descBuf.set_value(config_param::WORKSPACE_PLACEMENT, config_value::WORKSPACE_EXTERNAL);
+
+    // We expect the following to throw because the decriptor has not been committed.
+    std::int64_t workspaceBytes = -10;
+    float* usmWorkspace = nullptr;
+    EXPECT_THROW(descUsm.get_value(config_param::WORKSPACE_EXTERNAL_BYTES, &workspaceBytes),
+                 oneapi::mkl::invalid_argument);
+    EXPECT_THROW(descUsm.set_workspace(usmWorkspace), oneapi::mkl::uninitialized);
+    commit_descriptor(descUsm, sycl_queue);
+    commit_descriptor(descBuf, sycl_queue);
+
+    descUsm.get_value(config_param::WORKSPACE_EXTERNAL_BYTES, &workspaceBytes);
+    EXPECT_GE(workspaceBytes, 0);
+
+    // We haven't set a workspace, so the following should fail;
+    EXPECT_THROW(compute_forward(descUsm, fftDataUsm), oneapi::mkl::invalid_argument);
+    sycl_queue.wait_and_throw();
+    EXPECT_THROW(compute_forward(descUsm, fftDataBuf), oneapi::mkl::invalid_argument);
+    sycl_queue.wait_and_throw();
+
+    if (workspaceBytes > 0) {
+        EXPECT_THROW(descUsm.set_workspace(nullptr), oneapi::mkl::invalid_argument);
+        sycl::buffer<float> undersizeWorkspace(
+            static_cast<std::size_t>(workspaceBytes) / sizeof(float) - 1);
+        EXPECT_THROW(descBuf.set_workspace(undersizeWorkspace), oneapi::mkl::invalid_argument);
+    }
+
+    usmWorkspace = sycl::malloc_device<float>(
+        static_cast<std::size_t>(workspaceBytes) / sizeof(float), sycl_queue);
+    sycl::buffer<float> bufferWorkspace(static_cast<std::size_t>(workspaceBytes) / sizeof(float));
+
+    descUsm.set_workspace(usmWorkspace);
+    descBuf.set_workspace(bufferWorkspace);
+
+    // Should work:
+    compute_forward(descUsm, fftDataUsm);
+    sycl_queue.wait_and_throw();
+    compute_forward(descBuf, fftDataBuf);
+    sycl_queue.wait_and_throw();
+    compute_backward(descUsm, fftDataUsm);
+    sycl_queue.wait_and_throw();
+    compute_backward(descBuf, fftDataBuf);
+    sycl_queue.wait_and_throw();
+
+    // Should not work:
+    EXPECT_THROW(compute_forward(descUsm, fftDataBuf), oneapi::mkl::invalid_argument);
+    EXPECT_THROW(compute_forward(descBuf, fftDataUsm), oneapi::mkl::invalid_argument);
+    EXPECT_THROW(compute_backward(descUsm, fftDataBuf), oneapi::mkl::invalid_argument);
+    EXPECT_THROW(compute_backward(descBuf, fftDataUsm), oneapi::mkl::invalid_argument);
+    sycl_queue.wait_and_throw();
+
+    // Free any allocations:
+    sycl::free(usmWorkspace, sycl_queue);
+    sycl::free(fftDataUsm, sycl_queue);
+}
+
+INSTANTIATE_TEST_SUITE_P(WorkspaceExternalTestSuite, WorkspaceExternalTests,
+                         testing::ValuesIn(devices), ::DeviceNamePrint());

--- a/tests/unit_tests/dft/source/workspace_external_tests.cpp
+++ b/tests/unit_tests/dft/source/workspace_external_tests.cpp
@@ -363,7 +363,8 @@ TEST_P(WorkspaceExternalTests, RecommitBehaviour) {
         commit_descriptor(desc_usm, sycl_queue);
     }
     catch (oneapi::mkl::unimplemented&) {
-        // Admit defeat, and just test that the API does as expected.
+        // DFT size may not be supported. Use a DFT size that probably will be, even if it
+        // won't actually use an external workspace internally.
         descriptor<precision::SINGLE, domain::COMPLEX> desc_usm2(2);
         desc_usm = std::move(desc_usm2);
         commit_descriptor(desc_usm, sycl_queue);

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -102,9 +102,9 @@ int main(int argc, char** argv) {
             for (auto dev : plat_devs) {
                 try {
                     /* Do not test for OpenCL backend on GPU */
-                    if (dev.is_gpu() && plat.get_info<sycl::info::platform::name>().find(
-                                            "OpenCL") != std::string::npos)
-                        continue;
+                    // if (dev.is_gpu() && plat.get_info<sycl::info::platform::name>().find(
+                    //                         "OpenCL") != std::string::npos)
+                    //     continue;
                     if (unique_devices.find(dev.get_info<sycl::info::device::name>()) ==
                         unique_devices.end()) {
                         unique_devices.insert(dev.get_info<sycl::info::device::name>());

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -102,9 +102,9 @@ int main(int argc, char** argv) {
             for (auto dev : plat_devs) {
                 try {
                     /* Do not test for OpenCL backend on GPU */
-                    // if (dev.is_gpu() && plat.get_info<sycl::info::platform::name>().find(
-                    //                         "OpenCL") != std::string::npos)
-                    //     continue;
+                    if (dev.is_gpu() && plat.get_info<sycl::info::platform::name>().find(
+                                            "OpenCL") != std::string::npos)
+                        continue;
                     if (unique_devices.find(dev.get_info<sycl::info::device::name>()) ==
                         unique_devices.end()) {
                         unique_devices.insert(dev.get_info<sycl::info::device::name>());


### PR DESCRIPTION
# Description

This PR implements the draft specification for external workspace at https://github.com/oneapi-src/oneAPI-spec/pull/509, which relates to oneMKL issue https://github.com/oneapi-src/oneMKL/issues/396.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. 
- [x] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC) **Draft PR for oneAPI spec linked, but this is not yet merged**
- [ ] What version of oneAPI spec the interface is targeted? 
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [x] Have you provided motivation for adding a new feature?
- [x] Have you added relevant tests?

Logs:
* [inteltest.txt](https://github.com/oneapi-src/oneMKL/files/13473985/inteltest.txt)
* [testamd.txt](https://github.com/oneapi-src/oneMKL/files/13473986/testamd.txt)
* [testnvidia.txt](https://github.com/oneapi-src/oneMKL/files/13473989/testnvidia.txt)

