### PR TITLE
[RNG][Tests] Skip several device tests for devices without fp64 support

### DIFF
--- a/tests/unit_tests/rng/device/include/moments.hpp
+++ b/tests/unit_tests/rng/device/include/moments.hpp
@@ -44,6 +44,27 @@ class moments_test {
 public:
     template <typename Queue>
     void operator()(Queue queue) {
+        // Note: the following methods of discrete distributions require double precision support
+        if ((std::is_same_v<
+                 Distribution,
+                 oneapi::mkl::rng::device::uniform<
+                     std::uint32_t, oneapi::mkl::rng::device::uniform_method::accurate>> ||
+             std::is_same_v<
+                 Distribution,
+                 oneapi::mkl::rng::device::uniform<
+                     std::int32_t, oneapi::mkl::rng::device::uniform_method::accurate>> ||
+             std::is_same_v<Distribution, oneapi::mkl::rng::device::poisson<
+                                              std::uint32_t,
+                                              oneapi::mkl::rng::device::poisson_method::devroye>> ||
+             std::is_same_v<
+                 Distribution,
+                 oneapi::mkl::rng::device::poisson<
+                     std::int32_t, oneapi::mkl::rng::device::poisson_method::devroye>>)&&!queue
+                .get_device()
+                .has(sycl::aspect::fp64)) {
+            status = test_skipped;
+            return;
+        }
         using Type = typename Distribution::result_type;
         // prepare array for random numbers
         std::vector<Type> r(N_GEN);


### PR DESCRIPTION
# Description
uniform discrete distribution with accurate method and poisson distributions require fp64 aspect - the tests were failing due to missing filter. Added check for fp64 aspect of device and proper skip

# Checklist

- [x] Do all unit tests pass locally? 
[test_rng.log](https://github.com/oneapi-src/oneMKL/files/14695515/test_rng.log)

- [x] Have you formatted the code using clang-format?
