### PR TITLE
[BLAS][portBLAS]Add wait to copy event in ROTMG operator

### DIFF
--- a/src/blas/backends/portblas/portblas_level1.cxx
+++ b/src/blas/backends/portblas/portblas_level1.cxx
@@ -370,10 +370,9 @@ sycl::event rotmg(sycl::queue &queue, real_t *d1, real_t *d2, real_t *x1, real_t
                   const std::vector<sycl::event> &dependencies) {
     auto y_d =
         (real_t *)sycl::malloc_device(sizeof(real_t), queue.get_device(), queue.get_context());
-    auto copy_in_event = queue.memcpy(y_d, &y1, sizeof(real_t), dependencies);
+    queue.memcpy(y_d, &y1, sizeof(real_t), dependencies).wait();
     auto rotmg_event = std::invoke([&]() -> sycl::event {
-        CALL_PORTBLAS_USM_FN(::blas::_rotmg, queue, d1, d2, x1, y_d, param,
-                             std::vector<sycl::event>{ copy_in_event });
+        CALL_PORTBLAS_USM_FN(::blas::_rotmg, queue, d1, d2, x1, y_d, param);
     });
     auto free_event = queue.submit([&](sycl::handler &cgh) {
         cgh.depends_on(rotmg_event);


### PR DESCRIPTION
# Description

Currently the dependencies on copy event isn't always respected with OpenCL on CPU devices, this cause random failure with this operator. 
To reproduce the failure, run `RotmgUsm` operator in a loop using OpenCL CPU portBLAS backend, it will eventually fail, it generally takes less that 10 iterations.
Adding a `wait` on the `memcpy` momentarily fix the issue while waiting for a proper compile fix.

Possible related issue https://github.com/intel/llvm/issues/14623

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[rotmg_amd_log.txt](https://github.com/user-attachments/files/16331757/rotmg_amd_log.txt)
[rotmg_cpu_log.txt](https://github.com/user-attachments/files/16331758/rotmg_cpu_log.txt)
[rotmg_nvidia_log.txt](https://github.com/user-attachments/files/16331759/rotmg_nvidia_log.txt)
[rotmg_pvc_log.txt](https://github.com/user-attachments/files/16331760/rotmg_pvc_log.txt)

- [x] Have you formatted the code using clang-format?


## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
