### PR TITLE
Add oneMKL Interfaces includes as -I if cmake >= 3.25

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,10 @@ if(BUILD_SHARED_LIBS)
   set_target_properties(onemkl PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR}
   )
+  # w/a for setting oneMKL Interfaces installed headers as -I instead of -isystem for cmake >= 3.25 for workable find_package(MKL) combination
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25.0")
+    set_target_properties(onemkl PROPERTIES EXPORT_NO_SYSTEM true)
+  endif()
 
   # Build dispatcher library
   set (ONEMKL_LIBS ${TARGET_DOMAINS})


### PR DESCRIPTION
The issue was reported here https://github.com/oneapi-src/oneMKL/issues/306 wile using INTERFACE_INCLUDE_DIRECTORIES in oneMKLTargets cmake file. 

Details: 
I found this page https://gitlab.kitware.com/cmake/cmake/-/issues/22033
We do use "INTERFACE_INCLUDE_DIRECTORIES" in oneMKL opensource in our oneMKLTargets.cmake (you can find it in your installation folder here lib/cmake/oneMKL/oneMKLTargets.cmake)

set_target_properties(MKL::onemkl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"

To make your example workable, just add after target_link_libraries
set_target_properties(test PROPERTIES NO_SYSTEM_FROM_IMPORTED true)

However if we have cmake >= 3.25, we can set EXPORT_NO_SYSTEM on oneMKL Interfaces side to have the same behavior 
cmake documentation: https://cmake.org/cmake/help/latest/prop_tgt/EXPORT_NO_SYSTEM.html
This property affects the behavior of the [install(EXPORT)](https://cmake.org/cmake/help/latest/command/install.html#export) and [export()](https://cmake.org/cmake/help/latest/command/export.html#command:export) commands when they install or export the target respectively. When EXPORT_NO_SYSTEM is set to true, those commands generate an imported target with [SYSTEM](https://cmake.org/cmake/help/latest/prop_tgt/SYSTEM.html#prop_tgt:SYSTEM) property set to false.