### PR TITLE
[HIP] Fix libclang_rt.builtins.a not found

### DIFF
--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -71,4 +71,15 @@ if(is_dpcpp)
       INTERFACE_LINK_LIBRARIES ${SYCL_LIBRARY})
   endif()
 
-endif()
+  if(ENABLE_ROCBLAS_BACKEND OR ENABLE_ROCRAND_BACKEND OR ENABLE_ROCSOLVER_BACKEND)
+    # Allow find_package(HIP) to find the correct path to libclang_rt.builtins.a
+    # HIP's CMake uses the command `${HIP_CXX_COMPILER} -print-libgcc-file-name --rtlib=compiler-rt` to find this path.
+    # This can print a non-existing file if the compiler used is icpx.
+    if(NOT HIP_CXX_COMPILER)
+      find_path(HIP_CXX_COMPILER clang++
+        HINTS ENV HIPROOT ENV ROCM_PATH
+      )
+    endif()
+  endif()
+
+endif(is_dpcpp)

--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -457,11 +457,12 @@ Build FAQ
 
 clangrt builtins lib not found
   Encountered when trying to build oneMKL with some ROCm libraries. There are
-  several possible solutions: * If building Open DPC++ from source, add
-  ``compiler-rt`` to the external projects compile option:
-  ``--llvm-external-projects compiler-rt``. * The *clangrt* from ROCm can be
-  used, depending on ROCm version: ``export
-  LIBRARY_PATH=/path/to/rocm-$rocm-version$/llvm/lib/clang/$clang-version$/lib/linux/:$LIBRARY_PATH``
+  several possible solutions:
+
+  * If building Open DPC++ from source, add ``compiler-rt`` to the external
+    projects compile option: ``--llvm-external-projects compiler-rt``.
+  * Manually set the variable ``HIP_CXX_COMPILER`` to HIP's toolkit ``clang++``
+    path, for instance ``-DHIP_CXX_COMPILER=/opt/rocm/6.1.0/llvm/bin/clang++``.
 
 Could NOT find CBLAS (missing: CBLAS file)
   Encountered when tests are enabled along with the BLAS domain. The tests

--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -463,6 +463,8 @@ clangrt builtins lib not found
     projects compile option: ``--llvm-external-projects compiler-rt``.
   * Manually set the variable ``HIP_CXX_COMPILER`` to HIP's toolkit ``clang++``
     path, for instance ``-DHIP_CXX_COMPILER=/opt/rocm/6.1.0/llvm/bin/clang++``.
+    oneMKL may fail to link if the clang versions of ``icpx`` and ``rocm`` are
+    not compatible.
 
 Could NOT find CBLAS (missing: CBLAS file)
   Encountered when tests are enabled along with the BLAS domain. The tests


### PR DESCRIPTION
# Description

Using the compiler from oneAPI's Base Toolkit and the [Codeplay AMD plugin](https://developer.codeplay.com/products/oneapi/amd/home/) fails to compile by default with the error:
```
ninja: error: '/path/to/intel/oneapi/2024.2.0/compiler/2024.2/lib/clang/19/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a', needed by 'lib/libonemkl_sparse_blas_rocsparse.so.0', missing and no known rule to make it
```
As far as I know this is an issue for all ROC backends. The issue is that the command `find_package(HIP)` invokes `${HIP_CXX_COMPILER} -print-libgcc-file-name --rtlib=compiler-rt` to find the path of a dependency where `HIP_CXX_COMPILER` is set as `CMAKE_CXX_COMPILER` by default. This command is meant to be run with HIP's `clang++` but when `icpx` is used the command is outputting a non-existant file.

As the documentation suggests this can be worked around by building intel/llvm which is not user friendly. The second workaround of setting `LIBRARY_PATH` did not work for me using ROCm 6.1.0 so I am suggesting to remove it.
The suggested solution should be more resilient and does not need any more action from the user as the environment variables `HIPROOT` or `ROCM_PATH` should already be set to use the ROC libraries.

Fixes https://github.com/oneapi-src/oneMKL/issues/336

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? This does not affect the tests.
- [N/A] Have you formatted the code using clang-format?

## Bug fixes

- [N/A] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
