### PR TITLE
Revome requiring for TBB config and add condition to allow using loca…

### DIFF
--- a/cmake/mkl/MKLConfig.cmake
+++ b/cmake/mkl/MKLConfig.cmake
@@ -856,7 +856,7 @@ endforeach()
 
 # Threading selection
 if(MKL_THREADING STREQUAL "tbb_thread" OR MKL_SYCL_THREADING STREQUAL "tbb_thread")
-  find_package(TBB REQUIRED CONFIG COMPONENTS tbb)
+  find_package(TBB CONFIG COMPONENTS tbb)
   if(TARGET TBB::tbb)
     if(MKL_THREADING STREQUAL "tbb_thread")
       set(MKL_THREAD_LIB $<TARGET_LINKER_FILE:TBB::tbb>)

--- a/cmake/oneMKLConfig.cmake
+++ b/cmake/oneMKLConfig.cmake
@@ -23,7 +23,7 @@ include(CMakeFindDependencyMacro)
 #find_dependency(MKL REQUIRED)
 # try to search for SYCLConfig first to find compiler. If it's not present, use local FindCompiler.cmake
 find_package(SYCL QUIET)
-if(NOT SYCL_FOUND)
+if(NOT ${SYCL_FOUND})
   find_package(Compiler REQUIRED)
 endif()
 

--- a/cmake/oneMKLConfig.cmake
+++ b/cmake/oneMKLConfig.cmake
@@ -21,6 +21,10 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 include(CMakeFindDependencyMacro)
 
 #find_dependency(MKL REQUIRED)
-find_dependency(SYCL REQUIRED)
+# try to search for SYCLConfig first to find compiler. If it's not present, use local FindCompiler.cmake
+find_package(SYCL QUIET)
+if(NOT SYCL_FOUND)
+  find_package(Compiler REQUIRED)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/oneMKLTargets.cmake")


### PR DESCRIPTION
1. Remove "required" from searching tbb config file to allow it using hints if tbbcofig is not present
2. The issue with searching for compiler was reported here https://github.com/oneapi-src/oneMKL/issues/306
The problem is that find_dependency(SYCL REQUIRED) requires SYCLConfig to be present, but sometimes it could be missed. Changes in this PR allow to use internal findcompiler in case if SYCLConfig is not present in env (find_package generates and sets <package>_FOUND to true if it completes successfully, so I just check if the variable is set to true or not)