### PR TITLE
[DFT] Fix warnings in the DFT domain (2024 release)

### DIFF
--- a/src/dft/backends/cufft/CMakeLists.txt
+++ b/src/dft/backends/cufft/CMakeLists.txt
@@ -34,10 +34,9 @@ target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
-          ${MKL_INCLUDE}
 )
 
-target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT} ${MKL_COPT})
+target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
 
 if (${CMAKE_VERSION} VERSION_LESS "3.17.0")
   find_package(CUDA REQUIRED)
@@ -48,7 +47,7 @@ else()
   target_link_libraries(${LIB_OBJ} PRIVATE CUDA::cufft CUDA::cuda_driver)
 endif()
 
-target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ${MKL_LINK_SYCL})
+target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL)
 
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -92,7 +92,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
         detail::host_task<class host_kernel_back_inplace>(cgh, [=]() {
             DFT_ERROR status =
-                DftiComputeBackward(desc_acc[detail::DIR::bwd], inout_acc.get_pointer());
+                DftiComputeBackward(desc_acc[detail::DIR::bwd], detail::acc_to_ptr(inout_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/backends/mklcpu", "compute_backward",
@@ -123,8 +123,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         auto im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_split_back_inplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], re_acc.get_pointer(),
-                                                   im_acc.get_pointer());
+            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], detail::acc_to_ptr(re_acc),
+                                                   detail::acc_to_ptr(im_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/backends/mklcpu", "compute_backward",
@@ -155,9 +155,9 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_back_outofplace>(cgh, [=]() {
-            auto in_ptr = const_cast<bwd<descriptor_type> *>(&in_acc.get_pointer()[0]);
+            auto in_ptr = const_cast<bwd<descriptor_type> *>(detail::acc_to_ptr(in_acc));
             DFT_ERROR status =
-                DftiComputeBackward(desc_acc[detail::DIR::bwd], in_ptr, out_acc.get_pointer());
+                DftiComputeBackward(desc_acc[detail::DIR::bwd], in_ptr, detail::acc_to_ptr(out_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/backends/mklcpu", "compute_backward",
@@ -192,11 +192,10 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_back_outofplace>(cgh, [=]() {
-            auto inre_ptr = const_cast<scalar<descriptor_type> *>(&inre_acc.get_pointer()[0]);
-            auto inim_ptr = const_cast<scalar<descriptor_type> *>(&inim_acc.get_pointer()[0]);
-            DFT_ERROR status =
-                DftiComputeBackward(desc_acc[detail::DIR::bwd], inre_ptr, inim_ptr,
-                                    outre_acc.get_pointer(), outim_acc.get_pointer());
+            auto inre_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inre_acc));
+            auto inim_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inim_acc));
+            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], inre_ptr, inim_ptr,
+                                                   detail::acc_to_ptr(outre_acc), detail::acc_to_ptr(outim_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/backends/mklcpu", "compute_backward",

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -123,8 +123,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         auto im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_split_back_inplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], detail::acc_to_ptr(re_acc),
-                                                   detail::acc_to_ptr(im_acc));
+            DFT_ERROR status = DftiComputeBackward(
+                desc_acc[detail::DIR::bwd], detail::acc_to_ptr(re_acc), detail::acc_to_ptr(im_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/backends/mklcpu", "compute_backward",
@@ -156,8 +156,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
 
         detail::host_task<class host_kernel_back_outofplace>(cgh, [=]() {
             auto in_ptr = const_cast<bwd<descriptor_type> *>(detail::acc_to_ptr(in_acc));
-            DFT_ERROR status =
-                DftiComputeBackward(desc_acc[detail::DIR::bwd], in_ptr, detail::acc_to_ptr(out_acc));
+            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], in_ptr,
+                                                   detail::acc_to_ptr(out_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/backends/mklcpu", "compute_backward",
@@ -194,8 +194,9 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
         detail::host_task<class host_kernel_split_back_outofplace>(cgh, [=]() {
             auto inre_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inre_acc));
             auto inim_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inim_acc));
-            DFT_ERROR status = DftiComputeBackward(desc_acc[detail::DIR::bwd], inre_ptr, inim_ptr,
-                                                   detail::acc_to_ptr(outre_acc), detail::acc_to_ptr(outim_acc));
+            DFT_ERROR status =
+                DftiComputeBackward(desc_acc[detail::DIR::bwd], inre_ptr, inim_ptr,
+                                    detail::acc_to_ptr(outre_acc), detail::acc_to_ptr(outim_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/backends/mklcpu", "compute_backward",

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -124,8 +124,8 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         auto im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_split_inplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], detail::acc_to_ptr(re_acc),
-                                                  detail::acc_to_ptr(im_acc));
+            DFT_ERROR status = DftiComputeForward(
+                desc_acc[detail::DIR::fwd], detail::acc_to_ptr(re_acc), detail::acc_to_ptr(im_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",
@@ -194,8 +194,9 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         detail::host_task<class host_kernel_split_outofplace>(cgh, [=]() {
             auto inre_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inre_acc));
             auto inim_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inim_acc));
-            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], inre_ptr, inim_ptr,
-                                                  detail::acc_to_ptr(outre_acc), detail::acc_to_ptr(outim_acc));
+            DFT_ERROR status =
+                DftiComputeForward(desc_acc[detail::DIR::fwd], inre_ptr, inim_ptr,
+                                   detail::acc_to_ptr(outre_acc), detail::acc_to_ptr(outim_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -93,7 +93,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         auto inout_acc = inout.template get_access<sycl::access::mode::read_write>(cgh);
         detail::host_task<class host_kernel_inplace>(cgh, [=]() {
             DFT_ERROR status =
-                DftiComputeForward(desc_acc[detail::DIR::fwd], inout_acc.get_pointer());
+                DftiComputeForward(desc_acc[detail::DIR::fwd], detail::acc_to_ptr(inout_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",
@@ -124,8 +124,8 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         auto im_acc = inout_im.template get_access<sycl::access::mode::read_write>(cgh);
 
         detail::host_task<class host_kernel_split_inplace>(cgh, [=]() {
-            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], re_acc.get_pointer(),
-                                                  im_acc.get_pointer());
+            DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], detail::acc_to_ptr(re_acc),
+                                                  detail::acc_to_ptr(im_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",
@@ -155,9 +155,9 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
         auto out_acc = out.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_outofplace>(cgh, [=]() {
-            auto in_ptr = const_cast<fwd<descriptor_type> *>(&in_acc.get_pointer()[0]);
+            auto in_ptr = const_cast<fwd<descriptor_type> *>(detail::acc_to_ptr(in_acc));
             DFT_ERROR status =
-                DftiComputeForward(desc_acc[detail::DIR::fwd], in_ptr, out_acc.get_pointer());
+                DftiComputeForward(desc_acc[detail::DIR::fwd], in_ptr, detail::acc_to_ptr(out_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",
@@ -192,10 +192,10 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
         auto outim_acc = out_im.template get_access<sycl::access::mode::write>(cgh);
 
         detail::host_task<class host_kernel_split_outofplace>(cgh, [=]() {
-            auto inre_ptr = const_cast<scalar<descriptor_type> *>(&inre_acc.get_pointer()[0]);
-            auto inim_ptr = const_cast<scalar<descriptor_type> *>(&inim_acc.get_pointer()[0]);
+            auto inre_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inre_acc));
+            auto inim_ptr = const_cast<scalar<descriptor_type> *>(detail::acc_to_ptr(inim_acc));
             DFT_ERROR status = DftiComputeForward(desc_acc[detail::DIR::fwd], inre_ptr, inim_ptr,
-                                                  outre_acc.get_pointer(), outim_acc.get_pointer());
+                                                  detail::acc_to_ptr(outre_acc), detail::acc_to_ptr(outim_acc));
             if (status != DFTI_NO_ERROR) {
                 throw oneapi::mkl::exception(
                     "dft/forward/mklcpu", "compute_forward",

--- a/src/dft/backends/mklcpu/mklcpu_helpers.hpp
+++ b/src/dft/backends/mklcpu/mklcpu_helpers.hpp
@@ -26,11 +26,7 @@
 // MKLCPU header
 #include "mkl_dfti.h"
 
-namespace oneapi {
-namespace mkl {
-namespace dft {
-namespace mklcpu {
-namespace detail {
+namespace oneapi::mkl::dft::mklcpu::detail {
 
 template <typename K, typename H, typename F>
 static inline auto host_task_internal(H& cgh, F f, int) -> decltype(cgh.host_task(f)) {
@@ -173,10 +169,12 @@ inline constexpr int to_mklcpu<dft::detail::config_param::PACKED_FORMAT>(
 
 using mklcpu_desc_t = DFTI_DESCRIPTOR_HANDLE;
 
-} // namespace detail
-} // namespace mklcpu
-} // namespace dft
-} // namespace mkl
-} // namespace oneapi
+template <typename AccType>
+typename AccType::value_type *acc_to_ptr(AccType acc) {
+    // no need to decorate the pointer with the address space for mklcpu since its just getting passed to the a host function.
+    return acc.template get_multi_ptr<sycl::access::decorated::no>().get();
+}
+
+} // namespace oneapi::mkl::dft::mklcpu::detail
 
 #endif // _ONEMKL_DFT_SRC_MKLCPU_HELPERS_HPP_

--- a/src/dft/backends/mklcpu/mklcpu_helpers.hpp
+++ b/src/dft/backends/mklcpu/mklcpu_helpers.hpp
@@ -170,7 +170,7 @@ inline constexpr int to_mklcpu<dft::detail::config_param::PACKED_FORMAT>(
 using mklcpu_desc_t = DFTI_DESCRIPTOR_HANDLE;
 
 template <typename AccType>
-typename AccType::value_type *acc_to_ptr(AccType acc) {
+typename AccType::value_type* acc_to_ptr(AccType acc) {
     // no need to decorate the pointer with the address space for mklcpu since its just getting passed to the a host function.
     return acc.template get_multi_ptr<sycl::access::decorated::no>().get();
 }

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -34,17 +34,16 @@ target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/include
           ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
-          ${MKL_INCLUDE}
 )
 
-target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT} ${MKL_COPT})
+target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
 
 find_package(HIP REQUIRED)
 find_package(rocfft REQUIRED)
 
 target_link_libraries(${LIB_OBJ} PRIVATE hip::host roc::rocfft)
 
-target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ${MKL_LINK_SYCL})
+target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL)
 
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -48,7 +48,7 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
         }
     }
     else {
-        // spec says strides_bwd is ignored and strides_fwd is reused for backward domain for in-place complex
+        // General consistency requirements for in-place complex domain transforms require that strides are the same forward and backward.
         modified_strides_fwd = modified_strides_bwd;
     }
 
@@ -164,7 +164,7 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
         }
     }
     else {
-        // spec says strides_bwd is ignored and strides_fwd is reused for backward domain for in-place complex
+        // General consistency requirements for in-place complex domain transforms require that strides are the same forward and backward.
         modified_strides_fwd = modified_strides_bwd;
     }
 

--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -29,36 +29,31 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
         return test_skipped;
     }
 
-    auto strides_fwd = this->strides_fwd;
-    auto strides_bwd = this->strides_bwd;
+    auto modified_strides_fwd = this->strides_fwd;
+    auto modified_strides_bwd = this->strides_bwd;
     if (domain == oneapi::mkl::dft::domain::REAL) {
         // both input and output strides must be set
-        if (strides_fwd.size() == 0) {
-            auto strides_tmp = get_conjugate_even_complex_strides(sizes);
-            strides_fwd = { strides_tmp[0] };
-            //to be able to calculate in place each row must fit backward data
-            for (size_t i = 0; i < sizes.size() - 1; i++) {
-                strides_fwd.push_back(strides_tmp[i + 1] * 2);
-            }
-            strides_fwd.push_back(1);
+        auto default_conjuate_strides = get_conjugate_even_complex_strides(sizes);
+        std::ptrdiff_t rank = static_cast<std::ptrdiff_t>(sizes.size());
+
+        if (modified_strides_fwd.size() == 0) {
+            modified_strides_fwd = std::vector<std::int64_t>(
+                default_conjuate_strides.begin(), default_conjuate_strides.begin() + rank + 1);
+            std::transform(modified_strides_fwd.begin() + 1, modified_strides_fwd.begin() + rank,
+                           modified_strides_fwd.begin() + 1, [](std::int64_t& s) { return 2 * s; });
         }
-        if (strides_bwd.size() == 0) {
-            auto strides_tmp = get_conjugate_even_complex_strides(sizes);
-            strides_bwd = { strides_tmp[0] };
-            //to be able to calculate in place each row must fit backward data
-            for (size_t i = 0; i < sizes.size() - 1; i++) {
-                strides_bwd.push_back(strides_tmp[i + 1]);
-            }
-            strides_bwd.push_back(1);
+        if (modified_strides_bwd.size() == 0) {
+            modified_strides_bwd = std::vector<std::int64_t>(
+                default_conjuate_strides.begin(), default_conjuate_strides.begin() + rank + 1);
         }
     }
     else {
-        // spec says strides_bwd is ignored and strides_fwd is reused for backward domain for in-place complex
-        strides_fwd = strides_bwd;
+        // spec says modified_strides_bwd is ignored and modified_strides_fwd is reused for backward domain for in-place complex
+        modified_strides_fwd = modified_strides_bwd;
     }
 
     auto [forward_distance, backward_distance] =
-        get_default_distances<domain, true>(sizes, strides_fwd, strides_bwd);
+        get_default_distances<domain, true>(sizes, modified_strides_fwd, modified_strides_bwd);
     auto ref_distance = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<>());
 
     descriptor_t descriptor{ sizes };
@@ -73,20 +68,22 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
     descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
-    if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_fwd.data());
+    if (modified_strides_fwd.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                             modified_strides_fwd.data());
     }
-    if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, strides_bwd.data());
+    if (modified_strides_bwd.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                             modified_strides_bwd.data());
     }
     commit_descriptor(descriptor, sycl_queue);
 
     std::vector<FwdInputType> inout_host(
-        strided_copy(input, sizes, strides_fwd, batches, forward_distance));
+        strided_copy(input, sizes, modified_strides_fwd, batches, forward_distance));
     int real_multiplier = (domain == oneapi::mkl::dft::domain::REAL ? 2 : 1);
     inout_host.resize(
         cast_unsigned(std::max(forward_distance, real_multiplier * backward_distance) * batches +
-                      get_default(strides_bwd, 0, 0L) * real_multiplier));
+                      get_default(modified_strides_bwd, 0, 0L) * real_multiplier));
 
     {
         sycl::buffer<FwdInputType, 1> inout_buf{ inout_host };
@@ -99,12 +96,13 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
             for (std::int64_t i = 0; i < batches; i++) {
                 EXPECT_TRUE(check_equal_strided<domain == oneapi::mkl::dft::domain::REAL>(
                     ptr_host + backward_distance * i, out_host_ref.data() + ref_distance * i, sizes,
-                    strides_bwd, abs_error_margin, rel_error_margin, std::cout));
+                    modified_strides_bwd, abs_error_margin, rel_error_margin, std::cout));
             }
         }
 
-        if (strides_bwd.size()) {
-            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_bwd.data());
+        if (modified_strides_bwd.size()) {
+            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                                 modified_strides_bwd.data());
         }
         else {
             //for real case strides are always set at the top of the test
@@ -112,9 +110,9 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
             descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
                                  input_strides.data());
         }
-        if (strides_fwd.size()) {
+        if (modified_strides_fwd.size()) {
             descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                                 strides_fwd.data());
+                                 modified_strides_fwd.data());
         }
         else {
             auto output_strides = get_default_strides(sizes);
@@ -135,7 +133,7 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
     for (std::int64_t i = 0; i < batches; i++) {
         EXPECT_TRUE(check_equal_strided<false>(
             inout_host.data() + forward_distance * i, fwd_data_ref.data() + ref_distance * i, sizes,
-            strides_fwd, abs_error_margin, rel_error_margin, std::cout));
+            modified_strides_fwd, abs_error_margin, rel_error_margin, std::cout));
     }
 
     return !::testing::Test::HasFailure();
@@ -147,36 +145,31 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
         return test_skipped;
     }
 
-    auto strides_fwd = this->strides_fwd;
-    auto strides_bwd = this->strides_bwd;
+    auto modified_strides_fwd = this->strides_fwd;
+    auto modified_strides_bwd = this->strides_bwd;
     if (domain == oneapi::mkl::dft::domain::REAL) {
         // both input and output strides must be set
-        if (strides_fwd.size() == 0) {
-            auto strides_tmp = get_conjugate_even_complex_strides(sizes);
-            strides_fwd = { strides_tmp[0] };
-            //to be able to calculate in place each row must fit backward data
-            for (size_t i = 0; i < sizes.size() - 1; i++) {
-                strides_fwd.push_back(strides_tmp[i + 1] * 2);
-            }
-            strides_fwd.push_back(1);
+        auto default_conjuate_strides = get_conjugate_even_complex_strides(sizes);
+        std::ptrdiff_t rank = static_cast<std::ptrdiff_t>(sizes.size());
+
+        if (modified_strides_fwd.size() == 0) {
+            modified_strides_fwd = std::vector<std::int64_t>(
+                default_conjuate_strides.begin(), default_conjuate_strides.begin() + rank + 1);
+            std::transform(modified_strides_fwd.begin() + 1, modified_strides_fwd.begin() + rank,
+                           modified_strides_fwd.begin() + 1, [](std::int64_t& s) { return 2 * s; });
         }
-        if (strides_bwd.size() == 0) {
-            auto strides_tmp = get_conjugate_even_complex_strides(sizes);
-            strides_bwd = { strides_tmp[0] };
-            //to be able to calculate in place each row must fit backward data
-            for (size_t i = 0; i < sizes.size() - 1; i++) {
-                strides_bwd.push_back(strides_tmp[i + 1]);
-            }
-            strides_bwd.push_back(1);
+        if (modified_strides_bwd.size() == 0) {
+            modified_strides_bwd = std::vector<std::int64_t>(
+                default_conjuate_strides.begin(), default_conjuate_strides.begin() + rank + 1);
         }
     }
     else {
-        // spec says strides_bwd is ignored and strides_fwd is reused for backward domain for in-place complex
-        strides_fwd = strides_bwd;
+        // spec says modified_strides_bwd is ignored and modified_strides_fwd is reused for backward domain for in-place complex
+        modified_strides_fwd = modified_strides_bwd;
     }
 
     auto [forward_distance, backward_distance] =
-        get_default_distances<domain, true>(sizes, strides_fwd, strides_bwd);
+        get_default_distances<domain, true>(sizes, modified_strides_fwd, modified_strides_bwd);
     auto ref_distance = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<>());
 
     descriptor_t descriptor = { sizes };
@@ -191,21 +184,24 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
     descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
-    if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_fwd.data());
+    if (modified_strides_fwd.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                             modified_strides_fwd.data());
     }
-    if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, strides_bwd.data());
+    if (modified_strides_bwd.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                             modified_strides_bwd.data());
     }
     commit_descriptor(descriptor, sycl_queue);
 
     auto ua_input = usm_allocator_t<FwdInputType>(cxt, *dev);
     std::vector<FwdInputType, decltype(ua_input)> inout(
-        strided_copy(input, sizes, strides_fwd, batches, forward_distance, ua_input), ua_input);
+        strided_copy(input, sizes, modified_strides_fwd, batches, forward_distance, ua_input),
+        ua_input);
     int real_multiplier = (domain == oneapi::mkl::dft::domain::REAL ? 2 : 1);
     inout.resize(
         cast_unsigned(std::max(forward_distance, real_multiplier * backward_distance) * batches +
-                      real_multiplier * get_default(strides_bwd, 0, 0L)));
+                      real_multiplier * get_default(modified_strides_bwd, 0, 0L)));
 
     std::vector<sycl::event> no_dependencies;
     oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType>(descriptor, inout.data(),
@@ -215,20 +211,22 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
     for (std::int64_t i = 0; i < batches; i++) {
         EXPECT_TRUE(check_equal_strided<domain == oneapi::mkl::dft::domain::REAL>(
             reinterpret_cast<FwdOutputType*>(inout.data()) + backward_distance * i,
-            out_host_ref.data() + ref_distance * i, sizes, strides_bwd, abs_error_margin,
+            out_host_ref.data() + ref_distance * i, sizes, modified_strides_bwd, abs_error_margin,
             rel_error_margin, std::cout));
     }
 
-    if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_bwd.data());
+    if (modified_strides_bwd.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                             modified_strides_bwd.data());
     }
     else {
         //for real case strides are always set at the top of the test
         auto input_strides = get_default_strides(sizes);
         descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, input_strides.data());
     }
-    if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, strides_fwd.data());
+    if (modified_strides_fwd.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                             modified_strides_fwd.data());
     }
     else {
         auto output_strides = get_default_strides(sizes);
@@ -245,9 +243,9 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
                   [this](auto& x) { x *= static_cast<PrecisionType>(forward_elements); });
 
     for (std::int64_t i = 0; i < batches; i++) {
-        EXPECT_TRUE(check_equal_strided<false>(inout.data() + forward_distance * i,
-                                               input.data() + ref_distance * i, sizes, strides_fwd,
-                                               abs_error_margin, rel_error_margin, std::cout));
+        EXPECT_TRUE(check_equal_strided<false>(
+            inout.data() + forward_distance * i, input.data() + ref_distance * i, sizes,
+            modified_strides_fwd, abs_error_margin, rel_error_margin, std::cout));
     }
 
     return !::testing::Test::HasFailure();

--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -48,7 +48,7 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
         }
     }
     else {
-        // spec says modified_strides_bwd is ignored and modified_strides_fwd is reused for backward domain for in-place complex
+        // spec says strides_bwd is ignored and strides_fwd is reused for backward domain for in-place complex
         modified_strides_fwd = modified_strides_bwd;
     }
 
@@ -164,7 +164,7 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
         }
     }
     else {
-        // spec says modified_strides_bwd is ignored and modified_strides_fwd is reused for backward domain for in-place complex
+        // spec says strides_bwd is ignored and strides_fwd is reused for backward domain for in-place complex
         modified_strides_fwd = modified_strides_bwd;
     }
 


### PR DESCRIPTION
# Description

This PR fixes a warning about shadowing in the dft in-place tests and also removes the calls to the now deprecated member function `get_pointer` (in the 2024.0.0 release) from the mklcpu backend. This still compiles with 2023.2.0.

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
