### PR TITLE
[Docs] add link to unit test readme and use correct github team names for maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,6 +320,6 @@ for (int i = 0; i < loop_size; i++) ...;
 
 ## Unit Tests
 
-oneMKL uses GoogleTest for functional testing.
+oneMKL uses GoogleTest for functional testing. For more information about how to build and run Unit Tests please see [oneMKL Interfaces Testing](tests/README.md)
 
 Be sure to extend the existing tests when fixing an issue, adding a new interface or new implementation under existing interfaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,6 +320,6 @@ for (int i = 0; i < loop_size; i++) ...;
 
 ## Unit Tests
 
-oneMKL uses GoogleTest for functional testing. For more information about how to build and run Unit Tests please see [Building and Running Tests](https://oneapi-src.github.io/oneMKL/building_and_running_tests.html)
+oneMKL uses GoogleTest for functional testing. For more information about how to build and run Unit Tests please see [Building and Running Tests](https://oneapi-src.github.io/oneMKL/building_and_running_tests.html).
 
 Be sure to extend the existing tests when fixing an issue, adding a new interface or new implementation under existing interfaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,6 +320,6 @@ for (int i = 0; i < loop_size; i++) ...;
 
 ## Unit Tests
 
-oneMKL uses GoogleTest for functional testing. For more information about how to build and run Unit Tests please see [oneMKL Interfaces Testing](tests/README.md)
+oneMKL uses GoogleTest for functional testing. For more information about how to build and run Unit Tests please see [Building and Running Tests](https://oneapi-src.github.io/oneMKL/building_and_running_tests.html)
 
 Be sure to extend the existing tests when fixing an issue, adding a new interface or new implementation under existing interfaces.

--- a/README.md
+++ b/README.md
@@ -549,14 +549,14 @@ For GitHub questions, issues, RFCs, or PRs you can contact maintainers via one o
 
 | GitHub team name | Description |
 :-----------|:------------|
-| [oneMKL-maintain](https://github.com/orgs/oneapi-src/teams/onemkl-maintain) | All oneMKL maintainers |
-| [oneMKL-arch-write](https://github.com/orgs/oneapi-src/teams/onemkl-arch-write) | oneMKL Architecture maintainers |
-| [oneMKL-blas-write](https://github.com/orgs/oneapi-src/teams/onemkl-blas-write) | oneMKL BLAS maintainers |
-| [oneMKL-dft-write](https://github.com/orgs/oneapi-src/teams/onemkl-dft-write) | oneMKL DFT maintainers |
-| [oneMKL-lapack-write](https://github.com/orgs/oneapi-src/teams/onemkl-lapack-write) | oneMKL LAPACK maintainers |
-| [oneMKL-rng-write](https://github.com/orgs/oneapi-src/teams/onemkl-rng-write) | oneMKL RNG maintainers |
-| [oneMKL-sparse-write](https://github.com/orgs/oneapi-src/teams/onemkl-sparse-write) | oneMKL Sparse Algebra maintainers |
-| [oneMKL-vm-write](https://github.com/orgs/oneapi-src/teams/onemkl-vm-write) | oneMKL Vector Math maintainers |
+| @oneapi-src/onemkl-maintain  | All oneMKL maintainers |
+| @oneapi-src/onemkl-arch-write | oneMKL Architecture maintainers |
+| @oneapi-src/onemkl-blas-write | oneMKL BLAS maintainers |
+| @oneapi-src/onemkl-dft-write | oneMKL DFT maintainers |
+| @oneapi-src/onemkl-lapack-write) | oneMKL LAPACK maintainers |
+| @oneapi-src/onemkl-rng-write | oneMKL RNG maintainers |
+| @oneapi-src/onemkl-sparse-write | oneMKL Sparse Algebra maintainers |
+| @oneapi-src/onemkl-vm-write | oneMKL Vector Math maintainers |
 
 ---
 

--- a/docs/building_and_running_tests.rst
+++ b/docs/building_and_running_tests.rst
@@ -33,7 +33,7 @@ and ``-DREF_LAPACK_ROOT=/path/to/lapack/install``.
 
 You can re-run tests without re-building the entire project.
 
-To run the tests, either run test binaries individually, or use `ctest` CMake test driver program.
+To run the tests, either run test binaries individually, or use ``ctest`` CMake test driver program.
 
 .. code-block:: bash
 

--- a/docs/building_and_running_tests.rst
+++ b/docs/building_and_running_tests.rst
@@ -37,7 +37,7 @@ To run the tests, either run test binaries individually, or use `ctest` CMake te
 
 .. code-block:: bash
 
- # Run all tests
+  # Run all tests
   ctest
   # Run only Gpu specific tests
   ctest -R Gpu

--- a/docs/building_and_running_tests.rst
+++ b/docs/building_and_running_tests.rst
@@ -31,8 +31,20 @@ following:
 and then used in oneMKL by setting ``-REF_BLAS_ROOT=/path/to/lapack/install``
 and ``-DREF_LAPACK_ROOT=/path/to/lapack/install``.
 
-To run the tests, either use the CMake test driver, by running ``ctest``, or run
-individual test binaries individually.
+You can re-run tests without re-building the entire project.
+
+To run the tests, either run test binaries individually, or use `ctest` CMake test driver program.
+
+.. code-block:: bash
+
+ # Run all tests
+  ctest
+  # Run only Gpu specific tests
+  ctest -R Gpu
+  # Exclude Cpu tests
+  ctest -E Cpu
+
+For more `ctest` options, refer to `ctest manual page <https://cmake.org/cmake/help/v3.13/manual/ctest.1.html>`_.
 
 When running tests you may encounter the issue ``BACKEND NOT FOUND EXCEPTION``,
 you may need to add your ``<oneMKL build directory>/lib`` to your

--- a/docs/building_and_running_tests.rst
+++ b/docs/building_and_running_tests.rst
@@ -44,7 +44,7 @@ To run the tests, either run test binaries individually, or use `ctest` CMake te
   # Exclude Cpu tests
   ctest -E Cpu
 
-For more `ctest` options, refer to `ctest manual page <https://cmake.org/cmake/help/v3.13/manual/ctest.1.html>`_.
+For more ``ctest`` options, refer to `ctest manual page <https://cmake.org/cmake/help/v3.13/manual/ctest.1.html>`_.
 
 When running tests you may encounter the issue ``BACKEND NOT FOUND EXCEPTION``,
 you may need to add your ``<oneMKL build directory>/lib`` to your

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,39 +3,9 @@
 ## Overview
 Inside the `unit_tests` directory, there are domain-level directories which contain domain-specific tests, usually per function or per configuration.
 
-## Steps
-Functional testing is enabled by default, so all relevant functional tests will run automatically after the project is built successfully.
+See [Building and Running Tests](https://oneapi-src.github.io/oneMKL/building_and_running_tests.html) documentation for more information about how to build and run the tests.
 
-*Note: A set of `build options` define a `build configuration`. `CMake` builds and runs different set of tests depending on your `build configuration`. This is because `CMake` generates an export header file (config.hpp) for the selected build configuration. Check `<path to onemkl>/src/config.hpp.in` and `<path to onemkl>/src/CMakeLists.txt` for details. For details on how `CMake` performs export header generation, refer to [CMake documentation](https://cmake.org/cmake/help/v3.13/module/GenerateExportHeader.html).*
-
-You can re-run tests without re-building the entire project.
-
-#### The `CMake` Approach Works for any Generator
-```bash
-cmake --build . --target test
-```
-
-#### To use Generator-specific Commands:
-
-```bash
-# For ninja
-ninja test
-```
-
-```bash
-# For GNU Makefiles
-ctest
-# Test filter use case - runs only Gpu specific tests
-ctest -R Gpu
-# Exclude filtering use case - excludes Cpu tests
-ctest -E Cpu
-```
-
-For more `ctest` options, refer to [ctest manual page](https://cmake.org/cmake/help/v3.13/manual/ctest.1.html).
-
-## BLAS
-
-The tests in the level\<x> directories are for the corresponding level\<x> BLAS routines. [GoogleTest](https://github.com/google/googletest) is used as the unit-testing framework.
+[GoogleTest](https://github.com/google/googletest) is used as the unit-testing framework.
 
 
 *Refer to `<path to onemkl>/deps/googletest/LICENSE` for GoogleTest license.*


### PR DESCRIPTION
# Description

PR adds a link to oneMKL Testing documentation to CONTRIBUTING.md.

PR adds correct github team names to the list of maintainers in README.md introduced by https://github.com/oneapi-src/oneMKL/pull/516

Fixes https://github.com/uxlfoundation/open-source-working-group/issues/63

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. N/A, documentation change
- [x] Have you formatted the code using clang-format? N/A, documentation change