### PR TITLE
[DFT][CMake] Fix inclusion of public include directories when linking against a DFT backend library

### DIFF
--- a/examples/dft/compile_time_dispatching/CMakeLists.txt
+++ b/examples/dft/compile_time_dispatching/CMakeLists.txt
@@ -30,19 +30,17 @@ foreach(dft_ct_source ${DFT_CT_SOURCES})
   add_executable(${EXAMPLE_NAME} ${dft_ct_source}.cpp)
   target_include_directories(${EXAMPLE_NAME}
       PUBLIC ${PROJECT_SOURCE_DIR}/examples/include
-      PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
   )
 
-if(domain STREQUAL "dft" AND ENABLE_MKLCPU_BACKEND AND ENABLE_CUFFT_BACKEND)
-  add_dependencies(${EXAMPLE_NAME} onemkl_${domain}_mklcpu onemkl_${domain}_cufft)
-  list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklcpu onemkl_${domain}_cufft)
-endif()
+  if(domain STREQUAL "dft" AND ENABLE_MKLCPU_BACKEND AND ENABLE_CUFFT_BACKEND)
+    add_dependencies(${EXAMPLE_NAME} onemkl_${domain}_mklcpu onemkl_${domain}_cufft)
+    list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklcpu onemkl_${domain}_cufft)
+  endif()
 
-target_link_libraries(${EXAMPLE_NAME} PUBLIC
-  ${ONEMKL_LIBRARIES_${domain}}
-  ONEMKL::SYCL::SYCL
-  onemkl_warnings
+  target_link_libraries(${EXAMPLE_NAME} PUBLIC
+    ${ONEMKL_LIBRARIES_${domain}}
+    onemkl_warnings
   )
 
   # Register example as ctest

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,13 @@ set(ENABLE_PORTBLAS_BACKEND_NVIDIA_GPU OFF CACHE INTERNAL "")
 # store path to CMAKE_CURRENT_BINARY_DIR to use it later (makes FetchContent_Declare workable)
 set(ONEMKL_GENERATED_INCLUDE_PATH ${CMAKE_CURRENT_BINARY_DIR})
 
+
+set(ONEMKL_INTERFACE_INCLUDE_DIRS
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
+
 # Build loader and backends for each domain
 add_custom_target(onemkl_backend_libs)
 foreach(domain ${TARGET_DOMAINS})
@@ -60,9 +67,7 @@ if(BUILD_SHARED_LIBS)
   add_dependencies(onemkl onemkl_backend_libs)
 
   target_include_directories(onemkl
-    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-           $<INSTALL_INTERFACE:include>
+    PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
   )
   set_target_properties(onemkl PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/src/dft/backends/cufft/CMakeLists.txt
+++ b/src/dft/backends/cufft/CMakeLists.txt
@@ -34,6 +34,9 @@ add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 target_include_directories(${LIB_OBJ}
   PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
 )
+target_include_directories(${LIB_NAME}
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin

--- a/src/dft/backends/cufft/CMakeLists.txt
+++ b/src/dft/backends/cufft/CMakeLists.txt
@@ -32,8 +32,10 @@ add_library(${LIB_OBJ} OBJECT
 add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
-  PRIVATE ${PROJECT_SOURCE_DIR}/include
-          ${PROJECT_SOURCE_DIR}/src
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
+target_include_directories(${LIB_OBJ}
+  PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
           ${ONEMKL_GENERATED_INCLUDE_PATH}
 )

--- a/src/dft/backends/mklcpu/CMakeLists.txt
+++ b/src/dft/backends/mklcpu/CMakeLists.txt
@@ -33,8 +33,10 @@ add_library(${LIB_OBJ} OBJECT
 add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
-  PRIVATE ${PROJECT_SOURCE_DIR}/include
-          ${PROJECT_SOURCE_DIR}/src
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
+target_include_directories(${LIB_OBJ}
+  PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
           ${ONEMKL_GENERATED_INCLUDE_PATH}
 )

--- a/src/dft/backends/mklcpu/CMakeLists.txt
+++ b/src/dft/backends/mklcpu/CMakeLists.txt
@@ -35,6 +35,10 @@ add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 target_include_directories(${LIB_OBJ}
   PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
 )
+target_include_directories(${LIB_NAME}
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
+
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -33,8 +33,10 @@ add_library(${LIB_OBJ} OBJECT
 add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
-  PRIVATE ${PROJECT_SOURCE_DIR}/include
-          ${PROJECT_SOURCE_DIR}/src
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
+target_include_directories(${LIB_OBJ}
+  PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
           ${ONEMKL_GENERATED_INCLUDE_PATH}
 )

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -35,6 +35,9 @@ add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 target_include_directories(${LIB_OBJ}
   PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
 )
+target_include_directories(${LIB_NAME}
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin

--- a/src/dft/backends/portfft/CMakeLists.txt
+++ b/src/dft/backends/portfft/CMakeLists.txt
@@ -93,6 +93,9 @@ target_link_libraries(${LIB_OBJ} PRIVATE onemkl_warnings)
 target_include_directories(${LIB_OBJ}
   PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
 )
+target_include_directories(${LIB_NAME}
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin

--- a/src/dft/backends/portfft/CMakeLists.txt
+++ b/src/dft/backends/portfft/CMakeLists.txt
@@ -91,8 +91,10 @@ endif()
 target_link_libraries(${LIB_OBJ} PRIVATE onemkl_warnings)
 
 target_include_directories(${LIB_OBJ}
-  PRIVATE ${PROJECT_SOURCE_DIR}/include
-          ${PROJECT_SOURCE_DIR}/src
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
+target_include_directories(${LIB_OBJ}
+  PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
 )
 

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -34,6 +34,9 @@ add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 target_include_directories(${LIB_OBJ}
   PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
 )
+target_include_directories(${LIB_NAME}
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -32,8 +32,10 @@ add_library(${LIB_OBJ} OBJECT
 add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
 target_include_directories(${LIB_OBJ}
-  PRIVATE ${PROJECT_SOURCE_DIR}/include
-          ${PROJECT_SOURCE_DIR}/src
+  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
+)
+target_include_directories(${LIB_OBJ}
+  PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin
           ${ONEMKL_GENERATED_INCLUDE_PATH}
 )


### PR DESCRIPTION
# Description

This PR ensures that linking against backend such as `target_link_library(myApp PRIVATE onemkl_dft_cufft` correctly includes the oneMKL public include directories.

Fixes https://github.com/oneapi-src/oneMKL/issues/442

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
  - [onemklinteldft.txt](https://github.com/user-attachments/files/16065255/onemklinteldft.txt)
  - [onemklrocmdft.txt](https://github.com/user-attachments/files/16065258/onemklrocmdft.txt)
  - [onemklcufftdft.txt](https://github.com/user-attachments/files/16065259/onemklcufftdft.txt)
  - [onemklcudadft_rebase.txt](https://github.com/user-attachments/files/16066516/onemklcudadft_rebase.txt) for after rebase, including CT example with MKLCPU DFT and CUFFT.
  - Tests build and run with *portFFT*, but some test cases failed. The changes in this PR should not be related to these problems.
- [N/A] Have you formatted the code using clang-format?

## Bug fixes

- [ish] Have you added relevant regression tests?
  - The compile-time DFT example has been modified to depend on the described functionality.
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
