### PR TITLE
[DFT][MKLGPU] Use FWD/BWD_STRIDES

### DIFF
--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -394,7 +394,7 @@ public:
 
     std::int64_t get_plan_workspace_size_bytes(cufftHandle handle) {
         std::size_t size = 0;
-        cufftGetSize(*plans[0], &size);
+        cufftGetSize(handle, &size);
         std::int64_t padded_size = static_cast<int64_t>(size);
         return padded_size;
     }

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -41,12 +41,15 @@ namespace detail {
 template <dft::detail::precision prec, dft::detail::domain dom, typename... ArgTs>
 inline auto compute_backward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&... args) {
     using mklgpu_desc_t = dft::descriptor<to_mklgpu(prec), to_mklgpu(dom)>;
+    using desc_shptr_t = std::shared_ptr<mklgpu_desc_t>;
+    using handle_t = std::pair<desc_shptr_t, desc_shptr_t>;
     auto commit_handle = dft::detail::get_commit(desc);
     if (commit_handle == nullptr || commit_handle->get_backend() != backend::mklgpu) {
         throw mkl::invalid_argument("DFT", "compute_backward",
                                     "DFT descriptor has not been commited for MKLGPU");
     }
-    auto mklgpu_desc = reinterpret_cast<mklgpu_desc_t *>(commit_handle->get_handle());
+    auto handle = reinterpret_cast<handle_t *>(commit_handle->get_handle());
+    auto mklgpu_desc = handle->second; // Second because backward DFT.
     int commit_status{ DFTI_UNCOMMITTED };
     mklgpu_desc->get_value(dft::config_param::COMMIT_STATUS, &commit_status);
     if (commit_status != DFTI_COMMITTED) {

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -211,7 +211,7 @@ private:
 
     // This is called by the workspace_helper, and is not part of the user API.
     virtual std::int64_t get_workspace_external_bytes_impl() override {
-        std::size_t workspaceSizeFwd = 0, workspaceSizeBwd;
+        std::size_t workspaceSizeFwd = 0, workspaceSizeBwd = 0;
         handle.first->get_value(dft::config_param::WORKSPACE_BYTES, &workspaceSizeFwd);
         handle.second->get_value(dft::config_param::WORKSPACE_BYTES, &workspaceSizeBwd);
         return static_cast<std::int64_t>(std::max(workspaceSizeFwd, workspaceSizeFwd));


### PR DESCRIPTION
# Description

* Intel(R) oneMKL 2024.1 deprecate the INPUT/OUTPUT_STRIDES API
* Using the old API causes error messages to be printed.
* This PR uses the new FWD/BWD_STRIDES API, but maintains support for older Intel(R) oneMKL.
* Fixes a warning
  * `sources/src/dft/backends/mklgpu/descriptor.cpp:30:29: warning: a declarative nested name specifier cannot name an alias template [-Walias-template-in-declaration-name]`
  * This warning seems to need nightly clang rather than icpx.
* It additionally fixes one-line bug in cuFFT (albeit one that doesn't seem to cause any issues).

Fixes https://github.com/oneapi-src/oneMKL/issues/487

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
  - [testres.txt](https://github.com/user-attachments/files/15827902/testres.txt)
  - Tests only attached for MKLGPU. Other domains have the minor modification to stop the compiler warning. Ctest has been run and passes.
- [x] Have you formatted the code using clang-format?
