### PR TITLE
[DFT][CMake] Check CUDA support with portFFT before using it as a target

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
           options: -DTARGET_DOMAINS=blas -DREF_BLAS_ROOT=${PWD}/lapack/install -DENABLE_PORTBLAS_BACKEND=ON -DENABLE_MKLCPU_BACKEND=OFF -DPORTBLAS_TUNING_TARGET=INTEL_CPU
           tests: '.*'
         - config: portFFT
-          options: -DENABLE_PORTFFT_BACKEND=ON -DENABLE_MKLCPU_BACKEND=OFF -DTARGET_DOMAINS=dft -DCMAKE_CXX_FLAGS="-fsycl -fsycl-targets=spir64"
+          options: -DENABLE_PORTFFT_BACKEND=ON -DENABLE_MKLCPU_BACKEND=OFF -DTARGET_DOMAINS=dft
           tests: 'DFT/CT/.*ComputeTests_in_place_COMPLEX.COMPLEX_SINGLE_in_place_buffer.sizes_8_batches_1*'
         - config: MKL BLAS
           options: -DTARGET_DOMAINS=blas -DREF_BLAS_ROOT=${PWD}/lapack/install

--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -36,6 +36,9 @@ if(is_dpcpp)
   if(UNIX)
     set(UNIX_INTERFACE_COMPILE_OPTIONS -fsycl)
     set(UNIX_INTERFACE_LINK_OPTIONS -fsycl)
+    # Check if the Nvidia target is supported. PortFFT uses this for choosing default configuration.
+    check_cxx_compiler_flag("-fsycl -fsycl-targets=nvptx64-nvidia-cuda" dpcpp_supports_nvptx64)
+
     if(ENABLE_CURAND_BACKEND OR ENABLE_CUSOLVER_BACKEND)
       list(APPEND UNIX_INTERFACE_COMPILE_OPTIONS
         -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda)

--- a/src/dft/backends/portfft/CMakeLists.txt
+++ b/src/dft/backends/portfft/CMakeLists.txt
@@ -36,7 +36,11 @@ if (IS_DPCPP AND UNIX AND NOT FOUND_TARGETS)
   set(TARGETS_LINK_OPTIONS -fsycl-unnamed-lambda)
 
   # spir64 must be last in the list due to a bug in dpcpp 2024.0.0
-  set(TARGETS_TRIPLES "nvptx64-nvidia-cuda,spir64")
+  if(dpcpp_supports_nvptx64)
+    set(TARGETS_TRIPLES "nvptx64-nvidia-cuda,spir64")
+  else()
+    set(TARGETS_TRIPLES "spir64")
+  endif()
 
   if (NOT (HIP_TARGETS STREQUAL ""))
     set(TARGETS_TRIPLES amdgcn-amd-amdhsa,${TARGETS_TRIPLES})
@@ -45,6 +49,8 @@ if (IS_DPCPP AND UNIX AND NOT FOUND_TARGETS)
   else()
     message(WARNING "Can't enable hip backend, HIP_TARGETS has not been set.")
   endif()
+  
+  message(STATUS "portFFT target triple set to ${TARGETS_TRIPLES}")
 
   list(APPEND TARGETS_COMPILE_OPTIONS -fsycl-targets=${TARGETS_TRIPLES})
   list(APPEND TARGETS_LINK_OPTIONS -fsycl-targets=${TARGETS_TRIPLES})

--- a/src/dft/backends/portfft/CMakeLists.txt
+++ b/src/dft/backends/portfft/CMakeLists.txt
@@ -36,10 +36,9 @@ if (IS_DPCPP AND UNIX AND NOT FOUND_TARGETS)
   set(TARGETS_LINK_OPTIONS -fsycl-unnamed-lambda)
 
   # spir64 must be last in the list due to a bug in dpcpp 2024.0.0
+  set(TARGETS_TRIPLES "spir64")
   if(dpcpp_supports_nvptx64)
-    set(TARGETS_TRIPLES "nvptx64-nvidia-cuda,spir64")
-  else()
-    set(TARGETS_TRIPLES "spir64")
+    set(TARGETS_TRIPLES nvptx64-nvidia-cuda,${TARGETS_TRIPLES})
   endif()
 
   if (NOT (HIP_TARGETS STREQUAL ""))


### PR DESCRIPTION
# Description

* The portFFT backends targets Nvidia by default
* In some situations, this causes a failure whilst compiling (CUDA might not be installed)
* This checks the target is supported before use

This solves the issue in the PR at https://github.com/oneapi-src/oneMKL/pull/495#discussion_r1609733715

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? Attach a log.
- [N/A] Have you formatted the code using clang-format?
