### PR TITLE
Allow multiple CUDA backends to be enabled at once

### DIFF
--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -120,13 +120,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy_batch, n,
-                                   alpha, x_buffer, incx, stride_x, y_buffer, incy, stride_y,
-                                   batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy_batch, n,
+                                        alpha, x_buffer, incx, stride_x, y_buffer, incy, stride_y,
+                                        batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy_batch, n, alpha,
-                                   x_buffer, incx, stride_x, y_buffer, incy, stride_y, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy_batch, n,
+                                        alpha, x_buffer, incx, stride_x, y_buffer, incy, stride_y,
+                                        batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride_usm.cpp
@@ -126,14 +126,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy_batch, n,
-                                   alpha, &x[0], incx, stride_x, &y[0], incy, stride_y, batch_size,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy_batch, n,
+                                        alpha, &x[0], incx, stride_x, &y[0], incy, stride_y,
+                                        batch_size, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy_batch, n, alpha,
-                                   &x[0], incx, stride_x, &y[0], incy, stride_y, batch_size,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy_batch, n,
+                                        alpha, &x[0], incx, stride_x, &y[0], incy, stride_y,
+                                        batch_size, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_usm.cpp
@@ -173,14 +173,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy_batch, n,
-                                   alpha, (const fp **)x_array, incx, y_array, incy, group_count,
-                                   group_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy_batch, n,
+                                        alpha, (const fp **)x_array, incx, y_array, incy,
+                                        group_count, group_size, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy_batch, n, alpha,
-                                   (const fp **)x_array, incx, y_array, incy, group_count,
-                                   group_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy_batch, n,
+                                        alpha, (const fp **)x_array, incx, y_array, incy,
+                                        group_count, group_size, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -117,12 +117,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy_batch, n,
-                                   x_buffer, incx, stride_x, y_buffer, incy, stride_y, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy_batch, n,
+                                        x_buffer, incx, stride_x, y_buffer, incy, stride_y,
+                                        batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy_batch, n,
-                                   x_buffer, incx, stride_x, y_buffer, incy, stride_y, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy_batch, n,
+                                        x_buffer, incx, stride_x, y_buffer, incy, stride_y,
+                                        batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride_usm.cpp
@@ -125,13 +125,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy_batch, n,
-                                   &x[0], incx, stride_x, &y[0], incy, stride_y, batch_size,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy_batch, n,
+                                        &x[0], incx, stride_x, &y[0], incy, stride_y, batch_size,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy_batch, n, &x[0],
-                                   incx, stride_x, &y[0], incy, stride_y, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy_batch, n,
+                                        &x[0], incx, stride_x, &y[0], incy, stride_y, batch_size,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/copy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_usm.cpp
@@ -169,14 +169,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy_batch, n,
-                                   (const fp **)x_array, incx, y_array, incy, group_count,
-                                   group_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy_batch, n,
+                                        (const fp **)x_array, incx, y_array, incy, group_count,
+                                        group_size, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy_batch, n,
-                                   (const fp **)x_array, incx, y_array, incy, group_count,
-                                   group_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy_batch, n,
+                                        (const fp **)x_array, incx, y_array, incy, group_count,
+                                        group_size, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -136,14 +136,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dgmm_batch,
-                                   left_right, m, n, A_buffer, lda, stride_a, x_buffer, incx,
-                                   stride_x, C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dgmm_batch,
+                                        left_right, m, n, A_buffer, lda, stride_a, x_buffer, incx,
+                                        stride_x, C_buffer, ldc, stride_c, batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dgmm_batch, left_right,
-                                   m, n, A_buffer, lda, stride_a, x_buffer, incx, stride_x,
-                                   C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dgmm_batch,
+                                        left_right, m, n, A_buffer, lda, stride_a, x_buffer, incx,
+                                        stride_x, C_buffer, ldc, stride_c, batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride_usm.cpp
@@ -142,14 +142,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dgmm_batch,
-                                   left_right, m, n, &A[0], lda, stride_a, &x[0], incx, stride_x,
-                                   &C[0], ldc, stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dgmm_batch,
+                                        left_right, m, n, &A[0], lda, stride_a, &x[0], incx,
+                                        stride_x, &C[0], ldc, stride_c, batch_size, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dgmm_batch, left_right,
-                                   m, n, &A[0], lda, stride_a, &x[0], incx, stride_x, &C[0], ldc,
-                                   stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dgmm_batch,
+                                        left_right, m, n, &A[0], lda, stride_a, &x[0], incx,
+                                        stride_x, &C[0], ldc, stride_c, batch_size, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_usm.cpp
@@ -205,16 +205,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dgmm_batch,
-                                   &left_right[0], &m[0], &n[0], (const fp **)&a_array[0], &lda[0],
-                                   (const fp **)&x_array[0], &incx[0], &c_array[0], &ldc[0],
-                                   group_count, &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dgmm_batch,
+                                        &left_right[0], &m[0], &n[0], (const fp **)&a_array[0],
+                                        &lda[0], (const fp **)&x_array[0], &incx[0], &c_array[0],
+                                        &ldc[0], group_count, &group_size[0], dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dgmm_batch,
-                                   &left_right[0], &m[0], &n[0], (const fp **)&a_array[0], &lda[0],
-                                   (const fp **)&x_array[0], &incx[0], &c_array[0], &ldc[0],
-                                   group_count, &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dgmm_batch,
+                                        &left_right[0], &m[0], &n[0], (const fp **)&a_array[0],
+                                        &lda[0], (const fp **)&x_array[0], &incx[0], &c_array[0],
+                                        &ldc[0], group_count, &group_size[0], dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -169,14 +169,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_batch, transa,
-                                   transb, m, n, k, alpha, A_buffer, lda, stride_a, B_buffer, ldb,
-                                   stride_b, beta, C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_batch,
+                                        transa, transb, m, n, k, alpha, A_buffer, lda, stride_a,
+                                        B_buffer, ldb, stride_b, beta, C_buffer, ldc, stride_c,
+                                        batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_batch, transa,
-                                   transb, m, n, k, alpha, A_buffer, lda, stride_a, B_buffer, ldb,
-                                   stride_b, beta, C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_batch,
+                                        transa, transb, m, n, k, alpha, A_buffer, lda, stride_a,
+                                        B_buffer, ldb, stride_b, beta, C_buffer, ldc, stride_c,
+                                        batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride_usm.cpp
@@ -195,14 +195,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_batch, transa,
-                                   transb, m, n, k, alpha, &A[0], lda, stride_a, &B[0], ldb,
-                                   stride_b, beta, &C[0], ldc, stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_batch,
+                                        transa, transb, m, n, k, alpha, &A[0], lda, stride_a, &B[0],
+                                        ldb, stride_b, beta, &C[0], ldc, stride_c, batch_size,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_batch, transa,
-                                   transb, m, n, k, alpha, &A[0], lda, stride_a, &B[0], ldb,
-                                   stride_b, beta, &C[0], ldc, stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_batch,
+                                        transa, transb, m, n, k, alpha, &A[0], lda, stride_a, &B[0],
+                                        ldb, stride_b, beta, &C[0], ldc, stride_c, batch_size,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_usm.cpp
@@ -246,18 +246,18 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_batch,
-                                   &transa[0], &transb[0], &m[0], &n[0], &k[0], &alpha[0],
-                                   (const fp **)&a_array[0], &lda[0], (const fp **)&b_array[0],
-                                   &ldb[0], &beta[0], &c_array[0], &ldc[0], group_count,
-                                   &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_batch,
+                                        &transa[0], &transb[0], &m[0], &n[0], &k[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], (const fp **)&b_array[0],
+                                        &ldb[0], &beta[0], &c_array[0], &ldc[0], group_count,
+                                        &group_size[0], dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_batch, &transa[0],
-                                   &transb[0], &m[0], &n[0], &k[0], &alpha[0],
-                                   (const fp **)&a_array[0], &lda[0], (const fp **)&b_array[0],
-                                   &ldb[0], &beta[0], &c_array[0], &ldc[0], group_count,
-                                   &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_batch,
+                                        &transa[0], &transb[0], &m[0], &n[0], &k[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], (const fp **)&b_array[0],
+                                        &ldb[0], &beta[0], &c_array[0], &ldc[0], group_count,
+                                        &group_size[0], dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -151,14 +151,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv_batch, transa,
-                                   m, n, alpha, A_buffer, lda, stride_a, x_buffer, incx, stride_x,
-                                   beta, y_buffer, incy, stride_y, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv_batch,
+                                        transa, m, n, alpha, A_buffer, lda, stride_a, x_buffer,
+                                        incx, stride_x, beta, y_buffer, incy, stride_y, batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv_batch, transa, m,
-                                   n, alpha, A_buffer, lda, stride_a, x_buffer, incx, stride_x,
-                                   beta, y_buffer, incy, stride_y, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv_batch,
+                                        transa, m, n, alpha, A_buffer, lda, stride_a, x_buffer,
+                                        incx, stride_x, beta, y_buffer, incy, stride_y, batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride_usm.cpp
@@ -155,14 +155,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv_batch, transa,
-                                   m, n, alpha, &A[0], lda, stride_a, &x[0], incx, stride_x, beta,
-                                   &y[0], incy, stride_y, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv_batch,
+                                        transa, m, n, alpha, &A[0], lda, stride_a, &x[0], incx,
+                                        stride_x, beta, &y[0], incy, stride_y, batch_size,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv_batch, transa, m,
-                                   n, alpha, &A[0], lda, stride_a, &x[0], incx, stride_x, beta,
-                                   &y[0], incy, stride_y, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv_batch,
+                                        transa, m, n, alpha, &A[0], lda, stride_a, &x[0], incx,
+                                        stride_x, beta, &y[0], incy, stride_y, batch_size,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_usm.cpp
@@ -223,17 +223,18 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv_batch,
-                                   &transa[0], &m[0], &n[0], &alpha[0], (const fp **)&a_array[0],
-                                   &lda[0], (const fp **)&x_array[0], &incx[0], &beta[0],
-                                   &y_array[0], &incy[0], group_count, &group_size[0],
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv_batch,
+                                        &transa[0], &m[0], &n[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], (const fp **)&x_array[0],
+                                        &incx[0], &beta[0], &y_array[0], &incy[0], group_count,
+                                        &group_size[0], dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv_batch, &transa[0],
-                                   &m[0], &n[0], &alpha[0], (const fp **)&a_array[0], &lda[0],
-                                   (const fp **)&x_array[0], &incx[0], &beta[0], &y_array[0],
-                                   &incy[0], group_count, &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv_batch,
+                                        &transa[0], &m[0], &n[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], (const fp **)&x_array[0],
+                                        &incx[0], &beta[0], &y_array[0], &incy[0], group_count,
+                                        &group_size[0], dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
@@ -133,12 +133,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy_batch,
-                                   trans, m, n, alpha, AB_buffer, lda, ldb, stride, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy_batch,
+                                        trans, m, n, alpha, AB_buffer, lda, ldb, stride,
+                                        batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy_batch, trans,
-                                   m, n, alpha, AB_buffer, lda, ldb, stride, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy_batch,
+                                        trans, m, n, alpha, AB_buffer, lda, ldb, stride,
+                                        batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride_usm.cpp
@@ -152,13 +152,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy_batch,
-                                   trans, m, n, alpha, &AB[0], lda, ldb, stride, batch_size,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy_batch,
+                                        trans, m, n, alpha, &AB[0], lda, ldb, stride, batch_size,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy_batch, trans,
-                                   m, n, alpha, &AB[0], lda, ldb, stride, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy_batch,
+                                        trans, m, n, alpha, &AB[0], lda, ldb, stride, batch_size,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/imatcopy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_usm.cpp
@@ -171,16 +171,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy_batch,
-                                   trans.data(), m.data(), n.data(), alpha.data(), ab_array.data(),
-                                   lda.data(), ldb.data(), group_count, group_size.data(),
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy_batch,
+                                        trans.data(), m.data(), n.data(), alpha.data(),
+                                        ab_array.data(), lda.data(), ldb.data(), group_count,
+                                        group_size.data(), dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy_batch,
-                                   trans.data(), m.data(), n.data(), alpha.data(), ab_array.data(),
-                                   lda.data(), ldb.data(), group_count, group_size.data(),
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy_batch,
+                                        trans.data(), m.data(), n.data(), alpha.data(),
+                                        ab_array.data(), lda.data(), ldb.data(), group_count,
+                                        group_size.data(), dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
@@ -147,14 +147,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd_batch,
-                                   transa, transb, m, n, alpha, A_buffer, lda, stride_a, beta,
-                                   B_buffer, ldb, stride_b, C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd_batch,
+                                        transa, transb, m, n, alpha, A_buffer, lda, stride_a, beta,
+                                        B_buffer, ldb, stride_b, C_buffer, ldc, stride_c,
+                                        batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd_batch, transa,
-                                   transb, m, n, alpha, A_buffer, lda, stride_a, beta, B_buffer,
-                                   ldb, stride_b, C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd_batch,
+                                        transa, transb, m, n, alpha, A_buffer, lda, stride_a, beta,
+                                        B_buffer, ldb, stride_b, C_buffer, ldc, stride_c,
+                                        batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/omatadd_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatadd_batch_stride_usm.cpp
@@ -172,14 +172,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd_batch,
-                                   transa, transb, m, n, alpha, &A[0], lda, stride_a, beta, &B[0],
-                                   ldb, stride_b, &C[0], ldc, stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd_batch,
+                                        transa, transb, m, n, alpha, &A[0], lda, stride_a, beta,
+                                        &B[0], ldb, stride_b, &C[0], ldc, stride_c, batch_size,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd_batch, transa,
-                                   transb, m, n, alpha, &A[0], lda, stride_a, beta, &B[0], ldb,
-                                   stride_b, &C[0], ldc, stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd_batch,
+                                        transa, transb, m, n, alpha, &A[0], lda, stride_a, beta,
+                                        &B[0], ldb, stride_b, &C[0], ldc, stride_c, batch_size,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
@@ -136,14 +136,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy_batch,
-                                   trans, m, n, alpha, A_buffer, lda, stride_a, B_buffer, ldb,
-                                   stride_b, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy_batch,
+                                        trans, m, n, alpha, A_buffer, lda, stride_a, B_buffer, ldb,
+                                        stride_b, batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy_batch, trans,
-                                   m, n, alpha, A_buffer, lda, stride_a, B_buffer, ldb, stride_b,
-                                   batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy_batch,
+                                        trans, m, n, alpha, A_buffer, lda, stride_a, B_buffer, ldb,
+                                        stride_b, batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/omatcopy_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_stride_usm.cpp
@@ -161,14 +161,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy_batch,
-                                   trans, m, n, alpha, &A[0], lda, stride_a, &B[0], ldb, stride_b,
-                                   batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy_batch,
+                                        trans, m, n, alpha, &A[0], lda, stride_a, &B[0], ldb,
+                                        stride_b, batch_size, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy_batch, trans,
-                                   m, n, alpha, &A[0], lda, stride_a, &B[0], ldb, stride_b,
-                                   batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy_batch,
+                                        trans, m, n, alpha, &A[0], lda, stride_a, &B[0], ldb,
+                                        stride_b, batch_size, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/omatcopy_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_usm.cpp
@@ -176,16 +176,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy_batch,
-                                   trans.data(), m.data(), n.data(), alpha.data(),
-                                   (const fp **)a_array.data(), lda.data(), b_array.data(),
-                                   ldb.data(), group_count, group_size.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy_batch,
+                                        trans.data(), m.data(), n.data(), alpha.data(),
+                                        (const fp **)a_array.data(), lda.data(), b_array.data(),
+                                        ldb.data(), group_count, group_size.data(), dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy_batch,
-                                   trans.data(), m.data(), n.data(), alpha.data(),
-                                   (const fp **)a_array.data(), lda.data(), b_array.data(),
-                                   ldb.data(), group_count, group_size.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy_batch,
+                                        trans.data(), m.data(), n.data(), alpha.data(),
+                                        (const fp **)a_array.data(), lda.data(), b_array.data(),
+                                        ldb.data(), group_count, group_size.data(), dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -155,14 +155,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk_batch,
-                                   upper_lower, trans, n, k, alpha, A_buffer, lda, stride_a, beta,
-                                   C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk_batch,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, stride_a,
+                                        beta, C_buffer, ldc, stride_c, batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk_batch,
-                                   upper_lower, trans, n, k, alpha, A_buffer, lda, stride_a, beta,
-                                   C_buffer, ldc, stride_c, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk_batch,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, stride_a,
+                                        beta, C_buffer, ldc, stride_c, batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride_usm.cpp
@@ -177,14 +177,14 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk_batch,
-                                   upper_lower, trans, n, k, alpha, &A[0], lda, stride_a, beta,
-                                   &C[0], ldc, stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk_batch,
+                                        upper_lower, trans, n, k, alpha, &A[0], lda, stride_a, beta,
+                                        &C[0], ldc, stride_c, batch_size, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk_batch,
-                                   upper_lower, trans, n, k, alpha, &A[0], lda, stride_a, beta,
-                                   &C[0], ldc, stride_c, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk_batch,
+                                        upper_lower, trans, n, k, alpha, &A[0], lda, stride_a, beta,
+                                        &C[0], ldc, stride_c, batch_size, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_usm.cpp
@@ -224,16 +224,16 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk_batch,
-                                   &upper_lower[0], &trans[0], &n[0], &k[0], &alpha[0],
-                                   (const fp **)&a_array[0], &lda[0], &beta[0], &c_array[0],
-                                   &ldc[0], group_count, &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk_batch,
+                                        &upper_lower[0], &trans[0], &n[0], &k[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], &beta[0], &c_array[0],
+                                        &ldc[0], group_count, &group_size[0], dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk_batch,
-                                   &upper_lower[0], &trans[0], &n[0], &k[0], &alpha[0],
-                                   (const fp **)&a_array[0], &lda[0], &beta[0], &c_array[0],
-                                   &ldc[0], group_count, &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk_batch,
+                                        &upper_lower[0], &trans[0], &n[0], &k[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], &beta[0], &c_array[0],
+                                        &ldc[0], group_count, &group_size[0], dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -161,14 +161,16 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm_batch,
-                                   left_right, upper_lower, trans, unit_nonunit, m, n, alpha,
-                                   A_buffer, lda, stride_a, B_buffer, ldb, stride_b, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm_batch,
+                                        left_right, upper_lower, trans, unit_nonunit, m, n, alpha,
+                                        A_buffer, lda, stride_a, B_buffer, ldb, stride_b,
+                                        batch_size);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm_batch, left_right,
-                                   upper_lower, trans, unit_nonunit, m, n, alpha, A_buffer, lda,
-                                   stride_a, B_buffer, ldb, stride_b, batch_size);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm_batch,
+                                        left_right, upper_lower, trans, unit_nonunit, m, n, alpha,
+                                        A_buffer, lda, stride_a, B_buffer, ldb, stride_b,
+                                        batch_size);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride_usm.cpp
@@ -164,14 +164,16 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm_batch,
-                                   left_right, upper_lower, trans, unit_nonunit, m, n, alpha, &A[0],
-                                   lda, stride_a, &B[0], ldb, stride_b, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm_batch,
+                                        left_right, upper_lower, trans, unit_nonunit, m, n, alpha,
+                                        &A[0], lda, stride_a, &B[0], ldb, stride_b, batch_size,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm_batch, left_right,
-                                   upper_lower, trans, unit_nonunit, m, n, alpha, &A[0], lda,
-                                   stride_a, &B[0], ldb, stride_b, batch_size, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm_batch,
+                                        left_right, upper_lower, trans, unit_nonunit, m, n, alpha,
+                                        &A[0], lda, stride_a, &B[0], ldb, stride_b, batch_size,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_usm.cpp
@@ -236,16 +236,18 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t group_count) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm_batch,
-                                   &left_right[0], &upper_lower[0], &trans[0], &unit_nonunit[0],
-                                   &m[0], &n[0], &alpha[0], (const fp **)&a_array[0], &lda[0],
-                                   &b_array[0], &ldb[0], group_count, &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm_batch,
+                                        &left_right[0], &upper_lower[0], &trans[0],
+                                        &unit_nonunit[0], &m[0], &n[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], &b_array[0], &ldb[0],
+                                        group_count, &group_size[0], dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm_batch,
-                                   &left_right[0], &upper_lower[0], &trans[0], &unit_nonunit[0],
-                                   &m[0], &n[0], &alpha[0], (const fp **)&a_array[0], &lda[0],
-                                   &b_array[0], &ldb[0], group_count, &group_size[0], dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm_batch,
+                                        &left_right[0], &upper_lower[0], &trans[0],
+                                        &unit_nonunit[0], &m[0], &n[0], &alpha[0],
+                                        (const fp **)&a_array[0], &lda[0], &b_array[0], &ldb[0],
+                                        group_count, &group_size[0], dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -127,14 +127,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_bias, transa,
-                                   transb, offsetc, m, n, k, alpha, A_buffer, lda, ao, B_buffer,
-                                   ldb, bo, beta, C_buffer, ldc, CO_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_bias,
+                                        transa, transb, offsetc, m, n, k, alpha, A_buffer, lda, ao,
+                                        B_buffer, ldb, bo, beta, C_buffer, ldc, CO_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_bias, transa,
-                                   transb, offsetc, m, n, k, alpha, A_buffer, lda, ao, B_buffer,
-                                   ldb, bo, beta, C_buffer, ldc, CO_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_bias, transa,
+                                        transb, offsetc, m, n, k, alpha, A_buffer, lda, ao,
+                                        B_buffer, ldb, bo, beta, C_buffer, ldc, CO_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias_usm.cpp
@@ -131,14 +131,16 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_bias, transa,
-                                   transb, offsetc, m, n, k, alpha, A.data(), lda, ao, B.data(),
-                                   ldb, bo, beta, C.data(), ldc, co.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm_bias,
+                                        transa, transb, offsetc, m, n, k, alpha, A.data(), lda, ao,
+                                        B.data(), ldb, bo, beta, C.data(), ldc, co.data(),
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_bias, transa,
-                                   transb, offsetc, m, n, k, alpha, A.data(), lda, ao, B.data(),
-                                   ldb, bo, beta, C.data(), ldc, co.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm_bias, transa,
+                                        transb, offsetc, m, n, k, alpha, A.data(), lda, ao,
+                                        B.data(), ldb, bo, beta, C.data(), ldc, co.data(),
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -109,14 +109,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemmt, upper_lower,
-                                   transa, transb, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemmt,
+                                        upper_lower, transa, transb, n, k, alpha, A_buffer, lda,
+                                        B_buffer, ldb, beta, C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemmt, upper_lower,
-                                   transa, transb, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemmt,
+                                        upper_lower, transa, transb, n, k, alpha, A_buffer, lda,
+                                        B_buffer, ldb, beta, C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/gemmt_usm.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt_usm.cpp
@@ -110,14 +110,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemmt, upper_lower,
-                                   transa, transb, n, k, alpha, A.data(), lda, B.data(), ldb, beta,
-                                   C.data(), ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemmt,
+                                        upper_lower, transa, transb, n, k, alpha, A.data(), lda,
+                                        B.data(), ldb, beta, C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemmt, upper_lower,
-                                   transa, transb, n, k, alpha, A.data(), lda, B.data(), ldb, beta,
-                                   C.data(), ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemmt,
+                                        upper_lower, transa, transb, n, k, alpha, A.data(), lda,
+                                        B.data(), ldb, beta, C.data(), ldc, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/imatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy.cpp
@@ -127,12 +127,12 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy, trans, m,
-                                   n, alpha, AB_buffer, lda, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy,
+                                        trans, m, n, alpha, AB_buffer, lda, ldb);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy, trans, m, n,
-                                   alpha, AB_buffer, lda, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy, trans,
+                                        m, n, alpha, AB_buffer, lda, ldb);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy_usm.cpp
@@ -133,12 +133,12 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy, trans, m,
-                                   n, alpha, &AB[0], lda, ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::imatcopy,
+                                        trans, m, n, alpha, &AB[0], lda, ldb, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy, trans, m, n,
-                                   alpha, &AB[0], lda, ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::imatcopy, trans,
+                                        m, n, alpha, &AB[0], lda, ldb, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/omatadd.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd.cpp
@@ -142,14 +142,14 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd, transa,
-                                   transb, m, n, alpha, A_buffer, lda, beta, B_buffer, ldb,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd,
+                                        transa, transb, m, n, alpha, A_buffer, lda, beta, B_buffer,
+                                        ldb, C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd, transa,
-                                   transb, m, n, alpha, A_buffer, lda, beta, B_buffer, ldb,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd, transa,
+                                        transb, m, n, alpha, A_buffer, lda, beta, B_buffer, ldb,
+                                        C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/omatadd_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd_usm.cpp
@@ -147,14 +147,14 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd, transa,
-                                   transb, m, n, alpha, &A[0], lda, beta, &B[0], ldb, &C[0], ldc,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatadd,
+                                        transa, transb, m, n, alpha, &A[0], lda, beta, &B[0], ldb,
+                                        &C[0], ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd, transa,
-                                   transb, m, n, alpha, &A[0], lda, beta, &B[0], ldb, &C[0], ldc,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatadd, transa,
+                                        transb, m, n, alpha, &A[0], lda, beta, &B[0], ldb, &C[0],
+                                        ldc, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/omatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy.cpp
@@ -136,12 +136,12 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy, trans, m,
-                                   n, alpha, A_buffer, lda, B_buffer, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy,
+                                        trans, m, n, alpha, A_buffer, lda, B_buffer, ldb);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy, trans, m, n,
-                                   alpha, A_buffer, lda, B_buffer, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy, trans,
+                                        m, n, alpha, A_buffer, lda, B_buffer, ldb);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/omatcopy2.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy2.cpp
@@ -133,12 +133,14 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy2, trans, m,
-                                   n, alpha, A_buffer, lda, stride_a, B_buffer, ldb, stride_b);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy2,
+                                        trans, m, n, alpha, A_buffer, lda, stride_a, B_buffer, ldb,
+                                        stride_b);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy2, trans, m, n,
-                                   alpha, A_buffer, lda, stride_a, B_buffer, ldb, stride_b);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy2, trans,
+                                        m, n, alpha, A_buffer, lda, stride_a, B_buffer, ldb,
+                                        stride_b);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/omatcopy2_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy2_usm.cpp
@@ -143,13 +143,14 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy2, trans, m,
-                                   n, alpha, &A[0], lda, stride_a, &B[0], ldb, stride_b,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy2,
+                                        trans, m, n, alpha, &A[0], lda, stride_a, &B[0], ldb,
+                                        stride_b, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy2, trans, m, n,
-                                   alpha, &A[0], lda, stride_a, &B[0], ldb, stride_b, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy2, trans,
+                                        m, n, alpha, &A[0], lda, stride_a, &B[0], ldb, stride_b,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy_usm.cpp
@@ -135,12 +135,12 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy, trans, m,
-                                   n, alpha, &A[0], lda, &B[0], ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::omatcopy,
+                                        trans, m, n, alpha, &A[0], lda, &B[0], ldb, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy, trans, m, n,
-                                   alpha, &A[0], lda, &B[0], ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::omatcopy, trans,
+                                        m, n, alpha, &A[0], lda, &B[0], ldb, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -93,12 +93,12 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::asum, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::asum, N,
+                                        x_buffer, incx, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::asum, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::asum, N, x_buffer,
+                                        incx, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/asum_usm.cpp
+++ b/tests/unit_tests/blas/level1/asum_usm.cpp
@@ -109,12 +109,12 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::asum, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::asum, N,
+                                        x.data(), incx, result_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::asum, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::asum, N, x.data(),
+                                        incx, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -98,12 +98,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpby, N, alpha,
-                                   x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpby, N,
+                                        alpha, x_buffer, incx, beta, y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpby, N, alpha,
-                                   x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpby, N, alpha,
+                                        x_buffer, incx, beta, y_buffer, incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/axpby_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpby_usm.cpp
@@ -101,12 +101,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpby, N, alpha,
-                                   x.data(), incx, beta, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpby, N,
+                                        alpha, x.data(), incx, beta, y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpby, N, alpha,
-                                   x.data(), incx, beta, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpby, N, alpha,
+                                        x.data(), incx, beta, y.data(), incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -98,12 +98,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy, N, alpha,
-                                   x_buffer, incx, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy, N, alpha,
+                                        x_buffer, incx, y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy, N, alpha,
-                                   x_buffer, incx, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy, N, alpha,
+                                        x_buffer, incx, y_buffer, incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/axpy_usm.cpp
+++ b/tests/unit_tests/blas/level1/axpy_usm.cpp
@@ -101,12 +101,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy, N, alpha,
-                                   x.data(), incx, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::axpy, N, alpha,
+                                        x.data(), incx, y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy, N, alpha,
-                                   x.data(), incx, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::axpy, N, alpha,
+                                        x.data(), incx, y.data(), incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -96,12 +96,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy, N, x_buffer,
-                                   incx, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy, N,
+                                        x_buffer, incx, y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy, N, x_buffer,
-                                   incx, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy, N, x_buffer,
+                                        incx, y_buffer, incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/copy_usm.cpp
+++ b/tests/unit_tests/blas/level1/copy_usm.cpp
@@ -100,12 +100,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy, N, x.data(),
-                                   incx, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::copy, N,
+                                        x.data(), incx, y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy, N, x.data(),
-                                   incx, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::copy, N, x.data(),
+                                        incx, y.data(), incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -97,12 +97,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dot, N, x_buffer,
-                                   incx, y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dot, N,
+                                        x_buffer, incx, y_buffer, incy, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dot, N, x_buffer, incx,
-                                   y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dot, N, x_buffer,
+                                        incx, y_buffer, incy, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/dot_usm.cpp
+++ b/tests/unit_tests/blas/level1/dot_usm.cpp
@@ -109,12 +109,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dot, N, x.data(),
-                                   incx, y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dot, N,
+                                        x.data(), incx, y.data(), incy, result_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dot, N, x.data(), incx,
-                                   y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dot, N, x.data(),
+                                        incx, y.data(), incy, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -99,12 +99,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotc, N, x_buffer,
-                                   incx, y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotc, N,
+                                        x_buffer, incx, y_buffer, incy, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotc, N, x_buffer,
-                                   incx, y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotc, N, x_buffer,
+                                        incx, y_buffer, incy, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/dotc_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotc_usm.cpp
@@ -102,12 +102,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotc, N, x.data(),
-                                   incx, y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotc, N,
+                                        x.data(), incx, y.data(), incy, result_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotc, N, x.data(),
-                                   incx, y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotc, N, x.data(),
+                                        incx, y.data(), incy, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -99,12 +99,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotu, N, x_buffer,
-                                   incx, y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotu, N,
+                                        x_buffer, incx, y_buffer, incy, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotu, N, x_buffer,
-                                   incx, y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotu, N, x_buffer,
+                                        incx, y_buffer, incy, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/dotu_usm.cpp
+++ b/tests/unit_tests/blas/level1/dotu_usm.cpp
@@ -102,12 +102,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotu, N, x.data(),
-                                   incx, y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::dotu, N,
+                                        x.data(), incx, y.data(), incy, result_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotu, N, x.data(),
-                                   incx, y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::dotu, N, x.data(),
+                                        incx, y.data(), incy, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -94,12 +94,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamax, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamax, N,
+                                        x_buffer, incx, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamax, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamax, N,
+                                        x_buffer, incx, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -108,12 +108,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamax, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamax, N,
+                                        x.data(), incx, result_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamax, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamax, N,
+                                        x.data(), incx, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -94,12 +94,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamin, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamin, N,
+                                        x_buffer, incx, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamin, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamin, N,
+                                        x_buffer, incx, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -108,12 +108,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamin, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::iamin, N,
+                                        x.data(), incx, result_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamin, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::iamin, N,
+                                        x.data(), incx, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -94,12 +94,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::nrm2, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::nrm2, N,
+                                        x_buffer, incx, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::nrm2, N, x_buffer,
-                                   incx, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::nrm2, N, x_buffer,
+                                        incx, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/nrm2_usm.cpp
+++ b/tests/unit_tests/blas/level1/nrm2_usm.cpp
@@ -109,12 +109,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::nrm2, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::nrm2, N,
+                                        x.data(), incx, result_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::nrm2, N, x.data(),
-                                   incx, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::nrm2, N, x.data(),
+                                        incx, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -99,12 +99,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rot, N, x_buffer,
-                                   incx, y_buffer, incy, c, s);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rot, N,
+                                        x_buffer, incx, y_buffer, incy, c, s);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rot, N, x_buffer, incx,
-                                   y_buffer, incy, c, s);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rot, N, x_buffer,
+                                        incx, y_buffer, incy, c, s);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rot_usm.cpp
+++ b/tests/unit_tests/blas/level1/rot_usm.cpp
@@ -102,12 +102,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rot, N, x.data(),
-                                   incx, y.data(), incy, c, s, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rot, N,
+                                        x.data(), incx, y.data(), incy, c, s, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rot, N, x.data(), incx,
-                                   y.data(), incy, c, s, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rot, N, x.data(),
+                                        incx, y.data(), incy, c, s, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -105,12 +105,12 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotg, a_buffer,
-                                   b_buffer, c_buffer, s_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotg, a_buffer,
+                                        b_buffer, c_buffer, s_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotg, a_buffer,
-                                   b_buffer, c_buffer, s_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotg, a_buffer,
+                                        b_buffer, c_buffer, s_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rotg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotg_usm.cpp
@@ -127,12 +127,12 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotg, a_p, b_p, c_p,
-                                   s_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotg, a_p, b_p,
+                                        c_p, s_p, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotg, a_p, b_p, c_p,
-                                   s_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotg, a_p, b_p,
+                                        c_p, s_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -102,12 +102,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotm, N, x_buffer,
-                                   incx, y_buffer, incy, param_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotm, N,
+                                        x_buffer, incx, y_buffer, incy, param_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotm, N, x_buffer,
-                                   incx, y_buffer, incy, param_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotm, N, x_buffer,
+                                        incx, y_buffer, incy, param_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rotm_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotm_usm.cpp
@@ -103,12 +103,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotm, N, x.data(),
-                                   incx, y.data(), incy, param.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotm, N,
+                                        x.data(), incx, y.data(), incy, param.data(), dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotm, N, x.data(),
-                                   incx, y.data(), incy, param.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotm, N, x.data(),
+                                        incx, y.data(), incy, param.data(), dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -102,12 +102,12 @@ int test(device* dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotmg, d1_buffer,
-                                   d2_buffer, x1_buffer, y1, param_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotmg,
+                                        d1_buffer, d2_buffer, x1_buffer, y1, param_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotmg, d1_buffer,
-                                   d2_buffer, x1_buffer, y1, param_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotmg, d1_buffer,
+                                        d2_buffer, x1_buffer, y1, param_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/rotmg_usm.cpp
+++ b/tests/unit_tests/blas/level1/rotmg_usm.cpp
@@ -122,12 +122,12 @@ int test(device *dev, oneapi::mkl::layout layout) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotmg, d1_p, d2_p,
-                                   x1_p, y1, param.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::rotmg, d1_p,
+                                        d2_p, x1_p, y1, param.data(), dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotmg, d1_p, d2_p,
-                                   x1_p, y1, param.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::rotmg, d1_p, d2_p,
+                                        x1_p, y1, param.data(), dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -95,12 +95,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::scal, N, alpha,
-                                   x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::scal, N, alpha,
+                                        x_buffer, incx);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::scal, N, alpha,
-                                   x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::scal, N, alpha,
+                                        x_buffer, incx);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/scal_usm.cpp
+++ b/tests/unit_tests/blas/level1/scal_usm.cpp
@@ -101,12 +101,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::scal, N, alpha,
-                                   x.data(), incx, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::scal, N, alpha,
+                                        x.data(), incx, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::scal, N, alpha,
-                                   x.data(), incx, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::scal, N, alpha,
+                                        x.data(), incx, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -97,12 +97,12 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sdsdot, N, alpha,
-                                   x_buffer, incx, y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sdsdot, N,
+                                        alpha, x_buffer, incx, y_buffer, incy, result_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sdsdot, N, alpha,
-                                   x_buffer, incx, y_buffer, incy, result_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sdsdot, N, alpha,
+                                        x_buffer, incx, y_buffer, incy, result_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/sdsdot_usm.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot_usm.cpp
@@ -100,12 +100,13 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sdsdot, N, alpha,
-                                   x.data(), incx, y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sdsdot, N,
+                                        alpha, x.data(), incx, y.data(), incy, result_p,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sdsdot, N, alpha,
-                                   x.data(), incx, y.data(), incy, result_p, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sdsdot, N, alpha,
+                                        x.data(), incx, y.data(), incy, result_p, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -96,12 +96,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::swap, N, x_buffer,
-                                   incx, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::swap, N,
+                                        x_buffer, incx, y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::swap, N, x_buffer,
-                                   incx, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::swap, N, x_buffer,
+                                        incx, y_buffer, incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level1/swap_usm.cpp
+++ b/tests/unit_tests/blas/level1/swap_usm.cpp
@@ -100,12 +100,12 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::swap, N, x.data(),
-                                   incx, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::swap, N,
+                                        x.data(), incx, y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::swap, N, x.data(),
-                                   incx, y.data(), incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::swap, N, x.data(),
+                                        incx, y.data(), incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -109,13 +109,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gbmv, transa, m, n,
-                                   kl, ku, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
-                                   incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gbmv, transa,
+                                        m, n, kl, ku, alpha, A_buffer, lda, x_buffer, incx, beta,
+                                        y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gbmv, transa, m, n, kl,
-                                   ku, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gbmv, transa, m,
+                                        n, kl, ku, alpha, A_buffer, lda, x_buffer, incx, beta,
+                                        y_buffer, incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/gbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gbmv_usm.cpp
@@ -110,14 +110,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gbmv, transa, m, n,
-                                   kl, ku, alpha, A.data(), lda, x.data(), incx, beta, y.data(),
-                                   incy, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gbmv, transa,
+                                        m, n, kl, ku, alpha, A.data(), lda, x.data(), incx, beta,
+                                        y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gbmv, transa, m, n, kl,
-                                   ku, alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gbmv, transa, m,
+                                        n, kl, ku, alpha, A.data(), lda, x.data(), incx, beta,
+                                        y.data(), incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -106,12 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv, transa, m, n,
-                                   alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv, transa,
+                                        m, n, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
+                                        incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv, transa, m, n,
-                                   alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv, transa, m,
+                                        n, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
+                                        incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/gemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/gemv_usm.cpp
@@ -109,14 +109,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv, transa, m, n,
-                                   alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemv, transa,
+                                        m, n, alpha, A.data(), lda, x.data(), incx, beta, y.data(),
+                                        incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv, transa, m, n,
-                                   alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemv, transa, m,
+                                        n, alpha, A.data(), lda, x.data(), incx, beta, y.data(),
+                                        incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -103,12 +103,12 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::ger, m, n, alpha,
-                                   x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::ger, m, n,
+                                        alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::ger, m, n, alpha,
-                                   x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::ger, m, n, alpha,
+                                        x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/ger_usm.cpp
+++ b/tests/unit_tests/blas/level2/ger_usm.cpp
@@ -106,12 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::ger, m, n, alpha,
-                                   x.data(), incx, y.data(), incy, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::ger, m, n,
+                                        alpha, x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::ger, m, n, alpha,
-                                   x.data(), incx, y.data(), incy, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::ger, m, n, alpha,
+                                        x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -103,12 +103,12 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gerc, m, n, alpha,
-                                   x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gerc, m, n,
+                                        alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gerc, m, n, alpha,
-                                   x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gerc, m, n, alpha,
+                                        x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/gerc_usm.cpp
+++ b/tests/unit_tests/blas/level2/gerc_usm.cpp
@@ -106,12 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gerc, m, n, alpha,
-                                   x.data(), incx, y.data(), incy, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gerc, m, n,
+                                        alpha, x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gerc, m, n, alpha,
-                                   x.data(), incx, y.data(), incy, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gerc, m, n, alpha,
+                                        x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -103,12 +103,12 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::geru, m, n, alpha,
-                                   x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::geru, m, n,
+                                        alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::geru, m, n, alpha,
-                                   x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::geru, m, n, alpha,
+                                        x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/geru_usm.cpp
+++ b/tests/unit_tests/blas/level2/geru_usm.cpp
@@ -106,12 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::geru, m, n, alpha,
-                                   x.data(), incx, y.data(), incy, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::geru, m, n,
+                                        alpha, x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::geru, m, n, alpha,
-                                   x.data(), incx, y.data(), incy, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::geru, m, n, alpha,
+                                        x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -105,13 +105,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hbmv, upper_lower,
-                                   n, k, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
-                                   incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hbmv,
+                                        upper_lower, n, k, alpha, A_buffer, lda, x_buffer, incx,
+                                        beta, y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hbmv, upper_lower, n,
-                                   k, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hbmv, upper_lower,
+                                        n, k, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
+                                        incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hbmv_usm.cpp
@@ -108,14 +108,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hbmv, upper_lower,
-                                   n, k, alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hbmv,
+                                        upper_lower, n, k, alpha, A.data(), lda, x.data(), incx,
+                                        beta, y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hbmv, upper_lower, n,
-                                   k, alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hbmv, upper_lower,
+                                        n, k, alpha, A.data(), lda, x.data(), incx, beta, y.data(),
+                                        incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -103,12 +103,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemv, upper_lower,
-                                   n, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemv,
+                                        upper_lower, n, alpha, A_buffer, lda, x_buffer, incx, beta,
+                                        y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemv, upper_lower, n,
-                                   alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemv, upper_lower,
+                                        n, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
+                                        incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hemv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hemv_usm.cpp
@@ -107,14 +107,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemv, upper_lower,
-                                   n, alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemv,
+                                        upper_lower, n, alpha, A.data(), lda, x.data(), incx, beta,
+                                        y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemv, upper_lower, n,
-                                   alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemv, upper_lower,
+                                        n, alpha, A.data(), lda, x.data(), incx, beta, y.data(),
+                                        incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -100,12 +100,12 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her,
+                                        upper_lower, n, alpha, x_buffer, incx, A_buffer, lda);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her, upper_lower,
+                                        n, alpha, x_buffer, incx, A_buffer, lda);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -103,12 +103,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2, upper_lower,
-                                   n, alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2,
+                                        upper_lower, n, alpha, x_buffer, incx, y_buffer, incy,
+                                        A_buffer, lda);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2, upper_lower, n,
-                                   alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2, upper_lower,
+                                        n, alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/her2_usm.cpp
+++ b/tests/unit_tests/blas/level2/her2_usm.cpp
@@ -107,14 +107,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2, upper_lower,
-                                   n, alpha, x.data(), incx, y.data(), incy, A.data(), lda,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2,
+                                        upper_lower, n, alpha, x.data(), incx, y.data(), incy,
+                                        A.data(), lda, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2, upper_lower, n,
-                                   alpha, x.data(), incx, y.data(), incy, A.data(), lda,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2, upper_lower,
+                                        n, alpha, x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/her_usm.cpp
+++ b/tests/unit_tests/blas/level2/her_usm.cpp
@@ -103,12 +103,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her,
+                                        upper_lower, n, alpha, x.data(), incx, A.data(), lda,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her, upper_lower,
+                                        n, alpha, x.data(), incx, A.data(), lda, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -102,12 +102,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpmv, upper_lower,
-                                   n, alpha, A_buffer, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpmv,
+                                        upper_lower, n, alpha, A_buffer, x_buffer, incx, beta,
+                                        y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpmv, upper_lower, n,
-                                   alpha, A_buffer, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpmv, upper_lower,
+                                        n, alpha, A_buffer, x_buffer, incx, beta, y_buffer, incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpmv_usm.cpp
@@ -106,14 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpmv, upper_lower,
-                                   n, alpha, A.data(), x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpmv,
+                                        upper_lower, n, alpha, A.data(), x.data(), incx, beta,
+                                        y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpmv, upper_lower, n,
-                                   alpha, A.data(), x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpmv, upper_lower,
+                                        n, alpha, A.data(), x.data(), incx, beta, y.data(), incy,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -100,12 +100,12 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr,
+                                        upper_lower, n, alpha, x_buffer, incx, A_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr, upper_lower,
+                                        n, alpha, x_buffer, incx, A_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -102,12 +102,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr2, upper_lower,
-                                   n, alpha, x_buffer, incx, y_buffer, incy, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr2,
+                                        upper_lower, n, alpha, x_buffer, incx, y_buffer, incy,
+                                        A_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr2, upper_lower, n,
-                                   alpha, x_buffer, incx, y_buffer, incy, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr2, upper_lower,
+                                        n, alpha, x_buffer, incx, y_buffer, incy, A_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hpr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr2_usm.cpp
@@ -106,13 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr2, upper_lower,
-                                   n, alpha, x.data(), incx, y.data(), incy, A.data(),
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr2,
+                                        upper_lower, n, alpha, x.data(), incx, y.data(), incy,
+                                        A.data(), dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr2, upper_lower, n,
-                                   alpha, x.data(), incx, y.data(), incy, A.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr2, upper_lower,
+                                        n, alpha, x.data(), incx, y.data(), incy, A.data(),
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/hpr_usm.cpp
+++ b/tests/unit_tests/blas/level2/hpr_usm.cpp
@@ -103,12 +103,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hpr,
+                                        upper_lower, n, alpha, x.data(), incx, A.data(),
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hpr, upper_lower,
+                                        n, alpha, x.data(), incx, A.data(), dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -103,13 +103,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sbmv, upper_lower,
-                                   n, k, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
-                                   incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sbmv,
+                                        upper_lower, n, k, alpha, A_buffer, lda, x_buffer, incx,
+                                        beta, y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sbmv, upper_lower, n,
-                                   k, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sbmv, upper_lower,
+                                        n, k, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
+                                        incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/sbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/sbmv_usm.cpp
@@ -107,14 +107,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sbmv, upper_lower,
-                                   n, k, alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::sbmv,
+                                        upper_lower, n, k, alpha, A.data(), lda, x.data(), incx,
+                                        beta, y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sbmv, upper_lower, n,
-                                   k, alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::sbmv, upper_lower,
+                                        n, k, alpha, A.data(), lda, x.data(), incx, beta, y.data(),
+                                        incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -102,12 +102,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spmv, upper_lower,
-                                   n, alpha, A_buffer, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spmv,
+                                        upper_lower, n, alpha, A_buffer, x_buffer, incx, beta,
+                                        y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spmv, upper_lower, n,
-                                   alpha, A_buffer, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spmv, upper_lower,
+                                        n, alpha, A_buffer, x_buffer, incx, beta, y_buffer, incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/spmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/spmv_usm.cpp
@@ -106,14 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spmv, upper_lower,
-                                   n, alpha, A.data(), x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spmv,
+                                        upper_lower, n, alpha, A.data(), x.data(), incx, beta,
+                                        y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spmv, upper_lower, n,
-                                   alpha, A.data(), x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spmv, upper_lower,
+                                        n, alpha, A.data(), x.data(), incx, beta, y.data(), incy,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -99,12 +99,12 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr,
+                                        upper_lower, n, alpha, x_buffer, incx, A_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr, upper_lower,
+                                        n, alpha, x_buffer, incx, A_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -102,12 +102,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr2, upper_lower,
-                                   n, alpha, x_buffer, incx, y_buffer, incy, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr2,
+                                        upper_lower, n, alpha, x_buffer, incx, y_buffer, incy,
+                                        A_buffer);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr2, upper_lower, n,
-                                   alpha, x_buffer, incx, y_buffer, incy, A_buffer);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr2, upper_lower,
+                                        n, alpha, x_buffer, incx, y_buffer, incy, A_buffer);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/spr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr2_usm.cpp
@@ -106,13 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr2, upper_lower,
-                                   n, alpha, x.data(), incx, y.data(), incy, A.data(),
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr2,
+                                        upper_lower, n, alpha, x.data(), incx, y.data(), incy,
+                                        A.data(), dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr2, upper_lower, n,
-                                   alpha, x.data(), incx, y.data(), incy, A.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr2, upper_lower,
+                                        n, alpha, x.data(), incx, y.data(), incy, A.data(),
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/spr_usm.cpp
+++ b/tests/unit_tests/blas/level2/spr_usm.cpp
@@ -102,12 +102,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::spr,
+                                        upper_lower, n, alpha, x.data(), incx, A.data(),
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::spr, upper_lower,
+                                        n, alpha, x.data(), incx, A.data(), dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -102,12 +102,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symv, upper_lower,
-                                   n, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symv,
+                                        upper_lower, n, alpha, A_buffer, lda, x_buffer, incx, beta,
+                                        y_buffer, incy);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symv, upper_lower, n,
-                                   alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer, incy);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symv, upper_lower,
+                                        n, alpha, A_buffer, lda, x_buffer, incx, beta, y_buffer,
+                                        incy);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/symv_usm.cpp
+++ b/tests/unit_tests/blas/level2/symv_usm.cpp
@@ -106,14 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symv, upper_lower,
-                                   n, alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symv,
+                                        upper_lower, n, alpha, A.data(), lda, x.data(), incx, beta,
+                                        y.data(), incy, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symv, upper_lower, n,
-                                   alpha, A.data(), lda, x.data(), incx, beta, y.data(), incy,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symv, upper_lower,
+                                        n, alpha, A.data(), lda, x.data(), incx, beta, y.data(),
+                                        incy, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -99,12 +99,12 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr,
+                                        upper_lower, n, alpha, x_buffer, incx, A_buffer, lda);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr, upper_lower, n,
-                                   alpha, x_buffer, incx, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr, upper_lower,
+                                        n, alpha, x_buffer, incx, A_buffer, lda);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -102,12 +102,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2, upper_lower,
-                                   n, alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2,
+                                        upper_lower, n, alpha, x_buffer, incx, y_buffer, incy,
+                                        A_buffer, lda);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2, upper_lower, n,
-                                   alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2, upper_lower,
+                                        n, alpha, x_buffer, incx, y_buffer, incy, A_buffer, lda);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/syr2_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr2_usm.cpp
@@ -106,14 +106,14 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2, upper_lower,
-                                   n, alpha, x.data(), incx, y.data(), incy, A.data(), lda,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2,
+                                        upper_lower, n, alpha, x.data(), incx, y.data(), incy,
+                                        A.data(), lda, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2, upper_lower, n,
-                                   alpha, x.data(), incx, y.data(), incy, A.data(), lda,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2, upper_lower,
+                                        n, alpha, x.data(), incx, y.data(), incy, A.data(), lda,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/syr_usm.cpp
+++ b/tests/unit_tests/blas/level2/syr_usm.cpp
@@ -102,12 +102,13 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr,
+                                        upper_lower, n, alpha, x.data(), incx, A.data(), lda,
+                                        dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr, upper_lower, n,
-                                   alpha, x.data(), incx, A.data(), lda, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr, upper_lower,
+                                        n, alpha, x.data(), incx, A.data(), lda, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -102,12 +102,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbmv, upper_lower,
-                                   transa, unit_nonunit, n, k, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbmv,
+                                        upper_lower, transa, unit_nonunit, n, k, A_buffer, lda,
+                                        x_buffer, incx);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbmv, upper_lower,
-                                   transa, unit_nonunit, n, k, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbmv, upper_lower,
+                                        transa, unit_nonunit, n, k, A_buffer, lda, x_buffer, incx);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tbmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbmv_usm.cpp
@@ -107,14 +107,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbmv, upper_lower,
-                                   transa, unit_nonunit, n, k, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbmv,
+                                        upper_lower, transa, unit_nonunit, n, k, A.data(), lda,
+                                        x.data(), incx, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbmv, upper_lower,
-                                   transa, unit_nonunit, n, k, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbmv, upper_lower,
+                                        transa, unit_nonunit, n, k, A.data(), lda, x.data(), incx,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -102,12 +102,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbsv, upper_lower,
-                                   transa, unit_nonunit, n, k, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbsv,
+                                        upper_lower, transa, unit_nonunit, n, k, A_buffer, lda,
+                                        x_buffer, incx);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbsv, upper_lower,
-                                   transa, unit_nonunit, n, k, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbsv, upper_lower,
+                                        transa, unit_nonunit, n, k, A_buffer, lda, x_buffer, incx);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tbsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tbsv_usm.cpp
@@ -107,14 +107,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbsv, upper_lower,
-                                   transa, unit_nonunit, n, k, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tbsv,
+                                        upper_lower, transa, unit_nonunit, n, k, A.data(), lda,
+                                        x.data(), incx, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbsv, upper_lower,
-                                   transa, unit_nonunit, n, k, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tbsv, upper_lower,
+                                        transa, unit_nonunit, n, k, A.data(), lda, x.data(), incx,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -100,12 +100,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpmv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpmv,
+                                        upper_lower, transa, unit_nonunit, n, A_buffer, x_buffer,
+                                        incx);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpmv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpmv, upper_lower,
+                                        transa, unit_nonunit, n, A_buffer, x_buffer, incx);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tpmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpmv_usm.cpp
@@ -105,12 +105,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpmv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), x.data(), incx, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpmv,
+                                        upper_lower, transa, unit_nonunit, n, A.data(), x.data(),
+                                        incx, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpmv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), x.data(), incx, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpmv, upper_lower,
+                                        transa, unit_nonunit, n, A.data(), x.data(), incx,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -100,12 +100,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpsv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpsv,
+                                        upper_lower, transa, unit_nonunit, n, A_buffer, x_buffer,
+                                        incx);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpsv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpsv, upper_lower,
+                                        transa, unit_nonunit, n, A_buffer, x_buffer, incx);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/tpsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/tpsv_usm.cpp
@@ -105,12 +105,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpsv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), x.data(), incx, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::tpsv,
+                                        upper_lower, transa, unit_nonunit, n, A.data(), x.data(),
+                                        incx, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpsv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), x.data(), incx, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::tpsv, upper_lower,
+                                        transa, unit_nonunit, n, A.data(), x.data(), incx,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -100,12 +100,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmv,
+                                        upper_lower, transa, unit_nonunit, n, A_buffer, lda,
+                                        x_buffer, incx);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmv, upper_lower,
+                                        transa, unit_nonunit, n, A_buffer, lda, x_buffer, incx);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/trmv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trmv_usm.cpp
@@ -105,14 +105,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmv,
+                                        upper_lower, transa, unit_nonunit, n, A.data(), lda,
+                                        x.data(), incx, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmv, upper_lower,
+                                        transa, unit_nonunit, n, A.data(), lda, x.data(), incx,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -100,12 +100,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsv,
+                                        upper_lower, transa, unit_nonunit, n, A_buffer, lda,
+                                        x_buffer, incx);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsv, upper_lower,
-                                   transa, unit_nonunit, n, A_buffer, lda, x_buffer, incx);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsv, upper_lower,
+                                        transa, unit_nonunit, n, A_buffer, lda, x_buffer, incx);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level2/trsv_usm.cpp
+++ b/tests/unit_tests/blas/level2/trsv_usm.cpp
@@ -105,14 +105,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsv,
+                                        upper_lower, transa, unit_nonunit, n, A.data(), lda,
+                                        x.data(), incx, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsv, upper_lower,
-                                   transa, unit_nonunit, n, A.data(), lda, x.data(), incx,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsv, upper_lower,
+                                        transa, unit_nonunit, n, A.data(), lda, x.data(), incx,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -112,14 +112,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm, transa,
-                                   transb, m, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm, transa,
+                                        transb, m, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta,
+                                        C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm, transa, transb,
-                                   m, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta, C_buffer,
-                                   ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm, transa,
+                                        transb, m, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta,
+                                        C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/gemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/gemm_usm.cpp
@@ -113,14 +113,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm, transa,
-                                   transb, m, n, k, alpha, A.data(), lda, B.data(), ldb, beta,
-                                   C.data(), ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::gemm, transa,
+                                        transb, m, n, k, alpha, A.data(), lda, B.data(), ldb, beta,
+                                        C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm, transa, transb,
-                                   m, n, k, alpha, A.data(), lda, B.data(), ldb, beta, C.data(),
-                                   ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::gemm, transa,
+                                        transb, m, n, k, alpha, A.data(), lda, B.data(), ldb, beta,
+                                        C.data(), ldc, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -111,14 +111,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemm, left_right,
-                                   upper_lower, m, n, alpha, A_buffer, lda, B_buffer, ldb, beta,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemm,
+                                        left_right, upper_lower, m, n, alpha, A_buffer, lda,
+                                        B_buffer, ldb, beta, C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemm, left_right,
-                                   upper_lower, m, n, alpha, A_buffer, lda, B_buffer, ldb, beta,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemm, left_right,
+                                        upper_lower, m, n, alpha, A_buffer, lda, B_buffer, ldb,
+                                        beta, C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/hemm_usm.cpp
+++ b/tests/unit_tests/blas/level3/hemm_usm.cpp
@@ -111,14 +111,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemm, left_right,
-                                   upper_lower, m, n, alpha, A.data(), lda, B.data(), ldb, beta,
-                                   C.data(), ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::hemm,
+                                        left_right, upper_lower, m, n, alpha, A.data(), lda,
+                                        B.data(), ldb, beta, C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemm, left_right,
-                                   upper_lower, m, n, alpha, A.data(), lda, B.data(), ldb, beta,
-                                   C.data(), ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::hemm, left_right,
+                                        upper_lower, m, n, alpha, A.data(), lda, B.data(), ldb,
+                                        beta, C.data(), ldc, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -112,14 +112,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2k, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta, C_buffer,
-                                   ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2k,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, B_buffer,
+                                        ldb, beta, C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2k, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta, C_buffer,
-                                   ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2k,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, B_buffer,
+                                        ldb, beta, C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/her2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/her2k_usm.cpp
@@ -113,14 +113,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2k, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, B.data(), ldb, beta, C.data(),
-                                   ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::her2k,
+                                        upper_lower, trans, n, k, alpha, A.data(), lda, B.data(),
+                                        ldb, beta, C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2k, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, B.data(), ldb, beta, C.data(),
-                                   ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::her2k,
+                                        upper_lower, trans, n, k, alpha, A.data(), lda, B.data(),
+                                        ldb, beta, C.data(), ldc, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -104,12 +104,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::herk, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, beta, C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::herk,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, beta,
+                                        C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::herk, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, beta, C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::herk, upper_lower,
+                                        trans, n, k, alpha, A_buffer, lda, beta, C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/herk_usm.cpp
+++ b/tests/unit_tests/blas/level3/herk_usm.cpp
@@ -108,14 +108,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::herk, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, beta, C.data(), ldc,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::herk,
+                                        upper_lower, trans, n, k, alpha, A.data(), lda, beta,
+                                        C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::herk, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, beta, C.data(), ldc,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::herk, upper_lower,
+                                        trans, n, k, alpha, A.data(), lda, beta, C.data(), ldc,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -111,14 +111,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symm, left_right,
-                                   upper_lower, m, n, alpha, A_buffer, lda, B_buffer, ldb, beta,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symm,
+                                        left_right, upper_lower, m, n, alpha, A_buffer, lda,
+                                        B_buffer, ldb, beta, C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symm, left_right,
-                                   upper_lower, m, n, alpha, A_buffer, lda, B_buffer, ldb, beta,
-                                   C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symm, left_right,
+                                        upper_lower, m, n, alpha, A_buffer, lda, B_buffer, ldb,
+                                        beta, C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/symm_usm.cpp
+++ b/tests/unit_tests/blas/level3/symm_usm.cpp
@@ -111,14 +111,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symm, left_right,
-                                   upper_lower, m, n, alpha, A.data(), lda, B.data(), ldb, beta,
-                                   C.data(), ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::symm,
+                                        left_right, upper_lower, m, n, alpha, A.data(), lda,
+                                        B.data(), ldb, beta, C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symm, left_right,
-                                   upper_lower, m, n, alpha, A.data(), lda, B.data(), ldb, beta,
-                                   C.data(), ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::symm, left_right,
+                                        upper_lower, m, n, alpha, A.data(), lda, B.data(), ldb,
+                                        beta, C.data(), ldc, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -107,14 +107,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2k, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta, C_buffer,
-                                   ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2k,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, B_buffer,
+                                        ldb, beta, C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2k, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, B_buffer, ldb, beta, C_buffer,
-                                   ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2k,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, B_buffer,
+                                        ldb, beta, C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/syr2k_usm.cpp
+++ b/tests/unit_tests/blas/level3/syr2k_usm.cpp
@@ -108,14 +108,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2k, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, B.data(), ldb, beta, C.data(),
-                                   ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syr2k,
+                                        upper_lower, trans, n, k, alpha, A.data(), lda, B.data(),
+                                        ldb, beta, C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2k, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, B.data(), ldb, beta, C.data(),
-                                   ldc, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syr2k,
+                                        upper_lower, trans, n, k, alpha, A.data(), lda, B.data(),
+                                        ldb, beta, C.data(), ldc, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -103,12 +103,13 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, beta, C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk,
+                                        upper_lower, trans, n, k, alpha, A_buffer, lda, beta,
+                                        C_buffer, ldc);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk, upper_lower,
-                                   trans, n, k, alpha, A_buffer, lda, beta, C_buffer, ldc);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk, upper_lower,
+                                        trans, n, k, alpha, A_buffer, lda, beta, C_buffer, ldc);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/syrk_usm.cpp
+++ b/tests/unit_tests/blas/level3/syrk_usm.cpp
@@ -106,14 +106,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, beta, C.data(), ldc,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::syrk,
+                                        upper_lower, trans, n, k, alpha, A.data(), lda, beta,
+                                        C.data(), ldc, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk, upper_lower,
-                                   trans, n, k, alpha, A.data(), lda, beta, C.data(), ldc,
-                                   dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::syrk, upper_lower,
+                                        trans, n, k, alpha, A.data(), lda, beta, C.data(), ldc,
+                                        dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -111,14 +111,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A_buffer, lda,
-                                   B_buffer, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmm,
+                                        left_right, upper_lower, transa, unit_nonunit, m, n, alpha,
+                                        A_buffer, lda, B_buffer, ldb);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A_buffer, lda,
-                                   B_buffer, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmm, left_right,
+                                        upper_lower, transa, unit_nonunit, m, n, alpha, A_buffer,
+                                        lda, B_buffer, ldb);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/trmm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trmm_usm.cpp
@@ -113,14 +113,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A.data(), lda,
-                                   B.data(), ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trmm,
+                                        left_right, upper_lower, transa, unit_nonunit, m, n, alpha,
+                                        A.data(), lda, B.data(), ldb, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A.data(), lda,
-                                   B.data(), ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trmm, left_right,
+                                        upper_lower, transa, unit_nonunit, m, n, alpha, A.data(),
+                                        lda, B.data(), ldb, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -111,14 +111,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A_buffer, lda,
-                                   B_buffer, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm,
+                                        left_right, upper_lower, transa, unit_nonunit, m, n, alpha,
+                                        A_buffer, lda, B_buffer, ldb);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A_buffer, lda,
-                                   B_buffer, ldb);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm, left_right,
+                                        upper_lower, transa, unit_nonunit, m, n, alpha, A_buffer,
+                                        lda, B_buffer, ldb);
                 break;
             default: break;
         }

--- a/tests/unit_tests/blas/level3/trsm_usm.cpp
+++ b/tests/unit_tests/blas/level3/trsm_usm.cpp
@@ -113,14 +113,14 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
 #else
         switch (layout) {
             case oneapi::mkl::layout::col_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A.data(), lda,
-                                   B.data(), ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::column_major::trsm,
+                                        left_right, upper_lower, transa, unit_nonunit, m, n, alpha,
+                                        A.data(), lda, B.data(), ldb, dependencies);
                 break;
             case oneapi::mkl::layout::row_major:
-                TEST_RUN_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm, left_right,
-                                   upper_lower, transa, unit_nonunit, m, n, alpha, A.data(), lda,
-                                   B.data(), ldb, dependencies);
+                TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::mkl::blas::row_major::trsm, left_right,
+                                        upper_lower, transa, unit_nonunit, m, n, alpha, A.data(),
+                                        lda, B.data(), ldb, dependencies);
                 break;
             default: break;
         }

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -228,6 +228,61 @@
         TEST_RUN_PORTFFT_SELECT(q, func, __VA_ARGS__);                     \
     } while (0);
 
+#define TEST_RUN_BLAS_CT_SELECT(q, func, ...)                              \
+    do {                                                                   \
+        if (CHECK_HOST_OR_CPU(q))                                          \
+            TEST_RUN_INTELCPU_SELECT(q, func, __VA_ARGS__);                \
+        else if (q.get_device().is_gpu()) {                                \
+            unsigned int vendor_id = static_cast<unsigned int>(            \
+                q.get_device().get_info<sycl::info::device::vendor_id>()); \
+            if (vendor_id == INTEL_ID)                                     \
+                TEST_RUN_INTELGPU_SELECT(q, func, __VA_ARGS__);            \
+            else if (vendor_id == NVIDIA_ID) {                             \
+                TEST_RUN_NVIDIAGPU_CUBLAS_SELECT(q, func, __VA_ARGS__);    \
+            }                                                              \
+            else if (vendor_id == AMD_ID) {                                \
+                TEST_RUN_AMDGPU_ROCBLAS_SELECT(q, func, __VA_ARGS__);      \
+            }                                                              \
+        }                                                                  \
+        TEST_RUN_PORTBLAS_SELECT(q, func, __VA_ARGS__);                    \
+    } while (0);
+
+#define TEST_RUN_RNG_CT_SELECT(q, func, ...)                               \
+    do {                                                                   \
+        if (CHECK_HOST_OR_CPU(q))                                          \
+            TEST_RUN_INTELCPU_SELECT(q, func, __VA_ARGS__);                \
+        else if (q.get_device().is_gpu()) {                                \
+            unsigned int vendor_id = static_cast<unsigned int>(            \
+                q.get_device().get_info<sycl::info::device::vendor_id>()); \
+            if (vendor_id == INTEL_ID)                                     \
+                TEST_RUN_INTELGPU_SELECT(q, func, __VA_ARGS__);            \
+            else if (vendor_id == NVIDIA_ID) {                             \
+                TEST_RUN_NVIDIAGPU_CURAND_SELECT(q, func, __VA_ARGS__);    \
+            }                                                              \
+            else if (vendor_id == AMD_ID) {                                \
+                TEST_RUN_AMDGPU_ROCRAND_SELECT(q, func, __VA_ARGS__);      \
+            }                                                              \
+        }                                                                  \
+    } while (0);
+
+#define TEST_RUN_LAPACK_CT_SELECT(q, func, ...)                            \
+    do {                                                                   \
+        if (CHECK_HOST_OR_CPU(q))                                          \
+            TEST_RUN_INTELCPU_SELECT(q, func, __VA_ARGS__);                \
+        else if (q.get_device().is_gpu()) {                                \
+            unsigned int vendor_id = static_cast<unsigned int>(            \
+                q.get_device().get_info<sycl::info::device::vendor_id>()); \
+            if (vendor_id == INTEL_ID)                                     \
+                TEST_RUN_INTELGPU_SELECT(q, func, __VA_ARGS__);            \
+            else if (vendor_id == NVIDIA_ID) {                             \
+                TEST_RUN_NVIDIAGPU_CUSOLVER_SELECT(q, func, __VA_ARGS__);  \
+            }                                                              \
+            else if (vendor_id == AMD_ID) {                                \
+                TEST_RUN_AMDGPU_ROCSOLVER_SELECT(q, func, __VA_ARGS__);    \
+            }                                                              \
+        }                                                                  \
+    } while (0);
+
 void print_error_code(sycl::exception const &e);
 
 class DeviceNamePrint {

--- a/tests/unit_tests/lapack/source/gebrd.cpp
+++ b/tests/unit_tests/lapack/source/gebrd.cpp
@@ -73,8 +73,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
             oneapi::mkl::lapack::gebrd_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::gebrd_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::gebrd_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -85,8 +85,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
         oneapi::mkl::lapack::gebrd(queue, m, n, A_dev, lda, d_dev, e_dev, tauq_dev, taup_dev,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::gebrd, m, n, A_dev, lda, d_dev, e_dev,
-                           tauq_dev, taup_dev, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::gebrd, m, n, A_dev, lda, d_dev, e_dev,
+                                  tauq_dev, taup_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -146,8 +146,8 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             oneapi::mkl::lapack::gebrd_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::gebrd_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::gebrd_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -162,9 +162,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::gebrd, m, n, A_dev, lda, d_dev,
-                           e_dev, tauq_dev, taup_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::gebrd, m, n, A_dev, lda,
+                                  d_dev, e_dev, tauq_dev, taup_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/geqrf.cpp
+++ b/tests/unit_tests/lapack/source/geqrf.cpp
@@ -65,8 +65,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
             oneapi::mkl::lapack::geqrf_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::geqrf_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::geqrf_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -77,8 +77,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
         oneapi::mkl::lapack::geqrf(queue, m, n, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::geqrf, m, n, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::geqrf, m, n, A_dev, lda, tau_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -122,8 +122,8 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             oneapi::mkl::lapack::geqrf_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::geqrf_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::geqrf_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -138,9 +138,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::geqrf, m, n, A_dev, lda,
-                           tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::geqrf, m, n, A_dev, lda,
+                                  tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/geqrf_batch_group.cpp
@@ -99,7 +99,7 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             queue, m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(
+        TEST_RUN_LAPACK_CT_SELECT(
             queue, scratchpad_size = oneapi::mkl::lapack::geqrf_batch_scratchpad_size<fp>,
             m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
@@ -124,9 +124,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          lda_vec.data(), tau_dev_ptrs, group_count,
                                          group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::geqrf_batch, m_vec.data(), n_vec.data(),
-                           A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::geqrf_batch, m_vec.data(),
+                                  n_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs,
+                                  group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -236,7 +237,7 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             queue, m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(
+        TEST_RUN_LAPACK_CT_SELECT(
             queue, scratchpad_size = oneapi::mkl::lapack::geqrf_batch_scratchpad_size<fp>,
             m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
@@ -265,10 +266,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::geqrf_batch, m_vec.data(),
-                           n_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::geqrf_batch,
+                                  m_vec.data(), n_vec.data(), A_dev_ptrs, lda_vec.data(),
+                                  tau_dev_ptrs, group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/geqrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/geqrf_batch_stride.cpp
@@ -65,9 +65,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, int64_
             queue, m, n, lda, stride_a, stride_tau, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::geqrf_batch_scratchpad_size<fp>,
-                           m, n, lda, stride_a, stride_tau, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::geqrf_batch_scratchpad_size<fp>, m, n,
+            lda, stride_a, stride_tau, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -78,8 +78,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, int64_
         oneapi::mkl::lapack::geqrf_batch(queue, m, n, A_dev, lda, stride_a, tau_dev, stride_tau,
                                          batch_size, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::geqrf_batch, m, n, A_dev, lda, stride_a,
-                           tau_dev, stride_tau, batch_size, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::geqrf_batch, m, n, A_dev, lda,
+                                  stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -137,9 +138,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             queue, m, n, lda, stride_a, stride_tau, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::geqrf_batch_scratchpad_size<fp>,
-                           m, n, lda, stride_a, stride_tau, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::geqrf_batch_scratchpad_size<fp>, m, n,
+            lda, stride_a, stride_tau, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -154,9 +155,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::geqrf_batch, m, n, A_dev, lda,
-                           stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::geqrf_batch, m, n, A_dev,
+                                  lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/gerqf.cpp
+++ b/tests/unit_tests/lapack/source/gerqf.cpp
@@ -65,8 +65,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
             oneapi::mkl::lapack::gerqf_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::gerqf_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::gerqf_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -77,8 +77,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
         oneapi::mkl::lapack::gerqf(queue, m, n, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::gerqf, m, n, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::gerqf, m, n, A_dev, lda, tau_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -122,8 +122,8 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             oneapi::mkl::lapack::gerqf_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::gerqf_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::gerqf_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -138,9 +138,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::gerqf, m, n, A_dev, lda,
-                           tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::gerqf, m, n, A_dev, lda,
+                                  tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/gesvd.cpp
+++ b/tests/unit_tests/lapack/source/gesvd.cpp
@@ -75,8 +75,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::jobsvd jobu, oneapi::mkl::jo
             queue, jobu, jobvt, m, n, lda, ldu, ldvt);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::gesvd_scratchpad_size<fp>,
-                           jobu, jobvt, m, n, lda, ldu, ldvt);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::gesvd_scratchpad_size<fp>,
+                                  jobu, jobvt, m, n, lda, ldu, ldvt);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -87,8 +88,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::jobsvd jobu, oneapi::mkl::jo
         oneapi::mkl::lapack::gesvd(queue, jobu, jobvt, m, n, A_dev, lda, s_dev, U_dev, ldu, Vt_dev,
                                    ldvt, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::gesvd, jobu, jobvt, m, n, A_dev, lda, s_dev,
-                           U_dev, ldu, Vt_dev, ldvt, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::gesvd, jobu, jobvt, m, n, A_dev, lda,
+                                  s_dev, U_dev, ldu, Vt_dev, ldvt, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -196,8 +197,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::jobsvd jobu, oneapi::m
             queue, jobu, jobvt, m, n, lda, ldu, ldvt);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::gesvd_scratchpad_size<fp>,
-                           jobu, jobvt, m, n, lda, ldu, ldvt);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::gesvd_scratchpad_size<fp>,
+                                  jobu, jobvt, m, n, lda, ldu, ldvt);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -212,9 +214,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::jobsvd jobu, oneapi::m
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::gesvd, jobu, jobvt, m, n, A_dev,
-                           lda, s_dev, U_dev, ldu, Vt_dev, ldvt, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::gesvd, jobu, jobvt, m, n,
+                                  A_dev, lda, s_dev, U_dev, ldu, Vt_dev, ldvt, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrf.cpp
+++ b/tests/unit_tests/lapack/source/getrf.cpp
@@ -68,8 +68,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
             oneapi::mkl::lapack::getrf_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::getrf_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrf_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -80,8 +80,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, uint64
         oneapi::mkl::lapack::getrf(queue, m, n, A_dev, lda, ipiv_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getrf, m, n, A_dev, lda, ipiv_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getrf, m, n, A_dev, lda, ipiv_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -125,8 +125,8 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             oneapi::mkl::lapack::getrf_scratchpad_size<fp>(queue, m, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::getrf_scratchpad_size<fp>,
-                           m, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrf_scratchpad_size<fp>, m, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -141,9 +141,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrf, m, n, A_dev, lda,
-                           ipiv_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrf, m, n, A_dev, lda,
+                                  ipiv_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrf_batch_group.cpp
@@ -103,7 +103,7 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             queue, m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(
+        TEST_RUN_LAPACK_CT_SELECT(
             queue, scratchpad_size = oneapi::mkl::lapack::getrf_batch_scratchpad_size<fp>,
             m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
@@ -128,9 +128,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          lda_vec.data(), ipiv_dev_ptrs, group_count,
                                          group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getrf_batch, m_vec.data(), n_vec.data(),
-                           A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getrf_batch, m_vec.data(),
+                                  n_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs,
+                                  group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -245,7 +246,7 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             queue, m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(
+        TEST_RUN_LAPACK_CT_SELECT(
             queue, scratchpad_size = oneapi::mkl::lapack::getrf_batch_scratchpad_size<fp>,
             m_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
@@ -274,10 +275,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrf_batch, m_vec.data(),
-                           n_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, func_event = oneapi::mkl::lapack::getrf_batch, m_vec.data(), n_vec.data(),
+            A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, group_count, group_sizes_vec.data(),
+            scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getrf_batch_stride.cpp
@@ -65,9 +65,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, int64_
             queue, m, n, lda, stride_a, stride_ipiv, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getrf_batch_scratchpad_size<fp>,
-                           m, n, lda, stride_a, stride_ipiv, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrf_batch_scratchpad_size<fp>, m, n,
+            lda, stride_a, stride_ipiv, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -78,8 +78,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, int64_
         oneapi::mkl::lapack::getrf_batch(queue, m, n, A_dev, lda, stride_a, ipiv_dev, stride_ipiv,
                                          batch_size, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getrf_batch, m, n, A_dev, lda, stride_a,
-                           ipiv_dev, stride_ipiv, batch_size, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getrf_batch, m, n, A_dev, lda,
+                                  stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -137,9 +138,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             queue, m, n, lda, stride_a, stride_ipiv, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getrf_batch_scratchpad_size<fp>,
-                           m, n, lda, stride_a, stride_ipiv, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrf_batch_scratchpad_size<fp>, m, n,
+            lda, stride_a, stride_ipiv, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -154,9 +155,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t lda, 
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrf_batch, m, n, A_dev, lda,
-                           stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrf_batch, m, n, A_dev,
+                                  lda, stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getri.cpp
+++ b/tests/unit_tests/lapack/source/getri.cpp
@@ -73,8 +73,8 @@ bool accuracy(const sycl::device& dev, int64_t n, int64_t lda, uint64_t seed) {
         const auto scratchpad_size = oneapi::mkl::lapack::getri_scratchpad_size<fp>(queue, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::getri_scratchpad_size<fp>,
-                           n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getri_scratchpad_size<fp>, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -85,8 +85,8 @@ bool accuracy(const sycl::device& dev, int64_t n, int64_t lda, uint64_t seed) {
 #ifdef CALL_RT_API
         oneapi::mkl::lapack::getri(queue, n, A_dev, lda, ipiv_dev, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getri, n, A_dev, lda, ipiv_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getri, n, A_dev, lda, ipiv_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -135,8 +135,8 @@ bool usm_dependency(const sycl::device& dev, int64_t n, int64_t lda, uint64_t se
         const auto scratchpad_size = oneapi::mkl::lapack::getri_scratchpad_size<fp>(queue, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::getri_scratchpad_size<fp>,
-                           n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getri_scratchpad_size<fp>, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -152,8 +152,9 @@ bool usm_dependency(const sycl::device& dev, int64_t n, int64_t lda, uint64_t se
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getri, n, A_dev, lda, ipiv_dev,
-                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getri, n, A_dev, lda,
+                                  ipiv_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getri_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getri_batch_group.cpp
@@ -110,9 +110,9 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             queue, n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>,
-                           n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>,
+            n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -138,9 +138,9 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          ipiv_dev_ptrs, group_count, group_sizes_vec.data(),
                                          scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getri_batch, n_vec.data(), A_dev_ptrs,
-                           lda_vec.data(), ipiv_dev_ptrs, group_count, group_sizes_vec.data(),
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getri_batch, n_vec.data(), A_dev_ptrs,
+                                  lda_vec.data(), ipiv_dev_ptrs, group_count,
+                                  group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -258,9 +258,9 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             queue, n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>,
-                           n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>,
+            n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -290,10 +290,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getri_batch, n_vec.data(),
-                           A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getri_batch,
+                                  n_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs,
+                                  group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getri_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getri_batch_stride.cpp
@@ -72,9 +72,9 @@ bool accuracy(const sycl::device& dev, int64_t n, int64_t lda, int64_t stride_a,
             queue, n, lda, stride_a, stride_ipiv, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>,
-                           n, lda, stride_a, stride_ipiv, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>, n, lda,
+            stride_a, stride_ipiv, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -86,8 +86,9 @@ bool accuracy(const sycl::device& dev, int64_t n, int64_t lda, int64_t stride_a,
         oneapi::mkl::lapack::getri_batch(queue, n, A_dev, lda, stride_a, ipiv_dev, stride_ipiv,
                                          batch_size, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getri_batch, n, A_dev, lda, stride_a,
-                           ipiv_dev, stride_ipiv, batch_size, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getri_batch, n, A_dev, lda, stride_a,
+                                  ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -151,9 +152,9 @@ bool usm_dependency(const sycl::device& dev, int64_t n, int64_t lda, int64_t str
             queue, n, lda, stride_a, stride_ipiv, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>,
-                           n, lda, stride_a, stride_ipiv, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getri_batch_scratchpad_size<fp>, n, lda,
+            stride_a, stride_ipiv, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -169,9 +170,9 @@ bool usm_dependency(const sycl::device& dev, int64_t n, int64_t lda, int64_t str
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getri_batch, n, A_dev, lda,
-                           stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getri_batch, n, A_dev,
+                                  lda, stride_a, ipiv_dev, stride_ipiv, batch_size, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrs.cpp
+++ b/tests/unit_tests/lapack/source/getrs.cpp
@@ -73,8 +73,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::transpose trans, int64_t n, 
             oneapi::mkl::lapack::getrs_scratchpad_size<fp>(queue, trans, n, nrhs, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::getrs_scratchpad_size<fp>,
-                           trans, n, nrhs, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::getrs_scratchpad_size<fp>,
+                                  trans, n, nrhs, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -87,8 +88,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::transpose trans, int64_t n, 
         oneapi::mkl::lapack::getrs(queue, trans, n, nrhs, A_dev, lda, ipiv_dev, B_dev, ldb,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getrs, trans, n, nrhs, A_dev, lda, ipiv_dev,
-                           B_dev, ldb, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getrs, trans, n, nrhs, A_dev, lda,
+                                  ipiv_dev, B_dev, ldb, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -144,8 +145,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::transpose trans, int64
             oneapi::mkl::lapack::getrs_scratchpad_size<fp>(queue, trans, n, nrhs, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::getrs_scratchpad_size<fp>,
-                           trans, n, nrhs, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::getrs_scratchpad_size<fp>,
+                                  trans, n, nrhs, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -162,9 +164,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::transpose trans, int64
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrs, trans, n, nrhs, A_dev,
-                           lda, ipiv_dev, B_dev, ldb, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrs, trans, n, nrhs,
+                                  A_dev, lda, ipiv_dev, B_dev, ldb, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrs_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/getrs_batch_group.cpp
@@ -132,10 +132,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>,
-                           trans_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(),
-                           ldb_vec.data(), group_count, group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>,
+            trans_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(), ldb_vec.data(),
+            group_count, group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -167,10 +167,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          ldb_vec.data(), group_count, group_sizes_vec.data(),
                                          scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getrs_batch, trans_vec.data(), n_vec.data(),
-                           nrhs_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs, B_dev_ptrs,
-                           ldb_vec.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-                           scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getrs_batch, trans_vec.data(),
+                                  n_vec.data(), nrhs_vec.data(), A_dev_ptrs, lda_vec.data(),
+                                  ipiv_dev_ptrs, B_dev_ptrs, ldb_vec.data(), group_count,
+                                  group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -318,10 +318,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>,
-                           trans_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(),
-                           ldb_vec.data(), group_count, group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>,
+            trans_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(), ldb_vec.data(),
+            group_count, group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -356,10 +356,11 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrs_batch, trans_vec.data(),
-                           n_vec.data(), nrhs_vec.data(), A_dev_ptrs, lda_vec.data(), ipiv_dev_ptrs,
-                           B_dev_ptrs, ldb_vec.data(), group_count, group_sizes_vec.data(),
-                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrs_batch,
+                                  trans_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs,
+                                  lda_vec.data(), ipiv_dev_ptrs, B_dev_ptrs, ldb_vec.data(),
+                                  group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/getrs_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/getrs_batch_stride.cpp
@@ -78,9 +78,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::transpose trans, int64_t n, 
             queue, trans, n, nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>,
-                           trans, n, nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>, trans, n,
+            nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -94,9 +94,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::transpose trans, int64_t n, 
                                          stride_ipiv, B_dev, ldb, stride_b, batch_size,
                                          scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::getrs_batch, trans, n, nrhs, A_dev, lda,
-                           stride_a, ipiv_dev, stride_ipiv, B_dev, ldb, stride_b, batch_size,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::getrs_batch, trans, n, nrhs, A_dev,
+                                  lda, stride_a, ipiv_dev, stride_ipiv, B_dev, ldb, stride_b,
+                                  batch_size, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -167,9 +167,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::transpose trans, int64
             queue, trans, n, nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>,
-                           trans, n, nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::getrs_batch_scratchpad_size<fp>, trans, n,
+            nrhs, lda, stride_a, stride_ipiv, ldb, stride_b, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -187,10 +187,10 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::transpose trans, int64
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrs_batch, trans, n, nrhs,
-                           A_dev, lda, stride_a, ipiv_dev, stride_ipiv, B_dev, ldb, stride_b,
-                           batch_size, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::getrs_batch, trans, n,
+                                  nrhs, A_dev, lda, stride_a, ipiv_dev, stride_ipiv, B_dev, ldb,
+                                  stride_b, batch_size, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/heevd.cpp
+++ b/tests/unit_tests/lapack/source/heevd.cpp
@@ -62,8 +62,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl::uplo 
             oneapi::mkl::lapack::heevd_scratchpad_size<fp>(queue, jobz, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::heevd_scratchpad_size<fp>,
-                           jobz, uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::heevd_scratchpad_size<fp>,
+                                  jobz, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -74,8 +75,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl::uplo 
         oneapi::mkl::lapack::heevd(queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::heevd, jobz, uplo, n, A_dev, lda, w_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::heevd, jobz, uplo, n, A_dev, lda,
+                                  w_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -119,8 +120,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
             oneapi::mkl::lapack::heevd_scratchpad_size<fp>(queue, jobz, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::heevd_scratchpad_size<fp>,
-                           jobz, uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::heevd_scratchpad_size<fp>,
+                                  jobz, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -135,9 +137,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::heevd, jobz, uplo, n, A_dev,
-                           lda, w_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::heevd, jobz, uplo, n,
+                                  A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/hegvd.cpp
+++ b/tests/unit_tests/lapack/source/hegvd.cpp
@@ -68,8 +68,9 @@ bool accuracy(const sycl::device& dev, int64_t itype, oneapi::mkl::job jobz, one
             oneapi::mkl::lapack::hegvd_scratchpad_size<fp>(queue, itype, jobz, uplo, n, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::hegvd_scratchpad_size<fp>,
-                           itype, jobz, uplo, n, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::hegvd_scratchpad_size<fp>,
+                                  itype, jobz, uplo, n, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -81,8 +82,8 @@ bool accuracy(const sycl::device& dev, int64_t itype, oneapi::mkl::job jobz, one
         oneapi::mkl::lapack::hegvd(queue, itype, jobz, uplo, n, A_dev, lda, B_dev, ldb, w_dev,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::hegvd, itype, jobz, uplo, n, A_dev, lda,
-                           B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::hegvd, itype, jobz, uplo, n, A_dev,
+                                  lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -255,8 +256,9 @@ bool usm_dependency(const sycl::device& dev, int64_t itype, oneapi::mkl::job job
             oneapi::mkl::lapack::hegvd_scratchpad_size<fp>(queue, itype, jobz, uplo, n, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::hegvd_scratchpad_size<fp>,
-                           itype, jobz, uplo, n, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::hegvd_scratchpad_size<fp>,
+                                  itype, jobz, uplo, n, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -272,9 +274,9 @@ bool usm_dependency(const sycl::device& dev, int64_t itype, oneapi::mkl::job job
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::hegvd, itype, jobz, uplo, n,
-                           A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::hegvd, itype, jobz, uplo,
+                                  n, A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/hetrd.cpp
+++ b/tests/unit_tests/lapack/source/hetrd.cpp
@@ -66,8 +66,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::hetrd_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::hetrd_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::hetrd_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -81,8 +81,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::hetrd(queue, uplo, n, A_dev, lda, d_dev, e_dev, tau_dev,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::hetrd, uplo, n, A_dev, lda, d_dev, e_dev,
-                           tau_dev, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::hetrd, uplo, n, A_dev, lda, d_dev,
+                                  e_dev, tau_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -179,8 +179,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::hetrd_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::hetrd_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::hetrd_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -198,9 +198,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::hetrd, uplo, n, A_dev, lda,
-                           d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::hetrd, uplo, n, A_dev,
+                                  lda, d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/hetrf.cpp
+++ b/tests/unit_tests/lapack/source/hetrf.cpp
@@ -66,8 +66,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::hetrf_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::hetrf_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::hetrf_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -79,8 +79,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::hetrf(queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::hetrf, uplo, n, A_dev, lda, ipiv_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::hetrf, uplo, n, A_dev, lda, ipiv_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -239,8 +239,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::hetrf_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::hetrf_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::hetrf_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -256,9 +256,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::hetrf, uplo, n, A_dev, lda,
-                           ipiv_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::hetrf, uplo, n, A_dev,
+                                  lda, ipiv_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgbr.cpp
+++ b/tests/unit_tests/lapack/source/orgbr.cpp
@@ -82,8 +82,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::generate vect, int64_t m, in
             oneapi::mkl::lapack::orgbr_scratchpad_size<fp>(queue, vect, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::orgbr_scratchpad_size<fp>,
-                           vect, m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::orgbr_scratchpad_size<fp>,
+                                  vect, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -95,8 +96,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::generate vect, int64_t m, in
         oneapi::mkl::lapack::orgbr(queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::orgbr, vect, m, n, k, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::orgbr, vect, m, n, k, A_dev, lda,
+                                  tau_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -156,8 +157,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
             oneapi::mkl::lapack::orgbr_scratchpad_size<fp>(queue, vect, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::orgbr_scratchpad_size<fp>,
-                           vect, m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::orgbr_scratchpad_size<fp>,
+                                  vect, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -173,9 +175,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgbr, vect, m, n, k, A_dev,
-                           lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgbr, vect, m, n, k,
+                                  A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgqr.cpp
+++ b/tests/unit_tests/lapack/source/orgqr.cpp
@@ -71,8 +71,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
             oneapi::mkl::lapack::orgqr_scratchpad_size<fp>(queue, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::orgqr_scratchpad_size<fp>,
-                           m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgqr_scratchpad_size<fp>, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -84,8 +84,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
         oneapi::mkl::lapack::orgqr(queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::orgqr, m, n, k, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::orgqr, m, n, k, A_dev, lda, tau_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -132,8 +132,8 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
             oneapi::mkl::lapack::orgqr_scratchpad_size<fp>(queue, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::orgqr_scratchpad_size<fp>,
-                           m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgqr_scratchpad_size<fp>, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -149,9 +149,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgqr, m, n, k, A_dev, lda,
-                           tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgqr, m, n, k, A_dev,
+                                  lda, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_group.cpp
@@ -106,10 +106,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>,
-                           m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
-                           group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>,
+            m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
+            group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -134,9 +134,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
                                          group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::orgqr_batch, m_vec.data(), n_vec.data(),
-                           k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::orgqr_batch, m_vec.data(),
+                                  n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(),
+                                  tau_dev_ptrs, group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -250,10 +251,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>,
-                           m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
-                           group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>,
+            m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
+            group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -282,10 +283,11 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgqr_batch, m_vec.data(),
-                           n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs,
-                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgqr_batch,
+                                  m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs,
+                                  lda_vec.data(), tau_dev_ptrs, group_count, group_sizes_vec.data(),
+                                  scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgqr_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/orgqr_batch_stride.cpp
@@ -71,9 +71,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
             queue, m, n, k, lda, stride_a, stride_tau, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>,
-                           m, n, k, lda, stride_a, stride_tau, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>, m, n, k,
+            lda, stride_a, stride_tau, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -85,8 +85,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
         oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, A_dev, lda, stride_a, tau_dev, stride_tau,
                                          batch_size, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::orgqr_batch, m, n, k, A_dev, lda, stride_a,
-                           tau_dev, stride_tau, batch_size, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::orgqr_batch, m, n, k, A_dev, lda,
+                                  stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -148,9 +149,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
             queue, m, n, k, lda, stride_a, stride_tau, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>,
-                           m, n, k, lda, stride_a, stride_tau, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgqr_batch_scratchpad_size<fp>, m, n, k,
+            lda, stride_a, stride_tau, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -166,9 +167,10 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgqr_batch, m, n, k, A_dev,
-                           lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgqr_batch, m, n, k,
+                                  A_dev, lda, stride_a, tau_dev, stride_tau, batch_size,
+                                  scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/orgtr.cpp
+++ b/tests/unit_tests/lapack/source/orgtr.cpp
@@ -69,8 +69,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::orgtr_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::orgtr_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgtr_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -82,8 +82,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::orgtr(queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::orgtr, uplo, n, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::orgtr, uplo, n, A_dev, lda, tau_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -133,8 +133,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::orgtr_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::orgtr_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::orgtr_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -150,9 +150,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgtr, uplo, n, A_dev, lda,
-                           tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::orgtr, uplo, n, A_dev,
+                                  lda, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();

--- a/tests/unit_tests/lapack/source/ormqr.cpp
+++ b/tests/unit_tests/lapack/source/ormqr.cpp
@@ -79,8 +79,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ormqr_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ormqr_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -93,8 +94,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
         oneapi::mkl::lapack::ormqr(queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev,
                                    ldc, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ormqr, left_right, trans, m, n, k, A_dev,
-                           lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ormqr, left_right, trans, m, n, k,
+                                  A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -165,8 +166,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ormqr_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ormqr_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -183,9 +185,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ormqr, left_right, trans, m, n,
-                           k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ormqr, left_right, trans,
+                                  m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ormrq.cpp
+++ b/tests/unit_tests/lapack/source/ormrq.cpp
@@ -89,8 +89,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ormrq_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ormrq_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -103,8 +104,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
         oneapi::mkl::lapack::ormrq(queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev,
                                    ldc, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ormrq, left_right, trans, m, n, k, A_dev,
-                           lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ormrq, left_right, trans, m, n, k,
+                                  A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -174,8 +175,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ormrq_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ormrq_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -192,9 +194,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ormrq, left_right, trans, m, n,
-                           k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ormrq, left_right, trans,
+                                  m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ormtr.cpp
+++ b/tests/unit_tests/lapack/source/ormtr.cpp
@@ -77,8 +77,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, int64_
             queue, side, uplo, trans, m, n, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ormtr_scratchpad_size<fp>,
-                           side, uplo, trans, m, n, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ormtr_scratchpad_size<fp>,
+                                  side, uplo, trans, m, n, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -91,8 +92,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, int64_
         oneapi::mkl::lapack::ormtr(queue, side, uplo, trans, m, n, A_dev, lda, tau_dev, C_dev, ldc,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ormtr, side, uplo, trans, m, n, A_dev, lda,
-                           tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ormtr, side, uplo, trans, m, n, A_dev,
+                                  lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -164,8 +165,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, 
             queue, side, uplo, trans, m, n, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ormtr_scratchpad_size<fp>,
-                           side, uplo, trans, m, n, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ormtr_scratchpad_size<fp>,
+                                  side, uplo, trans, m, n, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -182,9 +184,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, 
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ormtr, side, uplo, trans, m, n,
-                           A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ormtr, side, uplo, trans,
+                                  m, n, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();

--- a/tests/unit_tests/lapack/source/potrf.cpp
+++ b/tests/unit_tests/lapack/source/potrf.cpp
@@ -64,8 +64,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::potrf_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::potrf_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrf_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -75,8 +75,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
 #ifdef CALL_RT_API
         oneapi::mkl::lapack::potrf(queue, uplo, n, A_dev, lda, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::potrf, uplo, n, A_dev, lda, scratchpad_dev,
-                           scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::potrf, uplo, n, A_dev, lda,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -117,8 +117,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::potrf_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::potrf_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrf_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -133,8 +133,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
                                        std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrf, uplo, n, A_dev, lda,
-                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrf, uplo, n, A_dev,
+                                  lda, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrf_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/potrf_batch_group.cpp
@@ -95,7 +95,7 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(
+        TEST_RUN_LAPACK_CT_SELECT(
             queue, scratchpad_size = oneapi::mkl::lapack::potrf_batch_scratchpad_size<fp>,
             uplo_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
@@ -117,9 +117,9 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          lda_vec.data(), group_count, group_sizes_vec.data(),
                                          scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::potrf_batch, uplo_vec.data(), n_vec.data(),
-                           A_dev_ptrs, lda_vec.data(), group_count, group_sizes_vec.data(),
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::potrf_batch, uplo_vec.data(),
+                                  n_vec.data(), A_dev_ptrs, lda_vec.data(), group_count,
+                                  group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -218,7 +218,7 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(
+        TEST_RUN_LAPACK_CT_SELECT(
             queue, scratchpad_size = oneapi::mkl::lapack::potrf_batch_scratchpad_size<fp>,
             uplo_vec.data(), n_vec.data(), lda_vec.data(), group_count, group_sizes_vec.data());
 #endif
@@ -244,10 +244,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrf_batch, uplo_vec.data(),
-                           n_vec.data(), A_dev_ptrs, lda_vec.data(), group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrf_batch,
+                                  uplo_vec.data(), n_vec.data(), A_dev_ptrs, lda_vec.data(),
+                                  group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrf_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/potrf_batch_stride.cpp
@@ -62,9 +62,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             queue, uplo, n, lda, stride_a, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::potrf_batch_scratchpad_size<fp>,
-                           uplo, n, lda, stride_a, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrf_batch_scratchpad_size<fp>, uplo, n,
+            lda, stride_a, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -75,8 +75,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::potrf_batch(queue, uplo, n, A_dev, lda, stride_a, batch_size,
                                          scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::potrf_batch, uplo, n, A_dev, lda, stride_a,
-                           batch_size, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::potrf_batch, uplo, n, A_dev, lda,
+                                  stride_a, batch_size, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -128,9 +128,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             queue, uplo, n, lda, stride_a, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::potrf_batch_scratchpad_size<fp>,
-                           uplo, n, lda, stride_a, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrf_batch_scratchpad_size<fp>, uplo, n,
+            lda, stride_a, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -145,9 +145,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrf_batch, uplo, n, A_dev,
-                           lda, stride_a, batch_size, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrf_batch, uplo, n,
+                                  A_dev, lda, stride_a, batch_size, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potri.cpp
+++ b/tests/unit_tests/lapack/source/potri.cpp
@@ -68,8 +68,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::potri_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::potri_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potri_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -79,8 +79,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
 #ifdef CALL_RT_API
         oneapi::mkl::lapack::potri(queue, uplo, n, A_dev, lda, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::potri, uplo, n, A_dev, lda, scratchpad_dev,
-                           scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::potri, uplo, n, A_dev, lda,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -151,8 +151,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::potri_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::potri_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potri_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -167,8 +167,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
                                        std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potri, uplo, n, A_dev, lda,
-                           scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potri, uplo, n, A_dev,
+                                  lda, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrs.cpp
+++ b/tests/unit_tests/lapack/source/potrs.cpp
@@ -71,8 +71,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::potrs_scratchpad_size<fp>(queue, uplo, n, nrhs, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::potrs_scratchpad_size<fp>,
-                           uplo, n, nrhs, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::potrs_scratchpad_size<fp>,
+                                  uplo, n, nrhs, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -84,8 +85,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::potrs(queue, uplo, n, nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::potrs, uplo, n, nrhs, A_dev, lda, B_dev, ldb,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::potrs, uplo, n, nrhs, A_dev, lda,
+                                  B_dev, ldb, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -137,8 +138,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::potrs_scratchpad_size<fp>(queue, uplo, n, nrhs, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::potrs_scratchpad_size<fp>,
-                           uplo, n, nrhs, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::potrs_scratchpad_size<fp>,
+                                  uplo, n, nrhs, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -154,9 +156,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrs, uplo, n, nrhs, A_dev,
-                           lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrs, uplo, n, nrhs,
+                                  A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrs_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/potrs_batch_group.cpp
@@ -119,10 +119,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>,
-                           uplo_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(),
-                           ldb_vec.data(), group_count, group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>,
+            uplo_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(), ldb_vec.data(),
+            group_count, group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -148,9 +148,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          group_count, group_sizes_vec.data(), scratchpad_dev,
                                          scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::potrs_batch, uplo_vec.data(), n_vec.data(),
-                           nrhs_vec.data(), A_dev_ptrs, lda_vec.data(), B_dev_ptrs, ldb_vec.data(),
-                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::potrs_batch, uplo_vec.data(),
+                                  n_vec.data(), nrhs_vec.data(), A_dev_ptrs, lda_vec.data(),
+                                  B_dev_ptrs, ldb_vec.data(), group_count, group_sizes_vec.data(),
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -281,10 +282,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             group_count, group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>,
-                           uplo_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(),
-                           ldb_vec.data(), group_count, group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>,
+            uplo_vec.data(), n_vec.data(), nrhs_vec.data(), lda_vec.data(), ldb_vec.data(),
+            group_count, group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -313,10 +314,11 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrs_batch, uplo_vec.data(),
-                           n_vec.data(), nrhs_vec.data(), A_dev_ptrs, lda_vec.data(), B_dev_ptrs,
-                           ldb_vec.data(), group_count, group_sizes_vec.data(), scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrs_batch,
+                                  uplo_vec.data(), n_vec.data(), nrhs_vec.data(), A_dev_ptrs,
+                                  lda_vec.data(), B_dev_ptrs, ldb_vec.data(), group_count,
+                                  group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/potrs_batch_stride.cpp
@@ -76,9 +76,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             queue, uplo, n, nrhs, lda, stride_a, ldb, stride_b, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>,
-                           uplo, n, nrhs, lda, stride_a, ldb, stride_b, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>, uplo, n,
+            nrhs, lda, stride_a, ldb, stride_b, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -90,9 +90,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::potrs_batch(queue, uplo, n, nrhs, A_dev, lda, stride_a, B_dev, ldb,
                                          stride_b, batch_size, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::potrs_batch, uplo, n, nrhs, A_dev, lda,
-                           stride_a, B_dev, ldb, stride_b, batch_size, scratchpad_dev,
-                           scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::potrs_batch, uplo, n, nrhs, A_dev,
+                                  lda, stride_a, B_dev, ldb, stride_b, batch_size, scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -161,9 +161,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             queue, uplo, n, nrhs, lda, stride_a, ldb, stride_b, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>,
-                           uplo, n, nrhs, lda, stride_a, ldb, stride_b, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::potrs_batch_scratchpad_size<fp>, uplo, n,
+            nrhs, lda, stride_a, ldb, stride_b, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -179,9 +179,10 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             scratchpad_dev, scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrs_batch, uplo, n, nrhs,
-                           A_dev, lda, stride_a, B_dev, ldb, stride_b, batch_size, scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::potrs_batch, uplo, n,
+                                  nrhs, A_dev, lda, stride_a, B_dev, ldb, stride_b, batch_size,
+                                  scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/syevd.cpp
+++ b/tests/unit_tests/lapack/source/syevd.cpp
@@ -62,8 +62,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl::uplo 
             oneapi::mkl::lapack::syevd_scratchpad_size<fp>(queue, jobz, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::syevd_scratchpad_size<fp>,
-                           jobz, uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::syevd_scratchpad_size<fp>,
+                                  jobz, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -74,8 +75,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl::uplo 
         oneapi::mkl::lapack::syevd(queue, jobz, uplo, n, A_dev, lda, w_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::syevd, jobz, uplo, n, A_dev, lda, w_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::syevd, jobz, uplo, n, A_dev, lda,
+                                  w_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -119,8 +120,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
             oneapi::mkl::lapack::syevd_scratchpad_size<fp>(queue, jobz, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::syevd_scratchpad_size<fp>,
-                           jobz, uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::syevd_scratchpad_size<fp>,
+                                  jobz, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -135,9 +137,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::job jobz, oneapi::mkl:
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::syevd, jobz, uplo, n, A_dev,
-                           lda, w_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::syevd, jobz, uplo, n,
+                                  A_dev, lda, w_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/sygvd.cpp
+++ b/tests/unit_tests/lapack/source/sygvd.cpp
@@ -68,8 +68,9 @@ bool accuracy(const sycl::device& dev, int64_t itype, oneapi::mkl::job jobz, one
             oneapi::mkl::lapack::sygvd_scratchpad_size<fp>(queue, itype, jobz, uplo, n, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::sygvd_scratchpad_size<fp>,
-                           itype, jobz, uplo, n, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::sygvd_scratchpad_size<fp>,
+                                  itype, jobz, uplo, n, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -81,8 +82,8 @@ bool accuracy(const sycl::device& dev, int64_t itype, oneapi::mkl::job jobz, one
         oneapi::mkl::lapack::sygvd(queue, itype, jobz, uplo, n, A_dev, lda, B_dev, ldb, w_dev,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::sygvd, itype, jobz, uplo, n, A_dev, lda,
-                           B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::sygvd, itype, jobz, uplo, n, A_dev,
+                                  lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -260,8 +261,9 @@ bool usm_dependency(const sycl::device& dev, int64_t itype, oneapi::mkl::job job
             oneapi::mkl::lapack::sygvd_scratchpad_size<fp>(queue, itype, jobz, uplo, n, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::sygvd_scratchpad_size<fp>,
-                           itype, jobz, uplo, n, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::sygvd_scratchpad_size<fp>,
+                                  itype, jobz, uplo, n, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -277,9 +279,9 @@ bool usm_dependency(const sycl::device& dev, int64_t itype, oneapi::mkl::job job
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::sygvd, itype, jobz, uplo, n,
-                           A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::sygvd, itype, jobz, uplo,
+                                  n, A_dev, lda, B_dev, ldb, w_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/sytrd.cpp
+++ b/tests/unit_tests/lapack/source/sytrd.cpp
@@ -66,8 +66,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::sytrd_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::sytrd_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::sytrd_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -81,8 +81,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::sytrd(queue, uplo, n, A_dev, lda, d_dev, e_dev, tau_dev,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::sytrd, uplo, n, A_dev, lda, d_dev, e_dev,
-                           tau_dev, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::sytrd, uplo, n, A_dev, lda, d_dev,
+                                  e_dev, tau_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -179,8 +179,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::sytrd_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::sytrd_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::sytrd_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -198,9 +198,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::sytrd, uplo, n, A_dev, lda,
-                           d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::sytrd, uplo, n, A_dev,
+                                  lda, d_dev, e_dev, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/sytrf.cpp
+++ b/tests/unit_tests/lapack/source/sytrf.cpp
@@ -63,8 +63,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::sytrf_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::sytrf_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::sytrf_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -76,8 +76,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::sytrf(queue, uplo, n, A_dev, lda, ipiv_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::sytrf, uplo, n, A_dev, lda, ipiv_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::sytrf, uplo, n, A_dev, lda, ipiv_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -236,8 +236,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::sytrf_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::sytrf_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::sytrf_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -253,9 +253,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::sytrf, uplo, n, A_dev, lda,
-                           ipiv_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::sytrf, uplo, n, A_dev,
+                                  lda, ipiv_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/trtrs.cpp
+++ b/tests/unit_tests/lapack/source/trtrs.cpp
@@ -74,8 +74,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, oneapi::mkl::tran
             queue, uplo, trans, diag, n, nrhs, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::trtrs_scratchpad_size<fp>,
-                           uplo, trans, diag, n, nrhs, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::trtrs_scratchpad_size<fp>,
+                                  uplo, trans, diag, n, nrhs, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -87,8 +88,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, oneapi::mkl::tran
         oneapi::mkl::lapack::trtrs(queue, uplo, trans, diag, n, nrhs, A_dev, lda, B_dev, ldb,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::trtrs, uplo, trans, diag, n, nrhs, A_dev,
-                           lda, B_dev, ldb, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::trtrs, uplo, trans, diag, n, nrhs,
+                                  A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -136,8 +137,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, oneapi::mkl
             queue, uplo, trans, diag, n, nrhs, lda, ldb);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::trtrs_scratchpad_size<fp>,
-                           uplo, trans, diag, n, nrhs, lda, ldb);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::trtrs_scratchpad_size<fp>,
+                                  uplo, trans, diag, n, nrhs, lda, ldb);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -153,9 +155,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, oneapi::mkl
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::trtrs, uplo, trans, diag, n,
-                           nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::trtrs, uplo, trans, diag,
+                                  n, nrhs, A_dev, lda, B_dev, ldb, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungbr.cpp
+++ b/tests/unit_tests/lapack/source/ungbr.cpp
@@ -82,8 +82,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::generate vect, int64_t m, in
             oneapi::mkl::lapack::ungbr_scratchpad_size<fp>(queue, vect, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ungbr_scratchpad_size<fp>,
-                           vect, m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ungbr_scratchpad_size<fp>,
+                                  vect, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -95,8 +96,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::generate vect, int64_t m, in
         oneapi::mkl::lapack::ungbr(queue, vect, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ungbr, vect, m, n, k, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ungbr, vect, m, n, k, A_dev, lda,
+                                  tau_dev, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -156,8 +157,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
             oneapi::mkl::lapack::ungbr_scratchpad_size<fp>(queue, vect, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ungbr_scratchpad_size<fp>,
-                           vect, m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::ungbr_scratchpad_size<fp>,
+                                  vect, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -173,9 +175,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::generate vect, int64_t
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungbr, vect, m, n, k, A_dev,
-                           lda, tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungbr, vect, m, n, k,
+                                  A_dev, lda, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungqr.cpp
+++ b/tests/unit_tests/lapack/source/ungqr.cpp
@@ -70,8 +70,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
             oneapi::mkl::lapack::ungqr_scratchpad_size<fp>(queue, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ungqr_scratchpad_size<fp>,
-                           m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungqr_scratchpad_size<fp>, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -83,8 +83,8 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
         oneapi::mkl::lapack::ungqr(queue, m, n, k, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ungqr, m, n, k, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ungqr, m, n, k, A_dev, lda, tau_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -131,8 +131,8 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
             oneapi::mkl::lapack::ungqr_scratchpad_size<fp>(queue, m, n, k, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ungqr_scratchpad_size<fp>,
-                           m, n, k, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungqr_scratchpad_size<fp>, m, n, k, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -148,9 +148,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungqr, m, n, k, A_dev, lda,
-                           tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungqr, m, n, k, A_dev,
+                                  lda, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_group.cpp
@@ -106,10 +106,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
             group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>,
-                           m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
-                           group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>,
+            m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
+            group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -134,9 +134,10 @@ bool accuracy(const sycl::device& dev, uint64_t seed) {
                                          A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
                                          group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ungqr_batch, m_vec.data(), n_vec.data(),
-                           k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs, group_count,
-                           group_sizes_vec.data(), scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ungqr_batch, m_vec.data(),
+                                  n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(),
+                                  tau_dev_ptrs, group_count, group_sizes_vec.data(), scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -250,10 +251,10 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             group_sizes_vec.data());
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>,
-                           m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
-                           group_sizes_vec.data());
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>,
+            m_vec.data(), n_vec.data(), k_vec.data(), lda_vec.data(), group_count,
+            group_sizes_vec.data());
 #endif
         auto scratchpad_dev = device_alloc<fp>(queue, scratchpad_size);
 
@@ -282,10 +283,11 @@ bool usm_dependency(const sycl::device& dev, uint64_t seed) {
             std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungqr_batch, m_vec.data(),
-                           n_vec.data(), k_vec.data(), A_dev_ptrs, lda_vec.data(), tau_dev_ptrs,
-                           group_count, group_sizes_vec.data(), scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungqr_batch,
+                                  m_vec.data(), n_vec.data(), k_vec.data(), A_dev_ptrs,
+                                  lda_vec.data(), tau_dev_ptrs, group_count, group_sizes_vec.data(),
+                                  scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungqr_batch_stride.cpp
+++ b/tests/unit_tests/lapack/source/ungqr_batch_stride.cpp
@@ -71,9 +71,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
             queue, m, n, k, lda, stride_a, stride_tau, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>,
-                           m, n, k, lda, stride_a, stride_tau, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>, m, n, k,
+            lda, stride_a, stride_tau, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -85,8 +85,9 @@ bool accuracy(const sycl::device& dev, int64_t m, int64_t n, int64_t k, int64_t 
         oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, A_dev, lda, stride_a, tau_dev, stride_tau,
                                          batch_size, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ungqr_batch, m, n, k, A_dev, lda, stride_a,
-                           tau_dev, stride_tau, batch_size, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ungqr_batch, m, n, k, A_dev, lda,
+                                  stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
+                                  scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -148,9 +149,9 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
             queue, m, n, k, lda, stride_a, stride_tau, batch_size);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue,
-                           scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>,
-                           m, n, k, lda, stride_a, stride_tau, batch_size);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungqr_batch_scratchpad_size<fp>, m, n, k,
+            lda, stride_a, stride_tau, batch_size);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -166,9 +167,10 @@ bool usm_dependency(const sycl::device& dev, int64_t m, int64_t n, int64_t k, in
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungqr_batch, m, n, k, A_dev,
-                           lda, stride_a, tau_dev, stride_tau, batch_size, scratchpad_dev,
-                           scratchpad_size, std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungqr_batch, m, n, k,
+                                  A_dev, lda, stride_a, tau_dev, stride_tau, batch_size,
+                                  scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/ungtr.cpp
+++ b/tests/unit_tests/lapack/source/ungtr.cpp
@@ -69,8 +69,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             oneapi::mkl::lapack::ungtr_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ungtr_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungtr_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -82,8 +82,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
         oneapi::mkl::lapack::ungtr(queue, uplo, n, A_dev, lda, tau_dev, scratchpad_dev,
                                    scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::ungtr, uplo, n, A_dev, lda, tau_dev,
-                           scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::ungtr, uplo, n, A_dev, lda, tau_dev,
+                                  scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -133,8 +133,8 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
             oneapi::mkl::lapack::ungtr_scratchpad_size<fp>(queue, uplo, n, lda);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::ungtr_scratchpad_size<fp>,
-                           uplo, n, lda);
+        TEST_RUN_LAPACK_CT_SELECT(
+            queue, scratchpad_size = oneapi::mkl::lapack::ungtr_scratchpad_size<fp>, uplo, n, lda);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -150,9 +150,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, 
                                        scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungtr, uplo, n, A_dev, lda,
-                           tau_dev, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::ungtr, uplo, n, A_dev,
+                                  lda, tau_dev, scratchpad_dev, scratchpad_size,
+                                  std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();

--- a/tests/unit_tests/lapack/source/unmqr.cpp
+++ b/tests/unit_tests/lapack/source/unmqr.cpp
@@ -79,8 +79,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::unmqr_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::unmqr_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -93,8 +94,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
         oneapi::mkl::lapack::unmqr(queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev,
                                    ldc, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::unmqr, left_right, trans, m, n, k, A_dev,
-                           lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::unmqr, left_right, trans, m, n, k,
+                                  A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -165,8 +166,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::unmqr_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::unmqr_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -183,9 +185,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::unmqr, left_right, trans, m, n,
-                           k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::unmqr, left_right, trans,
+                                  m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/unmrq.cpp
+++ b/tests/unit_tests/lapack/source/unmrq.cpp
@@ -89,8 +89,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::unmrq_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::unmrq_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -103,8 +104,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::side left_right, oneapi::mkl
         oneapi::mkl::lapack::unmrq(queue, left_right, trans, m, n, k, A_dev, lda, tau_dev, C_dev,
                                    ldc, scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::unmrq, left_right, trans, m, n, k, A_dev,
-                           lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::unmrq, left_right, trans, m, n, k,
+                                  A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -174,8 +175,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             queue, left_right, trans, m, n, k, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::unmrq_scratchpad_size<fp>,
-                           left_right, trans, m, n, k, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::unmrq_scratchpad_size<fp>,
+                                  left_right, trans, m, n, k, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -192,9 +194,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::side left_right,
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::unmrq, left_right, trans, m, n,
-                           k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::unmrq, left_right, trans,
+                                  m, n, k, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
 

--- a/tests/unit_tests/lapack/source/unmtr.cpp
+++ b/tests/unit_tests/lapack/source/unmtr.cpp
@@ -77,8 +77,9 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, int64_
             queue, side, uplo, trans, m, n, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::unmtr_scratchpad_size<fp>,
-                           side, uplo, trans, m, n, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::unmtr_scratchpad_size<fp>,
+                                  side, uplo, trans, m, n, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -91,8 +92,8 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, int64_
         oneapi::mkl::lapack::unmtr(queue, side, uplo, trans, m, n, A_dev, lda, tau_dev, C_dev, ldc,
                                    scratchpad_dev, scratchpad_size);
 #else
-        TEST_RUN_CT_SELECT(queue, oneapi::mkl::lapack::unmtr, side, uplo, trans, m, n, A_dev, lda,
-                           tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
+        TEST_RUN_LAPACK_CT_SELECT(queue, oneapi::mkl::lapack::unmtr, side, uplo, trans, m, n, A_dev,
+                                  lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size);
 #endif
         queue.wait_and_throw();
 
@@ -164,8 +165,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, 
             queue, side, uplo, trans, m, n, lda, ldc);
 #else
         int64_t scratchpad_size;
-        TEST_RUN_CT_SELECT(queue, scratchpad_size = oneapi::mkl::lapack::unmtr_scratchpad_size<fp>,
-                           side, uplo, trans, m, n, lda, ldc);
+        TEST_RUN_LAPACK_CT_SELECT(queue,
+                                  scratchpad_size = oneapi::mkl::lapack::unmtr_scratchpad_size<fp>,
+                                  side, uplo, trans, m, n, lda, ldc);
 #endif
         auto scratchpad_dev = device_alloc<data_T>(queue, scratchpad_size);
 
@@ -182,9 +184,9 @@ bool usm_dependency(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t m, 
             scratchpad_size, std::vector<sycl::event>{ in_event });
 #else
         sycl::event func_event;
-        TEST_RUN_CT_SELECT(queue, func_event = oneapi::mkl::lapack::unmtr, side, uplo, trans, m, n,
-                           A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev, scratchpad_size,
-                           std::vector<sycl::event>{ in_event });
+        TEST_RUN_LAPACK_CT_SELECT(queue, func_event = oneapi::mkl::lapack::unmtr, side, uplo, trans,
+                                  m, n, A_dev, lda, tau_dev, C_dev, ldc, scratchpad_dev,
+                                  scratchpad_size, std::vector<sycl::event>{ in_event });
 #endif
         result = check_dependency(queue, in_event, func_event);
         queue.wait_and_throw();

--- a/tests/unit_tests/rng/include/rng_test_common.hpp
+++ b/tests/unit_tests/rng/include/rng_test_common.hpp
@@ -112,7 +112,7 @@ public:
 #ifdef CALL_RT_API
         test_(queue, args...);
 #else
-        TEST_RUN_CT_SELECT(queue, test_, args...);
+        TEST_RUN_RNG_CT_SELECT(queue, test_, args...);
 #endif
 
         return test_.status;


### PR DESCRIPTION
# Description

For compile-time linking our tests currently assume only one CUDA backend (eg cublas, curand, cusolver) is enabled at once. This PR fixes this limitation.

Fixes #127

The substantive changes are only in `tests/unit_tests/include/test_helper.hpp`, all the other changes are just text replacement of some macro names.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? [test_issue127.txt](https://github.com/oneapi-src/oneMKL/files/13688469/test_issue127.txt)
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [ ] Have you added relevant regression tests? (not applicable)
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
