### PR TITLE
[rocBLAS] Fix issues with rocBLAS 4.0.0

### DIFF
--- a/cmake/FindrocBLAS.cmake
+++ b/cmake/FindrocBLAS.cmake
@@ -34,6 +34,7 @@ list(APPEND CMAKE_PREFIX_PATH
 
 find_package(HIP QUIET)
 find_package(rocblas REQUIRED)
+set(ROCBLAS_VERSION ${rocblas_VERSION})
 
 # this is work around to avoid duplication half creation in both HIP and SYCL
 add_compile_definitions(HIP_NO_HALF)
@@ -47,6 +48,8 @@ find_package_handle_standard_args(rocBLAS
       HIP_LIBRARIES
       ROCBLAS_INCLUDE_DIR
       ROCBLAS_LIBRARIES
+    VERSION_VAR
+      ROCBLAS_VERSION
 )
 # OPENCL_INCLUDE_DIR
 if(NOT TARGET ONEMKL::rocBLAS::rocBLAS)

--- a/cmake/FindrocBLAS.cmake
+++ b/cmake/FindrocBLAS.cmake
@@ -51,11 +51,18 @@ find_package_handle_standard_args(rocBLAS
     VERSION_VAR
       ROCBLAS_VERSION
 )
+
+if (DEFINED rocblas_INCLUDE_DIR)
+  set(ROCBLAS_LIB_PATH "${rocblas_INCLUDE_DIR}/../lib/librocblas.so")
+else()
+  set(ROCBLAS_LIB_PATH "${HIP_PATH}/../rocblas/lib/librocblas.so")
+endif()
+
 # OPENCL_INCLUDE_DIR
 if(NOT TARGET ONEMKL::rocBLAS::rocBLAS)
   add_library(ONEMKL::rocBLAS::rocBLAS SHARED IMPORTED)
   set_target_properties(ONEMKL::rocBLAS::rocBLAS PROPERTIES
-      IMPORTED_LOCATION "${HIP_PATH}/../rocblas/lib/librocblas.so"
+      IMPORTED_LOCATION "${ROCBLAS_LIB_PATH}"
       INTERFACE_INCLUDE_DIRECTORIES "${ROCBLAS_INCLUDE_DIR};${HIP_INCLUDE_DIRS};"
       INTERFACE_LINK_LIBRARIES "Threads::Threads;${ROCBLAS_LIBRARIES};"
   )

--- a/src/blas/backends/rocblas/CMakeLists.txt
+++ b/src/blas/backends/rocblas/CMakeLists.txt
@@ -41,6 +41,10 @@ target_include_directories(${LIB_OBJ}
           ${ONEMKL_GENERATED_INCLUDE_PATH}
 )
 
+if (${ROCBLAS_VERSION} VERSION_GREATER_EQUAL "4.0")
+  target_compile_definitions(${LIB_OBJ} PRIVATE ROCBLAS_NO_LEGACY_TRMM)
+endif()
+
 if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
     target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
     target_compile_options(ONEMKL::SYCL::SYCL INTERFACE

--- a/src/blas/backends/rocblas/rocblas_level3.cpp
+++ b/src/blas/backends/rocblas/rocblas_level3.cpp
@@ -381,10 +381,19 @@ inline void trmm(Func func, sycl::queue &queue, side left_right, uplo upper_lowe
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             rocblas_status err;
+
+// rocblas version 4.0.0 removed the legacy BLAS trmm implementation
+#ifdef ROCBLAS_NO_LEGACY_TRMM
             ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
+                                    m, n, (rocDataType *)&alpha, a_, lda, b_, ldb, b_, ldb);
+#else
+	    ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+                                    get_rocblas_fill_mode(upper_lower),
+                                    get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);
+#endif
         });
     });
 }
@@ -805,10 +814,19 @@ inline sycl::event trmm(Func func, sycl::queue &queue, side left_right, uplo upp
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto b_ = reinterpret_cast<rocDataType *>(b);
             rocblas_status err;
+
+// rocblas version 4.0.0 removed the legacy BLAS trmm implementation
+#ifdef ROCBLAS_NO_LEGACY_TRMM
+            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+                                    get_rocblas_fill_mode(upper_lower),
+                                    get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
+                                    m, n, (rocDataType *)&alpha, a_, lda, b_, ldb, b_, ldb);
+#else
             ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);
+#endif
         });
     });
 


### PR DESCRIPTION
# Description

rocBLAS 4.0.0 [removed support for the legacy BLAS inplace trmm](https://github.com/ROCm/rocBLAS/blob/develop/CHANGELOG.md#removals), so calls to trmm cause a compilation error. The old functionality is provided by just duplicating the last two arguments of trmm (see also [here](https://rocblas.readthedocs.io/en/master/API_Reference_Guide.html#announced-in-rocblas-3-0)).

To fix this, I am defining a macro `ROCBLAS_NO_LEGACY_TRMM` depending on the rocBLAS version which is then used in an `#ifdef` to decide which version of the function to call. 

I also had to change slightly the way the path to `librocblas.so` is constructed in `FindrocBLAS.cmake`. I'm not sure if this is also related to the rocBLAS version or if this is a general issue on some systems, so I can also put that in a separated PR if you prefer.  

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
  I don't have an AMD gpu to test, I'm just assessing the state of compiling oneMKL with AdaptiveCpp to see if #307 needs any updates and can the maybe be merged. 
- [x] Have you formatted the code using clang-format?
