### PR TITLE
[BLAS::portBLAS backend] Add CUDA_TARGET

### DIFF
--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -290,6 +290,10 @@ definitions in 2 ways:
   The list of portBLAS targets can be found
   `here <https://github.com/codeplaysoftware/portBLAS#cmake-options>`_.
   This will automatically set ``-fsycl-targets`` if needed.
+  In case of ``AMD_GPU`` target, it is mandatory to set one or more device
+  architectures by means of ``HIP_TARGETS``, e.g., ``-DHIP_TARGETS=gfx90a``.
+  In case of ``NVIDIA_GPU`` target, it is possible to select a specific device
+  architecture by means of ``CUDA_TARGET``, e.g., ``-DCUDA_TARGET=sm_80``.
 #.
   If one target is set via ``-fsycl-targets`` the configuration step will
   try to automatically detect the portBLAS tuning target. One can manually

--- a/src/blas/backends/portblas/CMakeLists.txt
+++ b/src/blas/backends/portblas/CMakeLists.txt
@@ -78,6 +78,12 @@ if(PORTBLAS_TUNING_TARGET)
         -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda)
       target_link_options(ONEMKL::SYCL::SYCL INTERFACE
         -fsycl-targets=nvptx64-nvidia-cuda)
+      if(DEFINED CUDA_TARGET)
+        target_compile_options(ONEMKL::SYCL::SYCL INTERFACE
+          -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGET})
+        target_link_options(ONEMKL::SYCL::SYCL INTERFACE
+          -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGET})
+      endif()
     else()
       message(WARNING "Compiler is not supported."
       " Unable to automatically set the required flags for the target '${PORTBLAS_TUNING_TARGET}'."


### PR DESCRIPTION
# Description

This patch adds the `CUDA_TARGET` CMake variable for setting a specific device architecture in case of `NVIDIA_GPU` tuning target.

This avoids the need of device code translation performed at runtime from the DPCPP default CUDA target architecture (`sm_50`) to the one of the actual device.     

# Checklist

## All Submissions

- [*] Do all unit tests pass locally? Attached [log](https://github.com/oneapi-src/oneMKL/files/15024376/ctest-add-cuda-target.txt).
- [*] Have you formatted the code using clang-format?


