### PR TITLE
[DFT] Improve support for different ROCm versions

### DIFF
--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -41,9 +41,21 @@ target_include_directories(${LIB_OBJ}
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
 
 find_package(HIP REQUIRED)
-find_package(rocfft REQUIRED)
+find_package(rocfft 1.0.21 REQUIRED)
 
 target_link_libraries(${LIB_OBJ} PRIVATE hip::host roc::rocfft)
+
+# Allow to compile for different ROCm versions.
+# Starting ROCm >=6.0 the include files are one directory level deeper.
+find_path(
+  rocfft_EXTRA_INCLUDE_DIR
+  rocfft.h
+  PATHS ${rocfft_INCLUDE_DIR}
+  PATH_SUFFIXES rocfft
+  NO_DEFAULT_PATH
+  REQUIRED
+)
+target_include_directories(${LIB_OBJ} PRIVATE ${rocfft_EXTRA_INCLUDE_DIR})
 
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL)
 

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -41,11 +41,13 @@ target_include_directories(${LIB_OBJ}
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
 
 find_package(HIP REQUIRED)
+# Require the minimum rocFFT version matching with ROCm 5.4.3.
 find_package(rocfft 1.0.21 REQUIRED)
 
 target_link_libraries(${LIB_OBJ} PRIVATE hip::host roc::rocfft)
 
-# Allow to compile for different ROCm versions.
+# Allow to compile for different ROCm versions. See the README for the supported
+# ROCm versions.
 # Starting ROCm >=6.0 the include files are one directory level deeper.
 find_path(
   rocfft_EXTRA_INCLUDE_DIR


### PR DESCRIPTION
# Description

- Improves the include path to allow compiling rocFFT backend with ROCm>=6.0.
- Sets the minimum required rocFFT version in CMake to match with the README version. The rocFFT backend does not compile with older rocFFT version so adding a minimum version improves the error message for the user.

Attached is the test log on AMD using the Codeplay plugin. Currently it supports the ROCm version 5.4.3. 
[dft_rocm_tests.txt](https://github.com/oneapi-src/oneMKL/files/14920531/dft_rocm_tests.txt)
I have verified that this builds with ROCm 6.0.0 but this can't be run using the Codeplay plugins yet.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

## Bug fixes

- [N/A] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
