### PR TITLE
[Build][Docs][CI] BUILD_FUNCTIONAL_TESTS=False by default

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,7 @@ jobs:
       if: steps.domain_check.outputs.result == 'true'
       run: |
         source /opt/intel/oneapi/setvars.sh
-        cmake -DTARGET_DOMAINS=${{ matrix.domain }} -DENABLE_MKLGPU_BACKEND=OFF -DBUILD_FUNCTIONAL_TESTS=ON -DCMAKE_VERBOSE_MAKEFILE=on ${{ matrix.build_options }} -B build
+        cmake -DTARGET_DOMAINS=${{ matrix.domain }} -DENABLE_MKLGPU_BACKEND=OFF -DBUILD_FUNCTIONAL_TESTS=ON -DCMAKE_VERBOSE_MAKEFILE=ON ${{ matrix.build_options }} -B build
         cmake --build build ${PARALLEL}
     - name: Run tests
       if: steps.domain_check.outputs.result == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,7 @@ jobs:
       if: steps.domain_check.outputs.result == 'true'
       run: |
         source /opt/intel/oneapi/setvars.sh
-        cmake -DTARGET_DOMAINS=${{ matrix.domain }} -DENABLE_MKLGPU_BACKEND=off -DCMAKE_VERBOSE_MAKEFILE=on ${{ matrix.build_options }} -B build
+        cmake -DTARGET_DOMAINS=${{ matrix.domain }} -DENABLE_MKLGPU_BACKEND=OFF -DBUILD_FUNCTIONAL_TESTS=ON -DCMAKE_VERBOSE_MAKEFILE=on ${{ matrix.build_options }} -B build
         cmake --build build ${PARALLEL}
     - name: Run tests
       if: steps.domain_check.outputs.result == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(ONEMKL_SYCL_IMPLEMENTATION "dpc++" CACHE STRING "Name of the SYCL compiler")
 set(HIP_TARGETS "" CACHE STRING "Target HIP architectures")
 
 ## Testing
-option(BUILD_FUNCTIONAL_TESTS "" ON)
+option(BUILD_FUNCTIONAL_TESTS "" OFF)
 
 ## Examples
 option(BUILD_EXAMPLES "" ON)

--- a/docs/building_and_running_tests.rst
+++ b/docs/building_and_running_tests.rst
@@ -3,7 +3,7 @@
 Building and Running Tests
 ==========================
 
-The functional tests are enabled by default, and can be enabled/disabled
+The functional tests are disabled by default, and can be enabled/disabled
 with the CMake build parameter ``-DBUILD_FUNCTIONAL_TESTS=True/False``. Only
 the tests relevant to the enabled backends and target domains will be built.
 

--- a/docs/building_the_project_with_adaptivecpp.rst
+++ b/docs/building_the_project_with_adaptivecpp.rst
@@ -40,7 +40,7 @@ On Linux (other OSes are not supported with the AdaptiveCpp compiler):
           -DENABLE_<BACKEND_NAME>_BACKEND=True     \ # Enable backend(s) (optional)
           -DENABLE_<BACKEND_NAME_2>_BACKEND=True   \ # Multiple backends can be enabled at once.
           -DHIPSYCL_TARGETS=omp/;hip:gfx90a,gfx906 \ # Set target architectures depending on supported devices.
-          -DBUILD_FUNCTIONAL_TESTS=False           \ # See section *Building the tests* for more on building tests. True by default.
+          -DBUILD_FUNCTIONAL_TESTS=False           \ # See page *Building and Running Tests* for more on building tests. False by default.
           -DBUILD_EXAMPLES=False                   # Optional: True by default.
   cmake --build .
   cmake --install . --prefix <path_to_install_dir> # required to have full package structure
@@ -61,11 +61,11 @@ If a backend library supports multiple domains (i.e. BLAS, RNG), it may be
 desirable to only enable selected domains. For this, the ``TARGET_DOMAINS``
 variable should be set. For further details, see :ref:`_build_target_domains`.
 
-By default, the library also additionally builds examples and tests. These can
-be disabled by setting the parameters ``BUILD_FUNCTIONAL_TESTS`` and
-``BUILD_EXAMPLES`` to False. Building the functional tests may require additional
-external libraries. See the section :ref:`building_and_running_tests` for more
-information.
+By default, the library builds examples. These can be disabled by setting the
+parameter ``BUILD_EXAMPLES`` to ``False``. Tests are disabled by default, but
+can be enabled by setting ``BUILD_FUNCTIONAL_TESTS`` to ``True``. Building the
+functional tests requires additional external libraries for the BLAS and LAPACK
+domains. See the section :ref:`building_and_running_tests` for more information.
 
 The most important supported build options are:
 
@@ -98,7 +98,7 @@ The most important supported build options are:
      - True      
    * - BUILD_FUNCTIONAL_TESTS
      - True, False
-     - True      
+     - False      
    * - BUILD_EXAMPLES
      - True, False
      - True      

--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -48,7 +48,7 @@ for Windows`_ for building on Windows):
           -DENABLE_MKLGPU_BACKEND=False          \ # Optional: The MKLGPU backend is True by default.
           -DENABLE_<BACKEND_NAME>_BACKEND=True   \ # Enable any other backend(s) (optional)
           -DENABLE_<BACKEND_NAME_2>_BACKEND=True \ # Multiple backends can be enabled at once.
-          -DBUILD_FUNCTIONAL_TESTS=False         \ # See page *Building and Running Tests* for more on building tests. True by default.
+          -DBUILD_FUNCTIONAL_TESTS=False         \ # See page *Building and Running Tests* for more on building tests. False by default.
           -DBUILD_EXAMPLES=False                   # Optional: True by default.
   cmake --build .
   cmake --install . --prefix <path_to_install_dir>  # required to have full package structure
@@ -72,11 +72,11 @@ If a backend library supports multiple domains (i.e., BLAS, LAPACK, DFT, RNG,
 sparse BLAS), it may be desirable to only enable selected domains. For this, the
 ``TARGET_DOMAINS`` variable should be set. See the section `TARGET_DOMAINS`_.
 
-By default, the library also additionally builds examples and tests. These can
-be disabled by setting the parameters ``BUILD_FUNCTIONAL_TESTS`` and
-``BUILD_EXAMPLES`` to ``False``. Building the functional tests requires
-additional external libraries for the BLAS and LAPACK domains. See the section
-:ref:`building_and_running_tests` for more information.
+By default, the library builds examples. These can be disabled by setting the
+parameter ``BUILD_EXAMPLES`` to ``False``. Tests are disabled by default, but
+can be enabled by setting ``BUILD_FUNCTIONAL_TESTS`` to ``True``. Building the
+functional tests requires additional external libraries for the BLAS and LAPACK
+domains. See the section :ref:`building_and_running_tests` for more information.
 
 The most important supported build options are:
 
@@ -130,7 +130,7 @@ The most important supported build options are:
      - False      
    * - BUILD_FUNCTIONAL_TESTS
      - True, False
-     - True      
+     - False      
    * - BUILD_EXAMPLES
      - True, False
      - True      
@@ -355,8 +355,7 @@ disabled using the Ninja build system:
       -DENABLE_CUFFT_BACKEND=True \
       -DENABLE_CUBLAS_BACKEND=True \
       -DENABLE_CUSOLVER_BACKEND=True \
-      -DENABLE_CURAND_BACKEND=True \
-      -DBUILD_FUNCTIONAL_TESTS=False
+      -DENABLE_CURAND_BACKEND=True
 
 ``$ONEMKL_DIR`` points at the oneMKL source directly. The x86 CPU (``MKLCPU``)
 and Intel GPU (``MKLGPU``) backends are enabled by default, but are disabled
@@ -376,8 +375,7 @@ disabled:
       -DENABLE_ROCFFT_BACKEND=True  \ 
       -DENABLE_ROCBLAS_BACKEND=True \
       -DENABLE_ROCSOLVER_BACKEND=True \ 
-      -DHIP_TARGETS=gfx90a \
-      -DBUILD_FUNCTIONAL_TESTS=False
+      -DHIP_TARGETS=gfx90a
 
 ``$ONEMKL_DIR`` points at the oneMKL source directly. The x86 CPU (``MKLCPU``)
 and Intel GPU (``MKLGPU``) backends are enabled by default, but are disabled
@@ -396,6 +394,7 @@ GPU and Nvidia GPU with testing enabled:
       -DENABLE_ROCFFT_BACKEND=True \
       -DENABLE_CUFFT_BACKEND=True \
       -DTARGET_DOMAINS=dft \
+      -DBUILD_FUNCTIONAL_TESTS=True \
       -DBUILD_EXAMPLES=False
 
 Note that this is not a supported configuration, and requires Codeplay's oneAPI


### PR DESCRIPTION
# Description

* Currently tests build by default
  * This adds additional dependencies, tripping users up.
  * This slows down builds where the tests are not used.
* This PR disabled tests by default and
  * Updates the documentation
  * Updates the Github CI

Fixes https://github.com/oneapi-src/oneMKL/issues/443

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? Attach a log.
- [N/A] Have you formatted the code using clang-format?

