### PR TITLE
README: add UXL Foundation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# oneAPI Math Kernel Library (oneMKL) Interfaces
+[![UXL Foundation Logo](https://github.com/uxlfoundation/artwork/blob/main/foundation/uxl-foundation-logo-horizontal-color.png)][UXL Foundation]
 
-<img align="left" src="https://spec.oneapi.io/oneapi-logo-white-scaled.jpg" alt="oneAPI logo">
+# oneAPI Math Kernel Library (oneMKL) Interfaces
 
 oneMKL Interfaces is an open-source implementation of the oneMKL Data Parallel C++ (DPC++) interface according to the [oneMKL specification](https://spec.oneapi.com/versions/latest/elements/oneMKL/source/index.html). It works with multiple devices (backends) using device-specific libraries underneath.
 
-oneMKL is part of [oneAPI](https://oneapi.io).
+oneMKL is part of the [UXL Foundation](http://www.uxlfoundation.org).
 <br/><br/>
 
 <table>

--- a/README.md
+++ b/README.md
@@ -533,6 +533,16 @@ Product | Supported Version | License
 
 ---
 
+## Governance
+
+The oneMKL Interfaces project is governed by the UXL Foundation and you can get involved in this project in multiple ways. It is possible to join the [Math Special Interest Group (SIG)](https://github.com/uxlfoundation/foundation/tree/main/math) meetings where the groups discuss and demonstrate work using this project. Members can also join the Open Source and Specification Working Group meetings.
+
+You can also join the mailing lists for the [UXL Foundation](https://lists.uxlfoundation.org/g/main/subgroups) to be informed of when meetings are happening and receive the latest information and discussions.
+
+You can contribute to this project and also contribute to the specification for this project, read the [CONTRIBUTING](CONTRIBUTING.md) page for more information.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ Product | Supported Version | License
 
 ## Governance
 
-The oneMKL Interfaces project is governed by the UXL Foundation and you can get involved in this project in multiple ways. It is possible to join the [Math Special Interest Group (SIG)](https://github.com/uxlfoundation/foundation/tree/main/math) meetings where the groups discuss and demonstrate work using this project. Members can also join the Open Source and Specification Working Group meetings.
+The oneMKL Interfaces project is governed by the UXL Foundation and you can get involved in this project in multiple ways. It is possible to join the [Math Special Interest Group (SIG)](https://github.com/uxlfoundation/foundation/tree/main/math) meetings where the group discusses and demonstrates work using this project. Members can also join the Open Source and Specification Working Group meetings.
 
 You can also join the mailing lists for the [UXL Foundation](https://lists.uxlfoundation.org/g/main/subgroups) to be informed of when meetings are happening and receive the latest information and discussions.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![UXL Foundation Logo](https://github.com/uxlfoundation/artwork/blob/main/foundation/uxl-foundation-logo-horizontal-color.png)]
+<img src="https://github.com/uxlfoundation/artwork/blob/main/foundation/uxl-foundation-logo-horizontal-color.png" alt="UXL Foundation Logo" width="250"/>
 
 # oneAPI Math Kernel Library (oneMKL) Interfaces
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![UXL Foundation Logo](https://github.com/uxlfoundation/artwork/blob/main/foundation/uxl-foundation-logo-horizontal-color.png)][UXL Foundation]
+[![UXL Foundation Logo](https://github.com/uxlfoundation/artwork/blob/main/foundation/uxl-foundation-logo-horizontal-color.png)]
 
 # oneAPI Math Kernel Library (oneMKL) Interfaces
 


### PR DESCRIPTION
# Description

oneMKL Interfaces project is part of UXL Foundation now, this PR adds new logo, UXL Foundation link, and new Governance section to README.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? N/A, documentation change
- [x] Have you formatted the code using clang-format? N/A, documentation change
