### PR TITLE
[RNG] Added -fsycl -fsycl-device-code-split=per_kernel at the linking stage to have device code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ cmake_minimum_required (VERSION 3.13)
 # Define build type
 set(DEFAULT_BUILD_TYPE "Release")
 
-message("==> CMakeLists.txt")
-
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
     message(STATUS "CMAKE_BUILD_TYPE: None, set to ${DEFAULT_BUILD_TYPE} by default")
     set(CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE} CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ cmake_minimum_required (VERSION 3.13)
 # Define build type
 set(DEFAULT_BUILD_TYPE "Release")
 
+message("==> CMakeLists.txt")
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
     message(STATUS "CMAKE_BUILD_TYPE: None, set to ${DEFAULT_BUILD_TYPE} by default")
     set(CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE} CACHE STRING

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -17,10 +17,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
+message("1. cmake/CMakeLists.txt")
+
 install(FILES FindCompiler.cmake
         DESTINATION "lib/cmake/${PROJECT_NAME}"
 )
-
+message("2. cmake/CMakeLists.txt")
 if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
   install(FILES mkl/MKLConfig.cmake
         DESTINATION "lib/cmake/${PROJECT_NAME}"

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -20,7 +20,6 @@
 install(FILES FindCompiler.cmake
         DESTINATION "lib/cmake/${PROJECT_NAME}"
 )
-
 if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
   install(FILES mkl/MKLConfig.cmake
         DESTINATION "lib/cmake/${PROJECT_NAME}"

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -17,12 +17,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-message("1. cmake/CMakeLists.txt")
-
 install(FILES FindCompiler.cmake
         DESTINATION "lib/cmake/${PROJECT_NAME}"
 )
-message("2. cmake/CMakeLists.txt")
+
 if(ENABLE_MKLGPU_BACKEND OR ENABLE_MKLCPU_BACKEND)
   install(FILES mkl/MKLConfig.cmake
         DESTINATION "lib/cmake/${PROJECT_NAME}"

--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -18,10 +18,8 @@
 #===============================================================================
 
 include_guard()
-
 include(CheckCXXCompilerFlag)
 include(FindPackageHandleStandardArgs)
-
 check_cxx_compiler_flag("-fsycl" is_dpcpp)
 
 if(is_dpcpp)

--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -17,12 +17,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
+message("1. FindCompiler.cmake")
 include_guard()
-
+message("2. FindCompiler.cmake")
 include(CheckCXXCompilerFlag)
 include(FindPackageHandleStandardArgs)
-
+message("3. FindCompiler.cmake")
 check_cxx_compiler_flag("-fsycl" is_dpcpp)
+message("is_dpcpp = ${is_dpcpp}")
 
 if(is_dpcpp)
   # Workaround for internal compiler error during linking if -fsycl is used

--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -17,14 +17,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-message("1. FindCompiler.cmake")
 include_guard()
-message("2. FindCompiler.cmake")
+
 include(CheckCXXCompilerFlag)
 include(FindPackageHandleStandardArgs)
-message("3. FindCompiler.cmake")
+
 check_cxx_compiler_flag("-fsycl" is_dpcpp)
-message("is_dpcpp = ${is_dpcpp}")
 
 if(is_dpcpp)
   # Workaround for internal compiler error during linking if -fsycl is used

--- a/examples/rng/device/CMakeLists.txt
+++ b/examples/rng/device/CMakeLists.txt
@@ -60,6 +60,7 @@ foreach(rng_device_source ${RNG_DEVICE_SOURCES})
   )
 
   if(is_dpcpp)
+    message("is_dpcpp in examples/rng/device")
     target_link_options(example_${domain}_${rng_device_source} PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
   endif()
 

--- a/examples/rng/device/CMakeLists.txt
+++ b/examples/rng/device/CMakeLists.txt
@@ -59,7 +59,7 @@ foreach(rng_device_source ${RNG_DEVICE_SOURCES})
       ONEMKL::SYCL::SYCL
   )
 
-  if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+  if(is_dpcpp)
     target_link_options(example_${domain}_${rng_device_source} PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
   endif()
 

--- a/examples/rng/device/CMakeLists.txt
+++ b/examples/rng/device/CMakeLists.txt
@@ -59,8 +59,7 @@ foreach(rng_device_source ${RNG_DEVICE_SOURCES})
       ONEMKL::SYCL::SYCL
   )
 
-  if(is_dpcpp)
-    message("is_dpcpp in examples/rng/device")
+  if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
     target_link_options(example_${domain}_${rng_device_source} PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
   endif()
 

--- a/examples/rng/device/CMakeLists.txt
+++ b/examples/rng/device/CMakeLists.txt
@@ -59,6 +59,10 @@ foreach(rng_device_source ${RNG_DEVICE_SOURCES})
       ONEMKL::SYCL::SYCL
   )
 
+  if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+    target_link_options(example_${domain}_${rng_device_source} PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
+  endif()
+
   # Register example as ctest
   foreach(device_filter ${DEVICE_FILTERS})
     add_test(NAME ${domain}/EXAMPLE/DEVICE/${rng_device_source}/${device_filter} COMMAND example_${domain}_${rng_device_source})

--- a/tests/unit_tests/rng/device/moments/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/moments/CMakeLists.txt
@@ -18,9 +18,9 @@
 #===============================================================================
 
 # Build object from all test sources
-set(SERVICE_TESTS_SOURCES "moments.cpp")
+set(MOMENTS_DEVICE_TESTS_SOURCES "moments.cpp")
 
-add_library(rng_device_moments_ct OBJECT ${SERVICE_TESTS_SOURCES})
+add_library(rng_device_moments_ct OBJECT ${MOMENTS_DEVICE_TESTS_SOURCES})
 target_compile_options(rng_device_moments_ct PRIVATE -DNOMINMAX)
 target_include_directories(rng_device_moments_ct
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -30,7 +30,11 @@ target_include_directories(rng_device_moments_ct
     PUBLIC ${CMAKE_BINARY_DIR}/bin
 )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
-  add_sycl_to_target(TARGET rng_device_moments_ct SOURCES ${SERVICE_TESTS_SOURCES})
+  add_sycl_to_target(TARGET rng_device_moments_ct SOURCES ${MOMENTS_DEVICE_TESTS_SOURCES})
 else()
   target_link_libraries(rng_device_moments_ct PUBLIC ONEMKL::SYCL::SYCL)
+endif()
+
+if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+  target_link_options(rng_device_moments_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()

--- a/tests/unit_tests/rng/device/moments/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/moments/CMakeLists.txt
@@ -35,6 +35,6 @@ else()
   target_link_libraries(rng_device_moments_ct PUBLIC ONEMKL::SYCL::SYCL)
 endif()
 
-if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+if(is_dpcpp)
   target_link_options(rng_device_moments_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()

--- a/tests/unit_tests/rng/device/moments/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/moments/CMakeLists.txt
@@ -36,5 +36,6 @@ else()
 endif()
 
 if(is_dpcpp)
+  message("is_dpcpp in unit_tests/moments")
   target_link_options(rng_device_moments_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()

--- a/tests/unit_tests/rng/device/moments/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/moments/CMakeLists.txt
@@ -35,7 +35,6 @@ else()
   target_link_libraries(rng_device_moments_ct PUBLIC ONEMKL::SYCL::SYCL)
 endif()
 
-if(is_dpcpp)
-  message("is_dpcpp in unit_tests/moments")
+if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
   target_link_options(rng_device_moments_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()

--- a/tests/unit_tests/rng/device/service/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/service/CMakeLists.txt
@@ -35,6 +35,6 @@ else()
   target_link_libraries(rng_device_service_ct PUBLIC ONEMKL::SYCL::SYCL)
 endif()
 
-if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+if(is_dpcpp)
   target_link_options(rng_device_service_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()

--- a/tests/unit_tests/rng/device/service/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/service/CMakeLists.txt
@@ -35,7 +35,6 @@ else()
   target_link_libraries(rng_device_service_ct PUBLIC ONEMKL::SYCL::SYCL)
 endif()
 
-if(is_dpcpp)
-  message("is_dpcpp in unit_tests/service")
+if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
   target_link_options(rng_device_service_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()

--- a/tests/unit_tests/rng/device/service/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/service/CMakeLists.txt
@@ -36,5 +36,6 @@ else()
 endif()
 
 if(is_dpcpp)
+  message("is_dpcpp in unit_tests/service")
   target_link_options(rng_device_service_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()

--- a/tests/unit_tests/rng/device/service/CMakeLists.txt
+++ b/tests/unit_tests/rng/device/service/CMakeLists.txt
@@ -18,9 +18,9 @@
 #===============================================================================
 
 # Build object from all test sources
-set(SERVICE_TESTS_SOURCES "skip_ahead.cpp")
+set(SERVICE_DEVICE_TESTS_SOURCES "skip_ahead.cpp")
 
-add_library(rng_device_service_ct OBJECT ${SERVICE_TESTS_SOURCES})
+add_library(rng_device_service_ct OBJECT ${SERVICE_DEVICE_TESTS_SOURCES})
 target_compile_options(rng_device_service_ct PRIVATE -DNOMINMAX)
 target_include_directories(rng_device_service_ct
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include
@@ -30,7 +30,11 @@ target_include_directories(rng_device_service_ct
     PUBLIC ${CMAKE_BINARY_DIR}/bin
 )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
-  add_sycl_to_target(TARGET rng_device_service_ct SOURCES ${SERVICE_TESTS_SOURCES})
+  add_sycl_to_target(TARGET rng_device_service_ct SOURCES ${SERVICE_DEVICE_TESTS_SOURCES})
 else()
   target_link_libraries(rng_device_service_ct PUBLIC ONEMKL::SYCL::SYCL)
+endif()
+
+if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+  target_link_options(rng_device_service_ct PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
 endif()


### PR DESCRIPTION
# Description

We must pass `-fsycl` flag at the linking stage in addition to the compilation stage so that device code is added to executable file from object file on Windows.
Otherwise, there is the failure in Device API tests and example: **No kernel named _ZTSZZN12moments_testIN6oneapi3mkl3rng6device13philox4x32x10ILi1EEENS3_7uniformIfNS3_14uniform_method8standardEEEEclIN4sycl3_V15queueEEEvT_ENKUlRNSD_7handlerEE_clESH_EUlNSD_4itemILi1ELb1EEEE_ was found -46 (PI_ERROR_INVALID_KERNEL_NAME)**

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
[logs_win_static.txt](https://github.com/user-attachments/files/16282892/logs_win_static.txt)
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
