### PR TITLE
[RNG] Workaround for get_multi_ptr with AdaptiveCPP

### DIFF
--- a/examples/rng/device/include/rng_example_helper.hpp
+++ b/examples/rng/device/include/rng_example_helper.hpp
@@ -29,12 +29,22 @@ struct has_member_code_meta<T, std::void_t<decltype(std::declval<T>().get_multi_
 
 template <typename T, typename std::enable_if<has_member_code_meta<T>::value>::type* = nullptr>
 auto get_multi_ptr(T acc) {
+// Workaround for AdaptiveCPP, as they do not yet support the get_multi_ptr function
+#ifndef __HIPSYCL__
     return acc.get_multi_ptr();
+#else
+    return acc.get_pointer();
+#endif
 };
 
 template <typename T, typename std::enable_if<!has_member_code_meta<T>::value>::type* = nullptr>
 auto get_multi_ptr(T acc) {
+// Workaround for AdaptiveCPP, as they do not yet support the get_multi_ptr function
+#ifndef __HIPSYCL__
     return acc.template get_multi_ptr<sycl::access::decorated::yes>();
+#else
+    return acc.get_pointer();
+#endif
 };
 
 #endif // _RNG_EXAMPLE_HELPER_HPP__

--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -56,8 +56,8 @@ class kernel_name {};
 template <typename Engine, typename Distr>
 class kernel_name_usm {};
 
-template <typename T, sycl::access_mode AccMode>
-T *get_raw_ptr(sycl::accessor<T, 1, AccMode> acc) {
+template <typename Acc>
+Acc::value_type* get_raw_ptr(Acc acc) {
 // Workaround for AdaptiveCPP, as they do not yet support the get_multi_ptr function
 #ifndef __HIPSYCL__
     return acc.template get_multi_ptr<sycl::access::decorated::no>().get_raw();

--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -57,7 +57,7 @@ template <typename Engine, typename Distr>
 class kernel_name_usm {};
 
 template <typename Acc>
-typename Acc::value_type* get_raw_ptr(Acc acc) {
+typename Acc::value_type *get_raw_ptr(Acc acc) {
 // Workaround for AdaptiveCPP, as they do not yet support the get_multi_ptr function
 #ifndef __HIPSYCL__
     return acc.template get_multi_ptr<sycl::access::decorated::no>().get_raw();

--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -58,7 +58,12 @@ class kernel_name_usm {};
 
 template <typename T, sycl::access_mode AccMode>
 T *get_raw_ptr(sycl::accessor<T, 1, AccMode> acc) {
+// Workaround for AdaptiveCPP, as they do not yet support the get_multi_ptr function
+#ifndef __HIPSYCL__
     return acc.template get_multi_ptr<sycl::access::decorated::no>().get_raw();
+#else
+    return acc.get_pointer();
+#endif
 }
 
 } // namespace mklcpu

--- a/src/rng/backends/mklcpu/cpu_common.hpp
+++ b/src/rng/backends/mklcpu/cpu_common.hpp
@@ -57,7 +57,7 @@ template <typename Engine, typename Distr>
 class kernel_name_usm {};
 
 template <typename Acc>
-Acc::value_type* get_raw_ptr(Acc acc) {
+typename Acc::value_type* get_raw_ptr(Acc acc) {
 // Workaround for AdaptiveCPP, as they do not yet support the get_multi_ptr function
 #ifndef __HIPSYCL__
     return acc.template get_multi_ptr<sycl::access::decorated::no>().get_raw();

--- a/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
+++ b/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
@@ -112,12 +112,20 @@ struct has_member_code_meta<T, std::void_t<decltype(std::declval<T>().get_multi_
 
 template <typename T, typename std::enable_if<has_member_code_meta<T>::value>::type* = nullptr>
 auto get_multi_ptr(T acc) {
+#ifndef __HIPSYCL__
     return acc.get_multi_ptr();
+#else
+    return acc.get_pointer();
+#endif
 };
 
 template <typename T, typename std::enable_if<!has_member_code_meta<T>::value>::type* = nullptr>
 auto get_multi_ptr(T acc) {
+#ifndef __HIPSYCL__
     return acc.template get_multi_ptr<sycl::access::decorated::yes>();
+#else
+    return acc.get_pointer();
+#endif
 };
 
 template <typename T>


### PR DESCRIPTION
# Description

This fix adds a workaround for AdaptiveCPP compiler as they not yet support the get_multi_ptr function.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
- [x] Have you formatted the code using clang-format?
