### PR TITLE
[BLAS] Fix AMD GPU backend with hipSYCL

### DIFF
--- a/src/blas/backends/rocblas/CMakeLists.txt
+++ b/src/blas/backends/rocblas/CMakeLists.txt
@@ -39,13 +39,21 @@ target_include_directories(${LIB_OBJ}
           ${PROJECT_BINARY_DIR}/bin
           ${ONEMKL_GENERATED_INCLUDE_PATH}
 )
-target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
-target_compile_options(ONEMKL::SYCL::SYCL INTERFACE
-    -fsycl-targets=amdgcn-amd-amdhsa -fsycl-unnamed-lambda
-    -Xsycl-target-backend --offload-arch=${HIP_TARGETS})
-target_link_options(ONEMKL::SYCL::SYCL INTERFACE
-    -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend 
-    --offload-arch=${HIP_TARGETS})
+
+if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+    target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
+    target_compile_options(ONEMKL::SYCL::SYCL INTERFACE
+        -fsycl-targets=amdgcn-amd-amdhsa -fsycl-unnamed-lambda
+        -Xsycl-target-backend --offload-arch=${HIP_TARGETS})
+    target_link_options(ONEMKL::SYCL::SYCL INTERFACE
+        -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend 
+        --offload-arch=${HIP_TARGETS})
+else()
+    target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
+    target_compile_options(ONEMKL::SYCL::SYCL INTERFACE)
+    target_link_options(ONEMKL::SYCL::SYCL INTERFACE)
+endif()
+
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL ONEMKL::rocBLAS::rocBLAS)
 target_compile_features(${LIB_OBJ} PUBLIC cxx_std_17)
 set_target_properties(${LIB_OBJ} PROPERTIES

--- a/src/blas/backends/rocblas/rocblas_helper.hpp
+++ b/src/blas/backends/rocblas/rocblas_helper.hpp
@@ -27,7 +27,7 @@
 
 #define _ROCBLAS_HELPER_HPP_
 
-#include <rocblas.h>
+#include <rocblas/rocblas.h>
 #include <complex>
 #include "oneapi/mkl/types.hpp"
 #include <hip/hip_runtime.h>

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -20,7 +20,7 @@
 **************************************************************************/
 #ifndef _ROCBLAS_TASK_HPP_
 #define _ROCBLAS_TASK_HPP_
-#include <rocblas.h>
+#include <rocblas/rocblas.h>
 #include <complex>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
# Description
BLAS rocBLAS backend is broken with hipSYCL compiler. This PR fixes it. It also removes all of the deprecation warnings. 

- [X] Do all unit tests pass locally? 
[fix_amd_hipsycl.log](https://github.com/oneapi-src/oneMKL/files/13994908/fix_amd_hipsycl.log)

- [X] Have you formatted the code using clang-format?
