### PR TITLE
Changed pi_context to ur_context_handle_t and include pi.hpp to ur.hpp

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -35,8 +35,8 @@ namespace cublas {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-thread_local cublas_handle<pi_context> CublasScopedContextHandler::handle_helper =
-    cublas_handle<pi_context>{};
+thread_local cublas_handle<ur_context_handle_t> CublasScopedContextHandler::handle_helper =
+    cublas_handle<ur_context_handle_t>{};
 
 CublasScopedContextHandler::CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle &ih)
         : ih(ih),
@@ -92,7 +92,7 @@ cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue &queue) 
     CUresult cuErr;
     CUcontext desired;
     CUDA_ERROR_FUNC(cuDevicePrimaryCtxRetain, cuErr, &desired, cudaDevice);
-    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+    auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
     CUstream streamId = get_stream(queue);
     cublasStatus_t err;
     auto it = handle_helper.cublas_handle_mapper_.find(piPlacedContext_);

--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -35,8 +35,13 @@ namespace cublas {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
+#ifdef _PI_INTERFACE_REMOVED_
 thread_local cublas_handle<ur_context_handle_t> CublasScopedContextHandler::handle_helper =
     cublas_handle<ur_context_handle_t>{};
+#else
+thread_local cublas_handle<pi_context> CublasScopedContextHandler::handle_helper =
+    cublas_handle<pi_context>{};
+#endif
 
 CublasScopedContextHandler::CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle &ih)
         : ih(ih),
@@ -92,7 +97,11 @@ cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue &queue) 
     CUresult cuErr;
     CUcontext desired;
     CUDA_ERROR_FUNC(cuDevicePrimaryCtxRetain, cuErr, &desired, cudaDevice);
+#ifdef _PI_INTERFACE_REMOVED_
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
+#else
+    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+#endif
     CUstream streamId = get_stream(queue);
     cublasStatus_t err;
     auto it = handle_helper.cublas_handle_mapper_.find(piPlacedContext_);

--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -35,7 +35,7 @@ namespace cublas {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 thread_local cublas_handle<ur_context_handle_t> CublasScopedContextHandler::handle_helper =
     cublas_handle<ur_context_handle_t>{};
 #else
@@ -97,7 +97,7 @@ cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue &queue) 
     CUresult cuErr;
     CUcontext desired;
     CUDA_ERROR_FUNC(cuDevicePrimaryCtxRetain, cuErr, &desired, cudaDevice);
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
 #else
     auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -36,8 +36,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>
@@ -88,7 +88,7 @@ class CublasScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     static thread_local cublas_handle<ur_context_handle_t> handle_helper;
 #else
     static thread_local cublas_handle<pi_context> handle_helper;

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -91,7 +91,7 @@ class CublasScopedContextHandler {
 #ifdef _PI_INTERFACE_REMOVED_
     static thread_local cublas_handle<ur_context_handle_t> handle_helper;
 #else
-    static thread_local cublas_handle<pi_xontext> handle_helper;
+    static thread_local cublas_handle<pi_context> handle_helper;
 #endif
     CUstream get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -28,12 +28,23 @@
 #include <sycl/backend/cuda.hpp>
 #endif
 #include <sycl/context.hpp>
-#include <sycl/detail/ur.hpp>
 #else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
+#endif
+
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
+#else
 #include <CL/sycl/detail/pi.hpp>
 #endif
+
 #include <atomic>
 #include <memory>
 #include <thread>
@@ -77,7 +88,11 @@ class CublasScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
+#ifdef _PI_INTERFACE_REMOVED_
     static thread_local cublas_handle<ur_context_handle_t> handle_helper;
+#else
+    static thread_local cublas_handle<pi_xontext> handle_helper;
+#endif
     CUstream get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);
 

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -28,11 +28,11 @@
 #include <sycl/backend/cuda.hpp>
 #endif
 #include <sycl/context.hpp>
-#include <sycl/detail/pi.hpp>
+#include <sycl/detail/ur.hpp>
 #else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/ur.hpp>
 #endif
 #include <atomic>
 #include <memory>
@@ -77,7 +77,7 @@ class CublasScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
-    static thread_local cublas_handle<pi_context> handle_helper;
+    static thread_local cublas_handle<ur_context_handle_t> handle_helper;
     CUstream get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);
 

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -32,7 +32,7 @@
 #else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/ur.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #endif
 #include <atomic>
 #include <memory>

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -38,8 +38,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -32,13 +32,21 @@
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "cublas_scope_handle.hpp"
+#else
+#include "cublas_scope_handle_hipsycl.hpp"
+
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
 #else
 #include <CL/sycl/detail/pi.hpp>
 #endif
-#else
-#include "cublas_scope_handle_hipsycl.hpp"
+
 namespace sycl {
 using interop_handler = sycl::interop_handle;
 }

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -32,10 +32,10 @@
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "cublas_scope_handle.hpp"
-#if __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/ur.hpp>
 #endif
 #else
 #include "cublas_scope_handle_hipsycl.hpp"

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -35,7 +35,7 @@
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/ur.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #endif
 #else
 #include "cublas_scope_handle_hipsycl.hpp"

--- a/src/blas/backends/rocblas/rocblas_scope_handle.cpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.cpp
@@ -50,7 +50,7 @@ rocblas_handle_container<T>::~rocblas_handle_container() noexcept(false) {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 thread_local rocblas_handle_container<ur_context_handle_t>
     RocblasScopedContextHandler::handle_helper = rocblas_handle_container<ur_context_handle_t>{};
 #else
@@ -113,7 +113,7 @@ rocblas_handle RocblasScopedContextHandler::get_handle(const sycl::queue &queue)
     hipError_t hipErr;
     hipCtx_t desired;
     HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, hipErr, &desired, hipDevice);
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
 #else
     auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);

--- a/src/blas/backends/rocblas/rocblas_scope_handle.cpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.cpp
@@ -50,8 +50,13 @@ rocblas_handle_container<T>::~rocblas_handle_container() noexcept(false) {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-thread_local rocblas_handle_container<ur_context_handle_t> RocblasScopedContextHandler::handle_helper =
-    rocblas_handle_container<ur_context_handle_t>{};
+#ifdef _PI_INTERFACE_REMOVED_
+thread_local rocblas_handle_container<ur_context_handle_t>
+    RocblasScopedContextHandler::handle_helper = rocblas_handle_container<ur_context_handle_t>{};
+#else
+thread_local rocblas_handle_container<pi_context> RocblasScopedContextHandler::handle_helper =
+    rocblas_handle_container<pi_context>{};
+#endif
 
 RocblasScopedContextHandler::RocblasScopedContextHandler(sycl::queue queue,
                                                          sycl::interop_handle &ih)
@@ -108,7 +113,11 @@ rocblas_handle RocblasScopedContextHandler::get_handle(const sycl::queue &queue)
     hipError_t hipErr;
     hipCtx_t desired;
     HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, hipErr, &desired, hipDevice);
+#ifdef _PI_INTERFACE_REMOVED_
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
+#else
+    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+#endif
     hipStream_t streamId = get_stream(queue);
     rocblas_status err;
     auto it = handle_helper.rocblas_handle_container_mapper_.find(piPlacedContext_);

--- a/src/blas/backends/rocblas/rocblas_scope_handle.cpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.cpp
@@ -50,8 +50,8 @@ rocblas_handle_container<T>::~rocblas_handle_container() noexcept(false) {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-thread_local rocblas_handle_container<pi_context> RocblasScopedContextHandler::handle_helper =
-    rocblas_handle_container<pi_context>{};
+thread_local rocblas_handle_container<ur_context_handle_t> RocblasScopedContextHandler::handle_helper =
+    rocblas_handle_container<ur_context_handle_t>{};
 
 RocblasScopedContextHandler::RocblasScopedContextHandler(sycl::queue queue,
                                                          sycl::interop_handle &ih)
@@ -108,7 +108,7 @@ rocblas_handle RocblasScopedContextHandler::get_handle(const sycl::queue &queue)
     hipError_t hipErr;
     hipCtx_t desired;
     HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, hipErr, &desired, hipDevice);
-    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+    auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
     hipStream_t streamId = get_stream(queue);
     rocblas_status err;
     auto it = handle_helper.rocblas_handle_container_mapper_.find(piPlacedContext_);

--- a/src/blas/backends/rocblas/rocblas_scope_handle.hpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.hpp
@@ -43,7 +43,7 @@ class RocblasScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &interop_h;
-    static thread_local rocblas_handle_container<pi_context> handle_helper;
+    static thread_local rocblas_handle_container<ur_context_handle_t> handle_helper;
     sycl::context get_context(const sycl::queue &queue);
     hipStream_t get_stream(const sycl::queue &queue);
 

--- a/src/blas/backends/rocblas/rocblas_scope_handle.hpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.hpp
@@ -26,6 +26,18 @@
 #include <unordered_map>
 #include "rocblas_helper.hpp"
 
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
+#else
+#include <CL/sycl/detail/pi.hpp>
+#endif
+
 namespace oneapi {
 namespace mkl {
 namespace blas {
@@ -43,7 +55,11 @@ class RocblasScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &interop_h;
+#ifdef _PI_INTERFACE_REMOVED_
     static thread_local rocblas_handle_container<ur_context_handle_t> handle_helper;
+#else
+    static thread_local rocblas_handle_container<pi_context> handle_helper;
+#endif
     sycl::context get_context(const sycl::queue &queue);
     hipStream_t get_stream(const sycl::queue &queue);
 

--- a/src/blas/backends/rocblas/rocblas_scope_handle.hpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.hpp
@@ -29,8 +29,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>
@@ -55,7 +55,7 @@ class RocblasScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &interop_h;
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     static thread_local rocblas_handle_container<ur_context_handle_t> handle_helper;
 #else
     static thread_local rocblas_handle_container<pi_context> handle_helper;

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -33,7 +33,7 @@
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/ur.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #endif
 #else
 #include "rocblas_scope_handle_hipsycl.hpp"

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -37,8 +37,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -30,15 +30,22 @@
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "rocblas_scope_handle.hpp"
+#else
+#include "rocblas_scope_handle_hipsycl.hpp"
+#endif
+
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
 #else
 #include <CL/sycl/detail/pi.hpp>
 #endif
-#else
-#include "rocblas_scope_handle_hipsycl.hpp"
 
-#endif
 namespace oneapi {
 namespace mkl {
 namespace blas {

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -30,10 +30,10 @@
 #include "oneapi/mkl/types.hpp"
 #ifndef __HIPSYCL__
 #include "rocblas_scope_handle.hpp"
-#if __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/ur.hpp>
 #endif
 #else
 #include "rocblas_scope_handle_hipsycl.hpp"

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
@@ -35,8 +35,8 @@ namespace cusolver {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-thread_local cusolver_handle<pi_context> CusolverScopedContextHandler::handle_helper =
-    cusolver_handle<pi_context>{};
+thread_local cusolver_handle<ur_context_handle_t> CusolverScopedContextHandler::handle_helper =
+    cusolver_handle<ur_context_handle_t>{};
 
 CusolverScopedContextHandler::CusolverScopedContextHandler(sycl::queue queue,
                                                            sycl::interop_handle &ih)
@@ -93,7 +93,7 @@ cusolverDnHandle_t CusolverScopedContextHandler::get_handle(const sycl::queue &q
     CUresult cuErr;
     CUcontext desired;
     CUDA_ERROR_FUNC(cuDevicePrimaryCtxRetain, cuErr, &desired, cudaDevice);
-    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+    auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
     CUstream streamId = get_stream(queue);
     cusolverStatus_t err;
     auto it = handle_helper.cusolver_handle_mapper_.find(piPlacedContext_);

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
@@ -35,7 +35,7 @@ namespace cusolver {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 thread_local cusolver_handle<ur_context_handle_t> CusolverScopedContextHandler::handle_helper =
     cusolver_handle<ur_context_handle_t>{};
 #else
@@ -98,7 +98,7 @@ cusolverDnHandle_t CusolverScopedContextHandler::get_handle(const sycl::queue &q
     CUresult cuErr;
     CUcontext desired;
     CUDA_ERROR_FUNC(cuDevicePrimaryCtxRetain, cuErr, &desired, cudaDevice);
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
 #else
     auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.cpp
@@ -35,8 +35,13 @@ namespace cusolver {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
+#ifdef _PI_INTERFACE_REMOVED_
 thread_local cusolver_handle<ur_context_handle_t> CusolverScopedContextHandler::handle_helper =
     cusolver_handle<ur_context_handle_t>{};
+#else
+thread_local cusolver_handle<pi_context> CusolverScopedContextHandler::handle_helper =
+    cusolver_handle<pi_context>{};
+#endif
 
 CusolverScopedContextHandler::CusolverScopedContextHandler(sycl::queue queue,
                                                            sycl::interop_handle &ih)
@@ -93,7 +98,11 @@ cusolverDnHandle_t CusolverScopedContextHandler::get_handle(const sycl::queue &q
     CUresult cuErr;
     CUcontext desired;
     CUDA_ERROR_FUNC(cuDevicePrimaryCtxRetain, cuErr, &desired, cudaDevice);
+#ifdef _PI_INTERFACE_REMOVED_
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
+#else
+    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+#endif
     CUstream streamId = get_stream(queue);
     cusolverStatus_t err;
     auto it = handle_helper.cusolver_handle_mapper_.find(piPlacedContext_);

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
@@ -28,11 +28,9 @@
 #include <sycl/backend/cuda.hpp>
 #endif
 #include <sycl/context.hpp>
-#include <sycl/detail/ur.hpp>
 #else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/pi.hpp>
 #endif
 #include <atomic>
 #include <memory>
@@ -40,6 +38,18 @@
 #include <unordered_map>
 #include "cusolver_helper.hpp"
 #include "cusolver_handle.hpp"
+
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
+#else
+#include <CL/sycl/detail/pi.hpp>
+#endif
 
 namespace oneapi {
 namespace mkl {
@@ -82,7 +92,11 @@ class CusolverScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
+#ifdef _PI_INTERFACE_REMOVED_
     static thread_local cusolver_handle<ur_context_handle_t> handle_helper;
+#else
+    static thread_local cusolver_handle<pi_context> handle_helper;
+#endif
     CUstream get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);
 

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
@@ -28,11 +28,11 @@
 #include <sycl/backend/cuda.hpp>
 #endif
 #include <sycl/context.hpp>
-#include <sycl/detail/pi.hpp>
+#include <sycl/detail/ur.hpp>
 #else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/ur.hpp>
 #endif
 #include <atomic>
 #include <memory>
@@ -82,7 +82,7 @@ class CusolverScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
-    static thread_local cusolver_handle<pi_context> handle_helper;
+    static thread_local cusolver_handle<ur_context_handle_t> handle_helper;
     CUstream get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);
 

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
@@ -42,8 +42,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>
@@ -92,7 +92,7 @@ class CusolverScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     static thread_local cusolver_handle<ur_context_handle_t> handle_helper;
 #else
     static thread_local cusolver_handle<pi_context> handle_helper;

--- a/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
+++ b/src/lapack/backends/cusolver/cusolver_scope_handle.hpp
@@ -32,7 +32,7 @@
 #else
 #include <CL/sycl/backend/cuda.hpp>
 #include <CL/sycl/context.hpp>
-#include <CL/sycl/detail/ur.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #endif
 #include <atomic>
 #include <memory>

--- a/src/lapack/backends/cusolver/cusolver_task.hpp
+++ b/src/lapack/backends/cusolver/cusolver_task.hpp
@@ -30,10 +30,10 @@
 #endif
 #include "oneapi/mkl/types.hpp"
 #include "cusolver_scope_handle.hpp"
-#if __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/ur.hpp>
 #endif
 namespace oneapi {
 namespace mkl {

--- a/src/lapack/backends/cusolver/cusolver_task.hpp
+++ b/src/lapack/backends/cusolver/cusolver_task.hpp
@@ -30,11 +30,19 @@
 #endif
 #include "oneapi/mkl/types.hpp"
 #include "cusolver_scope_handle.hpp"
+
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
 #else
 #include <CL/sycl/detail/pi.hpp>
 #endif
+
 namespace oneapi {
 namespace mkl {
 namespace lapack {

--- a/src/lapack/backends/cusolver/cusolver_task.hpp
+++ b/src/lapack/backends/cusolver/cusolver_task.hpp
@@ -34,8 +34,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>

--- a/src/lapack/backends/cusolver/cusolver_task.hpp
+++ b/src/lapack/backends/cusolver/cusolver_task.hpp
@@ -33,7 +33,7 @@
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/ur.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #endif
 namespace oneapi {
 namespace mkl {

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
@@ -37,8 +37,13 @@ namespace rocsolver {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
+#ifdef _PI_INTERFACE_REMOVED_
 thread_local rocsolver_handle<ur_context_handle_t> RocsolverScopedContextHandler::handle_helper =
     rocsolver_handle<ur_context_handle_t>{};
+#else
+thread_local rocsolver_handle<pi_context> RocsolverScopedContextHandler::handle_helper =
+    rocsolver_handle<pi_context>{};
+#endif
 
 RocsolverScopedContextHandler::RocsolverScopedContextHandler(sycl::queue queue,
                                                              sycl::interop_handle &ih)
@@ -95,7 +100,11 @@ rocblas_handle RocsolverScopedContextHandler::get_handle(const sycl::queue &queu
     hipError_t hipErr;
     hipCtx_t desired;
     HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, hipErr, &desired, hipDevice);
+#ifdef _PI_INTERFACE_REMOVED_
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
+#else
+    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+#endif
     hipStream_t streamId = get_stream(queue);
     rocblas_status err;
     auto it = handle_helper.rocsolver_handle_mapper_.find(piPlacedContext_);

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
@@ -37,8 +37,8 @@ namespace rocsolver {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-thread_local rocsolver_handle<pi_context> RocsolverScopedContextHandler::handle_helper =
-    rocsolver_handle<pi_context>{};
+thread_local rocsolver_handle<ur_context_handle_t> RocsolverScopedContextHandler::handle_helper =
+    rocsolver_handle<ur_context_handle_t>{};
 
 RocsolverScopedContextHandler::RocsolverScopedContextHandler(sycl::queue queue,
                                                              sycl::interop_handle &ih)
@@ -95,7 +95,7 @@ rocblas_handle RocsolverScopedContextHandler::get_handle(const sycl::queue &queu
     hipError_t hipErr;
     hipCtx_t desired;
     HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, hipErr, &desired, hipDevice);
-    auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);
+    auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
     hipStream_t streamId = get_stream(queue);
     rocblas_status err;
     auto it = handle_helper.rocsolver_handle_mapper_.find(piPlacedContext_);

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.cpp
@@ -37,7 +37,7 @@ namespace rocsolver {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 thread_local rocsolver_handle<ur_context_handle_t> RocsolverScopedContextHandler::handle_helper =
     rocsolver_handle<ur_context_handle_t>{};
 #else
@@ -100,7 +100,7 @@ rocblas_handle RocsolverScopedContextHandler::get_handle(const sycl::queue &queu
     hipError_t hipErr;
     hipCtx_t desired;
     HIP_ERROR_FUNC(hipDevicePrimaryCtxRetain, hipErr, &desired, hipDevice);
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     auto piPlacedContext_ = reinterpret_cast<ur_context_handle_t>(desired);
 #else
     auto piPlacedContext_ = reinterpret_cast<pi_context>(desired);

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
@@ -33,6 +33,18 @@
 #include "rocsolver_helper.hpp"
 #include "rocsolver_handle.hpp"
 
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
+#else
+#include <CL/sycl/detail/pi.hpp>
+#endif
+
 namespace oneapi {
 namespace mkl {
 namespace lapack {

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
@@ -43,7 +43,11 @@ class RocsolverScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
+#ifdef _PI_INTERFACE_REMOVED_
     static thread_local rocsolver_handle<ur_context_handle_t> handle_helper;
+#else
+    static thread_local rocsolver_handle<pi_context> handle_helper;
+#endif
     hipStream_t get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);
 

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
@@ -43,7 +43,7 @@ class RocsolverScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
-    static thread_local rocsolver_handle<pi_context> handle_helper;
+    static thread_local rocsolver_handle<ur_context_handle_t> handle_helper;
     hipStream_t get_stream(const sycl::queue &queue);
     sycl::context get_context(const sycl::queue &queue);
 

--- a/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_scope_handle.hpp
@@ -36,8 +36,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>
@@ -55,7 +55,7 @@ class RocsolverScopedContextHandler {
     sycl::context *placedContext_;
     bool needToRecover_;
     sycl::interop_handle &ih;
-#ifdef _PI_INTERFACE_REMOVED_
+#ifdef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
     static thread_local rocsolver_handle<ur_context_handle_t> handle_helper;
 #else
     static thread_local rocsolver_handle<pi_context> handle_helper;

--- a/src/lapack/backends/rocsolver/rocsolver_task.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_task.hpp
@@ -35,7 +35,7 @@
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/ur.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #endif
 
 namespace oneapi {

--- a/src/lapack/backends/rocsolver/rocsolver_task.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_task.hpp
@@ -36,8 +36,8 @@
 // After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
-#ifndef _PI_INTERFACE_REMOVED_
-#define _PI_INTERFACE_REMOVED_
+#ifndef ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
+#define ONEAPI_ONEMKL_PI_INTERFACE_REMOVED
 #endif
 #elif __has_include(<sycl/detail/pi.hpp>)
 #include <sycl/detail/pi.hpp>

--- a/src/lapack/backends/rocsolver/rocsolver_task.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_task.hpp
@@ -32,8 +32,15 @@
 #endif
 #include "oneapi/mkl/types.hpp"
 #include "rocsolver_scope_handle.hpp"
+
+// After Plugin Interface removal in DPC++ ur.hpp is the new include
 #if __has_include(<sycl/detail/ur.hpp>)
 #include <sycl/detail/ur.hpp>
+#ifndef _PI_INTERFACE_REMOVED_
+#define _PI_INTERFACE_REMOVED_
+#endif
+#elif __has_include(<sycl/detail/pi.hpp>)
+#include <sycl/detail/pi.hpp>
 #else
 #include <CL/sycl/detail/pi.hpp>
 #endif

--- a/src/lapack/backends/rocsolver/rocsolver_task.hpp
+++ b/src/lapack/backends/rocsolver/rocsolver_task.hpp
@@ -32,10 +32,10 @@
 #endif
 #include "oneapi/mkl/types.hpp"
 #include "rocsolver_scope_handle.hpp"
-#if __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
+#if __has_include(<sycl/detail/ur.hpp>)
+#include <sycl/detail/ur.hpp>
 #else
-#include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/detail/ur.hpp>
 #endif
 
 namespace oneapi {


### PR DESCRIPTION
# Description
After [plugin interface removal patch](https://github.com/intel/llvm/pull/14145) in **intel/llvm**, the oneMKL build broke. This PR fixes it by:
- changing all occurences of `#include pi.hpp` to `ur.hpp`
- changing `pi_context` to `ur_context_handle_t`

Also, for the build to work correctly again, this patch is needed:
- https://github.com/intel/llvm/pull/14830

