### PR TITLE
Update .gitignore to ignore all build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@
 .git/
 
 # Build
-build/
+build*/


### PR DESCRIPTION
Changing build/ to build*/ means that all build dirs can be ignored, so I can maintain separate `build/` `build_lapack/` `build_blas/` etc. directories that will all be successfully ignored by git.