### PR TITLE
[DFT][portFFT] Update GIT_TAG for portFFT download

### DIFF
--- a/src/dft/backends/portfft/CMakeLists.txt
+++ b/src/dft/backends/portfft/CMakeLists.txt
@@ -78,7 +78,7 @@ if (NOT portfft_FOUND)
 	FetchContent_Declare(
 		portfft
 		GIT_REPOSITORY https://github.com/codeplaysoftware/portFFT.git
-		GIT_TAG        e4251e8ef89a8ac4d851a4cc08a0577a28f953e0
+		GIT_TAG        f29d8e7c103f8b981f719e1194199ca4d5216895
 	)
 	FetchContent_MakeAvailable(portfft)
 	message(STATUS "portFFT - downloaded")


### PR DESCRIPTION
# Description

This PR updates the version of portFFT downloaded from CMake to bring back full compatibility on all hardware.

No issue was created, but it was highlighted in PR #528 log for portFFT. 
To reproduce build oneMKL with portFFT backend and run tests on Intel ARC GPU.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[arc_fix_log.txt](https://github.com/user-attachments/files/16762685/arc_fix_log.txt)
[mi210_log.txt](https://github.com/user-attachments/files/16762686/mi210_log.txt)
[nvidia_log.txt](https://github.com/user-attachments/files/16762687/nvidia_log.txt)
[pvc_log.txt](https://github.com/user-attachments/files/16762690/pvc_log.txt)

## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
