### PR TITLE
[BLAS][portBLAS] Update interface call for rotmg for portBLAS backend

### DIFF
--- a/src/blas/backends/portblas/portblas_level1.cxx
+++ b/src/blas/backends/portblas/portblas_level1.cxx
@@ -174,8 +174,7 @@ void rotm(sycl::queue &queue, std::int64_t n, sycl::buffer<real_t, 1> &x, std::i
 
 void rotmg(sycl::queue &queue, sycl::buffer<real_t, 1> &d1, sycl::buffer<real_t, 1> &d2,
            sycl::buffer<real_t, 1> &x1, real_t y1, sycl::buffer<real_t, 1> &param) {
-    sycl::buffer<real_t, 1> y1_buffer(&y1, sycl::range<1>{ 1 });
-    CALL_PORTBLAS_FN(::blas::_rotmg, queue, d1, d2, x1, y1_buffer, param);
+    CALL_PORTBLAS_FN(::blas::_rotmg, queue, d1, d2, x1, y1, param);
 }
 
 void scal(sycl::queue &queue, std::int64_t n, real_t alpha, sycl::buffer<real_t, 1> &x,
@@ -368,18 +367,7 @@ sycl::event rotm(sycl::queue &queue, std::int64_t n, real_t *x, std::int64_t inc
 
 sycl::event rotmg(sycl::queue &queue, real_t *d1, real_t *d2, real_t *x1, real_t y1, real_t *param,
                   const std::vector<sycl::event> &dependencies) {
-    auto y_d =
-        (real_t *)sycl::malloc_device(sizeof(real_t), queue.get_device(), queue.get_context());
-    auto copy_in_event = queue.memcpy(y_d, &y1, sizeof(real_t), dependencies);
-    auto rotmg_event = std::invoke([&]() -> sycl::event {
-        CALL_PORTBLAS_USM_FN(::blas::_rotmg, queue, d1, d2, x1, y_d, param,
-                             std::vector<sycl::event>{ copy_in_event });
-    });
-    auto free_event = queue.submit([&](sycl::handler &cgh) {
-        cgh.depends_on(rotmg_event);
-        cgh.host_task([=]() { sycl::free(y_d, queue); });
-    });
-    return free_event;
+    CALL_PORTBLAS_USM_FN(::blas::_rotmg, queue, d1, d2, x1, y1, param, dependencies);
 }
 
 sycl::event scal(sycl::queue &queue, std::int64_t n, real_t alpha, real_t *x, std::int64_t incx,


### PR DESCRIPTION
# Description

Currently the dependencies on copy event isn't always respected with OpenCL on CPU devices, this cause random failure with this operator.
To reproduce the failure, run `RotmgUsm` operator in a loop using OpenCL CPU portBLAS backend, it will eventually fail, it generally takes less that 10 iterations.
Due to internal changes in portBLAS the copies are not necessary anymore.

Possible related issue https://github.com/intel/llvm/issues/14623

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[rotmg_amd_log.txt](https://github.com/user-attachments/files/16438758/rotmg_amd_log.txt)
[rotmg_cpu_log.txt](https://github.com/user-attachments/files/16438760/rotmg_cpu_log.txt)
[rotmg_nvidia_log.txt](https://github.com/user-attachments/files/16438762/rotmg_nvidia_log.txt)
[rotmg_pvc_log.txt](https://github.com/user-attachments/files/16438764/rotmg_pvc_log.txt)

- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
