### PR TITLE
[README][Docs] Update LLVM compiler name in README and related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,12 @@ Header-based and backend-independent Device API can be called within ```sycl ker
 
 ### Supported Configurations:
 
-Supported domains: BLAS, LAPACK, RNG, DFT, SPARSE_BLAS
+Supported domains include: BLAS, LAPACK, RNG, DFT, SPARSE_BLAS
+
+Supported compilers include:
+- [Intel(R) oneAPI DPC++ Compiler](https://software.intel.com/en-us/oneapi/dpc-compiler): Intel proprietary compiler that supports CPUs and Intel GPUs. Intel(R) oneAPI DPC++ Compiler will be referred to as "Intel DPC++" in the "Supported Compiler" column of the tables below.
+- [oneAPI DPC++ Compiler](https://github.com/intel/llvm): Open source compiler that supports CPUs and Intel, NVIDIA, and AMD GPUs. oneAPI DPC++ Compiler will be referred to as "Open DPC++" in the "Supported Compiler" column of the tables below.
+- [hipSYCL Compiler](https://github.com/illuhad/hipSYCL): Open source compiler that supports CPUs and Intel, NVIDIA, and AMD GPUs.
 
 #### Linux*
 
@@ -174,126 +179,126 @@ Supported domains: BLAS, LAPACK, RNG, DFT, SPARSE_BLAS
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*, hipSYCL</td>
+            <td align="center">Intel DPC++, Open DPC++, hipSYCL</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuBLAS</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">LLVM*, hipSYCL</td>
+            <td align="center">Open DPC++, hipSYCL</td>
         </tr>
         <tr>
             <td align="center">x86 CPU</td>
             <td align="center">NETLIB LAPACK</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*, hipSYCL</td>
+            <td align="center">Intel DPC++, Open DPC++, hipSYCL</td>
         </tr>
 	    <tr >
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocBLAS</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">LLVM*, hipSYCL</td>
+            <td align="center">Open DPC++, hipSYCL</td>
         </tr>
 	    <tr >
             <td align="center">x86 CPU, Intel GPU, NVIDIA GPU, AMD GPU</td>
             <td align="center">portBLAS</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*</td>
+            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td rowspan=4 align="center">LAPACK</td>
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*</td>
+            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuSOLVER</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">LLVM*</td>
+            <td align="center">Open DPC++</td>
         </tr>
         <tr>
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocSOLVER</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">LLVM*</td>
+            <td align="center">Open DPC++</td>
         </tr>
         <tr>
             <td rowspan=4 align="center">RNG</td>
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*, hipSYCL</td>
+            <td align="center">Intel DPC++, Open DPC++, hipSYCL</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuRAND</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">LLVM*, hipSYCL</td>
+            <td align="center">Open DPC++, hipSYCL</td>
         </tr>
         <tr>
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocRAND</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">LLVM*, hipSYCL</td>
+            <td align="center">Open DPC++, hipSYCL</td>
         </tr>
         <tr>
             <td rowspan=5 align="center">DFT</td>
             <td align="center">Intel GPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td align="center">x86 CPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuFFT</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Open DPC++</td>
         </tr>
         <tr>
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocFFT</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Open DPC++</td>
         </tr>
         <tr>
             <td align="center">x86 CPU, Intel GPU, NVIDIA GPU, AMD GPU</td>
             <td align="center">portFFT (<a href="https://github.com/codeplaysoftware/portFFT#supported-configurations">limited API support</a>)</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">IntelDPC++</td>
         </tr>
         <tr>
             <td rowspan=2 align="center">SPARSE_BLAS</td>
             <td align="center">Intel GPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td align="center">x86 CPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
     </tbody>
 </table>
@@ -316,47 +321,45 @@ Supported domains: BLAS, LAPACK, RNG, DFT, SPARSE_BLAS
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*</td>
+            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td align="center">x86 CPU</td>
             <td align="center">NETLIB LAPACK</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*</td>
+            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td rowspan=2 align="center">LAPACK</td>
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*</td>
+            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
             <td rowspan=2 align="center">RNG</td>
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++, LLVM*</td>
+            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">DPC++</td>
+            <td align="center">Intel DPC++</td>
         </tr>
     </tbody>
 </table>
-
-\* LLVM - [Intel project for LLVM* technology](https://github.com/intel/llvm) with support for [NVIDIA CUDA](https://intel.github.io/llvm-docs/GetStartedGuide.html#build-dpc-toolchain-with-support-for-nvidia-cuda)
 
 ---
 
@@ -448,7 +451,7 @@ Microsoft Windows* Server | 2016, 2019 | *Not supported*
     <tbody>
         <td rowspan=5> Linux*/Windows* </td>
         <td rowspan=2> x86 CPU </td>
-        <td> Intel(R) oneAPI DPC++ Compiler <br> or <br> Intel project for LLVM* technology </td>
+        <td> Intel(R) oneAPI DPC++ Compiler <br> or <br> oneAPI DPC++ Compiler </td>
         <td> No</td>
         <tr>
             <td> Intel(R) oneAPI Math Kernel Library </td>
@@ -467,11 +470,11 @@ Microsoft Windows* Server | 2016, 2019 | *Not supported*
         </tr>
         <td rowspan=2> Linux* only </td>
         <td> NVIDIA GPU </td>
-        <td> Intel project for LLVM* technology <br> or <br> hipSYCL with CUDA backend and dependencies </td>
+        <td> oneAPI DPC++ Compiler <br> or <br> hipSYCL with CUDA backend and dependencies </td>
         <td> No </td>
         <tr>
             <td> AMD GPU </td>
-            <td> Intel project for LLVM* technology <br> or <br> hipSYCL with ROCm backend and dependencies </td>
+            <td> oneAPI DPC++ Compiler <br> or <br> hipSYCL with ROCm backend and dependencies </td>
             <td> No </td>
         </tr>
     </tbody>
@@ -498,8 +501,8 @@ Python | 3.6 or higher | No | *N/A* | *Pre-installed or Installed by user* | [PS
 [GNU* FORTRAN Compiler](https://gcc.gnu.org/wiki/GFortran) | 7.4.0 or higher | Yes | apt | /usr/bin | [GNU General Public License, version 3](https://gcc.gnu.org/onlinedocs/gcc-7.5.0/gfortran/Copying.html)
 [Intel(R) oneAPI DPC++ Compiler](https://software.intel.com/en-us/oneapi/dpc-compiler) | latest | No | *N/A* | *Installed by user* | [End User License Agreement for the Intel(R) Software Development Products](https://software.intel.com/en-us/license/eula-for-intel-software-development-products)
 [hipSYCL](https://github.com/illuhad/hipSYCL/) | later than [2cfa530](https://github.com/illuhad/hipSYCL/commit/2cfa5303fd88b8f84e539b5bb6ed41e49c6d6118) | No | *N/A* | *Installed by user* | [BSD-2-Clause License ](https://github.com/illuhad/hipSYCL/blob/develop/LICENSE)
-[Intel project for LLVM* technology binary for x86 CPU](https://github.com/intel/llvm/releases) | Daily builds | No | *N/A* | *Installed by user* | [Apache License v2](https://github.com/intel/llvm/blob/sycl/sycl/LICENSE.TXT)
-[Intel project for LLVM* technology source for NVIDIA and AMD GPUs](https://github.com/intel/llvm) | Daily source releases | No | *N/A* | *Installed by user* | [Apache License v2](https://github.com/intel/llvm/blob/sycl/sycl/LICENSE.TXT)
+[oneAPI DPC++ Compiler binary for x86 CPU](https://github.com/intel/llvm/releases) | Daily builds | No | *N/A* | *Installed by user* | [Apache License v2](https://github.com/intel/llvm/blob/sycl/sycl/LICENSE.TXT)
+[oneAPI DPC++ Compiler source for NVIDIA and AMD GPUs](https://github.com/intel/llvm) | Daily source releases | No | *N/A* | *Installed by user* | [Apache License v2](https://github.com/intel/llvm/blob/sycl/sycl/LICENSE.TXT)
 [Intel(R) oneAPI Math Kernel Library](https://software.intel.com/en-us/oneapi/onemkl) | latest | Yes | apt | /opt/intel/inteloneapi/mkl | [Intel Simplified Software License](https://software.intel.com/en-us/license/intel-simplified-software-license)
 [NVIDIA CUDA SDK](https://developer.nvidia.com/cublas) | 10.2 | No | *N/A* | *Installed by user* |[End User License Agreement](https://docs.nvidia.com/cuda/eula/index.html)
 [AMD rocBLAS](https://rocblas.readthedocs.io/en/rocm-4.5.2/) | 4.5 | No | *N/A* | *Installed by user* |[AMD License](https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/LICENSE.md)
@@ -539,8 +542,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
 ## License
 
-    Distributed under the Apache license 2.0. See [LICENSE](LICENSE) for more
-information.
+Distributed under the Apache license 2.0. See [LICENSE](LICENSE) for more information.
 
 ---
 
@@ -548,30 +550,27 @@ information.
 
 ### oneMKL
 
-1. What is the difference between the following oneMKL items?
+**Q: What is the difference between the following oneMKL items?**
    - The [oneAPI Specification for oneMKL](https://spec.oneapi.com/versions/latest/index.html)
    - The [oneAPI Math Kernel Library (oneMKL) Interfaces](https://github.com/oneapi-src/oneMKL) Project
    - The [Intel(R) oneAPI Math Kernel Library (oneMKL)](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html) Product
 
-Answer:
-
+**A:**
 - The [oneAPI Specification for oneMKL](https://spec.oneapi.com/versions/latest/index.html) defines the DPC++ interfaces for performance math library functions. The oneMKL specification can evolve faster and more frequently than implementations of the specification.
 
 - The [oneAPI Math Kernel Library (oneMKL) Interfaces](https://github.com/oneapi-src/oneMKL) Project is an open source implementation of the specification. The project goal is to demonstrate how the DPC++ interfaces documented in the oneMKL specification can be implemented for any math library and work for any target hardware. While the implementation provided here may not yet be the full implementation of the specification, the goal is to build it out over time. We encourage the community to contribute to this project and help to extend support to multiple hardware targets and other math libraries.
 
 - The [Intel(R) oneAPI Math Kernel Library (oneMKL)](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html) product is the Intel product implementation of the specification (with DPC++ interfaces) as well as similar functionality with C and Fortran interfaces, and is provided as part of Intel® oneAPI Base Toolkit. It is highly optimized for Intel CPU and Intel GPU hardware.
 
-2. I'm trying to use oneMKL Interfaces in my project using FetchContent, but I keep running into `ONEMKL::SYCL::SYCL target was not found` problem when I try to build the project. What should I do?
+**Q: I'm trying to use oneMKL Interfaces in my project using `FetchContent`**, but I keep running into `ONEMKL::SYCL::SYCL target was not found` problem when I try to build the project. What should I do?
 
-Answer:
-
+**A:**
 Make sure you set the compiler when you configure your project.
 E.g. `cmake -Bbuild . -DCMAKE_CXX_COMPILER=icpx`.
 
-3. I'm trying to use oneMKL Interfaces in my project using find_package(oneMKL). I set oneMKL/oneTBB and Compiler environment first, then I built and installed oneMKL Interfaces, and finally I tried to build my project using installed oneMKL Interfaces (e.g. like this `cmake -Bbuild -GNinja -DCMAKE_CXX_COMPILER=icpx -DoneMKL_ROOT=<path_to_installed_oneMKL_interfaces> .`) and I noticed that cmake includes installed oneMKL Interfaces headers as a system include which ends up as a lower priority than the installed oneMKL package includes which I set before for building oneMKL Interfaces. As a result, I get conflicts between oneMKL and installed oneMKL Interfaces headers. What should I do?
+**Q: I'm trying to use oneMKL Interfaces in my project using `find_package(oneMKL)`.** I set oneMKL/oneTBB and Compiler environment first, then I built and installed oneMKL Interfaces, and finally I tried to build my project using installed oneMKL Interfaces (e.g. like this `cmake -Bbuild -GNinja -DCMAKE_CXX_COMPILER=icpx -DoneMKL_ROOT=<path_to_installed_oneMKL_interfaces> .`) and I noticed that cmake includes installed oneMKL Interfaces headers as a system include which ends up as a lower priority than the installed oneMKL package includes which I set before for building oneMKL Interfaces. As a result, I get conflicts between oneMKL and installed oneMKL Interfaces headers. What should I do?
 
-Answer:
-
+**A:**
 Having installed oneMKL Interfaces headers as `-I` instead on system includes (as `-isystem`) helps to resolve this problem. We use `INTERFACE_INCLUDE_DIRECTORIES` to add paths to installed oneMKL Interfaces headers (check `oneMKLTargets.cmake` in `lib/cmake` to find it). It's a known limitation that `INTERFACE_INCLUDE_DIRECTORIES` puts headers paths as system headers. To avoid that:
 - Option 1: Use CMake >=3.25. In this case oneMKL Interfaces will be built with `EXPORT_NO_SYSTEM` property set to `true` and you won't see the issue.
 - Option 2: If you use CMake < 3.25, set `PROPERTIES NO_SYSTEM_FROM_IMPORTED true` for your target. E.g: `set_target_properties(test PROPERTIES NO_SYSTEM_FROM_IMPORTED true)`.

--- a/README.md
+++ b/README.md
@@ -18,49 +18,46 @@ oneMKL is part of [oneAPI](https://oneapi.io).
     </thead>
     <tbody>
         <tr>
-            <td rowspan=13 align="center">oneMKL interface</td>
-            <td rowspan=13 align="center">oneMKL selector</td>
-            <td align="center"><a href="https://software.intel.com/en-us/oneapi/onemkl">Intel(R) oneAPI Math Kernel Library</a> for x86 CPU</td>
-            <td align="center">x86 CPU</td>
+            <td rowspan=12 align="center">oneMKL interface</td>
+            <td rowspan=12 align="center">oneMKL selector</td>
+            <td align="center"><a href="https://software.intel.com/en-us/oneapi/onemkl">Intel(R) oneAPI Math Kernel Library (oneMKL)</a></td>
+            <td align="center">x86 CPU, Intel GPU</td>
+        </tr>
         </tr>
         <tr>
-            <td align="center"><a href="https://software.intel.com/en-us/oneapi/onemkl">Intel(R) oneAPI Math Kernel Library</a> for Intel GPU</td>
-            <td align="center">Intel GPU</td>
-        </tr>
-        <tr>
-            <td align="center"><a href="https://developer.nvidia.com/cublas"> NVIDIA cuBLAS</a> for NVIDIA GPU </td>
+            <td align="center"><a href="https://developer.nvidia.com/cublas"> NVIDIA cuBLAS</a></td>
             <td align="center">NVIDIA GPU</td>
         </tr>
 	<tr>
-            <td align="center"><a href="https://developer.nvidia.com/cusolver"> NVIDIA cuSOLVER</a> for NVIDIA GPU </td>
+            <td align="center"><a href="https://developer.nvidia.com/cusolver"> NVIDIA cuSOLVER</a></td>
             <td align="center">NVIDIA GPU</td>
 	</tr>
         <tr>
-            <td align="center"><a href="https://developer.nvidia.com/curand"> NVIDIA cuRAND</a> for NVIDIA GPU </td>
+            <td align="center"><a href="https://developer.nvidia.com/curand"> NVIDIA cuRAND</a></td>
             <td align="center">NVIDIA GPU</td>
         </tr>
         <tr>
-            <td align="center"><a href="https://developer.nvidia.com/cufft"> NVIDIA cuFFT</a> for NVIDIA GPU </td>
+            <td align="center"><a href="https://developer.nvidia.com/cufft"> NVIDIA cuFFT</a></td>
             <td align="center">NVIDIA GPU</td>
         </tr>
         <tr>
-            <td align="center"><a href="https://ww.netlib.org"> NETLIB LAPACK</a> for x86 CPU </td>
+            <td align="center"><a href="https://ww.netlib.org"> NETLIB LAPACK</a> </td>
             <td align="center">x86 CPU</td>
         </tr>
         <tr>
-            <td align="center"><a href="https://rocblas.readthedocs.io/en/rocm-4.5.2/"> AMD rocBLAS</a> for AMD GPU </td>
+            <td align="center"><a href="https://rocblas.readthedocs.io/en/rocm-4.5.2/"> AMD rocBLAS</a></td>
             <td align="center">AMD GPU</td>
         </tr>
         <tr>
-            <td align="center"><a href="https://github.com/ROCmSoftwarePlatform/rocSOLVER"> AMD rocSOLVER</a> for AMD GPU </td>
+            <td align="center"><a href="https://github.com/ROCmSoftwarePlatform/rocSOLVER"> AMD rocSOLVER</a></td>
             <td align="center">AMD GPU</td>
         </tr>
         <tr>
-            <td align="center"><a href="https://github.com/ROCmSoftwarePlatform/rocRAND"> AMD rocRAND</a> for AMD GPU </td>
+            <td align="center"><a href="https://github.com/ROCmSoftwarePlatform/rocRAND"> AMD rocRAND</a></td>
             <td align="center">AMD GPU</td>
         </tr>
         <tr>
-            <td align="center"><a href="https://github.com/ROCmSoftwarePlatform/rocFFT">AMD rocFFT</a> for AMD GPU </td>
+            <td align="center"><a href="https://github.com/ROCmSoftwarePlatform/rocFFT">AMD rocFFT</a></td>
             <td align="center">AMD GPU</td>
         </tr>
         <tr>

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Supported domains include: BLAS, LAPACK, RNG, DFT, SPARSE_BLAS
 Supported compilers include:
 - [Intel(R) oneAPI DPC++ Compiler](https://software.intel.com/en-us/oneapi/dpc-compiler): Intel proprietary compiler that supports CPUs and Intel GPUs. Intel(R) oneAPI DPC++ Compiler will be referred to as "Intel DPC++" in the "Supported Compiler" column of the tables below.
 - [oneAPI DPC++ Compiler](https://github.com/intel/llvm): Open source compiler that supports CPUs and Intel, NVIDIA, and AMD GPUs. oneAPI DPC++ Compiler will be referred to as "Open DPC++" in the "Supported Compiler" column of the tables below.
-- [hipSYCL Compiler](https://github.com/illuhad/hipSYCL): Open source compiler that supports CPUs and Intel, NVIDIA, and AMD GPUs.
+- [AdaptiveCpp Compiler](https://github.com/AdaptiveCpp/AdaptiveCpp) (formerly known as hipSYCL): Open source compiler that supports CPUs and Intel, NVIDIA, and AMD GPUs.</br>**Note**: The source code and some documents in this project still use the previous name hipSYCL during this transition period.
 
 #### Linux*
 
@@ -175,12 +175,12 @@ Supported compilers include:
             <td rowspan=9 align="center">BLAS</td>
             <td rowspan=3 align="center">x86 CPU</td>
             <td align="center">Intel(R) oneMKL</td>
-            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td align="center">NETLIB LAPACK</td>
-            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
@@ -202,7 +202,7 @@ Supported compilers include:
         <tr>
             <td rowspan=2 align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuBLAS</td>
-            <td align="center">Open DPC++</br>hipSYCL</td>
+            <td align="center">Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
@@ -213,7 +213,7 @@ Supported compilers include:
         <tr>
             <td rowspan=2 align="center">AMD GPU</td>
             <td align="center">AMD rocBLAS</td>
-            <td align="center">Open DPC++</br>hipSYCL</td>
+            <td align="center">Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
@@ -250,7 +250,7 @@ Supported compilers include:
             <td rowspan=4 align="center">RNG</td>
             <td align="center">x86 CPU</td>
             <td align="center">Intel(R) oneMKL</td>
-            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
@@ -262,13 +262,13 @@ Supported compilers include:
         <tr>
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuRAND</td>
-            <td align="center">Open DPC++</br>hipSYCL</td>
+            <td align="center">Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocRAND</td>
-            <td align="center">Open DPC++</br>hipSYCL</td>
+            <td align="center">Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
@@ -501,11 +501,11 @@ Microsoft Windows* Server | 2016, 2019 | *Not supported*
         </tr>
         <td rowspan=2> Linux* only </td>
         <td> NVIDIA GPU </td>
-        <td> oneAPI DPC++ Compiler <br> or <br> hipSYCL with CUDA backend and dependencies </td>
+        <td> oneAPI DPC++ Compiler <br> or <br> AdaptiveCpp with CUDA backend and dependencies </td>
         <td> No </td>
         <tr>
             <td> AMD GPU </td>
-            <td> oneAPI DPC++ Compiler <br> or <br> hipSYCL with ROCm backend and dependencies </td>
+            <td> oneAPI DPC++ Compiler <br> or <br> AdaptiveCpp with ROCm backend and dependencies </td>
             <td> No </td>
         </tr>
     </tbody>
@@ -531,7 +531,7 @@ Python | 3.6 or higher | No | *N/A* | *Pre-installed or Installed by user* | [PS
 [Ninja](https://ninja-build.org/) | 1.10.0 | Yes | conan-center | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [Apache License v2.0](https://github.com/ninja-build/ninja/blob/master/COPYING)
 [GNU* FORTRAN Compiler](https://gcc.gnu.org/wiki/GFortran) | 7.4.0 or higher | Yes | apt | /usr/bin | [GNU General Public License, version 3](https://gcc.gnu.org/onlinedocs/gcc-7.5.0/gfortran/Copying.html)
 [Intel(R) oneAPI DPC++ Compiler](https://software.intel.com/en-us/oneapi/dpc-compiler) | latest | No | *N/A* | *Installed by user* | [End User License Agreement for the Intel(R) Software Development Products](https://software.intel.com/en-us/license/eula-for-intel-software-development-products)
-[hipSYCL](https://github.com/illuhad/hipSYCL/) | later than [2cfa530](https://github.com/illuhad/hipSYCL/commit/2cfa5303fd88b8f84e539b5bb6ed41e49c6d6118) | No | *N/A* | *Installed by user* | [BSD-2-Clause License ](https://github.com/illuhad/hipSYCL/blob/develop/LICENSE)
+[AdaptiveCpp](https://github.com/AdaptiveCpp/AdaptiveCpp) | later than [2cfa530](https://github.com/AdaptiveCpp/AdaptiveCpp/commit/2cfa5303fd88b8f84e539b5bb6ed41e49c6d6118) | No | *N/A* | *Installed by user* | [BSD-2-Clause License ](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/LICENSE)
 [oneAPI DPC++ Compiler binary for x86 CPU](https://github.com/intel/llvm/releases) | Daily builds | No | *N/A* | *Installed by user* | [Apache License v2](https://github.com/intel/llvm/blob/sycl/sycl/LICENSE.TXT)
 [oneAPI DPC++ Compiler source for NVIDIA and AMD GPUs](https://github.com/intel/llvm) | Daily source releases | No | *N/A* | *Installed by user* | [Apache License v2](https://github.com/intel/llvm/blob/sycl/sycl/LICENSE.TXT)
 [Intel(R) oneAPI Math Kernel Library](https://software.intel.com/en-us/oneapi/onemkl) | latest | Yes | apt | /opt/intel/inteloneapi/mkl | [Intel Simplified Software License](https://software.intel.com/en-us/license/intel-simplified-software-license)

--- a/README.md
+++ b/README.md
@@ -169,136 +169,168 @@ Supported compilers include:
             <th>Domain</th>
             <th>Backend</th>
             <th>Library</th>
-            <th>Supported Link Type</th>
             <th>Supported Compiler</th>		
+            <th>Supported Link Type</th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <td rowspan=6 align="center">BLAS</td>
-            <td align="center">x86 CPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
+            <td rowspan=9 align="center">BLAS</td>
+            <td rowspan=3 align="center">x86 CPU</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++, hipSYCL</td>
         </tr>
         <tr>
-            <td align="center">Intel GPU</td>
-            <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++</td>
-        </tr>
-        <tr>
-            <td align="center">NVIDIA GPU</td>
-            <td align="center">NVIDIA cuBLAS</td>
-            <td align="center">Dynamic, Static</td>
-            <td align="center">Open DPC++, hipSYCL</td>
-        </tr>
-        <tr>
-            <td align="center">x86 CPU</td>
             <td align="center">NETLIB LAPACK</td>
+            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++, hipSYCL</td>
         </tr>
-	    <tr >
-            <td align="center">AMD GPU</td>
-            <td align="center">AMD rocBLAS</td>
-            <td align="center">Dynamic, Static</td>
-            <td align="center">Open DPC++, hipSYCL</td>
-        </tr>
-	    <tr >
-            <td align="center">x86 CPU, Intel GPU, NVIDIA GPU, AMD GPU</td>
+        <tr>
             <td align="center">portBLAS</td>
+            <td align="center">Intel DPC++</br>Open DPC++</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++</td>
+        </tr>
+        <tr>
+            <td rowspan=2 align="center">Intel GPU</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td align="center">portBLAS</td>
+            <td align="center">Intel DPC++</br>Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td rowspan=2 align="center">NVIDIA GPU</td>
+            <td align="center">NVIDIA cuBLAS</td>
+            <td align="center">Open DPC++</br>hipSYCL</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td align="center">portBLAS</td>
+            <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td rowspan=2 align="center">AMD GPU</td>
+            <td align="center">AMD rocBLAS</td>
+            <td align="center">Open DPC++</br>hipSYCL</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td align="center">portBLAS</td>
+            <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td rowspan=4 align="center">LAPACK</td>
             <td align="center">x86 CPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
-            <td align="center">Dynamic, Static</td>
+            <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuSOLVER</td>
-            <td align="center">Dynamic, Static</td>
             <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocSOLVER</td>
-            <td align="center">Dynamic, Static</td>
             <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td rowspan=4 align="center">RNG</td>
             <td align="center">x86 CPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++, hipSYCL</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
-            <td align="center">Dynamic, Static</td>
+            <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuRAND</td>
+            <td align="center">Open DPC++</br>hipSYCL</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Open DPC++, hipSYCL</td>
         </tr>
         <tr>
             <td align="center">AMD GPU</td>
             <td align="center">AMD rocRAND</td>
+            <td align="center">Open DPC++</br>hipSYCL</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Open DPC++, hipSYCL</td>
         </tr>
         <tr>
-            <td rowspan=5 align="center">DFT</td>
-            <td align="center">Intel GPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
-            <td align="center">Dynamic, Static</td>
+            <td rowspan=8 align="center">DFT</td>
+            <td rowspan=2 align="center">x86 CPU</td>
+            <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
-        </tr>
-        <tr>
-            <td align="center">x86 CPU</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++</td>
         </tr>
         <tr>
-            <td align="center">NVIDIA GPU</td>
-            <td align="center">NVIDIA cuFFT</td>
-            <td align="center">Dynamic, Static</td>
-            <td align="center">Open DPC++</td>
-        </tr>
-        <tr>
-            <td align="center">AMD GPU</td>
-            <td align="center">AMD rocFFT</td>
-            <td align="center">Dynamic, Static</td>
-            <td align="center">Open DPC++</td>
-        </tr>
-        <tr>
-            <td align="center">x86 CPU, Intel GPU, NVIDIA GPU, AMD GPU</td>
             <td align="center">portFFT (<a href="https://github.com/codeplaysoftware/portFFT#supported-configurations">limited API support</a>)</td>
+            <td align="center">Intel DPC++</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">IntelDPC++</td>
+        </tr>
+        <tr>
+            <td rowspan=2 align="center">Intel GPU</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td align="center">portFFT (<a href="https://github.com/codeplaysoftware/portFFT#supported-configurations">limited API support</a>)</td>
+            <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td rowspan=2 align="center">NVIDIA GPU</td>
+            <td align="center">NVIDIA cuFFT</td>
+            <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td align="center">portFFT (<a href="https://github.com/codeplaysoftware/portFFT#supported-configurations">limited API support</a>)</td>
+            <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td rowspan=2 align="center">AMD GPU</td>
+            <td align="center">AMD rocFFT</td>
+            <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td align="center">portFFT (<a href="https://github.com/codeplaysoftware/portFFT#supported-configurations">limited API support</a>)</td>
+            <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td rowspan=2 align="center">SPARSE_BLAS</td>
-            <td align="center">Intel GPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
-            <td align="center">Dynamic, Static</td>
+            <td align="center">x86 CPU</td>
+            <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
-            <td align="center">x86 CPU</td>
+            <td align="center">Intel GPU</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
     </tbody>
 </table>
@@ -311,52 +343,54 @@ Supported compilers include:
             <th>Domain</th>
             <th>Backend</th>
             <th>Library</th>
-            <th>Supported Link Type</th>
             <th>Supported Compiler</th>	
+            <th>Supported Link Type</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td rowspan=3 align="center">BLAS</td>
-            <td align="center">x86 CPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
+            <td rowspan=2 align="center">x86 CPU</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++</td>
+        </tr>
+        <tr>
+            <td align="center">NETLIB LAPACK</td>
+            <td align="center">Intel DPC++</br>Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
-            <td align="center">Dynamic, Static</td>
+            <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
-        </tr>
-        <tr>
-            <td align="center">x86 CPU</td>
-            <td align="center">NETLIB LAPACK</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td rowspan=2 align="center">LAPACK</td>
             <td align="center">x86 CPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
-            <td align="center">Dynamic, Static</td>
+            <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
             <td rowspan=2 align="center">RNG</td>
             <td align="center">x86 CPU</td>
-            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
+            <td align="center">Intel(R) oneMKL</td>
+            <td align="center">Intel DPC++</br>Open DPC++</td>
             <td align="center">Dynamic, Static</td>
-            <td align="center">Intel DPC++, Open DPC++</td>
         </tr>
         <tr>
             <td align="center">Intel GPU</td>
-            <td align="center">Dynamic, Static</td>
+            <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
+            <td align="center">Dynamic, Static</td>
         </tr>
     </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -91,56 +91,56 @@ There are two oneMKL selector layer implementations:
 
 - **Run-time dispatching**: The application is linked with the oneMKL library and the required backend is loaded at run-time based on device vendor (all libraries should be dynamic).
 
-Example of app.cpp with run-time dispatching:
-
-```cpp
-#include "oneapi/mkl.hpp"
-
-...
-cpu_dev = sycl::device(sycl::cpu_selector());
-gpu_dev = sycl::device(sycl::gpu_selector());
-
-sycl::queue cpu_queue(cpu_dev);
-sycl::queue gpu_queue(gpu_dev);
-
-oneapi::mkl::blas::column_major::gemm(cpu_queue, transA, transB, m, ...);
-oneapi::mkl::blas::column_major::gemm(gpu_queue, transA, transB, m, ...);
-```
-How to build an application with run-time dispatching:
-
-if OS is Linux, use icpx compiler. If OS is Windows, use icx compiler.
-Linux example:
-```cmd
-$> icpx -fsycl –I$ONEMKL/include app.cpp
-$> icpx -fsycl app.o –L$ONEMKL/lib –lonemkl
-```
+  Example of app.cpp with run-time dispatching:
+  
+  ```cpp
+  #include "oneapi/mkl.hpp"
+  
+  ...
+  cpu_dev = sycl::device(sycl::cpu_selector());
+  gpu_dev = sycl::device(sycl::gpu_selector());
+  
+  sycl::queue cpu_queue(cpu_dev);
+  sycl::queue gpu_queue(gpu_dev);
+  
+  oneapi::mkl::blas::column_major::gemm(cpu_queue, transA, transB, m, ...);
+  oneapi::mkl::blas::column_major::gemm(gpu_queue, transA, transB, m, ...);
+  ```
+  How to build an application with run-time dispatching:
+  
+  if OS is Linux, use icpx compiler. If OS is Windows, use icx compiler.
+  Linux example:
+  ```cmd
+  $> icpx -fsycl –I$ONEMKL/include app.cpp
+  $> icpx -fsycl app.o –L$ONEMKL/lib –lonemkl
+  ```
 
 - **Compile-time dispatching**: The application uses a templated backend selector API where the template parameters specify the required backends and third-party libraries and the application is linked with the required oneMKL backend wrapper libraries (libraries can be static or dynamic).
 
-Example of app.cpp with compile-time dispatching:
-
-```cpp
-#include "oneapi/mkl.hpp"
-
-...
-cpu_dev = sycl::device(sycl::cpu_selector());
-gpu_dev = sycl::device(sycl::gpu_selector());
-
-sycl::queue cpu_queue(cpu_dev);
-sycl::queue gpu_queue(gpu_dev);
-
-oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu> cpu_selector(cpu_queue);
-
-oneapi::mkl::blas::column_major::gemm(cpu_selector, transA, transB, m, ...);
-oneapi::mkl::blas::column_major::gemm(oneapi::mkl::backend_selector<oneapi::mkl::backend::cublas> {gpu_queue}, transA, transB, m, ...);
-```
-How to build an application with compile-time dispatching:
-
-```cmd
-$> clang++ -fsycl –I$ONEMKL/include app.cpp
-$> clang++ -fsycl app.o –L$ONEMKL/lib –lonemkl_blas_mklcpu –lonemkl_blas_cublas
-```
-
+  Example of app.cpp with compile-time dispatching:
+  
+  ```cpp
+  #include "oneapi/mkl.hpp"
+  
+  ...
+  cpu_dev = sycl::device(sycl::cpu_selector());
+  gpu_dev = sycl::device(sycl::gpu_selector());
+  
+  sycl::queue cpu_queue(cpu_dev);
+  sycl::queue gpu_queue(gpu_dev);
+  
+  oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu> cpu_selector(cpu_queue);
+  
+  oneapi::mkl::blas::column_major::gemm(cpu_selector, transA, transB, m, ...);
+  oneapi::mkl::blas::column_major::gemm(oneapi::mkl::backend_selector<oneapi::mkl::backend::cublas> {gpu_queue}, transA, transB, m, ...);
+  ```
+  How to build an application with compile-time dispatching:
+  
+  ```cmd
+  $> clang++ -fsycl –I$ONEMKL/include app.cpp
+  $> clang++ -fsycl app.o –L$ONEMKL/lib –lonemkl_blas_mklcpu –lonemkl_blas_cublas
+  ```
+  
 *Refer to [Selecting a Compiler](https://oneapi-src.github.io/oneMKL/selecting_a_compiler.html) for the choice between `icpx/icx` and `clang++` compilers.*
 
 #### Device API

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -286,7 +286,7 @@ Building for oneMKL
 
      # Inside <path to onemkl>
      mkdir build && cd build
-     cmake .. [-DCMAKE_CXX_COMPILER=<path_to_dpcpp_compiler>/bin/dpcpp]  # required only if dpcpp is not found in environment variable PATH
+     cmake .. [-DCMAKE_CXX_COMPILER=<path_to_icpx_compiler>/bin/icpx]    # required only if icpx is not found in environment variable PATH
               [-DCMAKE_C_COMPILER=<path_to_icx_compiler>/bin/icx]        # required only if icx is not found in environment variable PATH
               [-DMKL_ROOT=<mkl_install_prefix>]                          # required only if environment variable MKLROOT is not set
               [-DREF_BLAS_ROOT=<reference_blas_install_prefix>]          # required only for testing
@@ -301,7 +301,7 @@ Building for oneMKL
 
      # Inside <path to onemkl>
      md build && cd build
-     cmake .. -G Ninja [-DCMAKE_CXX_COMPILER=<path_to_dpcpp_compiler>\bin\dpcpp]  # required only if dpcpp is not found in environment variable PATH
+     cmake .. -G Ninja [-DCMAKE_CXX_COMPILER=<path_to_icx_compiler>\bin\icx]      # required only if icx is not found in environment variable PATH
                        [-DCMAKE_C_COMPILER=<path_to_icx_compiler>\bin\icx]        # required only if icx is not found in environment variable PATH
                        [-DMKL_ROOT=<mkl_install_prefix>]                          # required only if environment variable MKLROOT is not set
                        [-DREF_BLAS_ROOT=<reference_blas_install_prefix>]          # required only for testing
@@ -538,13 +538,13 @@ definitions in 2 ways:
 Build Options
 ^^^^^^^^^^^^^
 
-When building oneMKL the SYCL implementation can be determined, by setting the
+When building oneMKL the SYCL implementation can be specified by setting the
 ``ONEMKL_SYCL_IMPLEMENTATION`` option. Possible values are:
 
 * ``dpc++`` (default) for the
   `Intel(R) oneAPI DPC++ Compiler <https://software.intel.com/en-us/oneapi/dpc-compiler>`_
-  and for the ``clang++`` from
-  `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_ compilers.
+  and for the
+  `oneAPI DPC++ Compiler <https://github.com/intel/llvm>`_ compilers.
 * ``hipsycl`` for the `hipSYCL <https://github.com/illuhad/hipSYCL>`_ SYCL implementation.
 
 All options specified in the Conan section are available to CMake. You can

--- a/docs/selecting_a_compiler.rst
+++ b/docs/selecting_a_compiler.rst
@@ -3,17 +3,17 @@
 Selecting a Compiler
 ====================
 
-You must choose a compiler according to the required backend of your
+You must choose a compiler according to the required backend and the operating system of your
 application.
 
 * If your application requires Intel GPU, use
   `Intel(R) oneAPI DPC++ Compiler <https://software.intel.com/en-us/oneapi/dpc-compiler>`_ ``icpx`` on Linux or ``icx`` on Windows.
-* If your application requires NVIDIA GPU, use the latest release of
-  ``clang++`` from `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_ or use ``hipSYCL`` from the `hipSYCL repository <https://github.com/illuhad/hipSYCL>`_ (except for LAPACK domain).
-* If your application requires AMD GPU, use ``hipSYCL`` or use the latest release of ``clang++`` from `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_.
-* If no Intel GPU, NVIDIA GPU, or AMD GPU is required, on Linux you can use either
+* If your Linux application requires NVIDIA GPU, build ``clang++`` from the latest source of
+  `oneAPI DPC++ Compiler <https://github.com/intel/llvm>`_ with `support for NVIDIA CUDA <https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md#build-dpc-toolchain-with-support-for-nvidia-cuda>`_ or use ``hipSYCL`` from the `hipSYCL repository <https://github.com/illuhad/hipSYCL>`_ (except for LAPACK domain).
+* If your Linux application requires AMD GPU, build ``clang++`` from the latest source of `oneAPI DPC++ Compiler <https://github.com/intel/llvm>`_ with `support for HIP AMD <https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md#build-dpc-toolchain-with-support-for-hip-amd>`_ or use ``hipSYCL``.
+* If no Intel GPU, NVIDIA GPU, or AMD GPU is required, on Linux you can use
   `Intel(R) oneAPI DPC++ Compiler <https://software.intel.com/en-us/oneapi/dpc-compiler>`_
-  ``icpx``, ``clang++``, or ``hipSYCL`` and on Windows you can use either
+  ``icpx``, `oneAPI DPC++ Compiler <https://github.com/intel/llvm/releases>`_ ``clang++``, or ``hipSYCL``,
+  and on Windows you can use either
   `Intel(R) oneAPI DPC++ Compiler <https://software.intel.com/en-us/oneapi/dpc-compiler>`_
-  ``icx``, or ``clang-cl`` from
-  `Intel project for LLVM* technology <https://github.com/intel/llvm/releases>`_.
+  ``icx`` or `oneAPI DPC++ Compiler <https://github.com/intel/llvm/releases>`_ ``clang-cl``.


### PR DESCRIPTION
# Description

This PR replaces the usage of "Intel project for LLVM* technology" with the approved one "oneAPI DPC++ Compiler". In addition, the tables of "Supported Configurations" in README are reorganized for better readability.

Note that the current format of the tables is "library-centric":
<table>
    <thead>
        <tr align="center" >
            <th>Domain</th>
            <th>Backend</th>
            <th>Library</th>
            <th>Supported Link Type</th>
            <th>Supported Compiler</th>		
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan=4 align="center">BLAS</td>
            <td align="center">x86 CPU</td>
            <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
            <td align="center">Dynamic, Static</td>
            <td align="center">DPC++, LLVM*, hipSYCL</td>
        </tr>
        <tr>
            <td align="center">Intel GPU</td>
            <td align="center">Dynamic, Static</td>
            <td align="center">DPC++</td>
        </tr>
        <tr>
           <td align="center">...</td>
           <td align="center">...</td>
           <td align="center">...</td>
           <td align="center">...</td>
        </tr>
	    <tr>
            <td align="center">x86 CPU, Intel GPU, NVIDIA GPU, AMD GPU</td>
            <td align="center">portBLAS</td>
            <td align="center">Dynamic, Static</td>
            <td align="center">DPC++, LLVM*</td>
        </tr>
</table>
The underlying message of this table format is what a library can support. The table at the top of README already roughly covers this aspect.
</br></br>

The proposed table format is "application-centric":
<table>
    <thead>
        <tr align="center" >
            <th>Domain</th>
            <th>Backend</th>
            <th>Library</th>
            <th>Supported Compiler</th>		
            <th>Supported Link Type</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan=6 align="center">BLAS</td>
            <td rowspan=3 align="center">x86 CPU</td>
            <td align="center">Intel(R) oneMKL</td>
            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
            <td align="center">Dynamic, Static</td>
        </tr>
        <tr>
            <td align="center">NETLIB LAPACK</td>
            <td align="center">Intel DPC++</br>Open DPC++</br>hipSYCL</td>
            <td align="center">Dynamic, Static</td>
        </tr>
        <tr>
            <td align="center">portBLAS</td>
            <td align="center">Intel DPC++</br>Open DPC++</td>
            <td align="center">Dynamic, Static</td>
        </tr>
        <tr>
            <td rowspan=2 align="center">Intel GPU</td>
            <td align="center">Intel(R) oneMKL</td>
            <td align="center">Intel DPC++</td>
            <td align="center">Dynamic, Static</td>
        </tr>
        <tr>
            <td align="center">portBLAS</td>
            <td align="center">Intel DPC++</br>Open DPC++</td>
            <td align="center">Dynamic, Static</td>
        </tr>
        <tr>
           <td align="center">...</td>
           <td align="center">...</td>
           <td align="center">...</td>
           <td align="center">...</td>
        </tr>
</table>
For example, if an application requires BLAS on Intel GPUs, this format would make it easier to find out what configurations are available for the given application.

# Checklist

## All Submissions

- Do all unit tests pass locally? N/A, only documentation changes.
- Have you formatted the code using clang-format? N/A, only documentation changes.
