### PR TITLE
[CUDA][HIP] Use device to get native context

### DIFF
--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -81,9 +81,10 @@ public:
         }
         if (fix_context) {
             // cufftDestroy changes the context so change it back.
-            CUcontext interopContext =
-                sycl::get_native<sycl::backend::ext_oneapi_cuda>(this->get_queue().get_context());
-            if (cuCtxSetCurrent(interopContext) != CUDA_SUCCESS) {
+            CUdevice interopDevice =
+                sycl::get_native<sycl::backend::ext_oneapi_cuda>(this->get_queue().get_device());
+            CUcontext interopContext;
+            if (cuDevicePrimaryCtxRetain(&interopContext, interopDevice) != CUDA_SUCCESS) {
                 throw mkl::exception("dft/backends/cufft", __FUNCTION__,
                                      "Failed to change cuda context.");
             }

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
@@ -45,9 +45,11 @@ RocsolverScopedContextHandler::RocsolverScopedContextHandler(sycl::queue queue,
         : ih(ih),
           needToRecover_(false) {
     placedContext_ = new sycl::context(queue.get_context());
-    auto desired = sycl::get_native<sycl::backend::ext_oneapi_hip>(*placedContext_);
+    auto hipDevice = ih.get_native_device<sycl::backend::ext_oneapi_hip>();
     hipError_t err;
+    hipCtx_t desired;
     HIP_ERROR_FUNC(hipCtxGetCurrent, err, &original_);
+    HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, err, &desired, hipDevice);
     if (original_ != desired) {
         // Sets the desired context as the active one for the thread
         HIP_ERROR_FUNC(hipCtxSetCurrent, err, desired);
@@ -89,8 +91,11 @@ void ContextCallback(void *userData) {
 }
 
 rocblas_handle RocsolverScopedContextHandler::get_handle(const sycl::queue &queue) {
-    auto piPlacedContext_ = reinterpret_cast<pi_context>(
-        sycl::get_native<sycl::backend::ext_oneapi_hip>(*placedContext_));
+    auto hipDevice = ih.get_native_device<sycl::backend::ext_oneapi_hip>();
+    hipError_t hipErr;
+    hipCtx_t desired;
+    HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, hipErr, &desired, hipDevice);
+    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
     hipStream_t streamId = get_stream(queue);
     rocblas_status err;
     auto it = handle_helper.rocsolver_handle_mapper_.find(piPlacedContext_);


### PR DESCRIPTION
Since https://github.com/oneapi-src/unified-runtime/pull/999 it is no longer valid to get the native context from the SYCL context on a multi GPU system. The get native func for contexts has been deprecated for this reason. See https://github.com/intel/llvm/pull/10975

Similar ticket: https://github.com/oneapi-src/oneDNN/pull/1765