### PR TITLE
[BLAS][DFT][SPARSE][TESTS] Remove .template from `get_host_access` to fix build

### DIFF
--- a/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/axpy_batch_stride.cpp
@@ -150,7 +150,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, fp
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = true;
     for (i = 0; i < batch_size; i++) {
         good = good && check_equal_vector(y_accessor.get_pointer() + i * stride_y,

--- a/tests/unit_tests/blas/batch/copy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/copy_batch_stride.cpp
@@ -147,7 +147,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = true;
     for (i = 0; i < batch_size; i++) {
         good = good && check_equal_vector(y_accessor.get_pointer() + i * stride_y,

--- a/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/dgmm_batch_stride.cpp
@@ -166,7 +166,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right, 
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good = true;
     for (i = 0; i < batch_size; i++) {
         good = good &&

--- a/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemm_batch_stride.cpp
@@ -223,7 +223,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
     for (size_t i = 0; i < C_ref.size(); ++i) {
         C_cast_ref[i] = C_ref[i];
     }
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good = check_almost_equal_matrix(C_accessor, C_cast_ref, oneapi::mkl::layout::col_major,
                                           stride_c * batch_size, 1, stride_c * batch_size,
                                           error_mag, std::cout);

--- a/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/gemv_batch_stride.cpp
@@ -181,7 +181,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t incx, int64_t incy, in
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = true;
     for (i = 0; i < batch_size; i++) {
         good = good && check_equal_vector(y_accessor.get_pointer() + i * stride_y,

--- a/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/imatcopy_batch_stride.cpp
@@ -163,7 +163,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto AB_accessor = AB_buffer.template get_host_access(read_only);
+    auto AB_accessor = AB_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(AB_accessor, AB_ref, oneapi::mkl::layout::col_major,
                                    stride * batch_size, 1, stride * batch_size, 10, std::cout);
 

--- a/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatadd_batch_stride.cpp
@@ -179,7 +179,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(C_accessor, C_ref, oneapi::mkl::layout::col_major,
                                    stride_c * batch_size, 1, stride_c * batch_size, 10, std::cout);
 

--- a/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/omatcopy_batch_stride.cpp
@@ -166,7 +166,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto B_accessor = B_buffer.template get_host_access(read_only);
+    auto B_accessor = B_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(B_accessor, B_ref, oneapi::mkl::layout::col_major,
                                    stride_b * batch_size, 1, stride_b * batch_size, 10, std::cout);
 

--- a/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/syrk_batch_stride.cpp
@@ -185,7 +185,7 @@ int test(device *dev, oneapi::mkl::layout layout, int64_t batch_size) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, oneapi::mkl::layout::col_major, stride_c * batch_size,
                            1, stride_c * batch_size, 10 * k, std::cout);

--- a/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
+++ b/tests/unit_tests/blas/batch/trsm_batch_stride.cpp
@@ -192,7 +192,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto B_accessor = B_buffer.template get_host_access(read_only);
+    auto B_accessor = B_buffer.get_host_access(read_only);
     bool good =
         check_equal_trsm_matrix(B_accessor, B_ref, oneapi::mkl::layout::col_major, total_size_b, 1,
                                 total_size_b, 10 * std::max(m, n), std::cout);

--- a/tests/unit_tests/blas/extensions/gemm_bias.cpp
+++ b/tests/unit_tests/blas/extensions/gemm_bias.cpp
@@ -155,7 +155,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(C_accessor, C_ref, layout, m, n, ldc, 10 * k, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/extensions/gemmt.cpp
+++ b/tests/unit_tests/blas/extensions/gemmt.cpp
@@ -136,7 +136,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, layout, upper_lower, n, n, ldc, 10 * k, std::cout);
 

--- a/tests/unit_tests/blas/extensions/imatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/imatcopy.cpp
@@ -154,7 +154,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto AB_accessor = AB_buffer.template get_host_access(read_only);
+    auto AB_accessor = AB_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(AB_accessor, AB_ref, oneapi::mkl::layout::col_major, size, 1,
                                    size, 10, std::cout);
 

--- a/tests/unit_tests/blas/extensions/omatadd.cpp
+++ b/tests/unit_tests/blas/extensions/omatadd.cpp
@@ -170,7 +170,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(C_accessor, C_ref, oneapi::mkl::layout::col_major, size_c, 1,
                                    size_c, 10, std::cout);
 

--- a/tests/unit_tests/blas/extensions/omatcopy.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy.cpp
@@ -163,7 +163,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto B_accessor = B_buffer.template get_host_access(read_only);
+    auto B_accessor = B_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(B_accessor, B_ref, oneapi::mkl::layout::col_major, size_b, 1,
                                    size_b, 10, std::cout);
 

--- a/tests/unit_tests/blas/extensions/omatcopy2.cpp
+++ b/tests/unit_tests/blas/extensions/omatcopy2.cpp
@@ -162,7 +162,7 @@ int test(device *dev, oneapi::mkl::layout layout) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto B_accessor = B_buffer.template get_host_access(read_only);
+    auto B_accessor = B_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(B_accessor, B_ref, oneapi::mkl::layout::col_major, size_b, 1,
                                    size_b, 10, std::cout);
 

--- a/tests/unit_tests/blas/level1/asum.cpp
+++ b/tests/unit_tests/blas/level1/asum.cpp
@@ -119,7 +119,7 @@ int test(device* dev, oneapi::mkl::layout layout, int64_t N, int64_t incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_ref, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/axpby.cpp
+++ b/tests/unit_tests/blas/level1/axpby.cpp
@@ -124,7 +124,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, N, incy, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/axpy.cpp
+++ b/tests/unit_tests/blas/level1/axpy.cpp
@@ -124,7 +124,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, N, incy, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/copy.cpp
+++ b/tests/unit_tests/blas/level1/copy.cpp
@@ -122,7 +122,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, N, incy, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/dot.cpp
+++ b/tests/unit_tests/blas/level1/dot.cpp
@@ -123,7 +123,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_ref, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/dotc.cpp
+++ b/tests/unit_tests/blas/level1/dotc.cpp
@@ -125,7 +125,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_reference, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/dotu.cpp
+++ b/tests/unit_tests/blas/level1/dotu.cpp
@@ -125,7 +125,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_reference, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_ref, 0, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_ref, 0, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/nrm2.cpp
+++ b/tests/unit_tests/blas/level1/nrm2.cpp
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_ref, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/rot.cpp
+++ b/tests/unit_tests/blas/level1/rot.cpp
@@ -125,9 +125,9 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp_
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good_x = check_equal_vector(x_accessor, x_ref, N, incx, N, std::cout);
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good_y = check_equal_vector(y_accessor, y_ref, N, incy, N, std::cout);
 
     bool good = good_x && good_y;

--- a/tests/unit_tests/blas/level1/rotg.cpp
+++ b/tests/unit_tests/blas/level1/rotg.cpp
@@ -130,13 +130,13 @@ int test(device *dev, oneapi::mkl::layout layout) {
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto a_accessor = a_buffer.template get_host_access(read_only);
+    auto a_accessor = a_buffer.get_host_access(read_only);
     bool good_a = check_equal(a_accessor[0], a_ref, 4, std::cout);
-    auto b_accessor = b_buffer.template get_host_access(read_only);
+    auto b_accessor = b_buffer.get_host_access(read_only);
     bool good_b = check_equal(b_accessor[0], b_ref, 4, std::cout);
-    auto s_accessor = s_buffer.template get_host_access(read_only);
+    auto s_accessor = s_buffer.get_host_access(read_only);
     bool good_s = check_equal(s_accessor[0], s_ref, 4, std::cout);
-    auto c_accessor = c_buffer.template get_host_access(read_only);
+    auto c_accessor = c_buffer.get_host_access(read_only);
     bool good_c = check_equal(c_accessor[0], c_ref, 4, std::cout);
 
     bool good = good_a && good_b && good_c && good_s;

--- a/tests/unit_tests/blas/level1/rotm.cpp
+++ b/tests/unit_tests/blas/level1/rotm.cpp
@@ -127,9 +127,9 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, fp 
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good_x = check_equal_vector(x_accessor, x_ref, N, incx, N, std::cout);
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good_y = check_equal_vector(y_accessor, y_ref, N, incy, N, std::cout);
     bool good = good_x && good_y;
 

--- a/tests/unit_tests/blas/level1/rotmg.cpp
+++ b/tests/unit_tests/blas/level1/rotmg.cpp
@@ -130,13 +130,13 @@ int test(device* dev, oneapi::mkl::layout layout) {
 
     int error_mag = 50;
 
-    auto d1_accessor = d1_buffer.template get_host_access(read_only);
+    auto d1_accessor = d1_buffer.get_host_access(read_only);
     bool good_d1 = check_equal(d1_accessor[0], d1_ref, error_mag, std::cout);
-    auto d2_accessor = d2_buffer.template get_host_access(read_only);
+    auto d2_accessor = d2_buffer.get_host_access(read_only);
     bool good_d2 = check_equal(d2_accessor[0], d2_ref, error_mag, std::cout);
-    auto x1_accessor = x1_buffer.template get_host_access(read_only);
+    auto x1_accessor = x1_buffer.get_host_access(read_only);
     bool good_x1 = check_equal(x1_accessor[0], x1_ref, error_mag, std::cout);
-    auto param_accessor = param_buffer.template get_host_access(read_only);
+    auto param_accessor = param_buffer.get_host_access(read_only);
 
     constexpr fp unit_matrix = -2;
     constexpr fp rescaled_matrix = -1;

--- a/tests/unit_tests/blas/level1/scal.cpp
+++ b/tests/unit_tests/blas/level1/scal.cpp
@@ -120,7 +120,7 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, fp_scalar alp
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good = check_equal_vector(x_accessor, x_ref, N, incx, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/sdsdot.cpp
+++ b/tests/unit_tests/blas/level1/sdsdot.cpp
@@ -123,7 +123,7 @@ int test(device *dev, oneapi::mkl::layout layout, int N, int incx, int incy, flo
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto result_accessor = result_buffer.template get_host_access(read_only);
+    auto result_accessor = result_buffer.get_host_access(read_only);
     bool good = check_equal(result_accessor[0], result_ref, N, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level1/swap.cpp
+++ b/tests/unit_tests/blas/level1/swap.cpp
@@ -122,8 +122,8 @@ int test(device* dev, oneapi::mkl::layout layout, int N, int incx, int incy) {
 
     // Compare the results of reference implementation and DPC++ implementation.
 
-    auto y_accessor = y_buffer.template get_host_access(read_only);
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good_y = check_equal_vector(y_accessor, y_ref, N, incy, N, std::cout);
     bool good_x = check_equal_vector(x_accessor, x_ref, N, incx, N, std::cout);
     bool good = good_x && good_y;

--- a/tests/unit_tests/blas/level2/gbmv.cpp
+++ b/tests/unit_tests/blas/level2/gbmv.cpp
@@ -136,7 +136,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, y_len, incy, std::max<int>(m, n), std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/gemv.cpp
+++ b/tests/unit_tests/blas/level2/gemv.cpp
@@ -133,7 +133,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, y_len, incy, std::max<int>(m, n), std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/ger.cpp
+++ b/tests/unit_tests/blas/level2/ger.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(A_accessor, A_ref, layout, m, n, lda, std::max<int>(m, n), std::cout);
 

--- a/tests/unit_tests/blas/level2/gerc.cpp
+++ b/tests/unit_tests/blas/level2/gerc.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(A_accessor, A_ref, layout, m, n, lda, std::max<int>(m, n), std::cout);
 

--- a/tests/unit_tests/blas/level2/geru.cpp
+++ b/tests/unit_tests/blas/level2/geru.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, int m, int n, fp alpha, int in
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(A_accessor, A_ref, layout, m, n, lda, std::max<int>(m, n), std::cout);
 

--- a/tests/unit_tests/blas/level2/hbmv.cpp
+++ b/tests/unit_tests/blas/level2/hbmv.cpp
@@ -132,7 +132,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, n, incy, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/hemv.cpp
+++ b/tests/unit_tests/blas/level2/hemv.cpp
@@ -130,7 +130,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, n, incy, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/her.cpp
+++ b/tests/unit_tests/blas/level2/her.cpp
@@ -125,7 +125,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, lda, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/her2.cpp
+++ b/tests/unit_tests/blas/level2/her2.cpp
@@ -129,7 +129,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, lda, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/hpmv.cpp
+++ b/tests/unit_tests/blas/level2/hpmv.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, n, incy, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/hpr.cpp
+++ b/tests/unit_tests/blas/level2/hpr.cpp
@@ -125,7 +125,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, n, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/hpr2.cpp
+++ b/tests/unit_tests/blas/level2/hpr2.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, n, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/sbmv.cpp
+++ b/tests/unit_tests/blas/level2/sbmv.cpp
@@ -130,7 +130,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, n, incy, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/spmv.cpp
+++ b/tests/unit_tests/blas/level2/spmv.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, n, incy, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/spr.cpp
+++ b/tests/unit_tests/blas/level2/spr.cpp
@@ -124,7 +124,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, n, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/spr2.cpp
+++ b/tests/unit_tests/blas/level2/spr2.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, n, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/symv.cpp
+++ b/tests/unit_tests/blas/level2/symv.cpp
@@ -129,7 +129,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_accessor = y_buffer.template get_host_access(read_only);
+    auto y_accessor = y_buffer.get_host_access(read_only);
     bool good = check_equal_vector(y_accessor, y_ref, n, incy, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/syr.cpp
+++ b/tests/unit_tests/blas/level2/syr.cpp
@@ -124,7 +124,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, lda, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/syr2.cpp
+++ b/tests/unit_tests/blas/level2/syr2.cpp
@@ -128,7 +128,7 @@ int test(device *dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto A_accessor = A_buffer.template get_host_access(read_only);
+    auto A_accessor = A_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(A_accessor, A_ref, layout, n, n, lda, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/tbmv.cpp
+++ b/tests/unit_tests/blas/level2/tbmv.cpp
@@ -128,7 +128,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good = check_equal_vector(x_accessor, x_ref, n, incx, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/tbsv.cpp
+++ b/tests/unit_tests/blas/level2/tbsv.cpp
@@ -128,7 +128,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good = check_equal_trsv_vector(x_accessor, x_ref, n, incx, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/tpmv.cpp
+++ b/tests/unit_tests/blas/level2/tpmv.cpp
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good = check_equal_vector(x_accessor, x_ref, n, incx, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/tpsv.cpp
+++ b/tests/unit_tests/blas/level2/tpsv.cpp
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good = check_equal_trsv_vector(x_accessor, x_ref, n, incx, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/trmv.cpp
+++ b/tests/unit_tests/blas/level2/trmv.cpp
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good = check_equal_vector(x_accessor, x_ref, n, incx, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level2/trsv.cpp
+++ b/tests/unit_tests/blas/level2/trsv.cpp
@@ -126,7 +126,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto x_accessor = x_buffer.template get_host_access(read_only);
+    auto x_accessor = x_buffer.get_host_access(read_only);
     bool good = check_equal_trsv_vector(x_accessor, x_ref, n, incx, n, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level3/gemm.cpp
+++ b/tests/unit_tests/blas/level3/gemm.cpp
@@ -139,7 +139,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::transpose transa,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good = check_equal_matrix(C_accessor, C_ref, layout, m, n, ldc, 10 * k, std::cout);
 
     return (int)good;

--- a/tests/unit_tests/blas/level3/hemm.cpp
+++ b/tests/unit_tests/blas/level3/hemm.cpp
@@ -138,7 +138,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, layout, m, n, ldc, 10 * std::max(m, n), std::cout);
 

--- a/tests/unit_tests/blas/level3/her2k.cpp
+++ b/tests/unit_tests/blas/level3/her2k.cpp
@@ -139,7 +139,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, layout, n, n, ldc, 10 * std::max(n, k), std::cout);
 

--- a/tests/unit_tests/blas/level3/herk.cpp
+++ b/tests/unit_tests/blas/level3/herk.cpp
@@ -130,7 +130,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, layout, n, n, ldc, 10 * std::max(n, k), std::cout);
 

--- a/tests/unit_tests/blas/level3/symm.cpp
+++ b/tests/unit_tests/blas/level3/symm.cpp
@@ -138,7 +138,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, layout, m, n, ldc, 10 * std::max(m, n), std::cout);
 

--- a/tests/unit_tests/blas/level3/syr2k.cpp
+++ b/tests/unit_tests/blas/level3/syr2k.cpp
@@ -134,7 +134,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, layout, n, n, ldc, 10 * std::max(n, k), std::cout);
 

--- a/tests/unit_tests/blas/level3/syrk.cpp
+++ b/tests/unit_tests/blas/level3/syrk.cpp
@@ -129,7 +129,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::uplo upper_lower,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto C_accessor = C_buffer.template get_host_access(read_only);
+    auto C_accessor = C_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(C_accessor, C_ref, layout, n, n, ldc, 10 * std::max(n, k), std::cout);
 

--- a/tests/unit_tests/blas/level3/trmm.cpp
+++ b/tests/unit_tests/blas/level3/trmm.cpp
@@ -138,7 +138,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto B_accessor = B_buffer.template get_host_access(read_only);
+    auto B_accessor = B_buffer.get_host_access(read_only);
     bool good =
         check_equal_matrix(B_accessor, B_ref, layout, m, n, ldb, 10 * std::max(m, n), std::cout);
 

--- a/tests/unit_tests/blas/level3/trsm.cpp
+++ b/tests/unit_tests/blas/level3/trsm.cpp
@@ -138,7 +138,7 @@ int test(device* dev, oneapi::mkl::layout layout, oneapi::mkl::side left_right,
     }
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto B_accessor = B_buffer.template get_host_access(read_only);
+    auto B_accessor = B_buffer.get_host_access(read_only);
     bool good = check_equal_trsm_matrix(B_accessor, B_ref, layout, m, n, ldb, 10 * std::max(m, n),
                                         std::cout);
 

--- a/tests/unit_tests/dft/include/compute_inplace.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace.hpp
@@ -91,7 +91,7 @@ int DFT_Test<precision, domain>::test_in_place_buffer() {
         oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType>(descriptor, inout_buf);
 
         {
-            auto acc_host = inout_buf.template get_host_access();
+            auto acc_host = inout_buf.get_host_access();
             auto ptr_host = reinterpret_cast<FwdOutputType*>(acc_host.get_pointer());
             for (std::int64_t i = 0; i < batches; i++) {
                 EXPECT_TRUE(check_equal_strided<domain == oneapi::mkl::dft::domain::REAL>(

--- a/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_inplace_real_real.hpp
@@ -121,8 +121,8 @@ int DFT_Test<precision, domain>::test_in_place_real_real_buffer() {
                                                                        inout_im_buf);
 
         {
-            auto acc_inout_re = inout_re_buf.template get_host_access();
-            auto acc_inout_im = inout_im_buf.template get_host_access();
+            auto acc_inout_re = inout_re_buf.get_host_access();
+            auto acc_inout_im = inout_im_buf.get_host_access();
             std::vector<FwdOutputType> output_data(size_total, static_cast<FwdOutputType>(0));
             for (std::size_t i = 0; i < output_data.size(); ++i) {
                 output_data[i] = { acc_inout_re[i], acc_inout_im[i] };
@@ -136,8 +136,8 @@ int DFT_Test<precision, domain>::test_in_place_real_real_buffer() {
                                            PrecisionType>(descriptor, inout_re_buf, inout_im_buf);
 
         {
-            auto acc_inout_re = inout_re_buf.template get_host_access();
-            auto acc_inout_im = inout_im_buf.template get_host_access();
+            auto acc_inout_re = inout_re_buf.get_host_access();
+            auto acc_inout_im = inout_im_buf.get_host_access();
             std::vector<FwdInputType> output_data(size_total, static_cast<FwdInputType>(0));
             for (std::size_t i = 0; i < output_data.size(); ++i) {
                 output_data[i] = { acc_inout_re[i], acc_inout_im[i] };

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -70,7 +70,7 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
             descriptor, fwd_buf, bwd_buf);
 
         {
-            auto acc_bwd = bwd_buf.template get_host_access();
+            auto acc_bwd = bwd_buf.get_host_access();
             auto bwd_ptr = acc_bwd.get_pointer();
             for (std::int64_t i = 0; i < batches; i++) {
                 EXPECT_TRUE(check_equal_strided<domain == oneapi::mkl::dft::domain::REAL>(

--- a/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place_real_real.hpp
@@ -127,8 +127,8 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_buffer() {
             descriptor, in_dev_re, in_dev_im, out_dev_re, out_dev_im);
 
         {
-            auto acc_out_re = out_dev_re.template get_host_access();
-            auto acc_out_im = out_dev_im.template get_host_access();
+            auto acc_out_re = out_dev_re.get_host_access();
+            auto acc_out_im = out_dev_im.get_host_access();
             std::vector<FwdOutputType> output_data(size_total, static_cast<FwdOutputType>(0));
             for (std::size_t i = 0; i < output_data.size(); ++i) {
                 output_data[i] = { acc_out_re[i], acc_out_im[i] };
@@ -143,8 +143,8 @@ int DFT_Test<precision, domain>::test_out_of_place_real_real_buffer() {
             descriptor, out_dev_re, out_dev_im, out_back_dev_re, out_back_dev_im);
 
         {
-            auto acc_back_out_re = out_back_dev_re.template get_host_access();
-            auto acc_back_out_im = out_back_dev_im.template get_host_access();
+            auto acc_back_out_re = out_back_dev_re.get_host_access();
+            auto acc_back_out_im = out_back_dev_im.get_host_access();
             std::vector<FwdInputType> output_data(size_total, static_cast<FwdInputType>(0));
             for (std::size_t i = 0; i < output_data.size(); ++i) {
                 output_data[i] = { acc_back_out_re[i], acc_back_out_im[i] };

--- a/tests/unit_tests/sparse_blas/source/sparse_gemm_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemm_buffer.cpp
@@ -120,7 +120,7 @@ int test(sycl::device *dev, intType nrows_A, intType ncols_A, intType ncols_C,
                                 c_ref_host.data());
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto c_acc = c_buf.template get_host_access(sycl::read_only);
+    auto c_acc = c_buf.get_host_access(sycl::read_only);
     bool valid = check_equal_vector(c_acc, c_ref_host);
 
     ev_release.wait_and_throw();

--- a/tests/unit_tests/sparse_blas/source/sparse_gemv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_gemv_buffer.cpp
@@ -111,7 +111,7 @@ int test(sycl::device *dev, intType nrows, intType ncols, double density_A_matri
                                 y_ref_host.data());
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_acc = y_buf.template get_host_access(sycl::read_only);
+    auto y_acc = y_buf.get_host_access(sycl::read_only);
     bool valid = check_equal_vector(y_acc, y_ref_host);
 
     ev_release.wait_and_throw();

--- a/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
+++ b/tests/unit_tests/sparse_blas/source/sparse_trsv_buffer.cpp
@@ -119,7 +119,7 @@ int test(sycl::device *dev, intType m, double density_A_matrix, oneapi::mkl::ind
                                 y_ref_host.data());
 
     // Compare the results of reference implementation and DPC++ implementation.
-    auto y_acc = y_buf.template get_host_access(sycl::read_only);
+    auto y_acc = y_buf.get_host_access(sycl::read_only);
     bool valid = check_equal_vector(y_acc, y_ref_host);
 
     ev_release.wait_and_throw();


### PR DESCRIPTION
Remove .template from `get_host_access` to fix build. This is also cleaner code.

This fixes the build that became broken apparently due to a clang change: https://github.com/llvm/llvm-project/issues/94049

Note that a dpc++ patch is also required to fix the build due to an unrelated issue to the one described above:
https://github.com/intel/llvm/pull/14529

