### PR TITLE
[DFT][rocFFt] Address rocFFT failing tests

### DIFF
--- a/src/dft/backends/cufft/descriptor.cpp
+++ b/src/dft/backends/cufft/descriptor.cpp
@@ -22,9 +22,7 @@
 
 #include "oneapi/mkl/dft/detail/cufft/onemkl_dft_cufft.hpp"
 
-namespace oneapi {
-namespace mkl {
-namespace dft {
+namespace oneapi::mkl::dft::detail {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::cufft> selector) {
@@ -44,6 +42,4 @@ template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(
     backend_selector<backend::cufft>);
 template void descriptor<precision::DOUBLE, domain::REAL>::commit(backend_selector<backend::cufft>);
 
-} //namespace dft
-} //namespace mkl
-} //namespace oneapi
+} //namespace oneapi::mkl::dft::detail

--- a/src/dft/backends/portfft/descriptor.cpp
+++ b/src/dft/backends/portfft/descriptor.cpp
@@ -22,7 +22,7 @@
 
 #include "oneapi/mkl/dft/detail/portfft/onemkl_dft_portfft.hpp"
 
-namespace oneapi::mkl::dft {
+namespace oneapi::mkl::dft::detail {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::portfft> selector) {
@@ -44,4 +44,4 @@ template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(
 template void descriptor<precision::DOUBLE, domain::REAL>::commit(
     backend_selector<backend::portfft>);
 
-} // namespace oneapi::mkl::dft
+} // namespace oneapi::mkl::dft::detail

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -49,6 +49,14 @@ find_package(HIP REQUIRED)
 # Require the minimum rocFFT version matching with ROCm 5.4.3.
 find_package(rocfft 1.0.21 REQUIRED)
 
+if (${rocfft_VERSION_MAJOR} EQUAL "1" AND ${rocfft_VERSION_MINOR} EQUAL "0"
+    AND ((${rocfft_VERSION_PATCH} GREATER "22")
+    AND (${rocfft_VERSION_PATCH} LESS "31")  ))
+    message(WARNING "Due to a bug in rocFFT some tests fail with the version in\
+      use. If possible use a version greater of 1.0.30 or less of 1.0.23.
+      Current rocFFT version ${rocfft_VERSION}")
+endif()
+
 target_link_libraries(${LIB_OBJ} PRIVATE hip::host roc::rocfft)
 
 # Allow to compile for different ROCm versions. See the README for the supported
@@ -62,6 +70,7 @@ find_path(
   NO_DEFAULT_PATH
   REQUIRED
 )
+
 target_include_directories(${LIB_OBJ} PRIVATE ${rocfft_EXTRA_INCLUDE_DIR})
 
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL)

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -62,7 +62,6 @@ find_path(
   NO_DEFAULT_PATH
   REQUIRED
 )
-
 target_include_directories(${LIB_OBJ} PRIVATE ${rocfft_EXTRA_INCLUDE_DIR})
 
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL)

--- a/src/dft/backends/rocfft/CMakeLists.txt
+++ b/src/dft/backends/rocfft/CMakeLists.txt
@@ -49,14 +49,6 @@ find_package(HIP REQUIRED)
 # Require the minimum rocFFT version matching with ROCm 5.4.3.
 find_package(rocfft 1.0.21 REQUIRED)
 
-if (${rocfft_VERSION_MAJOR} EQUAL "1" AND ${rocfft_VERSION_MINOR} EQUAL "0"
-    AND ((${rocfft_VERSION_PATCH} GREATER "22")
-    AND (${rocfft_VERSION_PATCH} LESS "31")  ))
-    message(WARNING "Due to a bug in rocFFT some tests fail with the version in\
-      use. If possible use a version greater of 1.0.30 or less of 1.0.23.
-      Current rocFFT version ${rocfft_VERSION}")
-endif()
-
 target_link_libraries(${LIB_OBJ} PRIVATE hip::host roc::rocfft)
 
 # Allow to compile for different ROCm versions. See the README for the supported

--- a/src/dft/backends/rocfft/commit.cpp
+++ b/src/dft/backends/rocfft/commit.cpp
@@ -266,6 +266,8 @@ public:
         // Link to rocFFT issue: https://github.com/ROCm/rocFFT/issues/507
         if constexpr (rocfft_version_major == 1 && rocfft_version_minor == 0 &&
                       (rocfft_version_patch > 22 && rocfft_version_patch < 31)) {
+            // rocFFT's functional status for problems like cfoA:B:1xB:1:A is unknown as
+            // of 4ed3e97bb7c11531684168665d5a980fde0284c9 (due to project's implementation preventing testing thereof)
             if (dom == dft::domain::COMPLEX &&
                 config_values.placement == dft::config_value::NOT_INPLACE && dimensions > 2) {
                 if (stride_vecs.vec_a != stride_vecs.vec_b)

--- a/src/dft/backends/rocfft/commit.cpp
+++ b/src/dft/backends/rocfft/commit.cpp
@@ -274,7 +274,6 @@ public:
                     }
                     return true;
                 };
-                std::printf("hello\n");
                 if (!stride_checker(stride_vecs.vec_a, stride_vecs.vec_b))
                     throw oneapi::mkl::unimplemented(
                         "DFT", func,

--- a/src/dft/backends/rocfft/commit.cpp
+++ b/src/dft/backends/rocfft/commit.cpp
@@ -266,15 +266,9 @@ public:
         // Link to rocFFT issue: https://github.com/ROCm/rocFFT/issues/507
         if constexpr (rocfft_version_major == 1 && rocfft_version_minor == 0 &&
                       (rocfft_version_patch > 22 && rocfft_version_patch < 31)) {
-            if (dom == dft::domain::COMPLEX && dimensions > 2) {
-                auto stride_checker = [&](const auto& a, const auto& b) {
-                    for (ulong i = 0; i < dimensions; ++i) {
-                        if (a[i] != b[i])
-                            return false;
-                    }
-                    return true;
-                };
-                if (!stride_checker(stride_vecs.vec_a, stride_vecs.vec_b))
+            if (dom == dft::domain::COMPLEX &&
+                config_values.placement == dft::config_value::NOT_INPLACE && dimensions > 2) {
+                if (stride_vecs.vec_a != stride_vecs.vec_b)
                     throw oneapi::mkl::unimplemented(
                         "DFT", func,
                         "due to a bug in rocfft version in use, it requires fwd and bwd stride to be the same for COMPLEX out_of_place computations");

--- a/src/dft/backends/rocfft/descriptor.cpp
+++ b/src/dft/backends/rocfft/descriptor.cpp
@@ -22,9 +22,7 @@
 
 #include "oneapi/mkl/dft/detail/rocfft/onemkl_dft_rocfft.hpp"
 
-namespace oneapi {
-namespace mkl {
-namespace dft {
+namespace oneapi::mkl::dft::detail {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::rocfft> selector) {
@@ -46,6 +44,4 @@ template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(
 template void descriptor<precision::DOUBLE, domain::REAL>::commit(
     backend_selector<backend::rocfft>);
 
-} //namespace dft
-} //namespace mkl
-} //namespace oneapi
+} //namespace oneapi::mkl::dft::detail


### PR DESCRIPTION
# Description

This PR addresses two issues arose recently in rocFFT backend. Both issues are related to rocFFT internal changes.
One issue is fixed by small modification to oneMKL backend. The other issue cannot be fixed internally, but it was fixed by AMD and it will available in the future versions of rocFFT. 
To avoid that users incur with the second issues a warning is emitted during the configuration and eventually an exception is thrown. 

first issue -> https://github.com/ROCm/rocFFT/issues/504 
second issue -> https://github.com/ROCm/rocFFT/issues/507

Fixes # (GitHub issue)

This PR address oneMKL issue #559 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
older rocm version(5.4.3) -> [rocm5_4_3_full_log.txt](https://github.com/user-attachments/files/16817642/rocm5_4_3_full_log.txt)
current release -> [rocm6_1_fix_log.txt](https://github.com/user-attachments/files/16817651/rocm6_1_fix_log.txt)
rocFFT develop branch -> [develop_fix_log.txt](https://github.com/user-attachments/files/16817657/develop_fix_log.txt)

- [x] Have you formatted the code using clang-format?

## Bug fixes

- [x] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
 issue #559