### PR TITLE
Update SYCL support discovery to check for `-fsycl` flag.

### DIFF
--- a/cmake/mkl/MKLConfig.cmake
+++ b/cmake/mkl/MKLConfig.cmake
@@ -208,12 +208,28 @@ if(CMAKE_Fortran_COMPILER)
 endif()
 
 # Determine Compiler Family
-if(CXX_COMPILER_NAME STREQUAL "dpcpp" OR CXX_COMPILER_NAME STREQUAL "dpcpp.exe"
-    OR CXX_COMPILER_NAME STREQUAL "icpx" OR CXX_COMPILER_NAME STREQUAL "icx.exe")
-  set(SYCL_COMPILER ON)
+
+include(CMakePackageConfigHelpers)
+include(CheckCXXCompilerFlag)
+include(CheckIncludeFileCXX)
+include(GNUInstallDirs)
+
+# Check SYCL support by the compiler
+check_cxx_compiler_flag("-fsycl" _fsycl_option)
+if (_fsycl_option)
+  CHECK_INCLUDE_FILE_CXX("sycl/sycl.hpp" _sycl_header "-fsycl")
+  if (NOT _sycl_header)
+    CHECK_INCLUDE_FILE_CXX("CL/sycl.hpp" _sycl_header_old "-fsycl")
+  endif()
+  if (_sycl_header OR _sycl_header_old)
+    set(SYCL_COMPILER ON)
+  endif()
 endif()
-if(C_COMPILER_NAME MATCHES "^clang" OR CXX_COMPILER_NAME MATCHES "^clang")
-  set(CLANG_COMPILER ON)
+
+if(NOT DEFINED SYCL_COMPILER OR SYCL_COMPILER MATCHES OFF)
+  if(C_COMPILER_NAME MATCHES "^clang" OR CXX_COMPILER_NAME MATCHES "^clang")
+    set(CLANG_COMPILER ON)
+  endif()
 endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "PGI" OR CMAKE_CXX_COMPILER_ID STREQUAL "PGI" OR CMAKE_Fortran_COMPILER_ID STREQUAL "PGI"
     OR CMAKE_C_COMPILER_ID STREQUAL "NVHPC" OR CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"


### PR DESCRIPTION
# Description
oneMKL's CMake currently checks `CXX_COMPILER_NAME` and uses that to determine whether SYCL is supported.  This prevents SYCL support from being detected if the user compiles with their own build of `intel/llvm` (see issue #449).

This is a first stab at modifying `MKLConfig.cmake` to check for `-fsycl` support directly instead of inferring from the compiler name.  It is based on h[ow oneDPL checks for SYCL support](https://github.com/oneapi-src/oneDPL/blob/main/CMakeLists.txt#L79), which works for both release builds of IntelLLVM and custom builds of `intel/llvm`.

I have also modified the CMake to avoid setting `CLANG_COMPILER` if `SYCL_COMPILER` is set, as this is the behavior when using IntelLLVM.  I assume open-source DPC++ builds should behave similarly.

Fixes #449

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
