### PR TITLE
[RNG] Add explicit cast to T for operator<< of sycl::vec<T, 1> usage #4396

### DIFF
--- a/include/oneapi/mkl/rng/device/detail/mcg59_impl.hpp
+++ b/include/oneapi/mkl/rng/device/detail/mcg59_impl.hpp
@@ -197,10 +197,10 @@ protected:
             auto uni_res2 = mcg59_impl::generate(this->state_);
 
             if constexpr (VecSize == 1) {
-                uni_res1 >>= 27;
-                uni_res2 >>= 27;
+                uni_res1 >>= UIntType(27);
+                uni_res2 >>= UIntType(27);
 
-                return (uni_res2 << 32) + uni_res1;
+                return (uni_res2 << UIntType(32)) + uni_res1;
             }
             else {
                 sycl::vec<std::uint64_t, VecSize> vec_out;


### PR DESCRIPTION
# Description

Aligning with SYCL Spec (https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_vec_interface) carefully. We need to explicitly cast `int` to underlying type of `sycl::vec`.
Compilation failure can be seeing after following commit on the Compiler side:  https://github.com/intel/llvm/commit/d0a142af20b31f8a663ded534df4edcaaf3eee1c

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a ([moments.log](https://github.com/user-attachments/files/15822733/moments.log))
- [x] Have you formatted the code using clang-format?
