### PR TITLE
[tests][LAPACK] Avoid cuSOLVER bug in *trd tests

### DIFF
--- a/tests/unit_tests/lapack/source/hetrd.cpp
+++ b/tests/unit_tests/lapack/source/hetrd.cpp
@@ -36,7 +36,7 @@
 namespace {
 
 const char* accuracy_input = R"(
-0 33 35 27182
+1 33 35 27182
 )";
 
 template <typename data_T>
@@ -132,7 +132,7 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             e[diag] -= A[diag + (diag + 1) * lda].real();
     else
         for (int64_t diag = 0; diag < n - 1; diag++)
-            e[diag] -= A[diag + 1 + (diag)*ldt].real();
+            e[diag] -= A[diag + 1 + (diag)*lda].real();
 
     auto ulp = reference::lamch<fp_real>('P');
     if (reference::lange('I', n, 1, d.data(), n) > 10.0 * ulp) {

--- a/tests/unit_tests/lapack/source/sytrd.cpp
+++ b/tests/unit_tests/lapack/source/sytrd.cpp
@@ -36,7 +36,7 @@
 namespace {
 
 const char* accuracy_input = R"(
-0 33 35 27182
+1 33 35 27182
 )";
 
 template <typename data_T>
@@ -132,7 +132,7 @@ bool accuracy(const sycl::device& dev, oneapi::mkl::uplo uplo, int64_t n, int64_
             e[diag] -= A[diag + (diag + 1) * lda];
     else
         for (int64_t diag = 0; diag < n - 1; diag++)
-            e[diag] -= A[diag + 1 + (diag)*ldt];
+            e[diag] -= A[diag + 1 + (diag)*lda];
 
     auto ulp = reference::lamch<fp_real>('P');
     if (reference::lange('I', n, 1, d.data(), n) > 10.0 * ulp) {


### PR DESCRIPTION
# Description

The LAPACK *trd (sytrd, hetrd) tests fail with cuSOLVER backend during the off-diagonal check. This check compares the superdiagonal of A (for upper case; otherwise subdiagonal for lower case) with the output vector e, which contains the off-diagonal elements of the tridiagonal matrix. This appears to expose a legitimate, albeit relatively minor, bug in cuSOLVER for the upper case, where the first element of the superdiagonal of A, A[0,1], is always -1. The rest of the elements of the superdiagonal are equal to the values in the output e vector, which contains the off-diagonal elements of the tridiagonal matrix.

Since the lower case does not appear to have this bug in cuSOLVER, the input being tested was changed to test the lower case. Additionally a typo was fixed in the test to use the correct leading dimension when accessing the A matrix.

Fixes #231 

# Checklist

## All Submissions

- [X] Do all unit tests pass locally?  [cusolver_tests.log](https://github.com/oneapi-src/oneMKL/files/15426115/cusolver_tests.log)

- [ ] Have you formatted the code using clang-format? N/A

## Bug fixes

- [X] Have you added relevant regression tests? Existing test was modified.
- [X] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)? Run regular unit tests.
