### PR TITLE
[DFT] Add FWD/BWD_STRIDES to public API, deprecate INPUT/OUTPUT_STRIDES

### DIFF
--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -148,8 +148,8 @@ enum class config_param {
 
     PLACEMENT,
 
-    INPUT_STRIDES,
-    OUTPUT_STRIDES,
+    INPUT_STRIDES [[deprecated("Use FWD/BWD_STRIDES")]],
+    OUTPUT_STRIDES [[deprecated("Use FWD/BWD_STRIDES")]],
 
     FWD_DISTANCE,
     BWD_DISTANCE,
@@ -160,7 +160,10 @@ enum class config_param {
     ORDERING,
     TRANSPOSE,
     PACKED_FORMAT,
-    COMMIT_STATUS
+    COMMIT_STATUS,
+
+    FWD_STRIDES,
+    BWD_STRIDES
 };
 
 enum class config_value {
@@ -204,6 +207,8 @@ private:
 public:
     std::vector<std::int64_t> input_strides;
     std::vector<std::int64_t> output_strides;
+    std::vector<std::int64_t> fwd_strides;
+    std::vector<std::int64_t> bwd_strides;
     real_t bwd_scale;
     real_t fwd_scale;
     std::int64_t number_of_transforms;

--- a/src/dft/backends/cufft/backward.cpp
+++ b/src/dft/backends/cufft/backward.cpp
@@ -37,7 +37,7 @@ namespace oneapi::mkl::dft::cufft {
 namespace detail {
 //forward declaration
 template <dft::precision prec, dft::domain dom>
-std::array<std::int64_t, 2> get_offsets(dft::detail::commit_impl<prec, dom> *commit);
+std::array<std::int64_t, 2> get_offsets_bwd(dft::detail::commit_impl<prec, dom> *commit);
 
 template <dft::precision prec, dft::domain dom>
 cufftHandle get_bwd_plan(dft::detail::commit_impl<prec, dom> *commit) {
@@ -56,7 +56,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         offsets[0] *= 2; // offset is supplied in complex but we offset scalar pointer
@@ -102,7 +102,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         if (offsets[1] % 2 != 0) {
@@ -156,7 +156,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, fwd<descriptor
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         offsets[0] *= 2; // offset is supplied in complex but we offset scalar pointer
@@ -203,7 +203,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, bwd<descriptor
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         if (offsets[1] % 2 != 0) {

--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -34,6 +34,8 @@
 #include "oneapi/mkl/dft/detail/cufft/onemkl_dft_cufft.hpp"
 #include "oneapi/mkl/dft/types.hpp"
 
+#include "../stride_helper.hpp"
+
 #include <cufft.h>
 #include <cuda.h>
 
@@ -50,7 +52,7 @@ private:
     // We also need this because oneMKL uses a directionless "FWD_DISTANCE" and "BWD_DISTANCE" while cuFFT uses a directional "idist" and "odist".
     // plans[0] is forward, plans[1] is backward
     std::array<std::optional<cufftHandle>, 2> plans = { std::nullopt, std::nullopt };
-    std::array<std::int64_t, 2> offsets;
+    std::int64_t offset_fwd_in, offset_fwd_out, offset_bwd_in, offset_bwd_out;
 
 public:
     cufft_commit(sycl::queue& queue, const dft::detail::dft_values<prec, dom>& config_values)
@@ -147,126 +149,107 @@ public:
         std::array<int, max_supported_dims> n_copy;
         std::copy(config_values.dimensions.begin(), config_values.dimensions.end(), n_copy.data());
         const int rank = static_cast<int>(config_values.dimensions.size());
+
+        auto stride_api_choice = dft::detail::get_stride_api(config_values);
+        dft::detail::throw_on_invalid_stride_api("CUFFT commit", stride_api_choice);
+        dft::detail::stride_vectors<int> stride_vecs(config_values, stride_api_choice);
+        offset_fwd_in = stride_vecs.offset_fwd_in;
+        offset_fwd_out = stride_vecs.offset_fwd_out;
+        offset_bwd_in = stride_vecs.offset_bwd_in;
+        offset_bwd_out = stride_vecs.offset_bwd_out;
+
         // cufft ignores the first value in inembed and onembed, so there is no harm in putting offset there
-        std::vector<int> inembed{ config_values.input_strides.begin(),
-                                  config_values.input_strides.end() };
-        std::vector<int> onembed{ config_values.output_strides.begin(),
-                                  config_values.output_strides.end() };
-        auto i_min = std::min_element(inembed.begin() + 1, inembed.end());
-        auto o_min = std::min_element(onembed.begin() + 1, onembed.end());
+        auto a_min = std::min_element(stride_vecs.vec_a.begin() + 1, stride_vecs.vec_a.end());
+        auto b_min = std::min_element(stride_vecs.vec_b.begin() + 1, stride_vecs.vec_b.end());
         if constexpr (dom == dft::domain::REAL) {
-            if (i_min != inembed.begin() + rank) {
+            if ((a_min != stride_vecs.vec_a.begin() + rank) ||
+                (b_min != stride_vecs.vec_b.begin() + rank)) {
                 throw mkl::unimplemented(
                     "dft/backends/cufft", __FUNCTION__,
-                    "cufft requires the last input stride to be the the smallest one for real transforms!");
-            }
-            if (o_min != onembed.begin() + rank) {
-                throw mkl::unimplemented(
-                    "dft/backends/cufft", __FUNCTION__,
-                    "cufft requires the last output stride to be the the smallest one for real transforms!");
+                    "cufft requires the last stride to be the the smallest one for real transforms!");
             }
         }
         else {
-            if (config_values.placement == config_value::INPLACE) {
-                onembed = inembed;
-            }
-            else if (o_min - onembed.begin() != i_min - inembed.begin()) {
+            if (a_min - stride_vecs.vec_a.begin() != b_min - stride_vecs.vec_b.begin()) {
                 throw mkl::unimplemented(
                     "dft/backends/cufft", __FUNCTION__,
                     "cufft requires that if ordered by stride length, the order of strides is the same for input and output strides!");
             }
         }
-        const int istride = static_cast<int>(*i_min);
-        const int ostride = static_cast<int>(*o_min);
-        inembed.erase(i_min);
-        onembed.erase(o_min);
-        if (o_min - onembed.begin() != rank) {
+        const int a_stride = static_cast<int>(*a_min);
+        const int b_stride = static_cast<int>(*b_min);
+        stride_vecs.vec_a.erase(a_min);
+        stride_vecs.vec_b.erase(b_min);
+        int fwd_istride = a_stride;
+        int fwd_ostride = b_stride;
+        int bwd_istride =
+            stride_api_choice == dft::detail::stride_api::FB_STRIDES ? b_stride : a_stride;
+        int bwd_ostride =
+            stride_api_choice == dft::detail::stride_api::FB_STRIDES ? a_stride : b_stride;
+        if (a_min - stride_vecs.vec_a.begin() != rank) {
             // swap dimensions to have the last one have the smallest stride
-            std::swap(n_copy[o_min - onembed.begin() - 1], n_copy[rank - 1]);
+            std::swap(n_copy[a_min - stride_vecs.vec_a.begin() - 1], n_copy[rank - 1]);
         }
         for (int i = 1; i < rank; i++) {
-            if (inembed[i] % istride != 0) {
+            if ((stride_vecs.vec_a[i] % a_stride != 0) || (stride_vecs.vec_b[i] % b_stride != 0)) {
                 throw mkl::unimplemented(
                     "dft/backends/cufft", __FUNCTION__,
-                    "cufft requires an input stride to be divisible by all smaller input strides!");
+                    "cufft requires a stride to be divisible by all smaller strides!");
             }
-            inembed[i] /= istride;
-            if (onembed[i] % ostride != 0) {
-                throw mkl::unimplemented(
-                    "dft/backends/cufft", __FUNCTION__,
-                    "cufft requires an output stride to be divisible by all smaller output strides!");
-            }
-            onembed[i] /= ostride;
+            stride_vecs.vec_a[i] /= a_stride;
+            stride_vecs.vec_b[i] /= b_stride;
         }
         if (rank > 2) {
-            if (inembed[1] > inembed[2] && onembed[1] < onembed[2]) {
+            if (stride_vecs.vec_a[1] > stride_vecs.vec_a[2] &&
+                stride_vecs.vec_b[1] < stride_vecs.vec_b[2]) {
                 throw mkl::unimplemented(
                     "dft/backends/cufft", __FUNCTION__,
                     "cufft requires that if ordered by stride length, the order of strides is the same for input and output strides!");
             }
-            else if (inembed[1] < inembed[2] && onembed[1] < onembed[2]) {
+            else if (stride_vecs.vec_a[1] < stride_vecs.vec_a[2] &&
+                     stride_vecs.vec_b[1] < stride_vecs.vec_b[2]) {
                 // swap dimensions to have the first one have the biggest stride
-                std::swap(inembed[1], inembed[2]);
-                std::swap(onembed[1], onembed[2]);
+                std::swap(stride_vecs.vec_a[1], stride_vecs.vec_a[2]);
+                std::swap(stride_vecs.vec_b[1], stride_vecs.vec_b[2]);
                 std::swap(n_copy[0], n_copy[1]);
             }
-            if (inembed[1] % inembed[2] != 0) {
+            if ((stride_vecs.vec_a[1] % stride_vecs.vec_a[2] != 0) ||
+                (stride_vecs.vec_b[1] % stride_vecs.vec_b[2] != 0)) {
                 throw mkl::unimplemented(
                     "dft/backends/cufft", __FUNCTION__,
-                    "cufft requires an input stride to be divisible by all smaller input strides!");
+                    "cufft requires a stride to be divisible by all smaller strides!");
             }
-            if (onembed[1] % onembed[2] != 0) {
-                throw mkl::unimplemented(
-                    "dft/backends/cufft", __FUNCTION__,
-                    "cufft requires an output stride to be divisible by all smaller output strides!");
-            }
-            inembed[1] /= inembed[2];
-            onembed[1] /= onembed[2];
+            stride_vecs.vec_a[1] /= stride_vecs.vec_a[2];
+            stride_vecs.vec_b[1] /= stride_vecs.vec_b[2];
         }
-        offsets[0] = config_values.input_strides[0];
-        offsets[1] = config_values.output_strides[0];
         const int batch = static_cast<int>(config_values.number_of_transforms);
         const int fwd_dist = static_cast<int>(config_values.fwd_dist);
         const int bwd_dist = static_cast<int>(config_values.bwd_dist);
 
         // When creating real-complex descriptions, the strides will always be wrong for one of the directions.
         // This is because the least significant dimension is symmetric.
-        // If the strides are invalid (too small to fit) then just don't bother creating the plan.
-        bool valid_forward = true;
-        bool valid_backward = true;
-        if (rank > 1) {
-            if (dom == dft::domain::REAL) {
-                valid_forward = (n_copy[rank - 1] <= inembed[rank - 1] &&
-                                 (n_copy[rank - 1] / 2 + 1) <= onembed[rank - 1]);
-                valid_backward = (n_copy[rank - 1] <= onembed[rank - 1] &&
-                                  (n_copy[rank - 1] / 2 + 1) <= inembed[rank - 1]);
+        // If the strides are invalid (too small to fit) then just don't bother creating the plan
+        auto check_stride_validity = [&](auto strides_fwd, auto strides_bwd) {
+            int inner_nfwd = n_copy[rank - 1]; // inner dimensions of DFT
+            // Complex data is stored conjugate even for real domains
+            int inner_nbwd = dom == dft::domain::REAL ? inner_nfwd / 2 + 1 : inner_nfwd;
+            int inner_sfwd = strides_fwd.back(); // inner strides of DFT
+            int inner_sbwd = strides_bwd.back();
+            bool valid = true;
+            for (int r = 1; r < rank; ++r) {
+                valid = valid && (inner_nfwd <= inner_sfwd) && (inner_nbwd <= inner_sbwd);
+                inner_nfwd *= n_copy[rank - r - 1];
+                inner_nbwd *= n_copy[rank - r - 1];
+                inner_sfwd *= strides_fwd[rank - r - 1];
+                inner_sbwd *= strides_bwd[rank - r - 1];
             }
-            else {
-                valid_forward = valid_backward = (n_copy[rank - 1] <= inembed[rank - 1] &&
-                                                  n_copy[rank - 1] <= onembed[rank - 1]);
-            }
-            if (rank > 2) {
-                if (dom == dft::domain::REAL) {
-                    valid_forward =
-                        valid_forward && (n_copy[rank - 1] * n_copy[rank - 2] <=
-                                              inembed[rank - 1] * inembed[rank - 2] &&
-                                          (n_copy[rank - 1] / 2 + 1) * n_copy[rank - 2] <=
-                                              onembed[rank - 1] * onembed[rank - 2]);
-                    valid_backward =
-                        valid_backward && (n_copy[rank - 1] * n_copy[rank - 2] <=
-                                               onembed[rank - 1] * onembed[rank - 2] &&
-                                           (n_copy[rank - 1] / 2 + 1) * n_copy[rank - 2] <=
-                                               inembed[rank - 1] * inembed[rank - 2]);
-                }
-                else {
-                    valid_forward = valid_backward =
-                        valid_forward && (n_copy[rank - 1] * n_copy[rank - 2] <=
-                                              inembed[rank - 1] * inembed[rank - 2] &&
-                                          n_copy[rank - 1] * n_copy[rank - 2] <=
-                                              onembed[rank - 1] * onembed[rank - 2]);
-                }
-            }
-        }
+            return valid;
+        };
+
+        bool valid_forward = check_stride_validity(stride_vecs.fwd_in, stride_vecs.fwd_out);
+        bool valid_backward = stride_api_choice == dft::detail::stride_api::FB_STRIDES
+                                  ? valid_forward
+                                  : check_stride_validity(stride_vecs.bwd_out, stride_vecs.bwd_in);
 
         if (!valid_forward && !valid_backward) {
             throw mkl::exception("dft/backends/cufft", __FUNCTION__, "Invalid strides.");
@@ -282,11 +265,11 @@ public:
             res = cufftPlanMany(&fwd_plan, // plan
                                 rank, // rank
                                 n_copy.data(), // n
-                                inembed.data(), // inembed
-                                istride, // istride
+                                stride_vecs.fwd_in.data(), // inembed
+                                fwd_istride, // istride
                                 fwd_dist, // idist
-                                onembed.data(), // onembed
-                                ostride, // ostride
+                                stride_vecs.fwd_out.data(), // onembed
+                                fwd_ostride, // ostride
                                 bwd_dist, // odist
                                 fwd_type, // type
                                 batch // batch
@@ -311,11 +294,11 @@ public:
             res = cufftPlanMany(&bwd_plan, // plan
                                 rank, // rank
                                 n_copy.data(), // n
-                                inembed.data(), // inembed
-                                istride, // istride
+                                stride_vecs.bwd_in.data(), // inembed
+                                bwd_istride, // istride
                                 bwd_dist, // idist
-                                onembed.data(), // onembed
-                                ostride, // ostride
+                                stride_vecs.bwd_out.data(), // onembed
+                                bwd_ostride, // ostride
                                 fwd_dist, // odist
                                 bwd_type, // type
                                 batch // batch
@@ -347,8 +330,12 @@ public:
         return plans.data();
     }
 
-    std::array<std::int64_t, 2> get_offsets() noexcept {
-        return offsets;
+    std::array<std::int64_t, 2> get_offsets_fwd() noexcept {
+        return { offset_fwd_in, offset_fwd_out };
+    }
+
+    std::array<std::int64_t, 2> get_offsets_bwd() noexcept {
+        return { offset_bwd_in, offset_bwd_out };
     }
 
     virtual void set_workspace(scalar_type* usm_workspace) override {
@@ -436,22 +423,40 @@ create_commit(
 
 namespace detail {
 template <dft::precision prec, dft::domain dom>
-std::array<std::int64_t, 2> get_offsets(dft::detail::commit_impl<prec, dom>* commit) {
-    return static_cast<cufft_commit<prec, dom>*>(commit)->get_offsets();
+std::array<std::int64_t, 2> get_offsets_fwd(dft::detail::commit_impl<prec, dom>* commit) {
+    return static_cast<cufft_commit<prec, dom>*>(commit)->get_offsets_fwd();
 }
+
+template <dft::precision prec, dft::domain dom>
+std::array<std::int64_t, 2> get_offsets_bwd(dft::detail::commit_impl<prec, dom>* commit) {
+    return static_cast<cufft_commit<prec, dom>*>(commit)->get_offsets_bwd();
+}
+
 template std::array<std::int64_t, 2>
-get_offsets<dft::detail::precision::SINGLE, dft::detail::domain::REAL>(
+get_offsets_fwd<dft::detail::precision::SINGLE, dft::detail::domain::REAL>(
     dft::detail::commit_impl<dft::detail::precision::SINGLE, dft::detail::domain::REAL>*);
 template std::array<std::int64_t, 2>
-get_offsets<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>(
+get_offsets_fwd<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>(
     dft::detail::commit_impl<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>*);
 template std::array<std::int64_t, 2>
-get_offsets<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>(
+get_offsets_fwd<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>(
     dft::detail::commit_impl<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>*);
 template std::array<std::int64_t, 2>
-get_offsets<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>(
+get_offsets_fwd<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>(
     dft::detail::commit_impl<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>*);
 
+template std::array<std::int64_t, 2>
+get_offsets_bwd<dft::detail::precision::SINGLE, dft::detail::domain::REAL>(
+    dft::detail::commit_impl<dft::detail::precision::SINGLE, dft::detail::domain::REAL>*);
+template std::array<std::int64_t, 2>
+get_offsets_bwd<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>(
+    dft::detail::commit_impl<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>*);
+template std::array<std::int64_t, 2>
+get_offsets_bwd<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>(
+    dft::detail::commit_impl<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>*);
+template std::array<std::int64_t, 2>
+get_offsets_bwd<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>(
+    dft::detail::commit_impl<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>*);
 } //namespace detail
 
 } // namespace oneapi::mkl::dft::cufft

--- a/src/dft/backends/cufft/forward.cpp
+++ b/src/dft/backends/cufft/forward.cpp
@@ -39,7 +39,7 @@ namespace oneapi::mkl::dft::cufft {
 namespace detail {
 //forward declaration
 template <dft::precision prec, dft::domain dom>
-std::array<std::int64_t, 2> get_offsets(dft::detail::commit_impl<prec, dom> *commit);
+std::array<std::int64_t, 2> get_offsets_fwd(dft::detail::commit_impl<prec, dom> *commit);
 
 template <dft::precision prec, dft::domain dom>
 cufftHandle get_fwd_plan(dft::detail::commit_impl<prec, dom> *commit) {
@@ -59,7 +59,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         if (offsets[0] % 2 != 0) {
@@ -104,7 +104,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         if (offsets[0] % 2 != 0) {
@@ -158,7 +158,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         if (offsets[0] % 2 != 0) {
@@ -205,7 +205,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
     auto commit = detail::checked_get_commit(desc);
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         if (offsets[0] % 2 != 0) {

--- a/src/dft/backends/mklcpu/mklcpu_helpers.hpp
+++ b/src/dft/backends/mklcpu/mklcpu_helpers.hpp
@@ -74,8 +74,6 @@ inline constexpr DFTI_CONFIG_PARAM to_mklcpu(dft::detail::config_param param) {
         case iparam::COMPLEX_STORAGE: return DFTI_COMPLEX_STORAGE;
         case iparam::REAL_STORAGE: return DFTI_REAL_STORAGE;
         case iparam::CONJUGATE_EVEN_STORAGE: return DFTI_CONJUGATE_EVEN_STORAGE;
-        case iparam::INPUT_STRIDES: return DFTI_INPUT_STRIDES;
-        case iparam::OUTPUT_STRIDES: return DFTI_OUTPUT_STRIDES;
         case iparam::FWD_DISTANCE: return DFTI_FWD_DISTANCE;
         case iparam::BWD_DISTANCE: return DFTI_BWD_DISTANCE;
         case iparam::WORKSPACE: return DFTI_WORKSPACE;

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -66,8 +66,6 @@ inline constexpr dft::config_param to_mklgpu(dft::detail::config_param param) {
         case iparam::COMPLEX_STORAGE: return oparam::COMPLEX_STORAGE;
         case iparam::REAL_STORAGE: return oparam::REAL_STORAGE;
         case iparam::CONJUGATE_EVEN_STORAGE: return oparam::CONJUGATE_EVEN_STORAGE;
-        case iparam::INPUT_STRIDES: return oparam::INPUT_STRIDES;
-        case iparam::OUTPUT_STRIDES: return oparam::OUTPUT_STRIDES;
         case iparam::FWD_DISTANCE: return oparam::FWD_DISTANCE;
         case iparam::BWD_DISTANCE: return oparam::BWD_DISTANCE;
         case iparam::WORKSPACE: return oparam::WORKSPACE;

--- a/src/dft/backends/portfft/commit.cpp
+++ b/src/dft/backends/portfft/commit.cpp
@@ -127,11 +127,11 @@ public:
         bwd_desc.placement = config_values.placement == config_value::INPLACE
                                  ? pfft::placement::IN_PLACE
                                  : pfft::placement::OUT_OF_PLACE;
-        bwd_desc.forward_offset = static_cast<std::size_t>(stride_vecs.offset_bwd_in);
-        bwd_desc.backward_offset = static_cast<std::size_t>(stride_vecs.offset_bwd_out);
-        bwd_desc.forward_strides = { stride_vecs.bwd_in.cbegin() + 1, stride_vecs.bwd_in.cend() };
-        bwd_desc.backward_strides = { stride_vecs.bwd_out.cbegin() + 1,
-                                      stride_vecs.bwd_out.cend() };
+        bwd_desc.forward_offset = static_cast<std::size_t>(stride_vecs.offset_bwd_out);
+        bwd_desc.backward_offset = static_cast<std::size_t>(stride_vecs.offset_bwd_in);
+        bwd_desc.forward_strides = { stride_vecs.bwd_out.cbegin() + 1, stride_vecs.bwd_out.cend() };
+        bwd_desc.backward_strides = { stride_vecs.bwd_in.cbegin() + 1,
+                                      stride_vecs.bwd_in.cend() };
         bwd_desc.forward_distance = static_cast<std::size_t>(config_values.fwd_dist);
         bwd_desc.backward_distance = static_cast<std::size_t>(config_values.bwd_dist);
 

--- a/src/dft/backends/portfft/commit.cpp
+++ b/src/dft/backends/portfft/commit.cpp
@@ -35,6 +35,8 @@
 #include "oneapi/mkl/dft/detail/portfft/onemkl_dft_portfft.hpp"
 #include "oneapi/mkl/dft/types.hpp"
 
+#include "../stride_helper.hpp"
+
 #include "portfft_helper.hpp"
 
 // alias to avoid ambiguity
@@ -87,6 +89,10 @@ public:
                                      "portFFT does not supported transposed output");
         }
 
+        auto stride_api_choice = dft::detail::get_stride_api(config_values);
+        dft::detail::throw_on_invalid_stride_api("portFFT commit", stride_api_choice);
+        dft::detail::stride_vectors<std::int64_t> stride_vecs(config_values, stride_api_choice);
+
         // forward descriptor
         pfft::descriptor<scalar_type, domain> fwd_desc(
             { config_values.dimensions.cbegin(), config_values.dimensions.cend() });
@@ -100,12 +106,11 @@ public:
         fwd_desc.placement = config_values.placement == config_value::INPLACE
                                  ? pfft::placement::IN_PLACE
                                  : pfft::placement::OUT_OF_PLACE;
-        fwd_desc.forward_offset = static_cast<std::size_t>(config_values.input_strides[0]);
-        fwd_desc.backward_offset = static_cast<std::size_t>(config_values.output_strides[0]);
-        fwd_desc.forward_strides = { config_values.input_strides.cbegin() + 1,
-                                     config_values.input_strides.cend() };
-        fwd_desc.backward_strides = { config_values.output_strides.cbegin() + 1,
-                                      config_values.output_strides.cend() };
+        fwd_desc.forward_offset = static_cast<std::size_t>(stride_vecs.offset_fwd_in);
+        fwd_desc.backward_offset = static_cast<std::size_t>(stride_vecs.offset_fwd_out);
+        fwd_desc.forward_strides = { stride_vecs.fwd_in.cbegin() + 1, stride_vecs.fwd_in.cend() };
+        fwd_desc.backward_strides = { stride_vecs.fwd_out.cbegin() + 1,
+                                      stride_vecs.fwd_out.cend() };
         fwd_desc.forward_distance = static_cast<std::size_t>(config_values.fwd_dist);
         fwd_desc.backward_distance = static_cast<std::size_t>(config_values.bwd_dist);
 
@@ -122,12 +127,11 @@ public:
         bwd_desc.placement = config_values.placement == config_value::INPLACE
                                  ? pfft::placement::IN_PLACE
                                  : pfft::placement::OUT_OF_PLACE;
-        bwd_desc.forward_offset = static_cast<std::size_t>(config_values.output_strides[0]);
-        bwd_desc.backward_offset = static_cast<std::size_t>(config_values.input_strides[0]);
-        bwd_desc.forward_strides = { config_values.output_strides.cbegin() + 1,
-                                     config_values.output_strides.cend() };
-        bwd_desc.backward_strides = { config_values.input_strides.cbegin() + 1,
-                                      config_values.input_strides.cend() };
+        bwd_desc.forward_offset = static_cast<std::size_t>(stride_vecs.offset_bwd_in);
+        bwd_desc.backward_offset = static_cast<std::size_t>(stride_vecs.offset_bwd_out);
+        bwd_desc.forward_strides = { stride_vecs.bwd_in.cbegin() + 1, stride_vecs.bwd_in.cend() };
+        bwd_desc.backward_strides = { stride_vecs.bwd_out.cbegin() + 1,
+                                      stride_vecs.bwd_out.cend() };
         bwd_desc.forward_distance = static_cast<std::size_t>(config_values.fwd_dist);
         bwd_desc.backward_distance = static_cast<std::size_t>(config_values.bwd_dist);
 

--- a/src/dft/backends/rocfft/backward.cpp
+++ b/src/dft/backends/rocfft/backward.cpp
@@ -38,7 +38,7 @@ namespace oneapi::mkl::dft::rocfft {
 namespace detail {
 //forward declaration
 template <dft::precision prec, dft::domain dom>
-std::array<std::int64_t, 2> get_offsets(dft::detail::commit_impl<prec, dom> *commit);
+std::array<std::int64_t, 2> get_offsets_bwd(dft::detail::commit_impl<prec, dom> *commit);
 
 template <dft::precision prec, dft::domain dom>
 rocfft_plan get_bwd_plan(dft::detail::commit_impl<prec, dom> *commit) {
@@ -63,7 +63,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         offsets[0] *= 2; // offset is supplied in complex but we offset scalar pointer
@@ -100,7 +100,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if (offsets[0] != offsets[1]) {
         throw oneapi::mkl::unimplemented(
@@ -141,7 +141,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
@@ -175,7 +175,7 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc,
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     queue.submit([&](sycl::handler &cgh) {
         auto in_re_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
@@ -223,7 +223,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, fwd<descriptor
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         offsets[0] *= 2; // offset is supplied in complex but we offset scalar pointer
@@ -261,7 +261,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, scalar<descrip
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     if (offsets[0] != offsets[1]) {
         throw oneapi::mkl::unimplemented(
@@ -296,7 +296,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, bwd<descriptor
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     in += offsets[0];
     out += offsets[1];
@@ -330,7 +330,7 @@ ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, scalar<descrip
     auto queue = commit->get_queue();
     auto plan = detail::get_bwd_plan(commit);
     auto info = detail::get_bwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_bwd(commit);
 
     sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(deps);

--- a/src/dft/backends/rocfft/forward.cpp
+++ b/src/dft/backends/rocfft/forward.cpp
@@ -40,7 +40,7 @@ namespace oneapi::mkl::dft::rocfft {
 namespace detail {
 //forward declaration
 template <dft::precision prec, dft::domain dom>
-std::array<std::int64_t, 2> get_offsets(dft::detail::commit_impl<prec, dom> *commit);
+std::array<std::int64_t, 2> get_offsets_fwd(dft::detail::commit_impl<prec, dom> *commit);
 
 template <dft::precision prec, dft::domain dom>
 rocfft_plan get_fwd_plan(dft::detail::commit_impl<prec, dom> *commit) {
@@ -66,7 +66,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         offsets[1] *= 2; // offset is supplied in complex but we offset scalar pointer
@@ -103,7 +103,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if (offsets[0] != offsets[1]) {
         throw oneapi::mkl::unimplemented(
@@ -143,7 +143,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<fwd<descr
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     queue.submit([&](sycl::handler &cgh) {
         auto in_acc = in.template get_access<sycl::access::mode::read_write>(cgh);
@@ -177,7 +177,7 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc,
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     queue.submit([&](sycl::handler &cgh) {
         auto in_re_acc = in_re.template get_access<sycl::access::mode::read_write>(cgh);
@@ -225,7 +225,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if constexpr (std::is_floating_point_v<fwd<descriptor_type>>) {
         offsets[1] *= 2; // offset is supplied in complex but we offset scalar pointer
@@ -263,7 +263,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     if (offsets[0] != offsets[1]) {
         throw oneapi::mkl::unimplemented(
@@ -297,7 +297,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, fwd<descriptor_
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     in += offsets[0];
     out += offsets[1];
@@ -331,7 +331,7 @@ ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, scalar<descript
     auto queue = commit->get_queue();
     auto plan = detail::get_fwd_plan(commit);
     auto info = detail::get_fwd_info(commit);
-    auto offsets = detail::get_offsets(commit);
+    auto offsets = detail::get_offsets_fwd(commit);
 
     sycl::event sycl_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(deps);

--- a/src/dft/backends/stride_helper.hpp
+++ b/src/dft/backends/stride_helper.hpp
@@ -1,0 +1,151 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _DFT_DETAIL_STRIDE_HELPER_HPP_
+#define _DFT_DETAIL_STRIDE_HELPER_HPP_
+
+namespace oneapi::mkl::dft::detail {
+
+enum class stride_api {
+    INVALID, // Cannot choose: no valid choice
+    FB_STRIDES, // Use FWD_STRIDES and BWD_STRIDES
+    IO_STRIDES // Use INPUT_STRIDES and OUTPUT_STRIDES
+};
+
+/** Throw invalid_argument for stride_api::INVALID
+ *  @param function Function name to include in exception.
+ *  @param stride_choice The stride_api to check if INVALID. Default is INVALID.
+ * 
+ *  @throws invalid_argument on stride_api::INVALID.
+ */
+inline void throw_on_invalid_stride_api(const char* function,
+                                        stride_api stride_choice = stride_api::INVALID) {
+    if (stride_choice == stride_api::INVALID) {
+        throw mkl::invalid_argument(
+            "DFT", function,
+            "Invalid INPUT/OUTPUT or FWD/BACKWARD strides. API usage may have been mixed.");
+    }
+}
+
+// Helper class for mapping input / output strides for backend DFTs to config values.
+// Intended to be abused as required for each backend.
+template <typename StrideElemT>
+struct stride_vectors {
+    using stride_elem_t = StrideElemT;
+    using stride_vec_t = std::vector<StrideElemT>;
+
+    // The stride API being used.
+    const stride_api stride_choice;
+
+    // The storage for strides. vec_a is forward or input.
+    stride_vec_t vec_a, vec_b;
+
+    // Input and output strides for forward and backward DFTs.
+    stride_vec_t &fwd_in, &fwd_out, &bwd_in, &bwd_out;
+
+    // Input and output offsets for forward and backward DFTs.
+    StrideElemT offset_fwd_in, offset_fwd_out, offset_bwd_in, offset_bwd_out;
+
+    /** Initialize the forward / backwards input and output strides for this object.
+    *  @tparam ConfigT The config values type.
+    *  @param config_values The DFT config values.
+    *  @param stride_api The stride API choice. Must not be INVALID.
+    **/
+    template <typename ConfigT>
+    stride_vectors(const ConfigT& config_values, stride_api stride_choice)
+            : stride_choice(stride_choice),
+              fwd_in(vec_a),
+              fwd_out(vec_b),
+              bwd_in(stride_choice == stride_api::FB_STRIDES ? vec_b : vec_a),
+              bwd_out(stride_choice == stride_api::FB_STRIDES ? vec_a : vec_b) {
+        if (stride_choice == stride_api::INVALID) {
+            throw mkl::exception("DFT", "detail::stride_vector constructor",
+                                 "Internal error: invalid stride API");
+        }
+        auto& v1 = stride_choice == stride_api::FB_STRIDES ? config_values.fwd_strides
+                                                           : config_values.input_strides;
+        auto& v2 = stride_choice == stride_api::FB_STRIDES ? config_values.bwd_strides
+                                                           : config_values.output_strides;
+
+        vec_a.resize(v1.size());
+        vec_b.resize(v2.size());
+        for (std::size_t i{ 0 }; i < v1.size(); ++i) { // v1.size() == v2.size()
+            if constexpr (std::is_unsigned_v<StrideElemT>) {
+                if (v1[i] < 0 || v2[i] < 0) {
+                    throw mkl::unimplemented("DFT", "commit",
+                                             "Backend does not support negative strides.");
+                }
+            }
+            vec_a[i] = static_cast<StrideElemT>(v1[i]);
+            vec_b[i] = static_cast<StrideElemT>(v2[i]);
+        }
+        offset_fwd_in = fwd_in[0];
+        offset_fwd_out = fwd_out[0];
+        offset_bwd_in = bwd_in[0];
+        offset_bwd_out = bwd_out[0];
+    }
+};
+
+/** Determines whether INPUT/OUTPUT strides, or FWD/BWD strides API is used.
+ *  @tparam ConfigT The config values type.
+ *  @param config_values The DFT config values.
+ *  @returns Stride choice. INVALID if the choice could not be determined.
+ * 
+ *  @note This does not attempt to determine that the set strides are valid.
+ */
+template <typename ConfigT>
+inline stride_api get_stride_api(const ConfigT& config_values) {
+    auto n = config_values.dimensions.size();
+    // Test if FWD/BWD strides look like they should be used. If yes, use them.
+    if (config_values.fwd_strides.size() == n + 1 && config_values.bwd_strides.size() == n + 1) {
+        auto all_zero_fwd = true;
+        auto all_zero_bwd = true;
+        // If INPUT or OUTPUT have been set, these will be zeroed.
+        for (auto v : config_values.fwd_strides) {
+            all_zero_fwd = v == 0 && all_zero_fwd;
+        }
+        for (auto v : config_values.bwd_strides) {
+            all_zero_bwd = v == 0 && all_zero_bwd;
+        }
+        if (!all_zero_fwd && !all_zero_bwd) { // Both must be non-zero.
+            return stride_api::FB_STRIDES;
+        }
+    }
+    // FWD/BWD invalid. Test INPUT/OUTPUT for validity.
+    if (config_values.input_strides.size() == n + 1 &&
+        config_values.output_strides.size() == n + 1) {
+        auto all_zero_in = true;
+        auto all_zero_out = true;
+        // If FWD or BWD have been set, these will be zeroed.
+        for (auto v : config_values.input_strides) {
+            all_zero_in = v == 0 && all_zero_in;
+        }
+        for (auto v : config_values.output_strides) {
+            all_zero_out = v == 0 && all_zero_out;
+        }
+        if (!all_zero_in && !all_zero_out) { // Both must be non-zero.
+            return stride_api::IO_STRIDES;
+        }
+    }
+    return stride_api::INVALID;
+}
+
+} // namespace oneapi::mkl::dft::detail
+
+#endif //_DFT_DETAIL_STRIDE_HELPER_HPP_

--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -69,11 +69,11 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
     if (modified_strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES,
                              modified_strides_fwd.data());
     }
     if (modified_strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES,
                              modified_strides_bwd.data());
     }
     commit_descriptor(descriptor, sycl_queue);
@@ -99,27 +99,6 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
                     modified_strides_bwd, abs_error_margin, rel_error_margin, std::cout));
             }
         }
-
-        if (modified_strides_bwd.size()) {
-            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                                 modified_strides_bwd.data());
-        }
-        else {
-            //for real case strides are always set at the top of the test
-            auto input_strides = get_default_strides(sizes);
-            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                                 input_strides.data());
-        }
-        if (modified_strides_fwd.size()) {
-            descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                                 modified_strides_fwd.data());
-        }
-        else {
-            auto output_strides = get_default_strides(sizes);
-            descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                                 output_strides.data());
-        }
-        commit_descriptor(descriptor, sycl_queue);
 
         oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
                                            FwdInputType>(descriptor, inout_buf);
@@ -185,11 +164,11 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
     if (modified_strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES,
                              modified_strides_fwd.data());
     }
     if (modified_strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES,
                              modified_strides_bwd.data());
     }
     commit_descriptor(descriptor, sycl_queue);
@@ -214,25 +193,6 @@ int DFT_Test<precision, domain>::test_in_place_USM() {
             out_host_ref.data() + ref_distance * i, sizes, modified_strides_bwd, abs_error_margin,
             rel_error_margin, std::cout));
     }
-
-    if (modified_strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                             modified_strides_bwd.data());
-    }
-    else {
-        //for real case strides are always set at the top of the test
-        auto input_strides = get_default_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, input_strides.data());
-    }
-    if (modified_strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                             modified_strides_fwd.data());
-    }
-    else {
-        auto output_strides = get_default_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, output_strides.data());
-    }
-    commit_descriptor(descriptor, sycl_queue);
 
     sycl::event done =
         oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -46,15 +46,14 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
     if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_fwd.data());
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd.data());
     }
     if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, strides_bwd.data());
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd.data());
     }
     else if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                             complex_strides.data());
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, complex_strides.data());
     }
     commit_descriptor(descriptor, sycl_queue);
     std::vector<FwdInputType> fwd_data(
@@ -78,30 +77,6 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
                     strides_bwd, abs_error_margin, rel_error_margin, std::cout));
             }
         }
-
-        if (strides_bwd.size()) {
-            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_bwd.data());
-        }
-        else if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
-            const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                                 complex_strides.data());
-        }
-        else {
-            auto input_strides = get_default_strides(sizes);
-            descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                                 input_strides.data());
-        }
-        if (strides_fwd.size()) {
-            descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                                 strides_fwd.data());
-        }
-        else {
-            auto output_strides = get_default_strides(sizes);
-            descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                                 output_strides.data());
-        }
-        commit_descriptor(descriptor, sycl_queue);
 
         oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>,
                                            FwdOutputType, FwdInputType>(descriptor, bwd_buf,
@@ -144,15 +119,14 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
     if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_fwd.data());
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd.data());
     }
     if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, strides_bwd.data());
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd.data());
     }
     else if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
         const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                             complex_strides.data());
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, complex_strides.data());
     }
     commit_descriptor(descriptor, sycl_queue);
 
@@ -175,26 +149,6 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
             bwd_ptr + backward_distance * i, out_host_ref.data() + ref_distance * i, sizes,
             strides_bwd, abs_error_margin, rel_error_margin, std::cout));
     }
-
-    if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides_bwd.data());
-    }
-    else if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
-        const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, complex_strides.data());
-    }
-    else {
-        auto input_strides = get_default_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, input_strides.data());
-    }
-    if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, strides_fwd.data());
-    }
-    else {
-        auto output_strides = get_default_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES, output_strides.data());
-    }
-    commit_descriptor(descriptor, sycl_queue);
 
     oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>, FwdOutputType,
                                        FwdInputType>(descriptor, bwd.data(), fwd.data(),

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -98,8 +98,11 @@ static void set_and_get_lengths() {
     }
 }
 
+// Test for deprecated functionality
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
-static void set_and_get_strides() {
+static void set_and_get_io_strides() {
     oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_3d_lengths };
 
     EXPECT_THROW(descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, nullptr),
@@ -132,6 +135,8 @@ static void set_and_get_strides() {
 
     std::vector<std::int64_t> input_strides_before_set(strides_size);
     std::vector<std::int64_t> input_strides_after_set(strides_size);
+    std::vector<std::int64_t> fwd_strides_after_set(strides_size, -1);
+    std::vector<std::int64_t> bwd_strides_after_set(strides_size, -1);
 
     descriptor.get_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
                          input_strides_before_set.data());
@@ -139,7 +144,11 @@ static void set_and_get_strides() {
     descriptor.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, input_strides_value.data());
     descriptor.get_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
                          input_strides_after_set.data());
+    descriptor.get_value(oneapi::mkl::dft::config_param::FWD_STRIDES, fwd_strides_after_set.data());
+    descriptor.get_value(oneapi::mkl::dft::config_param::BWD_STRIDES, bwd_strides_after_set.data());
     EXPECT_EQ(input_strides_value, input_strides_after_set);
+    EXPECT_EQ(std::vector<std::int64_t>(strides_size, 0), fwd_strides_after_set);
+    EXPECT_EQ(std::vector<std::int64_t>(strides_size, 0), bwd_strides_after_set);
 
     std::vector<std::int64_t> output_strides_before_set(strides_size);
     std::vector<std::int64_t> output_strides_after_set(strides_size);
@@ -152,6 +161,67 @@ static void set_and_get_strides() {
                          output_strides_after_set.data());
     EXPECT_EQ(output_strides_value, output_strides_after_set);
 }
+
+template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
+static void set_and_get_fwd_bwd_strides() {
+    oneapi::mkl::dft::descriptor<precision, domain> descriptor{ default_3d_lengths };
+
+    EXPECT_THROW(descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, nullptr),
+                 oneapi::mkl::invalid_argument);
+    EXPECT_THROW(descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, nullptr),
+                 oneapi::mkl::invalid_argument);
+
+    constexpr std::int64_t strides_size = 4;
+    const std::int64_t default_stride_d1 = default_3d_lengths[2] * default_3d_lengths[1];
+    const std::int64_t default_stride_d2 = default_3d_lengths[2];
+    const std::int64_t default_stride_d3 = 1;
+
+    std::vector<std::int64_t> default_strides_value{ 0, default_stride_d1, default_stride_d2,
+                                                     default_stride_d3 };
+
+    std::vector<std::int64_t> fwd_strides_value;
+    std::vector<std::int64_t> bwd_strides_value;
+    if constexpr (domain == oneapi::mkl::dft::domain::COMPLEX) {
+        fwd_strides_value = { 50, default_stride_d1 * 2, default_stride_d2 * 2,
+                              default_stride_d3 * 2 };
+        bwd_strides_value = { 50, default_stride_d1 * 2, default_stride_d2 * 2,
+                              default_stride_d3 * 2 };
+    }
+    else {
+        fwd_strides_value = { 0, default_3d_lengths[1] * (default_3d_lengths[2] / 2 + 1) * 2,
+                              (default_3d_lengths[2] / 2 + 1) * 2, 1 };
+        bwd_strides_value = { 0, default_3d_lengths[1] * (default_3d_lengths[2] / 2 + 1),
+                              (default_3d_lengths[2] / 2 + 1), 1 };
+    }
+
+    std::vector<std::int64_t> fwd_strides_before_set(strides_size);
+    std::vector<std::int64_t> fwd_strides_after_set(strides_size);
+    std::vector<std::int64_t> input_strides_after_set(strides_size, -1);
+    std::vector<std::int64_t> output_strides_after_set(strides_size, -1);
+
+    descriptor.get_value(oneapi::mkl::dft::config_param::FWD_STRIDES,
+                         fwd_strides_before_set.data());
+    EXPECT_EQ(default_strides_value, fwd_strides_before_set);
+    descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, fwd_strides_value.data());
+    descriptor.get_value(oneapi::mkl::dft::config_param::FWD_STRIDES, fwd_strides_after_set.data());
+    descriptor.get_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                         input_strides_after_set.data());
+    descriptor.get_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                         output_strides_after_set.data());
+    EXPECT_EQ(fwd_strides_value, fwd_strides_after_set);
+    EXPECT_EQ(std::vector<std::int64_t>(strides_size, 0), input_strides_after_set);
+    EXPECT_EQ(std::vector<std::int64_t>(strides_size, 0), output_strides_after_set);
+
+    std::vector<std::int64_t> bwd_strides_before_set(strides_size);
+    std::vector<std::int64_t> bwd_strides_after_set(strides_size);
+    descriptor.get_value(oneapi::mkl::dft::config_param::BWD_STRIDES,
+                         bwd_strides_before_set.data());
+    EXPECT_EQ(default_strides_value, bwd_strides_before_set);
+    descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, bwd_strides_value.data());
+    descriptor.get_value(oneapi::mkl::dft::config_param::BWD_STRIDES, bwd_strides_after_set.data());
+    EXPECT_EQ(bwd_strides_value, bwd_strides_after_set);
+}
+#pragma clang diagnostic pop
 
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
 static void set_and_get_values() {
@@ -453,8 +523,11 @@ inline void recommit_values(sycl::queue& sycl_queue) {
           std::make_pair(config_param::CONJUGATE_EVEN_STORAGE, config_value::COMPLEX_COMPLEX) },
         { std::make_pair(config_param::PLACEMENT, config_value::NOT_INPLACE),
           std::make_pair(config_param::NUMBER_OF_TRANSFORMS, std::int64_t{ 5 }),
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           std::make_pair(config_param::INPUT_STRIDES, strides.data()),
           std::make_pair(config_param::OUTPUT_STRIDES, strides.data()),
+#pragma clang diagnostic pop
           std::make_pair(config_param::FWD_DISTANCE, std::int64_t{ 60 }),
           std::make_pair(config_param::BWD_DISTANCE, std::int64_t{ 70 }) },
         { std::make_pair(config_param::WORKSPACE, config_value::ALLOW),
@@ -600,7 +673,8 @@ static int test_move() {
 template <oneapi::mkl::dft::precision precision, oneapi::mkl::dft::domain domain>
 static int test_getter_setter() {
     set_and_get_lengths<precision, domain>();
-    set_and_get_strides<precision, domain>();
+    set_and_get_io_strides<precision, domain>();
+    set_and_get_fwd_bwd_strides<precision, domain>();
     set_and_get_values<precision, domain>();
     get_readonly_values<precision, domain>();
     set_readonly_values<precision, domain>();


### PR DESCRIPTION
# Description

* Adds the FWD/BWD_STRIDES API from the interface spec
* Deprecates old INPUT/OUTPUT_STRIDES using the deprecated attribute.
* Modifies DFT tests to use FWD/BWD_STRIDES API
  * The old API is no longer thoroughly tested
* Adds additional descriptor tests

Fixes https://github.com/oneapi-src/oneMKL/issues/488

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
  * [amdtest.txt](https://github.com/user-attachments/files/16113136/amdtest.txt)
  * [intel.txt](https://github.com/user-attachments/files/16113137/intel.txt)
  * [nvidiadft.txt](https://github.com/user-attachments/files/16113138/nvidiadft.txt)
  * [portfft2.txt](https://github.com/user-attachments/files/16113135/portfft2.txt)
    * PortFFT has failures that also exist in develop.
- [x] Have you formatted the code using clang-format?

## New interfaces

- [x] What version of oneAPI spec the interface is targeted?
  - Feature from https://github.com/uxlfoundation/oneAPI-spec/commit/3717a9a2dfd162e91b5a5065df5e9411ee9b7de7

## New features

- [x] Have you provided motivation for adding a new feature?
- [x] Have you added relevant tests?
  * Tests updated to use new functionality
