### PR TITLE
[RNG] Fixed some bugs for device API

### DIFF
--- a/examples/rng/device/uniform.cpp
+++ b/examples/rng/device/uniform.cpp
@@ -46,7 +46,7 @@ bool isDoubleSupported(sycl::device my_dev) {
 }
 
 // example parameters
-constexpr int seed = 777;
+constexpr std::uint64_t seed = 777;
 constexpr std::size_t n = 1024;
 constexpr int n_print = 10;
 

--- a/include/oneapi/mkl/rng/device/detail/mcg31m1_impl.hpp
+++ b/include/oneapi/mkl/rng/device/detail/mcg31m1_impl.hpp
@@ -142,14 +142,10 @@ static inline void skip_ahead(engine_state<oneapi::mkl::rng::device::mcg31m1<Vec
 
 template <std::int32_t VecSize>
 static inline void init(engine_state<oneapi::mkl::rng::device::mcg31m1<VecSize>>& state,
-                        std::uint64_t n, const std::uint32_t* seed_ptr, std::uint64_t offset) {
-    if (n == 0)
+                        std::uint32_t seed, std::uint64_t offset) {
+    state.s = custom_mod<std::uint32_t>(seed);
+    if (state.s == 0)
         state.s = 1;
-    else {
-        state.s = custom_mod<std::uint32_t>(seed_ptr[0]);
-        if (state.s == 0)
-            state.s = 1;
-    }
     skip_ahead(state, offset);
 }
 
@@ -183,11 +179,7 @@ template <std::int32_t VecSize>
 class engine_base<oneapi::mkl::rng::device::mcg31m1<VecSize>> {
 protected:
     engine_base(std::uint32_t seed, std::uint64_t offset = 0) {
-        mcg31m1_impl::init(this->state_, 1, &seed, offset);
-    }
-
-    engine_base(std::uint64_t n, const std::uint32_t* seed, std::uint64_t offset = 0) {
-        mcg31m1_impl::init(this->state_, n, seed, offset);
+        mcg31m1_impl::init(this->state_, seed, offset);
     }
 
     template <typename RealType>

--- a/include/oneapi/mkl/rng/device/detail/mcg59_impl.hpp
+++ b/include/oneapi/mkl/rng/device/detail/mcg59_impl.hpp
@@ -111,16 +111,8 @@ static inline void skip_ahead(engine_state<oneapi::mkl::rng::device::mcg59<VecSi
 
 template <std::int32_t VecSize>
 static inline void init(engine_state<oneapi::mkl::rng::device::mcg59<VecSize>>& state,
-                        std::uint64_t n, std::uint32_t* seed_ptr, std::uint64_t offset) {
-    if (n < 1) {
-        state.s = 1;
-    }
-    else if (n == 1) {
-        state.s = static_cast<uint64_t>(seed_ptr[0]) & mcg59_param::m_64;
-    }
-    else {
-        state.s = *(reinterpret_cast<std::uint64_t*>(&seed_ptr[0])) & mcg59_param::m_64;
-    }
+                        std::uint64_t seed, std::uint64_t offset) {
+    state.s = seed & mcg59_param::m_64;
     if (state.s == 0)
         state.s = 1;
 
@@ -154,12 +146,8 @@ static inline std::uint64_t generate_single(
 template <std::int32_t VecSize>
 class engine_base<oneapi::mkl::rng::device::mcg59<VecSize>> {
 protected:
-    engine_base(std::uint32_t seed, std::uint64_t offset = 0) {
-        mcg59_impl::init(this->state_, 1, &seed, offset);
-    }
-
-    engine_base(std::uint64_t n, const std::uint32_t* seed, std::uint64_t offset = 0) {
-        mcg59_impl::init(this->state_, n, seed, offset);
+    engine_base(std::uint64_t seed, std::uint64_t offset = 0) {
+        mcg59_impl::init(this->state_, seed, offset);
     }
 
     template <typename RealType>

--- a/include/oneapi/mkl/rng/device/engines.hpp
+++ b/include/oneapi/mkl/rng/device/engines.hpp
@@ -130,9 +130,6 @@ public:
     mcg31m1(std::uint32_t seed, std::uint64_t offset = 0)
             : detail::engine_base<mcg31m1<VecSize>>(seed, offset) {}
 
-    mcg31m1(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)
-            : detail::engine_base<mcg31m1<VecSize>>(seed.size(), seed.begin(), offset) {}
-
 private:
     template <typename Engine>
     friend void skip_ahead(Engine& engine, std::uint64_t num_to_skip);
@@ -157,11 +154,8 @@ public:
 
     mcg59() : detail::engine_base<mcg59<VecSize>>(default_seed) {}
 
-    mcg59(std::uint32_t seed, std::uint64_t offset = 0)
+    mcg59(std::uint64_t seed, std::uint64_t offset = 0)
             : detail::engine_base<mcg59<VecSize>>(seed, offset) {}
-
-    mcg59(std::initializer_list<std::uint32_t> seed, std::uint64_t offset = 0)
-            : detail::engine_base<mcg59<VecSize>>(seed.size(), seed.begin(), offset) {}
 
 private:
     template <typename Engine>


### PR DESCRIPTION
# Description

It doesn't make sense to keep constructors with `std::initializer_list` for `mcg31m1` and `mcg59` random generators since one seed value is enough. Size of the state for `mcg31m1` is 31 bits, `uint32_t` is enough to store the initial state. For `mcg59` size is 59 bits, `uint64_t` is enough. So, let's keep only `std::uint32_t seed` for `mcg31m1` and `std::uint64_t seed` for `mcg59`.

PR for the Spec is here: https://github.com/oneapi-src/oneAPI-spec/pull/525.

# Checklist

- [x] Do all unit tests pass locally? Attach a log. [log.txt](https://github.com/oneapi-src/oneMKL/files/14919838/log.txt)
- [x] Have you formatted the code using clang-format?
- [x] What version of oneAPI spec the interface is targeted?
        See https://github.com/oneapi-src/oneAPI-spec/pull/525
