### PR TITLE
[BLAS] fix iamin/iamax header to correspond to oneMKL backend

### DIFF
--- a/src/blas/backends/mkl_common/mkl_blas_backend.hxx
+++ b/src/blas/backends/mkl_common/mkl_blas_backend.hxx
@@ -1007,28 +1007,32 @@ void dotu(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>,
           sycl::buffer<std::complex<double>, 1> &result);
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1> &result);
+           sycl::buffer<std::int64_t, 1> &result, index_base base=index_base::zero);
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1> &result);
+           sycl::buffer<std::int64_t, 1> &result, index_base base=index_base::zero);
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result,
+           index_base base=index_base::zero);
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result,
+           index_base base=index_base::zero);
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1> &result);
+           sycl::buffer<std::int64_t, 1> &result, index_base base=index_base::zero);
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1> &result);
+           sycl::buffer<std::int64_t, 1> &result, index_base base=index_base::zero);
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result,
+           index_base base=index_base::zero);
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result,
+           index_base base=index_base::zero);
 
 void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx, sycl::buffer<float, 1> &result);


### PR DESCRIPTION
# Description

The local headers in `src/blas/backends/mkl_common/mkl_blas_backend.hxx` correspond to deprecated symbols in the oneMKL library backend. When those symbols are removed the oneMKL interfaces will no longer build with the oneMKL backend. This PR fixes the headers to avoid this.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. 
[test.txt](https://github.com/oneapi-src/oneMKL/files/14273891/test.txt)
- [x] Have you formatted the code using clang-format?

Testing was done with the 2024.0 version of the oneMKL library for the backend. One test (`blas/EXAMPLE/RT/gemm_usm/gpu`) fails but it is unrelated to this PR.