### PR TITLE
[blas::portBLAS] Update portBLAS cmake

### DIFF
--- a/src/blas/backends/portblas/CMakeLists.txt
+++ b/src/blas/backends/portblas/CMakeLists.txt
@@ -146,6 +146,10 @@ if (NOT PORTBLAS_FOUND)
   set(BLAS_ENABLE_BENCHMARK OFF)
   set(BLAS_ENABLE_TESTING OFF)
   set(ENABLE_EXPRESSION_TESTS OFF)
+  if(NOT PORTBLAS_TUNING_TARGET)
+    set(PORTBLAS_TUNING_TARGET "DEFAULT")
+  endif()
+  set(TUNING_TARGET ${PORTBLAS_TUNING_TARGET})
   set(BLAS_ENABLE_COMPLEX ON)
   # Set the policy to forward variables to portBLAS configure step
   set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
@@ -155,22 +159,13 @@ if (NOT PORTBLAS_FOUND)
     GIT_REPOSITORY https://github.com/codeplaysoftware/portBLAS
     GIT_TAG        master
   )
-  FetchContent_MakeAvailable(portBLAS)
+  FetchContent_MakeAvailable(portblas)
   message(STATUS "Looking for portBLAS - downloaded")
 
-  add_library(PORTBLAS::portblas INTERFACE IMPORTED)
-  target_include_directories(PORTBLAS::portblas
-    INTERFACE ${FETCHCONTENT_BASE_DIR}/portblas-src/include
-    INTERFACE ${FETCHCONTENT_BASE_DIR}/portblas-src/src
-  )
 else()
   message(STATUS "Looking for portBLAS - found")
+  add_library(portblas ALIAS PORTBLAS::portblas)
 endif()
-
-# This define is tuning portBLAS in header-only mode
-target_compile_definitions(PORTBLAS::portblas INTERFACE ${PORTBLAS_TUNING_TARGET})
-target_compile_definitions(PORTBLAS::portblas INTERFACE BLAS_ENABLE_COMPLEX=1)
-target_compile_options(ONEMKL::SYCL::SYCL INTERFACE "-DSB_ENABLE_USM=ON")
 
 set(SOURCES
   portblas_level1_double.cpp portblas_level1_float.cpp
@@ -196,7 +191,7 @@ target_include_directories(${LIB_OBJ}
 )
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
-target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL PORTBLAS::portblas)
+target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL portblas)
 
 set_target_properties(${LIB_OBJ} PROPERTIES
   POSITION_INDEPENDENT_CODE ON)

--- a/src/blas/backends/portblas/CMakeLists.txt
+++ b/src/blas/backends/portblas/CMakeLists.txt
@@ -149,6 +149,7 @@ if (NOT PORTBLAS_FOUND)
   if(NOT PORTBLAS_TUNING_TARGET)
     set(PORTBLAS_TUNING_TARGET "DEFAULT")
   endif()
+  # Following variable TUNING_TARGET will be used in portBLAS internal configuration
   set(TUNING_TARGET ${PORTBLAS_TUNING_TARGET})
   set(BLAS_ENABLE_COMPLEX ON)
   # Set the policy to forward variables to portBLAS configure step


### PR DESCRIPTION

# Description

This PR changes how cmake configures portBLAS backend. 
It removes differences between downloaded version and local version. Currently some compilation flags, definitions and headers inclusion are added  here and they are not necessary anymore.
It removes redefinition of portBLAS library target and it unifies library target name in a simpler one.
If not defined, it adds a default `PORTBLAS_TUNING_TARGET` and pass it to portBLAS cmake as `TUNING_TARGET`.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
-  [portblas_nvidia.txt](https://github.com/oneapi-src/oneMKL/files/15163677/portblas_nvidia.txt)
-  [portblas_amd.txt](https://github.com/oneapi-src/oneMKL/files/15163679/portblas_amd.txt)
-  [portblas_intel_iGPU.txt](https://github.com/oneapi-src/oneMKL/files/15163681/portblas_intel_iGPU.txt)