### PR TITLE
[Docs] add link to RFCs branch and fix links to oneMKL spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ For how to enable a new third-party library, see the [guidelines](docs/create_ne
 
 Before sending your pull requests, ensure that you follow this checklist:
 
-* If you are contributing a new interface, refer to the [library functionality guidelines](CONTRIBUTING.md#library-functionality-guidelines). It is strongly advised that you first open an [RFC issue](CONTRIBUTING.md#RFC-issue) with a detailed explanation of the expected use cases.
+* If you are contributing a new interface, refer to the [library functionality guidelines](CONTRIBUTING.md#library-functionality-guidelines). It is strongly advised that you first open an [RFC PR](CONTRIBUTING.md#RFC-process) with a detailed explanation of the expected use cases.
 
 * Ensure that your code includes proper documentation.
 
@@ -32,9 +32,12 @@ oneMKL focuses on the following criteria:
 For the new API to become a part of the open source project, it should be accepted as part of [oneMKL spec](https://spec.oneapi.com/versions/latest/elements/oneMKL/source/index.html).
 
 
-### RFC Issue
+### RFC Process
 
-Open a Request For Comment (RFC) issue when contributing new interfaces. In the RFC, please provide the following details:
+For changes impacting the public API or any significant changes in the library, such as adding new backend or changes to the architecture,
+please follow the [RFC process](https://github.com/oneapi-src/oneMKL/tree/rfcs).
+
+Please also provide the following details as part of the RFC:
 
 * Description of how the new interface meets [library functionality guidelines](CONTRIBUTING.md#library-functionality-guidelines).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ For how to enable a new third-party library, see the [guidelines](docs/create_ne
 
 Before sending your pull requests, ensure that you follow this checklist:
 
-* If you are contributing a new interface, refer to the [library functionality guidelines](CONTRIBUTING.md#library-functionality-guidelines). It is strongly advised that you first open an [RFC PR](CONTRIBUTING.md#RFC-process) with a detailed explanation of the expected use cases.
+* If you are contributing a new interface, refer to the [library functionality guidelines](CONTRIBUTING.md#library-functionality-guidelines). It is strongly advised that you first open an [RFC PR](CONTRIBUTING.md#Request-for-comments-process) with a detailed explanation of the expected use cases.
 
 * Ensure that your code includes proper documentation.
 
@@ -29,10 +29,10 @@ oneMKL focuses on the following criteria:
 
 3. *Complexity*: Functionality that is not trivial to implement directly or by combining existing primitives.
 
-For the new API to become a part of the open source project, it should be accepted as part of [oneMKL spec](https://spec.oneapi.com/versions/latest/elements/oneMKL/source/index.html).
+For the new API to become a part of the open source project, it should be accepted as part of [oneMKL spec](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/).
 
 
-### RFC Process
+### Request for Comments Process
 
 For changes impacting the public API or any significant changes in the library, such as adding new backend or changes to the architecture,
 please follow the [RFC process](https://github.com/oneapi-src/oneMKL/tree/rfcs).

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ You can also join the mailing lists for the [UXL Foundation](https://lists.uxlfo
 
 ## Contributing
 
-You can contribute to this project and also contribute to [the specification for this project](https://spec.oneapi.io/versions/latest/elements/oneMKL/source/index.html). Please read the [CONTRIBUTING](CONTRIBUTING.md) page for more information. You can also contact oneMKL developers and maintainers via [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using [#onemkl](https://uxlfoundation.slack.com/archives/onemkl) channel.
+You can contribute to this project and also contribute to [the specification for this project](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/). Please read the [CONTRIBUTING](CONTRIBUTING.md) page for more information. You can also contact oneMKL developers and maintainers via [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using [#onemkl](https://uxlfoundation.slack.com/archives/onemkl) channel.
 
 For GitHub questions, issues, RFCs, or PRs you can contact maintainers via one of the following GitHub teams based on the topic:
 

--- a/README.md
+++ b/README.md
@@ -572,12 +572,12 @@ Distributed under the Apache license 2.0. See [LICENSE](LICENSE) for more inform
 ### oneMKL
 
 **Q: What is the difference between the following oneMKL items?**
-   - The [oneAPI Specification for oneMKL](https://spec.oneapi.com/versions/latest/index.html)
+   - The [oneAPI Specification for oneMKL](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/)
    - The [oneAPI Math Kernel Library (oneMKL) Interfaces](https://github.com/oneapi-src/oneMKL) Project
    - The [Intel(R) oneAPI Math Kernel Library (oneMKL)](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html) Product
 
 **A:**
-- The [oneAPI Specification for oneMKL](https://spec.oneapi.com/versions/latest/index.html) defines the DPC++ interfaces for performance math library functions. The oneMKL specification can evolve faster and more frequently than implementations of the specification.
+- The [oneAPI Specification for oneMKL](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/) defines the DPC++ interfaces for performance math library functions. The oneMKL specification can evolve faster and more frequently than implementations of the specification.
 
 - The [oneAPI Math Kernel Library (oneMKL) Interfaces](https://github.com/oneapi-src/oneMKL) Project is an open source implementation of the specification. The project goal is to demonstrate how the DPC++ interfaces documented in the oneMKL specification can be implemented for any math library and work for any target hardware. While the implementation provided here may not yet be the full implementation of the specification, the goal is to build it out over time. We encourage the community to contribute to this project and help to extend support to multiple hardware targets and other math libraries.
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -4,6 +4,6 @@ Introduction
 ============
 
 oneMKL Interfaces is an open-source implementation of oneMKL Data Parallel C++
-(DPC++) interfaces according to the `oneMKL specification <https://spec.oneapi.com/versions/latest/elements/oneMKL/source/index.html>`_
+(DPC++) interfaces according to the `oneMKL specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/>`_
 that can work with multiple devices (backends) using device-specific
 libraries underneath.


### PR DESCRIPTION
# Description

PR adds info about new RFC process to Contributing page and fixes two more links to oneMKL spec that were affected after migration to UXL.

Fixes https://github.com/uxlfoundation/open-source-working-group/issues/13

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. N/A
- [x] Have you formatted the code using clang-format? N/A
