### PR TITLE
[BLAS][portBLAS] Add try/catch for portblas runtime exception & minor fix

### DIFF
--- a/src/blas/backends/portblas/portblas_common.hpp
+++ b/src/blas/backends/portblas/portblas_common.hpp
@@ -202,7 +202,7 @@ struct throw_if_unsupported_by_device {
         try {                                                                                   \
             std::apply(fn, args);                                                               \
         }                                                                                       \
-        catch (const std::runtime_error& e) {                                                   \
+        catch (const ::blas::unsupported_exception& e) {                                        \
             throw unimplemented("blas", e.what());                                              \
         }                                                                                       \
     }                                                                                           \
@@ -223,7 +223,7 @@ struct throw_if_unsupported_by_device {
         try {                                                                     \
             return std::apply(fn, args);                                          \
         }                                                                         \
-        catch (const std::runtime_error& e) {                                     \
+        catch (const ::blas::unsupported_exception& e) {                          \
             throw unimplemented("blas", e.what());                                \
         }                                                                         \
     }                                                                             \

--- a/src/blas/backends/portblas/portblas_common.hpp
+++ b/src/blas/backends/portblas/portblas_common.hpp
@@ -203,7 +203,7 @@ struct throw_if_unsupported_by_device {
             std::apply(fn, args);                                                               \
         }                                                                                       \
         catch (const std::runtime_error& e) {                                                   \
-            throw unimplemented("blas", "portBLAS operator not supported");                     \
+            throw unimplemented("blas", e.what());                                              \
         }                                                                                       \
     }                                                                                           \
     else {                                                                                      \
@@ -224,7 +224,7 @@ struct throw_if_unsupported_by_device {
             return std::apply(fn, args);                                          \
         }                                                                         \
         catch (const std::runtime_error& e) {                                     \
-            throw unimplemented("blas", "portBLAS operator not supported");       \
+            throw unimplemented("blas", e.what());                                \
         }                                                                         \
     }                                                                             \
     else {                                                                        \

--- a/src/blas/backends/portblas/portblas_common.hpp
+++ b/src/blas/backends/portblas/portblas_common.hpp
@@ -199,7 +199,12 @@ struct throw_if_unsupported_by_device {
         auto fn = [](auto&&... targs) {                                                         \
             portBLASFunc(std::forward<decltype(targs)>(targs)...);                              \
         };                                                                                      \
-        std::apply(fn, args);                                                                   \
+        try {                                                                                   \
+            std::apply(fn, args);                                                               \
+        }                                                                                       \
+        catch (const std::runtime_error& e) {                                                   \
+            throw unimplemented("blas", "portBLAS operator not supported");                     \
+        }                                                                                       \
     }                                                                                           \
     else {                                                                                      \
         throw unimplemented("blas", "portBLAS function");                                       \
@@ -215,7 +220,12 @@ struct throw_if_unsupported_by_device {
         auto fn = [](auto&&... targs) {                                           \
             return portblasFunc(std::forward<decltype(targs)>(targs)...).back();  \
         };                                                                        \
-        return std::apply(fn, args);                                              \
+        try {                                                                     \
+            return std::apply(fn, args);                                          \
+        }                                                                         \
+        catch (const std::runtime_error& e) {                                     \
+            throw unimplemented("blas", "portBLAS operator not supported");       \
+        }                                                                         \
     }                                                                             \
     else {                                                                        \
         throw unimplemented("blas", "portBLAS function");                         \

--- a/tests/unit_tests/blas/extensions/omatcopy2.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy2.cpp
@@ -177,6 +177,8 @@ TEST_P(Omatcopy2Tests, RealSinglePrecision) {
 }
 
 TEST_P(Omatcopy2Tests, RealDoublePrecision) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -185,6 +187,8 @@ TEST_P(Omatcopy2Tests, ComplexSinglePrecision) {
 }
 
 TEST_P(Omatcopy2Tests, ComplexDoublePrecision) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 

--- a/tests/unit_tests/blas/extensions/omatcopy2_usm.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy2_usm.cpp
@@ -186,6 +186,8 @@ TEST_P(Omatcopy2UsmTests, RealSinglePrecision) {
 }
 
 TEST_P(Omatcopy2UsmTests, RealDoublePrecision) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 
@@ -194,6 +196,8 @@ TEST_P(Omatcopy2UsmTests, ComplexSinglePrecision) {
 }
 
 TEST_P(Omatcopy2UsmTests, ComplexDoublePrecision) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam())));
 }
 


### PR DESCRIPTION
# Description

This PR adds exception handling to portBLAS backend implementation. This would allow us to handle corner cases in portBLAS.

It also adds a minor fix to `omatcopy2` tests adding check if double precision is supported by the device before running tests.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
[intel_arc_log.txt](https://github.com/user-attachments/files/16096302/intel_arc_log.txt)


- [x] Have you formatted the code using clang-format?