### PR TITLE
[BLAS:hipSYCL] Fix build issue

### DIFF
--- a/include/oneapi/mkl/bfloat16.hpp
+++ b/include/oneapi/mkl/bfloat16.hpp
@@ -1,0 +1,228 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _BFLOAT16_HPP__
+#define _BFLOAT16_HPP__
+
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+namespace oneapi {
+namespace mkl {
+
+namespace bfloat16_impl {
+
+template <typename T>
+struct is_float_double {
+    static constexpr bool value = false;
+};
+template <>
+struct is_float_double<float> {
+    static constexpr bool value = true;
+};
+template <>
+struct is_float_double<double> {
+    static constexpr bool value = true;
+};
+
+union float_raw {
+    float f;
+    std::uint32_t i;
+};
+
+static inline std::uint32_t float_to_raw(float f) {
+    float_raw r;
+    r.f = f;
+    return r.i;
+}
+
+static inline float raw_to_float(std::uint32_t i) {
+    float_raw r;
+    r.i = i;
+    return r.f;
+}
+
+} /* namespace bfloat16_impl */
+
+struct bfloat16 {
+    std::uint16_t raw;
+
+    bfloat16(int raw_, bool) : raw(raw_) {}
+
+    bfloat16() = default;
+    inline bfloat16(float f);
+    bfloat16(double d) : bfloat16(float(d)) {}
+    template <typename T>
+    bfloat16(T i, typename std::enable_if<std::is_integral<T>::value>::type *_ = nullptr)
+            : bfloat16(float(i)) {}
+
+    inline operator float() const;
+
+    bfloat16 operator+() const {
+        return *this;
+    }
+    bfloat16 operator-() const {
+        bfloat16 h = *this;
+        h.raw ^= 0x8000;
+        return h;
+    }
+
+    bfloat16 operator++() {
+        return (*this = *this + 1);
+    }
+    bfloat16 operator++(int) {
+        bfloat16 h = *this;
+        ++*this;
+        return h;
+    }
+    bfloat16 operator--() {
+        return (*this = *this - 1);
+    }
+    bfloat16 operator--(int) {
+        bfloat16 h = *this;
+        --*this;
+        return h;
+    }
+
+    friend float operator+(const bfloat16 &h1, const bfloat16 &h2) {
+        return float(h1) + float(h2);
+    }
+    friend float operator-(const bfloat16 &h1, const bfloat16 &h2) {
+        return float(h1) - float(h2);
+    }
+    friend float operator*(const bfloat16 &h1, const bfloat16 &h2) {
+        return float(h1) * float(h2);
+    }
+    friend float operator/(const bfloat16 &h1, const bfloat16 &h2) {
+        return float(h1) / float(h2);
+    }
+
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator+(
+        const bfloat16 &h, const T &o) {
+        return float(h) + float(o);
+    }
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator-(
+        const bfloat16 &h, const T &o) {
+        return float(h) - float(o);
+    }
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator*(
+        const bfloat16 &h, const T &o) {
+        return float(h) * float(o);
+    }
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator/(
+        const bfloat16 &h, const T &o) {
+        return float(h) / float(o);
+    }
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator+(
+        const T &o, const bfloat16 &h) {
+        return float(o) + float(h);
+    }
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator-(
+        const T &o, const bfloat16 &h) {
+        return float(o) - float(h);
+    }
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator*(
+        const T &o, const bfloat16 &h) {
+        return float(o) * float(h);
+    }
+    template <typename T>
+    friend typename std::enable_if<std::is_integral<T>::value, float>::type operator/(
+        const T &o, const bfloat16 &h) {
+        return float(o) / float(h);
+    }
+
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator+(
+        const bfloat16 &h, const T &o) {
+        return float(h) + o;
+    }
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator-(
+        const bfloat16 &h, const T &o) {
+        return float(h) - o;
+    }
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator*(
+        const bfloat16 &h, const T &o) {
+        return float(h) * o;
+    }
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator/(
+        const bfloat16 &h, const T &o) {
+        return float(h) / o;
+    }
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator+(
+        const T &o, const bfloat16 &h) {
+        return o + float(h);
+    }
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator-(
+        const T &o, const bfloat16 &h) {
+        return o - float(h);
+    }
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator*(
+        const T &o, const bfloat16 &h) {
+        return o * float(h);
+    }
+    template <typename T>
+    friend typename std::enable_if<bfloat16_impl::is_float_double<T>::value, T>::type operator/(
+        const T &o, const bfloat16 &h) {
+        return o / float(h);
+    }
+
+    template <typename T>
+    bfloat16 operator+=(const T &o) {
+        return *this = bfloat16(*this + o);
+    }
+    template <typename T>
+    bfloat16 operator-=(const T &o) {
+        return *this = bfloat16(*this - o);
+    }
+    template <typename T>
+    bfloat16 operator*=(const T &o) {
+        return *this = bfloat16(*this * o);
+    }
+    template <typename T>
+    bfloat16 operator/=(const T &o) {
+        return *this = bfloat16(*this / o);
+    }
+};
+
+bfloat16::bfloat16(float f) {
+    raw = bfloat16_impl::float_to_raw(f) >> 16; // RTZ
+}
+
+inline bfloat16::operator float() const {
+    return bfloat16_impl::raw_to_float(raw << 16);
+}
+
+} /* namespace mkl */
+} // namespace oneapi
+
+#endif /* _BFLOAT16_HPP__ */

--- a/include/oneapi/mkl/types.hpp
+++ b/include/oneapi/mkl/types.hpp
@@ -20,6 +20,10 @@
 #ifndef _ONEMKL_TYPES_HPP_
 #define _ONEMKL_TYPES_HPP_
 
+#ifdef __HIPSYCL__
+#include "oneapi/mkl/bfloat16.hpp"
+#endif
+
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else
@@ -29,7 +33,9 @@
 namespace oneapi {
 namespace mkl {
 
+#ifndef __HIPSYCL__
 using bfloat16 = sycl::ext::oneapi::bfloat16;
+#endif
 
 // BLAS flag types.
 enum class transpose : char { nontrans = 0, trans = 1, conjtrans = 3, N = 0, T = 1, C = 3 };

--- a/src/blas/backends/cublas/CMakeLists.txt
+++ b/src/blas/backends/cublas/CMakeLists.txt
@@ -38,10 +38,13 @@ target_include_directories(${LIB_OBJ}
           ${ONEMKL_GENERATED_INCLUDE_PATH}
 )
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
-target_compile_options(ONEMKL::SYCL::SYCL INTERFACE
-      -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda)
-target_link_options(ONEMKL::SYCL::SYCL INTERFACE
-      -fsycl-targets=nvptx64-nvidia-cuda)
+
+if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+    target_compile_options(ONEMKL::SYCL::SYCL INTERFACE
+          -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda)
+    target_link_options(ONEMKL::SYCL::SYCL INTERFACE
+          -fsycl-targets=nvptx64-nvidia-cuda)
+endif()
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ONEMKL::cuBLAS::cuBLAS)
 target_compile_features(${LIB_OBJ} PUBLIC cxx_std_11)
 set_target_properties(${LIB_OBJ} PROPERTIES

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -96,7 +96,9 @@ foreach(domain ${TARGET_DOMAINS})
   if(BUILD_SHARED_LIBS)
     add_executable(test_main_${domain}_rt main_test.cpp)
     target_include_directories(test_main_${domain}_rt PUBLIC ${GTEST_INCLUDE_DIR})
-    target_compile_options(test_main_${domain}_rt PRIVATE -fsycl)
+    if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+      target_compile_options(test_main_${domain}_rt PRIVATE -fsycl)
+    endif()
     target_link_libraries(test_main_${domain}_rt PUBLIC
       gtest
       gtest_main
@@ -186,7 +188,10 @@ foreach(domain ${TARGET_DOMAINS})
       ${${domain}_TEST_LIST_CT}
       ${${domain}_DEVICE_TEST_LIST_CT}
   )
-  target_link_options(test_main_${domain}_ct PUBLIC -fsycl-device-code-split=per_kernel)
+  
+  if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+    target_link_options(test_main_${domain}_ct PUBLIC -fsycl-device-code-split=per_kernel)
+  endif()
 
   string(TOUPPER ${domain} DOMAIN_PREFIX)
 


### PR DESCRIPTION
# Description

As reported in #434 CUDA backend is broken when used with hipSYCL. This PR enables it using LLVM-17 and latest branch from AdaptiveCPP (new name for hipSYCL).

Fixes # (GitHub issue)
#434 

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? Please see attached files: 
[hipsycl_cuda.log](https://github.com/oneapi-src/oneMKL/files/13876454/hipsycl_cuda.log)
[dpcpp_intel.log](https://github.com/oneapi-src/oneMKL/files/13876455/dpcpp_intel.log)

- [X] Have you formatted the code using clang-format?


