### PR TITLE
[BLAS][HIP] Fix blas support for rocBLAS 4+

### DIFF
--- a/src/blas/backends/rocblas/rocblas_level3.cpp
+++ b/src/blas/backends/rocblas/rocblas_level3.cpp
@@ -381,10 +381,17 @@ inline void trmm(Func func, sycl::queue &queue, side left_right, uplo upper_lowe
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             rocblas_status err;
+#if ROCBLAS_VERSION_MAJOR >= 4
+            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+                                    get_rocblas_fill_mode(upper_lower),
+                                    get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
+                                    m, n, (rocDataType *)&alpha, a_, lda, b_, ldb, b_, ldb);
+#else
             ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);
+#endif
         });
     });
 }
@@ -805,10 +812,17 @@ inline sycl::event trmm(Func func, sycl::queue &queue, side left_right, uplo upp
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto b_ = reinterpret_cast<rocDataType *>(b);
             rocblas_status err;
+#if ROCBLAS_VERSION_MAJOR >= 4
+            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+                                    get_rocblas_fill_mode(upper_lower),
+                                    get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
+                                    m, n, (rocDataType *)&alpha, a_, lda, b_, ldb, b_, ldb);
+#else
             ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);
+#endif
         });
     });
 


### PR DESCRIPTION
# Description

Patch is similar to https://github.com/oneapi-src/oneMKL/pull/448 (thanks @nilsfriess ) but with only the ifdef part to make the rocBLAS 4 build work.

I've tested with ROCm 5.4.3 (rocBLAS 2), and ROCm 6.1.0 (rocBLAS 4), I've also tested the build with ROCm 5.7.1 (rocBLAS 3), the new interface seemed to cause build issues with rocBLAS 3 so I kept the legacy one.

Information on the deprecated interface [here](https://rocblas.readthedocs.io/en/master/API_Reference_Guide.html#announced-in-rocblas-3-0).

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
  - [test_main_blas_rt-rocm-6.1.0.log](https://github.com/user-attachments/files/15902562/test_main_blas_rt-rocm-6.1.0.log) [test_main_blas_rt-rocm-5.4.3.log](https://github.com/user-attachments/files/15902563/test_main_blas_rt-rocm-5.4.3.log)
- [x] Have you formatted the code using clang-format?

cc @mmeterel @Rbiessy 