### PR TITLE
[DFT] Corrections to FWD/BWD_STRIDES API

### DIFF
--- a/src/dft/backends/cufft/commit.cpp
+++ b/src/dft/backends/cufft/commit.cpp
@@ -173,7 +173,7 @@ public:
             if (a_min - stride_vecs.vec_a.begin() != b_min - stride_vecs.vec_b.begin()) {
                 throw mkl::unimplemented(
                     "dft/backends/cufft", __FUNCTION__,
-                    "cufft requires that if ordered by stride length, the order of strides is the same for input and output strides!");
+                    "cufft requires that if ordered by stride length, the order of strides is the same for input/output or fwd/bwd strides!");
             }
         }
         const int a_stride = static_cast<int>(*a_min);

--- a/src/dft/backends/descriptor.cpp
+++ b/src/dft/backends/descriptor.cpp
@@ -22,9 +22,7 @@
 
 #include "../descriptor.cxx"
 
-namespace oneapi {
-namespace mkl {
-namespace dft {
+namespace oneapi::mkl::dft::detail {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(sycl::queue &queue) {
@@ -41,6 +39,4 @@ template void descriptor<precision::SINGLE, domain::REAL>::commit(sycl::queue &)
 template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(sycl::queue &);
 template void descriptor<precision::DOUBLE, domain::REAL>::commit(sycl::queue &);
 
-} //namespace dft
-} //namespace mkl
-} //namespace oneapi
+} //namespace oneapi::mkl::dft::detail

--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -22,9 +22,7 @@
 
 #include "oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp"
 
-namespace oneapi {
-namespace mkl {
-namespace dft {
+namespace oneapi::mkl::dft::detail {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
@@ -46,6 +44,4 @@ template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(
 template void descriptor<precision::DOUBLE, domain::REAL>::commit(
     backend_selector<backend::mklcpu>);
 
-} //namespace dft
-} //namespace mkl
-} //namespace oneapi
+} //namespace oneapi::mkl::dft::detail

--- a/src/dft/backends/mklgpu/descriptor.cpp
+++ b/src/dft/backends/mklgpu/descriptor.cpp
@@ -22,9 +22,7 @@
 
 #include "oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp"
 
-namespace oneapi {
-namespace mkl {
-namespace dft {
+namespace oneapi::mkl::dft::detail {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklgpu> selector) {
@@ -46,6 +44,4 @@ template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(
 template void descriptor<precision::DOUBLE, domain::REAL>::commit(
     backend_selector<backend::mklgpu>);
 
-} //namespace dft
-} //namespace mkl
-} //namespace oneapi
+} //namespace oneapi::mkl::dft::detail

--- a/src/dft/backends/rocfft/commit.cpp
+++ b/src/dft/backends/rocfft/commit.cpp
@@ -297,8 +297,8 @@ public:
                                                     auto& domain_lengths) {
             return dimensions == 1 ||
                    (domain_lengths[sindices[0]] <= svec[sindices[1]] &&
-                    (dimensions == 2 || domain_lengths[sindices[0]] * domain_lengths[sindices[1]] <=
-                                            svec[sindices[2]]));
+                    (dimensions == 2 ||
+                     svec[sindices[1]] * domain_lengths[sindices[1]] <= svec[sindices[2]]));
         };
 
         const bool vec_a_valid_as_fwd_domain =

--- a/tests/unit_tests/dft/include/compute_out_of_place.hpp
+++ b/tests/unit_tests/dft/include/compute_out_of_place.hpp
@@ -29,11 +29,26 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
         return test_skipped;
     }
 
-    auto [forward_distance, backward_distance] =
-        get_default_distances<domain>(sizes, strides_fwd, strides_bwd);
-    auto ref_distance = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<>());
-
     descriptor_t descriptor{ sizes };
+    auto strides_fwd_cpy = strides_fwd;
+    auto strides_bwd_cpy = strides_bwd;
+    if (strides_fwd_cpy.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd_cpy.data());
+    }
+    else {
+        strides_fwd_cpy.resize(sizes.size() + 1);
+        descriptor.get_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd_cpy.data());
+    }
+    if (strides_bwd_cpy.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd_cpy.data());
+    }
+    else {
+        strides_bwd_cpy.resize(sizes.size() + 1);
+        descriptor.get_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd_cpy.data());
+    }
+    auto [forward_distance, backward_distance] =
+        get_default_distances<domain>(sizes, strides_fwd_cpy, strides_bwd_cpy);
+    auto ref_distance = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<>());
     descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                          oneapi::mkl::dft::config_value::NOT_INPLACE);
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
@@ -45,22 +60,12 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
     descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
-    if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd.data());
-    }
-    if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd.data());
-    }
-    else if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
-        const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, complex_strides.data());
-    }
     commit_descriptor(descriptor, sycl_queue);
     std::vector<FwdInputType> fwd_data(
-        strided_copy(input, sizes, strides_fwd, batches, forward_distance));
+        strided_copy(input, sizes, strides_fwd_cpy, batches, forward_distance));
 
     auto tmp = std::vector<FwdOutputType>(
-        cast_unsigned(backward_distance * batches + get_default(strides_bwd, 0, 0L)), 0);
+        cast_unsigned(backward_distance * batches + get_default(strides_bwd_cpy, 0, 0L)), 0);
     {
         sycl::buffer<FwdInputType, 1> fwd_buf{ fwd_data };
         sycl::buffer<FwdOutputType, 1> bwd_buf{ tmp };
@@ -74,7 +79,7 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
             for (std::int64_t i = 0; i < batches; i++) {
                 EXPECT_TRUE(check_equal_strided<domain == oneapi::mkl::dft::domain::REAL>(
                     bwd_ptr + backward_distance * i, out_host_ref.data() + ref_distance * i, sizes,
-                    strides_bwd, abs_error_margin, rel_error_margin, std::cout));
+                    strides_bwd_cpy, abs_error_margin, rel_error_margin, std::cout));
             }
         }
 
@@ -88,9 +93,9 @@ int DFT_Test<precision, domain>::test_out_of_place_buffer() {
                   [this](auto &x) { x *= static_cast<PrecisionType>(forward_elements); });
 
     for (std::int64_t i = 0; i < batches; i++) {
-        EXPECT_TRUE(check_equal_strided<false>(fwd_data.data() + forward_distance * i,
-                                               input.data() + ref_distance * i, sizes, strides_fwd,
-                                               abs_error_margin, rel_error_margin, std::cout));
+        EXPECT_TRUE(check_equal_strided<false>(
+            fwd_data.data() + forward_distance * i, input.data() + ref_distance * i, sizes,
+            strides_fwd_cpy, abs_error_margin, rel_error_margin, std::cout));
     }
 
     return !::testing::Test::HasFailure();
@@ -103,10 +108,34 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
     }
     const std::vector<sycl::event> no_dependencies;
 
-    auto [forward_distance, backward_distance] =
-        get_default_distances<domain>(sizes, strides_fwd, strides_bwd);
-
     descriptor_t descriptor{ sizes };
+    auto strides_fwd_cpy = strides_fwd;
+    auto strides_bwd_cpy = strides_bwd;
+    if (strides_fwd_cpy.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd_cpy.data());
+    }
+    else {
+        strides_fwd_cpy.resize(sizes.size() + 1);
+        descriptor.get_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd_cpy.data());
+    }
+    if (strides_bwd_cpy.size()) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd_cpy.data());
+    }
+    else {
+        strides_bwd_cpy.resize(sizes.size() + 1);
+        descriptor.get_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd_cpy.data());
+    }
+    auto [forward_distance, backward_distance] =
+        get_default_distances<domain>(sizes, strides_fwd_cpy, strides_bwd_cpy);
+    auto ref_distance = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<>());
+    descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
+                         oneapi::mkl::dft::config_value::NOT_INPLACE);
+    if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
+        descriptor.set_value(oneapi::mkl::dft::config_param::CONJUGATE_EVEN_STORAGE,
+                             oneapi::mkl::dft::config_value::COMPLEX_COMPLEX);
+        descriptor.set_value(oneapi::mkl::dft::config_param::PACKED_FORMAT,
+                             oneapi::mkl::dft::config_value::CCE_FORMAT);
+    }
     descriptor.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                          oneapi::mkl::dft::config_value::NOT_INPLACE);
     if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
@@ -118,36 +147,26 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
     descriptor.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, batches);
     descriptor.set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, forward_distance);
     descriptor.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, backward_distance);
-    if (strides_fwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides_fwd.data());
-    }
-    if (strides_bwd.size()) {
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides_bwd.data());
-    }
-    else if constexpr (domain == oneapi::mkl::dft::domain::REAL) {
-        const auto complex_strides = get_conjugate_even_complex_strides(sizes);
-        descriptor.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, complex_strides.data());
-    }
     commit_descriptor(descriptor, sycl_queue);
 
     auto ua_input = usm_allocator_t<FwdInputType>(cxt, *dev);
     auto ua_output = usm_allocator_t<FwdOutputType>(cxt, *dev);
 
     std::vector<FwdInputType, decltype(ua_input)> fwd(
-        strided_copy(input, sizes, strides_fwd, batches, forward_distance, ua_input), ua_input);
+        strided_copy(input, sizes, strides_fwd_cpy, batches, forward_distance, ua_input), ua_input);
     std::vector<FwdOutputType, decltype(ua_output)> bwd(
-        cast_unsigned(backward_distance * batches + get_default(strides_bwd, 0, 0L)), ua_output);
+        cast_unsigned(backward_distance * batches + get_default(strides_bwd_cpy, 0, 0L)),
+        ua_output);
 
     oneapi::mkl::dft::compute_forward<descriptor_t, FwdInputType, FwdOutputType>(
         descriptor, fwd.data(), bwd.data(), no_dependencies)
         .wait_and_throw();
 
     auto bwd_ptr = &bwd[0];
-    auto ref_distance = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<>());
     for (std::int64_t i = 0; i < batches; i++) {
         EXPECT_TRUE(check_equal_strided<domain == oneapi::mkl::dft::domain::REAL>(
             bwd_ptr + backward_distance * i, out_host_ref.data() + ref_distance * i, sizes,
-            strides_bwd, abs_error_margin, rel_error_margin, std::cout));
+            strides_bwd_cpy, abs_error_margin, rel_error_margin, std::cout));
     }
 
     oneapi::mkl::dft::compute_backward<std::remove_reference_t<decltype(descriptor)>, FwdOutputType,
@@ -160,9 +179,9 @@ int DFT_Test<precision, domain>::test_out_of_place_USM() {
                   [this](auto &x) { x *= static_cast<PrecisionType>(forward_elements); });
 
     for (std::int64_t i = 0; i < batches; i++) {
-        EXPECT_TRUE(check_equal_strided<false>(fwd.data() + forward_distance * i,
-                                               input.data() + ref_distance * i, sizes, strides_fwd,
-                                               abs_error_margin, rel_error_margin, std::cout));
+        EXPECT_TRUE(check_equal_strided<false>(
+            fwd.data() + forward_distance * i, input.data() + ref_distance * i, sizes,
+            strides_fwd_cpy, abs_error_margin, rel_error_margin, std::cout));
     }
 
     return !::testing::Test::HasFailure();


### PR DESCRIPTION
# Description

In the PR that introduced the FWD/BWD STRIDE API (https://github.com/oneapi-src/oneMKL/pull/528), @raphael-egan provided some valuable feedback just as the PR was merged. This feedback included:

* Deviations from the oneAPI oneMKL specification
* General quality of life improvements

This PR aims to address these comments

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
  - See after [529521c](https://github.com/oneapi-src/oneMKL/pull/549/commits/529521c9841daec0b7b98df53d6349177241ef55)
- [x] Have you formatted the code using clang-format?

