### PR TITLE
[BLAS::portBLAS backend] Enable iamax, iamin and axpy_batch operators

### DIFF
--- a/src/blas/backends/portblas/portblas_batch.cxx
+++ b/src/blas/backends/portblas/portblas_batch.cxx
@@ -118,13 +118,15 @@ void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m
 void axpy_batch(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
                 std::int64_t incx, std::int64_t stridex, sycl::buffer<float, 1> &y,
                 std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
-    throw unimplemented("blas", "axpy_batch", "");
+    CALL_PORTBLAS_FN(::blas::_axpy_batch, queue, n, alpha, x, incx, stridex, y, incy, stridey,
+                     batch_size);
 }
 
 void axpy_batch(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double, 1> &x,
                 std::int64_t incx, std::int64_t stridex, sycl::buffer<double, 1> &y,
                 std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
-    throw unimplemented("blas", "axpy_batch", "");
+    CALL_PORTBLAS_FN(::blas::_axpy_batch, queue, n, alpha, x, incx, stridex, y, incy, stridey,
+                     batch_size);
 }
 
 void axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
@@ -573,14 +575,16 @@ sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, float alpha, const fl
                        std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy,
                        std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "axpy_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_axpy_batch, queue, n, alpha, x, incx, stridex, y, incy, stridey,
+                         batch_size, dependencies);
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                        std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy,
                        std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "axpy_batch", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_axpy_batch, queue, n, alpha, x, incx, stridex, y, incy, stridey,
+                         batch_size, dependencies);
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,

--- a/src/blas/backends/portblas/portblas_level1.cxx
+++ b/src/blas/backends/portblas/portblas_level1.cxx
@@ -33,7 +33,7 @@ void dotu(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<real_t>,
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<real_t, 1> &x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1> &result) {
-    throw unimplemented("blas", "iamax", "");
+    CALL_PORTBLAS_FN(::blas::_iamax, queue, n, x, incx, result);
 }
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1> &x,
@@ -43,7 +43,7 @@ void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<real_t>
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<real_t, 1> &x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1> &result) {
-    throw unimplemented("blas", "iamin", "");
+    CALL_PORTBLAS_FN(::blas::_iamin, queue, n, x, incx, result);
 }
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1> &x,
@@ -219,7 +219,7 @@ sycl::event dotu(sycl::queue &queue, std::int64_t n, const std::complex<real_t> 
 
 sycl::event iamax(sycl::queue &queue, std::int64_t n, const real_t *x, std::int64_t incx,
                   std::int64_t *result, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "iamax", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_iamax, queue, n, x, incx, result, dependencies);
 }
 
 sycl::event iamax(sycl::queue &queue, std::int64_t n, const std::complex<real_t> *x,
@@ -230,7 +230,7 @@ sycl::event iamax(sycl::queue &queue, std::int64_t n, const std::complex<real_t>
 
 sycl::event iamin(sycl::queue &queue, std::int64_t n, const real_t *x, std::int64_t incx,
                   std::int64_t *result, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "iamin", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_iamin, queue, n, x, incx, result, dependencies);
 }
 
 sycl::event iamin(sycl::queue &queue, std::int64_t n, const std::complex<real_t> *x,

--- a/src/blas/backends/portblas/portblas_level2.cxx
+++ b/src/blas/backends/portblas/portblas_level2.cxx
@@ -430,7 +430,8 @@ sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl:
 sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const real_t *a, real_t *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw unimplemented("blas", "tpsv", " for USM");
+    CALL_PORTBLAS_USM_FN(::blas::_tpsv, queue, upper_lower, trans, unit_diag, n, a, x, incx,
+                         dependencies);
 }
 
 sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,


### PR DESCRIPTION
# Description
This PR enables `iamax`,`iamin` and `axpy_batch` operators in portBLAS backend both for `buffers` and `usm`. 
It also enable `usm` support for `Tpsv`.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[iamax_log.txt](https://github.com/oneapi-src/oneMKL/files/13706298/iamax_log.txt)
[iamin_log.txt](https://github.com/oneapi-src/oneMKL/files/13706299/iamin_log.txt)
[axpy_batch_log.txt](https://github.com/oneapi-src/oneMKL/files/13706300/axpy_batch_log.txt)
[tpsv_usm_log.txt](https://github.com/oneapi-src/oneMKL/files/13706538/tpsv_usm_log.txt)


- [x] Have you formatted the code using clang-format?

