### PR TITLE
Fix warnings for -Wextra-semi and -Wsuggest-override

### DIFF
--- a/include/oneapi/mkl/detail/backend_selector_predicates.hpp
+++ b/include/oneapi/mkl/detail/backend_selector_predicates.hpp
@@ -35,7 +35,7 @@ namespace oneapi {
 namespace mkl {
 
 template <backend Backend>
-inline void backend_selector_precondition(sycl::queue&){};
+inline void backend_selector_precondition(sycl::queue&) {}
 
 template <>
 inline void backend_selector_precondition<backend::netlib>(sycl::queue& queue) {

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -79,7 +79,7 @@ public:
 
     inline std::int64_t get_workspace_external_bytes() {
         return external_workspace_helper_.get_rqd_workspace_bytes(*this);
-    };
+    }
 
     // set_workspace should be overridden for any backend that enables external workspaces.
     // If these are overridden, get_workspace_external_bytes_impl must also be overridden.
@@ -89,10 +89,10 @@ public:
     // but the required workspace size will always be zero, and any given workspace will not actually be used.
     virtual void set_workspace(scalar_type *usm_workspace) {
         external_workspace_helper_.set_workspace_throw(*this, usm_workspace);
-    };
+    }
     virtual void set_workspace(sycl::buffer<scalar_type> &buffer_workspace) {
         external_workspace_helper_.set_workspace_throw(*this, buffer_workspace);
-    };
+    }
 
     virtual void forward_ip_cc(descriptor_type &desc, sycl::buffer<fwd_type, 1> &inout) = 0;
     virtual void forward_ip_rr(descriptor_type &desc, sycl::buffer<scalar_type, 1> &inout_re,
@@ -176,7 +176,7 @@ protected:
     // This must be reimplemented for backends that support external workspaces.
     virtual std::int64_t get_workspace_external_bytes_impl() {
         return 0;
-    };
+    }
 };
 
 } // namespace oneapi::mkl::dft::detail

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -93,7 +93,7 @@ public:
 
     const dft_values<prec, dom>& get_values() const noexcept {
         return values_;
-    };
+    }
 
     void set_workspace(scalar_type* usm_workspace);
 

--- a/include/oneapi/mkl/exceptions.hpp
+++ b/include/oneapi/mkl/exceptions.hpp
@@ -47,7 +47,7 @@ public:
                     : "");
     }
 
-    const char *what() const noexcept {
+    const char *what() const noexcept override {
         return msg_.c_str();
     }
 };


### PR DESCRIPTION
# Description

* Project that enable the warnings -Wextra-semi and -Wsuggest-override are warned about extra semicolons and missing overrides in the oneMKL interface.
* This PR fixes these warnings.

This can be reproduced by setting `CMAKE_CXX_FLAGS=-Wsuggest-override -Wextra-semi`. 

Fixes warning generated due to oneMKL whilst compiling GROMACS.

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? Attach a log.
  * There are no semantic differences in the code.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
