### PR TITLE
[Sparse BLAS] remove deprecation warning when using oneMKL 2024.1 with sparse::trsv() on x86 CPU and Intel GPU backends

### DIFF
--- a/src/sparse_blas/backends/mkl_common/mkl_helper.hpp
+++ b/src/sparse_blas/backends/mkl_common/mkl_helper.hpp
@@ -20,6 +20,7 @@
 // MKLCPU and MKLGPU backends include
 // This include defines its own oneapi::mkl::sparse namespace with some of the types that are used here: matrix_handle_t, index_base, transpose, uolo, diag.
 #include <oneapi/mkl/spblas.hpp>
+#include "mkl_version.h"
 
 // Includes are set up so that oneapi::mkl::sparse namespace refers to the MKLCPU and MKLGPU backends namespace (oneMKL product)
 // in this file.

--- a/src/sparse_blas/backends/mkl_common/mkl_helper.hpp
+++ b/src/sparse_blas/backends/mkl_common/mkl_helper.hpp
@@ -20,7 +20,6 @@
 // MKLCPU and MKLGPU backends include
 // This include defines its own oneapi::mkl::sparse namespace with some of the types that are used here: matrix_handle_t, index_base, transpose, uolo, diag.
 #include <oneapi/mkl/spblas.hpp>
-#include "mkl_version.h"
 
 // Includes are set up so that oneapi::mkl::sparse namespace refers to the MKLCPU and MKLGPU backends namespace (oneMKL product)
 // in this file.

--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -87,8 +87,15 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>> trsv(sycl::queue& queue, upl
         throw mkl::unimplemented("sparse_blas/backends/mkl", __FUNCTION__,
                                  "Transposed or conjugate trsv is not supported");
     }
+
+#if defined(__INTEL_MKL__) && (__INTEL_MKL__ >= 2024) && (__INTEL_MKL_UPDATE__ >= 1)
+    const fpType alpha = fpType(1.0);
+    oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val, alpha,
+                              detail::get_handle(A_handle), x, y);
+#else
     oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
                               detail::get_handle(A_handle), x, y);
+#endif
 }
 
 template <typename fpType>
@@ -102,9 +109,16 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> trsv(
                                  "Transposed or conjugate trsv is not supported");
     }
     // TODO: Remove const_cast in future oneMKL release
+#if defined(__INTEL_MKL__) && (__INTEL_MKL__ >= 2024) && (__INTEL_MKL_UPDATE__ >= 1)
+    const fpType alpha = fpType(1.0);
+    return oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val, alpha,
+                                     detail::get_handle(A_handle), const_cast<fpType*>(x), y,
+                                     dependencies);
+#else
     return oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
                                      detail::get_handle(A_handle), const_cast<fpType*>(x), y,
                                      dependencies);
+#endif
 }
 
 template <typename fpType>

--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -89,14 +89,9 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>> trsv(sycl::queue& queue, upl
                                  "Transposed or conjugate trsv is not supported");
     }
 
-#if defined(__INTEL_MKL__) && (__INTEL_MKL__ >= 2024) && (__INTEL_MKL_UPDATE__ >= 1)
-    const fpType alpha = fpType(1.0);
+    const fpType alpha = static_cast<fpType>(1);
     oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val, alpha,
                               detail::get_handle(A_handle), x, y);
-#else
-    oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
-                              detail::get_handle(A_handle), x, y);
-#endif
 }
 
 template <typename fpType>
@@ -110,16 +105,10 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> trsv(
                                  "Transposed or conjugate trsv is not supported");
     }
     // TODO: Remove const_cast in future oneMKL release
-#if defined(__INTEL_MKL__) && (__INTEL_MKL__ >= 2024) && (__INTEL_MKL_UPDATE__ >= 1)
-    const fpType alpha = fpType(1.0);
+    const fpType alpha = static_cast<fpType>(1);
     return oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val, alpha,
                                      detail::get_handle(A_handle), const_cast<fpType*>(x), y,
                                      dependencies);
-#else
-    return oneapi::mkl::sparse::trsv(queue, uplo_val, transpose_val, diag_val,
-                                     detail::get_handle(A_handle), const_cast<fpType*>(x), y,
-                                     dependencies);
-#endif
 }
 
 template <typename fpType>

--- a/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
+++ b/src/sparse_blas/backends/mkl_common/mkl_operations.cxx
@@ -64,7 +64,8 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>> gemv(
     sycl::queue& queue, transpose transpose_val, const fpType alpha,
     detail::matrix_handle* A_handle, sycl::buffer<fpType, 1>& x, const fpType beta,
     sycl::buffer<fpType, 1>& y) {
-    oneapi::mkl::sparse::gemv(queue, transpose_val, alpha, detail::get_handle(A_handle), x, beta, y);
+    oneapi::mkl::sparse::gemv(queue, transpose_val, alpha, detail::get_handle(A_handle), x, beta,
+                              y);
 }
 
 template <typename fpType>
@@ -72,8 +73,8 @@ std::enable_if_t<detail::is_fp_supported_v<fpType>, sycl::event> gemv(
     sycl::queue& queue, transpose transpose_val, const fpType alpha,
     detail::matrix_handle* A_handle, const fpType* x, const fpType beta, fpType* y,
     const std::vector<sycl::event>& dependencies) {
-    return oneapi::mkl::sparse::gemv(queue, transpose_val, alpha, detail::get_handle(A_handle), x, beta, y,
-                                     dependencies);
+    return oneapi::mkl::sparse::gemv(queue, transpose_val, alpha, detail::get_handle(A_handle), x,
+                                     beta, y, dependencies);
 }
 
 template <typename fpType>


### PR DESCRIPTION
# Description

oneMKL 2024.1 deprecated sparse::trsv() without an alpha scaling factor and introduced a new sparse::trsv() with alpha. We update trsv backend calls to use the new one from oneMKL 2024.1 with constant fixed alpha == 1 to avoid the deprecation warnings.


# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you added relevant regression tests?  (N/A)
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?  (N/A)
