### PR TITLE
[BLAS][portBLAS] Update portBLAS to use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,8 +515,8 @@ Product | Supported Version | License
 [AMD rocSOLVER](https://github.com/ROCm/rocSOLVER) | 5.0.0 | [AMD License](https://github.com/ROCm/rocSOLVER/blob/develop/LICENSE.md)
 [AMD rocFFT](https://github.com/ROCm/rocFFT) | rocm-5.4.3 | [AMD License](https://github.com/ROCm/rocFFT/blob/rocm-5.4.3/LICENSE.md)
 [NETLIB LAPACK](https://www.netlib.org/) | [5d4180c](https://github.com/Reference-LAPACK/lapack/commit/5d4180cf8288ae6ad9a771d18793d15bd0c5643c) | [BSD like license](http://www.netlib.org/lapack/LICENSE.txt)
-[portBLAS](https://github.com/codeplaysoftware/portBLAS) | 0.1 | [Apache License v2.0](https://github.com/codeplaysoftware/portBLAS/blob/master/LICENSE)
-[portFFT](https://github.com/codeplaysoftware/portFFT) | 0.1 | [Apache License v2.0](https://github.com/codeplaysoftware/portFFT/blob/master/LICENSE)
+[portBLAS](https://github.com/codeplaysoftware/portBLAS) | 0.1 | [Apache License v2.0](https://github.com/codeplaysoftware/portBLAS/blob/main/LICENSE)
+[portFFT](https://github.com/codeplaysoftware/portFFT) | 0.1 | [Apache License v2.0](https://github.com/codeplaysoftware/portFFT/blob/main/LICENSE)
 
 ---
 

--- a/src/blas/backends/portblas/CMakeLists.txt
+++ b/src/blas/backends/portblas/CMakeLists.txt
@@ -158,7 +158,7 @@ if (NOT PORTBLAS_FOUND)
   FetchContent_Declare(
     portBLAS
     GIT_REPOSITORY https://github.com/codeplaysoftware/portBLAS
-    GIT_TAG        master
+    GIT_TAG        main
   )
   FetchContent_MakeAvailable(portblas)
   message(STATUS "Looking for portBLAS - downloaded")


### PR DESCRIPTION
# Description

Update portBLAS backend to use the new default `main` branch instead of `master`.
Also update the links in the README even though the redirection is working for http links.

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? (GitHub CI is enough to show portBLAS builds)
- [N/A] Have you formatted the code using clang-format?

