### PR TITLE
[RNG] Removed deprecated API from Device API tests and examples

### DIFF
--- a/examples/rng/device/include/rng_example_helper.hpp
+++ b/examples/rng/device/include/rng_example_helper.hpp
@@ -34,7 +34,7 @@ auto get_multi_ptr(T acc) {
 
 template <typename T, typename std::enable_if<!has_member_code_meta<T>::value>::type* = nullptr>
 auto get_multi_ptr(T acc) {
-    return acc.get_pointer();
+    return acc.template get_multi_ptr<sycl::access::decorated::yes>();
 };
 
 #endif // _RNG_EXAMPLE_HELPER_HPP__

--- a/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
+++ b/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
@@ -117,7 +117,7 @@ auto get_multi_ptr(T acc) {
 
 template <typename T, typename std::enable_if<!has_member_code_meta<T>::value>::type* = nullptr>
 auto get_multi_ptr(T acc) {
-    return acc.get_pointer();
+    return acc.template get_multi_ptr<sycl::access::decorated::yes>();
 };
 
 template <typename T>


### PR DESCRIPTION
There was a warning that `get_pointer()` is deprecated in SYCL2020 and `get_multi_ptr()` should be used.

# Checklist

- [x] Do all unit tests pass locally? Log: [log.txt](https://github.com/oneapi-src/oneMKL/files/13672356/log.txt)
- [x] Have you formatted the code using clang-format?
