### PR TITLE
GitHub: slack notification for RFCs

### DIFF
--- a/.github/workflows/slack-pr.yaml
+++ b/.github/workflows/slack-pr.yaml
@@ -24,6 +24,9 @@ env:
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   channel: "onemkl"
 
+permissions:
+  pull-requests: read
+
 jobs:
   rfc:
     name: RFC Notification

--- a/.github/workflows/slack-pr.yaml
+++ b/.github/workflows/slack-pr.yaml
@@ -1,0 +1,40 @@
+#===============================================================================
+# Copyright 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+name: Slack PR Notification
+on:
+  # use pull_request_target to run on PRs from forks and have access to secrets
+  pull_request_target:
+    types: [labeled]
+
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  channel: "onemkl"
+
+jobs:
+  rfc:
+    name: RFC Notification
+    runs-on: ubuntu-latest
+    # Trigger when labeling a PR with "RFC"
+    if: |
+      github.event.action == 'labeled' &&
+      contains(toJson(github.event.pull_request.labels.*.name), '"RFC"')
+    steps: 
+    - name: Notify Slack
+      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+      with:
+        channel-id: ${{ env.channel }}
+        slack-message: "${{ github.actor }} posted a RFC: ${{ github.event.pull_request.title }}. URL: ${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
# Description

Publish a notification to the onemkl channel in the UXL slack space when a PR is labeled RFC. To see a sample, look at rc-test channel. They are some test messages for onednn for the same workflow. This is the same workflow as https://github.com/oneapi-src/oneDNN/pull/1900. Only the channel name has changed.

To enable the notification, someone with admin privileges must add a secret called SLACK_BOT_TOKEN to the repo. I can provide the value of the token in a DM. After the secret is added and this PR is merged, then new PR's with the RFC label will trigger the notification.

Addresses part of https://github.com/orgs/uxlfoundation/projects/5?pane=issue&itemId=56606833


