### PR TITLE
[DFT] Correct overload resolution for OOP COMPLEX vs IP REAL_REAL

### DIFF
--- a/include/oneapi/mkl/dft/backward.hpp
+++ b/include/oneapi/mkl/dft/backward.hpp
@@ -60,9 +60,7 @@ void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_r
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type,
-          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
-                           bool> = true>
+template <typename descriptor_type, typename input_type, typename output_type>
 void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
                       sycl::buffer<output_type, 1> &out) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,
@@ -131,9 +129,7 @@ sycl::event compute_backward(descriptor_type &desc, data_type *inout_re, data_ty
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type,
-          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
-                           bool> = true>
+template <typename descriptor_type, typename input_type, typename output_type>
 sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
                              const std::vector<sycl::event> &dependencies = {}) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,

--- a/include/oneapi/mkl/dft/backward.hpp
+++ b/include/oneapi/mkl/dft/backward.hpp
@@ -44,7 +44,8 @@ void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) 
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
-template <typename descriptor_type, typename data_type>
+template <typename descriptor_type, typename data_type,
+          std::enable_if_t<detail::valid_ip_realreal_impl<descriptor_type, data_type>, bool> = true>
 void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
                       sycl::buffer<data_type, 1> &inout_im) {
     static_assert(detail::valid_compute_arg<descriptor_type, data_type>::value,
@@ -59,7 +60,9 @@ void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_r
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type>
+template <typename descriptor_type, typename input_type, typename output_type,
+          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
+                           bool> = true>
 void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
                       sycl::buffer<output_type, 1> &out) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,
@@ -114,7 +117,8 @@ sycl::event compute_backward(descriptor_type &desc, data_type *inout,
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
-template <typename descriptor_type, typename data_type>
+template <typename descriptor_type, typename data_type,
+          std::enable_if_t<detail::valid_ip_realreal_impl<descriptor_type, data_type>, bool> = true>
 sycl::event compute_backward(descriptor_type &desc, data_type *inout_re, data_type *inout_im,
                              const std::vector<sycl::event> &dependencies = {}) {
     static_assert(detail::valid_compute_arg<descriptor_type, data_type>::value,
@@ -127,7 +131,9 @@ sycl::event compute_backward(descriptor_type &desc, data_type *inout_re, data_ty
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type>
+template <typename descriptor_type, typename input_type, typename output_type,
+          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
+                           bool> = true>
 sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
                              const std::vector<sycl::event> &dependencies = {}) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -111,20 +111,6 @@ using valid_compute_arg = typename std::bool_constant<
     (std::is_same_v<descriptor_scalar_t<descriptor_type>, double> &&
      is_one_of<T, double, sycl::double2, sycl::double4, std::complex<double>>::value)>;
 
-// For out-of-place complex-complex DFTs, are the input and output types correct? For SFINAE.
-template <class descriptor_t, typename input_t, typename output_t>
-constexpr bool valid_oop_iotypes = []() {
-    if constexpr (is_complex_dft<descriptor_t>) {
-        // Both input and output types must be complex, otherwise select real-real inplace overload.
-        return is_complex<input_t> && is_complex<output_t>;
-    }
-    else {
-        // I/O can be real or complex - no issues resolving overload with real-real inplace.
-        return valid_compute_arg<descriptor_t, input_t>::value &&
-               valid_compute_arg<descriptor_t, output_t>::value;
-    }
-}();
-
 template <class descriptor_t, typename data_t>
 constexpr bool valid_ip_realreal_impl =
     is_complex_dft<descriptor_t>&& std::is_same_v<descriptor_scalar_t<descriptor_t>, data_t>;

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -106,9 +106,9 @@ using is_one_of = typename std::bool_constant<(std::is_same_v<T, Ts> || ...)>;
 
 template <typename descriptor_type, typename T>
 using valid_compute_arg = typename std::bool_constant<
-    (std::is_same_v<typename detail::descriptor_info<descriptor_type>::scalar_type, float> &&
+    (std::is_same_v<descriptor_scalar_t<descriptor_type>, float> &&
      is_one_of<T, float, sycl::float2, sycl::float4, std::complex<float>>::value) ||
-    (std::is_same_v<typename detail::descriptor_info<descriptor_type>::scalar_type, double> &&
+    (std::is_same_v<descriptor_scalar_t<descriptor_type>, double> &&
      is_one_of<T, double, sycl::double2, sycl::double4, std::complex<double>>::value)>;
 
 // For out-of-place complex-complex DFTs, are the input and output types correct? For SFINAE.

--- a/include/oneapi/mkl/dft/forward.hpp
+++ b/include/oneapi/mkl/dft/forward.hpp
@@ -61,9 +61,7 @@ void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type,
-          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
-                           bool> = true>
+template <typename descriptor_type, typename input_type, typename output_type>
 void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
                      sycl::buffer<output_type, 1> &out) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,
@@ -129,9 +127,7 @@ sycl::event compute_forward(descriptor_type &desc, data_type *inout_re, data_typ
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type,
-          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
-                           bool> = true>
+template <typename descriptor_type, typename input_type, typename output_type>
 sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
                             const std::vector<sycl::event> &dependencies = {}) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,

--- a/include/oneapi/mkl/dft/forward.hpp
+++ b/include/oneapi/mkl/dft/forward.hpp
@@ -45,7 +45,8 @@ void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
-template <typename descriptor_type, typename data_type>
+template <typename descriptor_type, typename data_type,
+          std::enable_if_t<detail::valid_ip_realreal_impl<descriptor_type, data_type>, bool> = true>
 void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
                      sycl::buffer<data_type, 1> &inout_im) {
     static_assert(detail::valid_compute_arg<descriptor_type, data_type>::value,
@@ -60,7 +61,9 @@ void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type>
+template <typename descriptor_type, typename input_type, typename output_type,
+          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
+                           bool> = true>
 void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
                      sycl::buffer<output_type, 1> &out) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,
@@ -114,26 +117,27 @@ sycl::event compute_forward(descriptor_type &desc, data_type *inout,
 }
 
 //In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
-template <typename descriptor_type, typename data_type>
+template <typename descriptor_type, typename data_type,
+          std::enable_if_t<detail::valid_ip_realreal_impl<descriptor_type, data_type>, bool> = true>
 sycl::event compute_forward(descriptor_type &desc, data_type *inout_re, data_type *inout_im,
                             const std::vector<sycl::event> &dependencies = {}) {
     static_assert(detail::valid_compute_arg<descriptor_type, data_type>::value,
                   "unexpected type for data_type");
-
     using scalar_type = typename detail::descriptor_info<descriptor_type>::scalar_type;
     return get_commit(desc)->forward_ip_rr(desc, reinterpret_cast<scalar_type *>(inout_re),
                                            reinterpret_cast<scalar_type *>(inout_im), dependencies);
 }
 
 //Out-of-place transform
-template <typename descriptor_type, typename input_type, typename output_type>
+template <typename descriptor_type, typename input_type, typename output_type,
+          std::enable_if_t<detail::valid_oop_iotypes<descriptor_type, input_type, output_type>,
+                           bool> = true>
 sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
                             const std::vector<sycl::event> &dependencies = {}) {
     static_assert(detail::valid_compute_arg<descriptor_type, input_type>::value,
                   "unexpected type for input_type");
     static_assert(detail::valid_compute_arg<descriptor_type, output_type>::value,
                   "unexpected type for output_type");
-
     using fwd_type = typename detail::descriptor_info<descriptor_type>::forward_type;
     using bwd_type = typename detail::descriptor_info<descriptor_type>::backward_type;
     return get_commit(desc)->forward_op_cc(desc, reinterpret_cast<fwd_type *>(in),


### PR DESCRIPTION
# Description

* OOP COMPLEX and IP REAL_REAL overload resolution is problematic
* Correct with SFINAE

Fixes # [(GitHub issue)](https://github.com/oneapi-src/oneMKL/issues/499)

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
 - [dfttest.txt](https://github.com/user-attachments/files/15514640/dfttest.txt)
- [x] Have you formatted the code using clang-format?

## New interfaces

It is unclear to me exactly what the spec intended and consequently. The spec does not define types for the data passed into DFT functions, only that there is sufficient space. This creates problems with resolving overloads however.

## Bug fixes

- [N/A] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
