### PR TITLE
[DFT] Add static_assert to check types passed into compute_foward and compute_backward

### DIFF
--- a/include/oneapi/mkl/dft/backward.hpp
+++ b/include/oneapi/mkl/dft/backward.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2024 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_r
                       sycl::buffer<data_type, 1> &inout_im) {
     static_assert(detail::valid_compute_arg<descriptor_type, data_type>::value,
                   "unexpected type for data_type");
+    static_assert(!detail::is_complex_arg<data_type>::value, "expected real type for data_type");
 
     using scalar_type = typename detail::descriptor_info<descriptor_type>::scalar_type;
     auto type_corrected_inout_re = inout_re.template reinterpret<scalar_type, 1>(
@@ -69,6 +70,13 @@ void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
 
     using fwd_type = typename detail::descriptor_info<descriptor_type>::forward_type;
     using bwd_type = typename detail::descriptor_info<descriptor_type>::backward_type;
+
+    // If the DFT is COMPLEX, the input and output types are expected to be complex.
+    static_assert(
+        !std::is_same_v<fwd_type, bwd_type> || (detail::is_complex_arg<input_type>::value &&
+                                                detail::is_complex_arg<output_type>::value),
+        "expected std::complex input_type and output_type");
+
     auto type_corrected_in = in.template reinterpret<bwd_type, 1>(
         detail::reinterpret_range<input_type, bwd_type>(in.size()));
     auto type_corrected_out = out.template reinterpret<fwd_type, 1>(
@@ -85,6 +93,9 @@ void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
                   "unexpected type for input_type");
     static_assert(detail::valid_compute_arg<descriptor_type, output_type>::value,
                   "unexpected type for output_type");
+    static_assert(
+        !detail::is_complex_arg<input_type>::value && !detail::is_complex_arg<output_type>::value,
+        "expected input_type and output_type to be real");
 
     using scalar_type = typename detail::descriptor_info<descriptor_type>::scalar_type;
     auto type_corrected_in_re = in_re.template reinterpret<scalar_type, 1>(
@@ -119,6 +130,7 @@ sycl::event compute_backward(descriptor_type &desc, data_type *inout_re, data_ty
                              const std::vector<sycl::event> &dependencies = {}) {
     static_assert(detail::valid_compute_arg<descriptor_type, data_type>::value,
                   "unexpected type for data_type");
+    static_assert(!detail::is_complex_arg<data_type>::value, "data_type is expected to be real");
 
     using scalar_type = typename detail::descriptor_info<descriptor_type>::scalar_type;
     return get_commit(desc)->backward_ip_rr(desc, reinterpret_cast<scalar_type *>(inout_re),
@@ -137,6 +149,13 @@ sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type 
 
     using fwd_type = typename detail::descriptor_info<descriptor_type>::forward_type;
     using bwd_type = typename detail::descriptor_info<descriptor_type>::backward_type;
+
+    // If the DFT is COMPLEX, the input and output types are expected to be complex.
+    static_assert(
+        !std::is_same_v<fwd_type, bwd_type> || (detail::is_complex_arg<input_type>::value &&
+                                                detail::is_complex_arg<output_type>::value),
+        "expected std::complex input_type and output_type");
+
     return get_commit(desc)->backward_op_cc(desc, reinterpret_cast<bwd_type *>(in),
                                             reinterpret_cast<fwd_type *>(out), dependencies);
 }
@@ -150,6 +169,9 @@ sycl::event compute_backward(descriptor_type &desc, input_type *in_re, input_typ
                   "unexpected type for input_type");
     static_assert(detail::valid_compute_arg<descriptor_type, output_type>::value,
                   "unexpected type for output_type");
+    static_assert(
+        !detail::is_complex_arg<input_type>::value && !detail::is_complex_arg<output_type>::value,
+        "expected input_type and output_type to be real");
 
     using scalar_type = typename detail::descriptor_info<descriptor_type>::scalar_type;
     return get_commit(desc)->backward_op_rr(desc, reinterpret_cast<scalar_type *>(in_re),

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2024 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -96,6 +96,12 @@ using valid_compute_arg = typename std::bool_constant<
      is_one_of<T, float, sycl::float2, sycl::float4, std::complex<float>>::value) ||
     (std::is_same_v<typename detail::descriptor_info<descriptor_type>::scalar_type, double> &&
      is_one_of<T, double, sycl::double2, sycl::double4, std::complex<double>>::value)>;
+
+template <typename T>
+class is_complex_arg : public std::false_type {};
+
+template <typename T>
+class is_complex_arg<std::complex<T>> : public std::true_type {};
 
 // compute the range of a reinterpreted buffer
 template <typename In, typename Out>


### PR DESCRIPTION
# Description

This adds static_asserts more rigidly check that input/output argument types are as expected.

Eg.
```c++
    auto in_usm = sycl::malloc_shared<std::complex<float>>(N, sycl_queue);
    auto out_usm = sycl::malloc_shared<std::complex<float>>(N, sycl_queue);
    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
                                 oneapi::mkl::dft::domain::COMPLEX>
        desc(static_cast<std::int64_t>(N));
    desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                   oneapi::mkl::dft::config_value::NOT_INPLACE);
    desc.commit(sycl_queue);
    auto compute_event = oneapi::mkl::dft::compute_forward(desc, in_usm, out_usm);
```
now fails because the user has inadverently used called the compute_forward for in-place real-real DFTs. The error would help the user identify that they ought to be using
```c++
  oneapi::mkl::dft::compute_forward<decltype(desc), std::complex<float>, std::complex<float>>(desc, in_usm, out_usm);
```

Partially resolves https://github.com/oneapi-src/oneMKL/issues/499

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?

[testres.txt](https://github.com/oneapi-src/oneMKL/files/15472131/testres.txt)
