### PR TITLE
Fix README documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,8 @@ Product | Supported Version | License
 - [About](https://oneapi-src.github.io/oneMKL/introduction.html)
 - Get Started
   - [Selecting a Compiler](https://oneapi-src.github.io/oneMKL/selecting_a_compiler.html)
-  - [Building the Project](https://oneapi-src.github.io/oneMKL/building_the_project.html)
+  - [Building the Project with DPC++](https://oneapi-src.github.io/oneMKL/building_the_project_with_dpcpp.html)
+  - [Building the Project with AdaptiveCpp](https://oneapi-src.github.io/oneMKL/building_the_project_with_adaptivecpp.html)
 - Developer Reference
   - [oneMKL Defined Datatypes](https://oneapi-src.github.io/oneMKL/onemkl-datatypes.html)
   - [Dense Linear Algebra](https://oneapi-src.github.io/oneMKL/domains/dense_linear_algebra.html)


### PR DESCRIPTION
# Description

The existing link is giving a 404 error as `building_the_project.rst` was split in 2 different files as of https://github.com/oneapi-src/oneMKL/pull/510.

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? Attach a log.
- [N/A] Have you formatted the code using clang-format?