### PR TITLE
[BLAS][cuBLAS] Fix cmake for cuBLAS backend

### DIFF
--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -25,6 +25,7 @@ find_path(OPENCL_INCLUDE_DIR CL/cl.h OpenCL/cl.h
 HINTS 
 ${OPENCL_INCLUDE_DIR}
 ${SYCL_BINARY_DIR}/../include/sycl/
+${SYCL_BINARY_DIR}/../../include/sycl/
 )
 # this is work around to avoid duplication half creation in both cuda and SYCL
 add_compile_definitions(CUDA_NO_HALF)


### PR DESCRIPTION
# Description

This PR fixes a configuration error for cuBLAS backend. Latest oneAPI release moved `clang++` binary into another folder adding one more layer, so the `cmake` is not capable of finding the correct headers. Adding another `HINT` to cmake solves it and it keeps compatibility with compilers built from scratch.

Fixes #444 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[cublas_test.txt](https://github.com/oneapi-src/oneMKL/files/14384270/cublas_test.txt)

