### PR TITLE
[Doc][Web] Fix build command with DPC++ in documentation webpage

### DIFF
--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -44,7 +44,7 @@ for Windows`_ for building on Windows):
   mkdir build && cd build
   cmake .. -DCMAKE_CXX_COMPILER=$CXX_COMPILER    \ # Should be icpx or clang++
           -DCMAKE_C_COMPILER=$C_COMPILER         \ # Should be icx or clang
-          -DENABLE_MKLGPU_BACKEND=False          \ # Optional: The MKLCPU backend is True by default.
+          -DENABLE_MKLCPU_BACKEND=False          \ # Optional: The MKLCPU backend is True by default.
           -DENABLE_MKLGPU_BACKEND=False          \ # Optional: The MKLGPU backend is True by default.
           -DENABLE_<BACKEND_NAME>_BACKEND=True   \ # Enable any other backend(s) (optional)
           -DENABLE_<BACKEND_NAME_2>_BACKEND=True \ # Multiple backends can be enabled at once.


### PR DESCRIPTION
## Changes
* One-liner fix in the ["Building the project with DPC++" webpage](https://oneapi-src.github.io/oneMKL/building_the_project_with_dpcpp.html) to use `MKLCPU` backend instead of the incorrectly twice-used `MKLGPU` backend.