### PR TITLE
GitHub workflow for running unit tests for MKL backend on CPU

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,10 +49,10 @@ jobs:
     - name: Configure/Build for a domain
       run: |
         source /opt/intel/oneapi/setvars.sh
-        cmake -DREF_BLAS_ROOT=${PWD}/lapack/install -DREF_LAPACK_ROOT=${PWD}/lapack/install -DTARGET_DOMAINS=${{ matrix.domain }} -B build
+        cmake -DREF_BLAS_ROOT=${PWD}/lapack/install -DREF_LAPACK_ROOT=${PWD}/lapack/install -DENABLE_MKLGPU_BACKEND=off -DTARGET_DOMAINS=${{ matrix.domain }} -B build
         cmake --build build ${PARALLEL}
     - name: Run tests
       run: |
         source /opt/intel/oneapi/setvars.sh
         # Run tests, skip GPU tests
-        ctest --test-dir build ${PARALLEL} -E 'gpu$'
+        ctest --test-dir build ${PARALLEL} -E 'ct$'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   mkl:
-    runs-on: ubuntu-latest
+    runs-on: intel-ubuntu-latest
     # One runner for each domain
     strategy:
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   mkl:
-    runs-on: [ubuntu-latest, intel-ubuntu-latest]
+    runs-on: intel-ubuntu-latest
     # One runner for each domain
     strategy:
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   mkl:
-    runs-on: intel-ubuntu-latest
+    runs-on: [ubuntu-latest, intel-ubuntu-latest]
     # One runner for each domain
     strategy:
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,10 +49,10 @@ jobs:
     - name: Configure/Build for a domain
       run: |
         source /opt/intel/oneapi/setvars.sh
-        cmake -DREF_BLAS_ROOT=${PWD}/lapack/install -DREF_LAPACK_ROOT=${PWD}/lapack/install -DENABLE_MKLGPU_BACKEND=off -DTARGET_DOMAINS=${{ matrix.domain }} -B build
+        cmake -DREF_BLAS_ROOT=${PWD}/lapack/install -DREF_LAPACK_ROOT=${PWD}/lapack/install -DENABLE_MKLGPU_BACKEND=off -DTARGET_DOMAINS=${{ matrix.domain }} -DCMAKE_VERBOSE_MAKEFILE=on -B build
         cmake --build build ${PARALLEL}
     - name: Run tests
       run: |
         source /opt/intel/oneapi/setvars.sh
         # Run tests, skip GPU tests
-        ctest --test-dir build ${PARALLEL} -E 'ct$'
+        ctest --test-dir build -j 1 -E 'ct$'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,57 @@
+name: "PR Tests"
+permissions: read-all
+
+# Trigger for PR an merge to develop branch
+on:
+  push:
+    branches: develop
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+  LAPACK_VERSION: 3.12.0
+  PARALLEL: -j 2
+
+jobs:
+  mkl:
+    runs-on: ubuntu-latest
+    # One runner for each domain
+    strategy:
+      matrix:
+        domain: [blas, dft, lapack, rng]
+    steps:
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - name: Restore netlib from cache
+      id: cache-lapack
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      with:
+        path: lapack/install
+        key: lapack-${{ env.LAPACK_VERSION }}
+    - name: Install netlib
+      if: steps.cache-lapack.outputs.cache-hit != 'true'
+      run: |
+        curl -sL https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v${LAPACK_VERSION}.tar.gz | tar zx
+        SHARED_OPT="lapack-${LAPACK_VERSION} -DBUILD_SHARED_LIBS=on -DCBLAS=on -DLAPACKE=on -DCMAKE_INSTALL_PREFIX=${PWD}/lapack/install"
+        # 32 bit int
+        cmake ${SHARED_OPT} -B lapack/build32 
+        cmake --build lapack/build32 ${PARALLEL} --target install
+        # 64 bit int
+        cmake ${SHARED_OPT} -DBUILD_INDEX64=on -B lapack/build64
+        cmake --build lapack/build64 ${PARALLEL} --target install
+    - name: Install oneapi
+      uses: rscohn2/setup-oneapi@2ad0cf6b74bc2426bdcee825cf88f9db719dd727 # v0.1.0
+      with:
+        components: |
+          icx@2024.1.0
+          mkl@2024.1.0
+    - name: Configure/Build for a domain
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cmake -DREF_BLAS_ROOT=${PWD}/lapack/install -DREF_LAPACK_ROOT=${PWD}/lapack/install -DTARGET_DOMAINS=${{ matrix.domain }} -B build
+        cmake --build build ${PARALLEL}
+    - name: Run tests
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        # Run tests, skip GPU tests
+        ctest --test-dir build ${PARALLEL} -E 'gpu$'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         domain: [blas, dft, lapack, rng]
+    name: MKL ${{ matrix.domain }} CPU
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Restore netlib from cache


### PR DESCRIPTION
# Description

GitHub Actions workflow to run unit tests for MKL/CPU. 

I disabled tests that require GPU by excluding tests where the name ends in `gpu`. RNG and DFT domains finish in 10 minutes. I am still waiting for BLAS/LAPACK to finish. We could have nightly testing that runs everything and PR testing that runs a smaller set. Any thoughts on how to reduce the testing for PR's?

@mkrainiuk