### PR TITLE
[Docs] Document the build of CUFFT, ROCFFT and PORTFFT backends

### DIFF
--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -460,41 +460,36 @@ To build with the rocRAND backend instead simply replace:
 .. code-block:: bash
 
    -DENABLE_ROCBLAS_BACKEND=True   \
-   -DTARGET_DOMAINS=blas
 
 With:
 
 .. code-block:: bash
 
    -DENABLE_ROCRAND_BACKEND=True   \
-   -DTARGET_DOMAINS=rng
 
 To build with the rocFFT backend instead simply replace:
 
 .. code-block:: bash\
 
    -DENABLE_ROCBLAS_BACKEND=True   \
-   -DTARGET_DOMAINS=blas
 
 With:
 
 .. code-block:: bash
 
    -DENABLE_ROCFFT_BACKEND=True   \
-   -DTARGET_DOMAINS=dft
 
 To build with the rocSOLVER backend instead simply replace:
 
 .. code-block:: bash\
 
    -DENABLE_ROCBLAS_BACKEND=True   \
-   -DTARGET_DOMAINS=blas
+
 With:
 
 .. code-block:: bash
 
    -DENABLE_ROCSOLVER_BACKEND=True   \
-   -DTARGET_DOMAINS=lapack
 
 **AMD GPU device architectures**  
 

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -582,9 +582,9 @@ project as a header-only library.
             -DTARGET_DOMAINS=dft \
             [-DPORTFFT_REGISTERS_PER_WI=128] \ # Example portFFT tuning parameter
             [-DREF_BLAS_ROOT=<reference_blas_install_prefix>] \ # required only for testing
-            [-DPORTFFT_DIR=<path to portBLAS install directory>]
+            [-DPORTFFT_DIR=<path to portFFT install directory>]
    cmake --build .
-   ./bin/test_main_blas_ct
+   ./bin/test_main_dft_ct
    cmake --install . --prefix <path_to_install_dir>
 
 

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -379,13 +379,7 @@ With:
 
    -DENABLE_CURAND_BACKEND=True   \
 
-To build with the cuFFT backend instead simply replace:
-
-.. code-block:: bash
-
-   -DENABLE_CUBLAS_BACKEND=True   \
-
-With:
+The CuFFT backend can be enabled in a similar way to the CuBLAS backend, by setting the following CMake variable to `True`:
 
 .. code-block:: bash
 
@@ -467,13 +461,7 @@ With:
 
    -DENABLE_ROCRAND_BACKEND=True   \
 
-To build with the rocFFT backend instead simply replace:
-
-.. code-block:: bash\
-
-   -DENABLE_ROCBLAS_BACKEND=True   \
-
-With:
+The rocFFT backend can be enabled in a similar way to the rocBLAS backend, by setting the following CMake variable to `True`:
 
 .. code-block:: bash
 

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -367,23 +367,13 @@ With the cuBLAS backend:
    ctest
    cmake --install . --prefix <path_to_install_dir>                        # required to have full package structure
 
-To build with the cuRAND backend instead simply replace:
+
+The CuFFT and CuRAND backends can be enabled in a similar way to the CuBLAS backend, by setting the corresponding CMake variable(s) to `True`:
 
 .. code-block:: bash
 
-   -DENABLE_CUBLAS_BACKEND=True   \
-
-With:
-
-.. code-block:: bash
-
+   -DENABLE_CUFFT_BACKEND=True    \
    -DENABLE_CURAND_BACKEND=True   \
-
-The CuFFT backend can be enabled in a similar way to the CuBLAS backend, by setting the following CMake variable to `True`:
-
-.. code-block:: bash
-
-   -DENABLE_CUFFT_BACKEND=True   \
 
 
 Building for ROCm (with hipSYCL)
@@ -449,34 +439,12 @@ With the AMD rocBLAS backend:
    ctest
    cmake --install . --prefix <path_to_install_dir>                        # required to have full package structure
 
-To build with the rocRAND backend instead simply replace:
+The rocRAND, rocFFT, and rocSOLVER backends can be enabled in a similar way to the rocBLAS backend, by setting the corresponding CMake variable(s) to `True`:
 
 .. code-block:: bash
 
-   -DENABLE_ROCBLAS_BACKEND=True   \
-
-With:
-
-.. code-block:: bash
-
-   -DENABLE_ROCRAND_BACKEND=True   \
-
-The rocFFT backend can be enabled in a similar way to the rocBLAS backend, by setting the following CMake variable to `True`:
-
-.. code-block:: bash
-
-   -DENABLE_ROCFFT_BACKEND=True   \
-
-To build with the rocSOLVER backend instead simply replace:
-
-.. code-block:: bash\
-
-   -DENABLE_ROCBLAS_BACKEND=True   \
-
-With:
-
-.. code-block:: bash
-
+   -DENABLE_ROCRAND_BACKEND=True     \
+   -DENABLE_ROCFFT_BACKEND=True      \
    -DENABLE_ROCSOLVER_BACKEND=True   \
 
 **AMD GPU device architectures**  

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -379,6 +379,18 @@ With:
 
    -DENABLE_CURAND_BACKEND=True   \
 
+To build with the cuFFT backend instead simply replace:
+
+.. code-block:: bash
+
+   -DENABLE_CUBLAS_BACKEND=True   \
+
+With:
+
+.. code-block:: bash
+
+   -DENABLE_CUFFT_BACKEND=True   \
+
 
 Building for ROCm (with hipSYCL)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -457,6 +469,20 @@ With:
    -DENABLE_ROCRAND_BACKEND=True   \
    -DTARGET_DOMAINS=rng
 
+To build with the rocFFT backend instead simply replace:
+
+.. code-block:: bash\
+
+   -DENABLE_ROCBLAS_BACKEND=True   \
+   -DTARGET_DOMAINS=blas
+
+With:
+
+.. code-block:: bash
+
+   -DENABLE_ROCFFT_BACKEND=True   \
+   -DTARGET_DOMAINS=dft
+
 To build with the rocSOLVER backend instead simply replace:
 
 .. code-block:: bash\
@@ -481,11 +507,13 @@ A few often-used architectures are listed below:
 
    * - Architecture
      - AMD GPU name
+   * - gfx90a
+     - AMD Instinct(TM) MI210/250/250X Accellerator
+   * - gfx908
+     - AMD Instinct(TM) MI 100 Accelerator
    * - gfx906
      - | AMD Radeon Instinct(TM) MI50/60 Accelerator
        | AMD Radeon(TM) (Pro) VII Graphics Card
-   * - gfx908
-     - AMD Instinct(TM) MI 100 Accelerator
    * - gfx900
      - | Radeon Instinct(TM) MI 25 Accelerator
        | Radeon(TM) RX Vega 64/56 Graphics
@@ -534,6 +562,48 @@ definitions in 2 ways:
   `DPC++ User Manual <https://intel.github.io/llvm-docs/UsersManual.html>`_
   for more information on ``-fsycl-targets``.
 
+Building for portFFT
+^^^^^^^^^^^^^^^^^^^^^^
+
+Note the portFFT backend is experimental and currently only supports a
+subset of the operations and features.
+The portFFT backend uses the `portFFT <https://github.com/codeplaysoftware/portFFT>`_
+project as a header-only library.
+
+* On Linux*
+
+.. code-block:: bash
+
+   # Inside <path to onemkl>
+   mkdir build && cd build
+   cmake .. -DENABLE_PORTFFT_BACKEND=ON \
+            -DENABLE_MKLCPU_BACKEND=OFF  \
+            -DENABLE_MKLGPU_BACKEND=OFF  \
+            -DTARGET_DOMAINS=dft \
+            [-DPORTFFT_REGISTERS_PER_WI=128] \ # Example portFFT tuning parameter
+            [-DREF_BLAS_ROOT=<reference_blas_install_prefix>] \ # required only for testing
+            [-DPORTFFT_DIR=<path to portBLAS install directory>]
+   cmake --build .
+   ./bin/test_main_blas_ct
+   cmake --install . --prefix <path_to_install_dir>
+
+
+portFFT will be downloaded automatically if not found.
+
+By default, the portFFT backend is not tuned for any specific device. The tuning flags are
+detailed in the `portFFT <https://github.com/codeplaysoftware/portFFT>`_ repository.
+The tuning parameters can be set at configuration time,
+with the above example showing how to set the tuning parameter
+``PORTFFT_REGISTERS_PER_WI``. Note that some tuning configurations may be incompatible
+with some targets.
+
+The portFFT library is compiled using the same ``-fsycl-targets`` as specified
+by the ``CMAKE_CXX_FLAGS``. If none are found, it will compile for
+``-fsycl-targets=nvptx64-nvidia-cuda,spir64``. To enable HIP targets,
+``HIP_TARGETS`` must be specified. See
+`DPC++ User Manual <https://intel.github.io/llvm-docs/UsersManual.html>`_
+for more information on ``-fsycl-targets``.
+
 
 Build Options
 ^^^^^^^^^^^^^
@@ -581,6 +651,10 @@ CMake.
      - True, False
      - False     
    * - *Not Supported*
+     - ENABLE_CUFFT_BACKEND
+     - True, False
+     - False     
+   * - *Not Supported*
      - ENABLE_CURAND_BACKEND
      - True, False
      - False     
@@ -592,12 +666,20 @@ CMake.
      - ENABLE_ROCBLAS_BACKEND
      - True, False
      - False     
+   * - *Not Supported*
+     - ENABLE_ROCFFT_BACKEND
+     - True, False
+     - False    
    * - enable_mklcpu_thread_tbb
      - ENABLE_MKLCPU_THREAD_TBB
      - True, False
      - True      
    * - *Not Supported*
      - ENABLE_PORTBLAS_BACKEND
+     - True, False
+     - False      
+   * - *Not Supported*
+     - ENABLE_PORTFFT_BACKEND
      - True, False
      - False      
    * - build_functional_tests


### PR DESCRIPTION
# Description

* Adds FFT backends to build documentation for ROCFFT, CUFFT and portFFT.
* Minor update of AMD device architectures

Fixes https://github.com/oneapi-src/oneMKL/issues/453

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? Attach a log.
  - Documentation changes only
- [N/A] Have you formatted the code using clang-format?
  - Documentation changes only

