### PR TITLE
[cmake] update MKLConfig to 2024.2.1 release

### DIFF
--- a/cmake/mkl/MKLConfig.cmake
+++ b/cmake/mkl/MKLConfig.cmake
@@ -19,7 +19,7 @@
 
 #===================================================================
 # CMake Config file for Intel(R) oneAPI Math Kernel Library (oneMKL)
-#===============================================================================
+#===================================================================
 
 #===============================================================================
 # Input parameters
@@ -30,12 +30,13 @@
 # MKL_ROOT: oneMKL root directory (May be required for non-standard install locations. Optional otherwise.)
 #    Default: use location from MKLROOT environment variable or <Full path to this file>/../../../ if MKLROOT is not defined
 # MKL_ARCH
-#    Values:  ia32 intel64
+#    Values:  ia32 [ia32 support is deprecated]
+#             intel64
 #    Default: intel64
 # MKL_LINK
 #    Values:  static, dynamic, sdl
 #    Default: dynamic
-#       Exceptions:- DPC++ doesn't support sdl
+#       Exceptions:- SYCL doesn't support sdl
 # MKL_THREADING
 #    Values:  sequential,
 #             intel_thread (Intel OpenMP),
@@ -43,7 +44,7 @@
 #             pgi_thread (PGI OpenMP) [PGI support is deprecated],
 #             tbb_thread
 #    Default: intel_thread
-#       Exceptions:- DPC++ defaults to oneTBB, PGI compiler on Windows defaults to pgi_thread
+#       Exceptions:- SYCL defaults to oneTBB, PGI compiler on Windows defaults to pgi_thread
 # MKL_INTERFACE (for MKL_ARCH=intel64 only)
 #    Values:  lp64, ilp64
 #       GNU or INTEL interface will be selected based on Compiler.
@@ -54,13 +55,13 @@
 #-----------------------------------
 # Special options (OFF by default)
 #-----------------------------------
-# ENABLE_BLAS95:      Enables BLAS Fortran95 API
-# ENABLE_LAPACK95:    Enables LAPACK Fortran95 API
-# ENABLE_BLACS:       Enables cluster BLAS library
-# ENABLE_CDFT:        Enables cluster DFT library
-# ENABLE_CPARDISO:    Enables cluster PARDISO functionality
-# ENABLE_SCALAPACK:   Enables cluster LAPACK library
-# ENABLE_OMP_OFFLOAD: Enables OpenMP Offload functionality
+# ENABLE_BLAS95:           Enables BLAS Fortran95 API in MKL::MKL
+# ENABLE_LAPACK95:         Enables LAPACK Fortran95 API in MKL::MKL
+# ENABLE_BLACS:            Enables cluster BLAS library in MKL::MKL
+# ENABLE_CDFT:             Enables cluster DFT library in MKL::MKL
+# ENABLE_SCALAPACK:        Enables cluster LAPACK library in MKL::MKL
+# ENABLE_OMP_OFFLOAD:      Enables OpenMP Offload functionality in MKL::MKL
+# ENABLE_TRY_SYCL_COMPILE: Enables compiling a test program that calls a oneMKL DPC++ API
 #
 #==================
 # Output parameters
@@ -75,7 +76,7 @@
 #     Provides all environment variables based on input parameters.
 #     Currently useful for mkl_rt linking and BLACS on Windows.
 #     Must be set as an ENVIRONMENT property.
-# Example:
+#     Example:
 #     add_test(NAME mytest COMMAND myexe)
 #     if(MKL_ENV)
 #       set_tests_properties(mytest PROPERTIES ENVIRONMENT "${MKL_ENV}")
@@ -88,12 +89,23 @@
 #
 # Below INTERFACE targets provide full link-lines for direct use.
 # Example:
-#     target_link_options(<my_linkable_target> PUBLIC $<LINK_ONLY:MKL::MKL>)
+#     target_link_options(<my_linkable_target> PUBLIC MKL::MKL)
 #
 # MKL::MKL
 #     Link line for C and Fortran API
 # MKL::MKL_SYCL
-#     Link line for DPC++ API
+#     Link line for SYCL API
+# MKL::MKL_SYCL::<domain>
+#     Link line for specific domain SYCL API
+#     Where <domain> could be: BLAS, LAPACK, DFT, SPARSE, RNG, STATS, VM, DATA_FITTING (experimental)
+# MKL::MKL_CDFT
+#     Link line for CDFT and Cluster FFTW API (includes MKL::MKL and MKL::MKL_BLACS)
+#     !IMPORTANT!: Because of specific link order it must not be used together
+#     with any other oneMKL targets in case of MKL_LINK=static on Linux
+# MKL::MKL_SCALAPACK
+#     Link line for ScaLAPACK and PBLAS API (includes MKL::MKL and MKL::MKL_BLACS)
+# MKL::MKL_BLACS
+#     Link line for BLACS and CPARDISO API (includes MKL::MKL)
 #
 # Note: For Device API, library linking is not required.
 #       Compile options can be added from the INTERFACE_COMPILE_OPTIONS property on MKL::MKL_SYCL
@@ -105,7 +117,7 @@
 
 include_guard()
 
-if(NOT MKL_LIBRARIES)
+if(NOT TARGET MKL::MKL)
 
 function(mkl_message MSG_MODE MSG_TEXT)
   if(MSG_MODE STREQUAL "FATAL_ERROR")
@@ -117,8 +129,14 @@ function(mkl_message MSG_MODE MSG_TEXT)
   endif()
 endfunction()
 
+macro(mkl_not_found_and_return NOT_FOUND_MSG)
+  set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${NOT_FOUND_MSG}")
+  set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+  return()
+endmacro()
+
 if(CMAKE_VERSION VERSION_LESS "3.13")
-  mkl_message(FATAL_ERROR "The minimum supported CMake version is 3.13. You are running version ${CMAKE_VERSION}.")
+  mkl_not_found_and_return("The minimum supported CMake version is 3.13. You are running version ${CMAKE_VERSION}.")
 endif()
 
 # Set CMake policies for well-defined behavior across CMake versions
@@ -135,16 +153,16 @@ foreach(lang ${languages})
 endforeach()
 list(REMOVE_DUPLICATES CURR_LANGS)
 
-option(ENABLE_BLAS95      "Enables BLAS Fortran95 API"            OFF)
-option(ENABLE_LAPACK95    "Enables LAPACK Fortran95 API"          OFF)
-option(ENABLE_BLACS       "Enables cluster BLAS library"          OFF)
-option(ENABLE_CDFT        "Enables cluster DFT library"           OFF)
-option(ENABLE_CPARDISO    "Enables cluster PARDISO functionality" OFF)
-option(ENABLE_SCALAPACK   "Enables cluster LAPACK library"        OFF)
-option(ENABLE_OMP_OFFLOAD "Enables OpenMP Offload functionality"  OFF)
+option(ENABLE_BLAS95           "Enables BLAS Fortran95 API"                    OFF)
+option(ENABLE_LAPACK95         "Enables LAPACK Fortran95 API"                  OFF)
+option(ENABLE_BLACS            "Enables cluster BLAS library"                  OFF)
+option(ENABLE_CDFT             "Enables cluster DFT library"                   OFF)
+option(ENABLE_SCALAPACK        "Enables cluster LAPACK library"                OFF)
+option(ENABLE_OMP_OFFLOAD      "Enables OpenMP Offload functionality"          OFF)
+option(ENABLE_TRY_SYCL_COMPILE "Enables compiling a oneMKL DPC++ test program" OFF)
 
 # Use MPI if any of these are enabled
-if(ENABLE_BLACS OR ENABLE_CDFT OR ENABLE_SCALAPACK OR ENABLE_CPARDISO)
+if(ENABLE_BLACS OR ENABLE_CDFT OR ENABLE_SCALAPACK)
   set(USE_MPI ON)
 endif()
 
@@ -170,7 +188,8 @@ function(define_param TARGET_PARAM DEFAULT_PARAM SUPPORTED_LIST)
         set(STR_LIST "${STR_LIST} ${opt}")
       endforeach()
       if(${ARGC} EQUAL 3)
-        mkl_message(FATAL_ERROR "Invalid ${TARGET_PARAM} `${${TARGET_PARAM}}`, options are: ${STR_LIST}")
+        mkl_message(WARNING "Invalid ${TARGET_PARAM} `${${TARGET_PARAM}}`, options are: ${STR_LIST}")
+        set(${TARGET_PARAM} "${${TARGET_PARAM}}_MKL_INVALID_PARAM" PARENT_SCOPE)
       elseif(${ARGC} EQUAL 4)
         mkl_message(${ARGV3} "Invalid ${TARGET_PARAM} `${${TARGET_PARAM}}`, options are: ${STR_LIST}")
         set(${TARGET_PARAM} "" PARENT_SCOPE)
@@ -186,9 +205,10 @@ endfunction()
 macro(check_required_vars)
   foreach(var IN ITEMS ${ARGV})
     if(NOT ${var})
-      set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "The required variable ${var} has an invalid value \"${${var}}\".")
-      set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
-      return()
+      mkl_not_found_and_return("The required variable ${var} has an invalid value \"${${var}}\".")
+    elseif(${${var}} MATCHES "_MKL_INVALID_PARAM$")
+      string(REPLACE "_MKL_INVALID_PARAM" "" INVALID_PARAM ${${var}})
+      mkl_not_found_and_return("The required variable ${var} has an invalid value \"${INVALID_PARAM}\".")
     endif()
   endforeach()
 endmacro()
@@ -267,6 +287,8 @@ endif()
 #================
 
 # Extensions
+set(SO_VER "2")
+set(SYCL_SO_VER "4")
 if(UNIX)
   set(LIB_PREFIX "lib")
   set(LIB_EXT ".a")
@@ -307,9 +329,9 @@ if(NOT DEFINED MKL_ROOT)
     set(MKL_ROOT_UPDATE_VERSION ${CMAKE_MATCH_1})
     set(MKL_ROOT_VERSION ${MKL_ROOT_MAJOR_VERSION}.${MKL_ROOT_UPDATE_VERSION})
     if(NOT MKL_ROOT_VERSION VERSION_EQUAL ${CMAKE_FIND_PACKAGE_NAME}_VERSION)
-      mkl_message(FATAL_ERROR "oneMKL ${MKL_ROOT_VERSION} specified by the environment variable MKLROOT \
-                               mismatches the found version ${${CMAKE_FIND_PACKAGE_NAME}_VERSION} \
-                               indicated by ${CMAKE_CURRENT_LIST_DIR}/MKLConfigVersion.cmake")
+      mkl_not_found_and_return("oneMKL ${MKL_ROOT_VERSION} specified by the environment variable MKLROOT \
+                                mismatches the found version ${${CMAKE_FIND_PACKAGE_NAME}_VERSION} \
+                                indicated by ${CMAKE_CURRENT_LIST_DIR}/MKLConfigVersion.cmake")
     endif()
   else()
     get_filename_component(MKL_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
@@ -344,6 +366,7 @@ define_param(MKL_ARCH DEFAULT_MKL_ARCH MKL_ARCH_LIST)
 check_required_vars(MKL_ARCH)
 if(MKL_ARCH STREQUAL "ia32")
   set(MKL_ARCH_DIR "32")
+  mkl_message(WARNING "ia32 support is deprecated and will be removed in the oneMKL 2025.0 release.")
 else()
   set(MKL_ARCH_DIR "")
 endif()
@@ -376,7 +399,7 @@ if(SYCL_COMPILER)
     set(MKL_SYCL_INTERFACE_FULL intel_${MKL_INTERFACE})
   endif()
   set(DEFAULT_MKL_SYCL_INTERFACE intel_ilp64)
-  set(MKL_SYCL_INTERFACE_LIST intel_ilp64)
+  set(MKL_SYCL_INTERFACE_LIST intel_lp64 intel_ilp64)
   define_param(MKL_SYCL_INTERFACE_FULL DEFAULT_MKL_SYCL_INTERFACE MKL_SYCL_INTERFACE_LIST STATUS)
   if(NOT MKL_SYCL_INTERFACE_FULL)
     set(SYCL_COMPILER OFF)
@@ -404,15 +427,15 @@ else()
       set(MKL_INTERFACE_FULL intel)
     endif()
   else()
-    mkl_message(FATAL_ERROR "OSX does not support MKL_ARCH ia32.")
+    mkl_not_found_and_return("OSX does not support MKL_ARCH ia32.")
   endif()
 endif()
+check_required_vars(MKL_INTERFACE_FULL)
 if(MKL_INTERFACE_FULL MATCHES "ilp64")
   set(MKL_INTERFACE "ilp64")
 else()
   set(MKL_INTERFACE "lp64")
 endif()
-check_required_vars(MKL_INTERFACE_FULL)
 
 # Define oneMKL headers
 find_path(MKL_INCLUDE mkl.h
@@ -474,7 +497,7 @@ define_param(MKL_THREADING DEFAULT_MKL_THREADING MKL_THREADING_LIST)
 check_required_vars(MKL_THREADING)
 
 # Define MKL_MPI
-if(USE_MPI)
+if(NOT MKL_LINK STREQUAL "sdl" AND NOT MKL_ARCH STREQUAL "ia32")
   set(DEFAULT_MKL_MPI intelmpi)
   if(UNIX)
     if(APPLE)
@@ -494,6 +517,8 @@ if(USE_MPI)
     set(MKL_MPI msmpi)
   endif()
   check_required_vars(MKL_MPI)
+else()
+  mkl_message(STATUS "MKL_MPI: Selected configuration is not supported by oneMKL cluster components")
 endif()
 
 # Provides a list of IMPORTED targets for the project
@@ -521,6 +546,9 @@ set(MKL_ENV "")              # Exported environment variables
 # Modify PATH variable to make it CMake-friendly
 set(OLD_PATH $ENV{PATH})
 string(REPLACE ";" "\;" OLD_PATH "${OLD_PATH}")
+# Modify LIBRARY_PATH variable to make it CMake-friendly
+set(ENV_LIBRARY_PATH $ENV{LIBRARY_PATH})
+string(REPLACE ":" ";" ENV_LIBRARY_PATH "${ENV_LIBRARY_PATH}")
 
 # Compiler options
 if(GNU_C_COMPILER OR GNU_Fortran_COMPILER)
@@ -552,17 +580,13 @@ endif()
 # For OpenMP Offload
 if(ENABLE_OMP_OFFLOAD)
   if(WIN32)
-    if(OPENMP_VERSION VERSION_GREATER_EQUAL "5.1")
-      if("Fortran" IN_LIST CURR_LANGS)
-        list(APPEND MKL_OFFLOAD_COPT -Qiopenmp -Qopenmp-targets:spir64 -DONEMKL_USE_OPENMP_VERSION=202011)
-      else()
-        list(APPEND MKL_OFFLOAD_COPT -Qiopenmp -Qopenmp-targets:spir64 -Qopenmp-version:51 -DONEMKL_USE_OPENMP_VERSION=202011)
-      endif()
-    else()
+    if("Fortran" IN_LIST CURR_LANGS)
       list(APPEND MKL_OFFLOAD_COPT -Qiopenmp -Qopenmp-targets:spir64)
+    else()
+      list(APPEND MKL_OFFLOAD_COPT -Qiopenmp -Qopenmp-targets:spir64 -Qopenmp-version:51)
     endif()
-    # -MD and -MDd are manually added here because offload functionality uses DPC++ runtime.
-    if(CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo")
+    # -MD and -MDd are manually added here because offload functionality uses SYCL runtime.
+    if(CMAKE_BUILD_TYPE MATCHES "Debug")
       list(APPEND MKL_OFFLOAD_COPT -MDd)
     else()
       list(APPEND MKL_OFFLOAD_COPT -MD)
@@ -570,14 +594,10 @@ if(ENABLE_OMP_OFFLOAD)
     list(APPEND MKL_OFFLOAD_LOPT -Qiopenmp -Qopenmp-targets:spir64 -fsycl)
     set(SKIP_LIBPATH ON)
   else()
-    if(OPENMP_VERSION VERSION_GREATER_EQUAL "5.1")
-      if("Fortran" IN_LIST CURR_LANGS)
-        list(APPEND MKL_OFFLOAD_COPT -fiopenmp -fopenmp-targets=spir64 -DONEMKL_USE_OPENMP_VERSION=202011)
-      else()
-        list(APPEND MKL_OFFLOAD_COPT -fiopenmp -fopenmp-targets=spir64 -fopenmp-version=51 -DONEMKL_USE_OPENMP_VERSION=202011)
-      endif()
-    else ()
+    if("Fortran" IN_LIST CURR_LANGS)
       list(APPEND MKL_OFFLOAD_COPT -fiopenmp -fopenmp-targets=spir64)
+    else()
+      list(APPEND MKL_OFFLOAD_COPT -fiopenmp -fopenmp-targets=spir64 -fopenmp-version=51)
     endif()
     list(APPEND MKL_OFFLOAD_LOPT -fiopenmp -fopenmp-targets=spir64 -fsycl)
     if(APPLE)
@@ -590,7 +610,11 @@ endif()
 
 # For selected Interface
 if(SYCL_COMPILER)
-  list(INSERT MKL_SYCL_COPT 0 "-DMKL_ILP64")
+  if(MKL_INTERFACE STREQUAL "ilp64")
+    list(INSERT MKL_SYCL_COPT 0 "-DMKL_ILP64")
+  else()
+    mkl_message(STATUS "Experimental oneMKL Data Fitting SYCL API does not support LP64 on CPU")
+  endif()
 endif()
 
 if(MKL_INTERFACE_FULL)
@@ -634,7 +658,7 @@ endif() # MKL_INTERFACE_FULL
 # All oneMKL Libraries
 if(SYCL_COMPILER)
   set(MKL_SYCL_IFACE_LIB mkl_${MKL_SYCL_INTERFACE_FULL})
-  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo" AND MKL_SYCL_THREADING STREQUAL "tbb_thread")
+  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug" AND MKL_SYCL_THREADING STREQUAL "tbb_thread")
     set(MKL_SYCL_THREAD mkl_tbb_threadd)
   else()
     set(MKL_SYCL_THREAD mkl_${MKL_SYCL_THREADING})
@@ -651,14 +675,14 @@ list(APPEND MKL_SYCL_LIBS mkl_sycl_rng)
 list(APPEND MKL_SYCL_LIBS mkl_sycl_stats)
 list(APPEND MKL_SYCL_LIBS mkl_sycl_vm)
 if(NOT MKL_LINK STREQUAL "static")
-  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo")
+  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
     list(TRANSFORM MKL_SYCL_LIBS APPEND "d")
   endif()
   list(APPEND MKL_SYCL ${MKL_SYCL_LIBS})
   # List for tracking incomplete onemKL package
   set(MISSED_MKL_SYCL_LIBS)
 else()
-  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo")
+  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
     set(MKL_SYCL         mkl_sycld)
   else()
     set(MKL_SYCL         mkl_sycl)
@@ -667,7 +691,7 @@ endif()
 
 set(MKL_IFACE_LIB     mkl_${MKL_INTERFACE_FULL})
 set(MKL_CORE          mkl_core)
-if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo" AND MKL_THREADING STREQUAL "tbb_thread")
+if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug" AND MKL_THREADING STREQUAL "tbb_thread")
   set(MKL_THREAD        mkl_tbb_threadd)
 else()
   set(MKL_THREAD        mkl_${MKL_THREADING})
@@ -750,9 +774,11 @@ if(ENABLE_LAPACK95)
   list(APPEND MKL_LIBRARIES ${MKL_LAPACK95})
   list(APPEND MKL_LINK_LINE MKL::${MKL_LAPACK95})
 endif()
-if(ENABLE_SCALAPACK)
+if(NOT MKL_LINK STREQUAL "sdl" AND NOT MKL_ARCH STREQUAL "ia32")
   list(APPEND MKL_LIBRARIES ${MKL_SCALAPACK})
-  list(APPEND MKL_LINK_LINE MKL::${MKL_SCALAPACK})
+  if(ENABLE_SCALAPACK)
+    list(APPEND MKL_LINK_LINE MKL::${MKL_SCALAPACK})
+  endif()
 endif()
 if(ENABLE_OMP_OFFLOAD AND NOT MKL_LINK STREQUAL "sdl")
   list(APPEND MKL_LIBRARIES ${MKL_SYCL})
@@ -760,9 +786,11 @@ if(ENABLE_OMP_OFFLOAD AND NOT MKL_LINK STREQUAL "sdl")
   list(APPEND MKL_LINK_LINE ${MKL_SYCL_T})
 endif()
 list(APPEND MKL_LINK_LINE ${START_GROUP})
-if(ENABLE_CDFT)
+if(NOT MKL_LINK STREQUAL "sdl" AND NOT MKL_ARCH STREQUAL "ia32")
   list(APPEND MKL_LIBRARIES ${MKL_CDFT})
-  list(APPEND MKL_LINK_LINE MKL::${MKL_CDFT})
+  if(ENABLE_CDFT)
+    list(APPEND MKL_LINK_LINE MKL::${MKL_CDFT})
+  endif()
 endif()
 if(MKL_LINK STREQUAL "sdl")
   list(APPEND MKL_LIBRARIES ${MKL_SDL})
@@ -771,9 +799,11 @@ else()
   list(APPEND MKL_LIBRARIES ${MKL_IFACE_LIB} ${MKL_THREAD} ${MKL_CORE})
   list(APPEND MKL_LINK_LINE MKL::${MKL_IFACE_LIB} MKL::${MKL_THREAD} MKL::${MKL_CORE})
 endif()
-if(USE_MPI)
+if(NOT MKL_LINK STREQUAL "sdl" AND NOT MKL_ARCH STREQUAL "ia32")
   list(APPEND MKL_LIBRARIES ${MKL_BLACS})
-  list(APPEND MKL_LINK_LINE MKL::${MKL_BLACS})
+  if(USE_MPI)
+    list(APPEND MKL_LINK_LINE MKL::${MKL_BLACS})
+  endif()
 endif()
 list(APPEND MKL_LINK_LINE ${END_GROUP})
 
@@ -795,7 +825,10 @@ foreach(lib ${MKL_REQUESTED_LIBRARIES})
                   NO_DEFAULT_PATH)
     add_library(MKL::${lib} STATIC IMPORTED)
   else()
-    find_library(${lib}_file NAMES ${LIB_PREFIX}${lib}${DLL_EXT} ${lib}
+    find_library(${lib}_file NAMES ${LIB_PREFIX}${lib}${DLL_EXT}
+                  ${LIB_PREFIX}${lib}${DLL_EXT}.${SO_VER}
+                  ${LIB_PREFIX}${lib}${DLL_EXT}.${SYCL_SO_VER}
+                  ${lib}
                   PATHS ${MKL_ROOT}
                   PATH_SUFFIXES "lib${MKL_ARCH_DIR}"
                   NO_DEFAULT_PATH)
@@ -805,14 +838,27 @@ foreach(lib ${MKL_REQUESTED_LIBRARIES})
     list(APPEND MISSED_MKL_SYCL_LIBS ${lib})
     set(MKL_SYCL_DOMAIN "")
     string(REGEX REPLACE "mkl_sycl_" "" MKL_SYCL_DOMAIN ${lib})
-    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo")
+    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
       string(REGEX REPLACE "d$" "" MKL_SYCL_DOMAIN ${MKL_SYCL_DOMAIN})
     endif()
     string(TOUPPER ${MKL_SYCL_DOMAIN} MKL_SYCL_DOMAIN)
     mkl_message(WARNING "Could NOT find MKL ${lib} for target MKL::MKL_SYCL::${MKL_SYCL_DOMAIN}")
   else()
-    check_required_vars(${lib}_file)
-    mkl_message(STATUS "Found ${${lib}_file}")
+    if(NOT USE_MPI AND (${lib} MATCHES "mkl_scalapack" OR ${lib} MATCHES "mkl_blacs" OR ${lib} MATCHES "mkl_cdft")
+            AND ${${lib}_file} STREQUAL "${lib}_file-NOTFOUND")
+      if(${lib} MATCHES "mkl_scalapack")
+        mkl_message(STATUS "Could NOT find MKL ${lib} for target MKL::MKL_SCALAPACK")
+      endif()
+      if(${lib} MATCHES "mkl_cdft")
+        mkl_message(STATUS "Could NOT find MKL ${lib} for target MKL::MKL_CDFT")
+      endif()
+      if(${lib} MATCHES "mkl_blacs")
+        mkl_message(STATUS "Could NOT find MKL ${lib} for targets MKL::MKL_SCALAPACK, MKL::MKL_CDFT, and MKL::MKL_BLACS")
+      endif()
+    else()
+      check_required_vars(${lib}_file)
+      mkl_message(STATUS "Found ${${lib}_file}")
+    endif()
   endif()
   # CMP0111, implemented in CMake 3.20+ requires a shared library target on Windows
   # to be defined with IMPLIB and LOCATION property.
@@ -844,9 +890,12 @@ foreach(lib ${MKL_REQUESTED_LIBRARIES})
         if(${lib} MATCHES "mkl_sycl" AND ${${lib}_file} STREQUAL "${lib}_file-NOTFOUND")
           mkl_message(WARNING "Could NOT find ${MKL_DLL_GLOB} for target MKL::MKL_SYCL::${MKL_SYCL_DOMAIN}")
         else()
-          mkl_message(FATAL_ERROR "${MKL_DLL_GLOB} not found")
+          mkl_not_found_and_return("${MKL_DLL_GLOB} not found")
         endif()
       endif()
+    endif()
+    if(NOT DEFINED MKL_DLL_DIR AND MKL_DLL_FILE)
+      get_filename_component(MKL_DLL_DIR ${MKL_DLL_FILE} DIRECTORY)
     endif()
   else()
     set_target_properties(MKL::${lib} PROPERTIES IMPORTED_LOCATION "${${lib}_file}")
@@ -902,6 +951,10 @@ if(MKL_THREADING STREQUAL "tbb_thread" OR MKL_SYCL_THREADING STREQUAL "tbb_threa
         list(APPEND MKL_SUPP_LINK -lc++)
       else()
         list(APPEND MKL_SUPP_LINK -lstdc++)
+        # force clang to link libstdc++
+        if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+          list(APPEND MKL_SUPP_LINK -stdlib=libstdc++ )
+        endif()
       endif()
     endif()
     if(MKL_SYCL_THREADING STREQUAL "tbb_thread")
@@ -934,7 +987,7 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
     set(OMP_LIBNAME ${LIB_PREFIX}${MKL_OMP_LIB}${LIB_EXT})
 
     find_library(OMP_LIBRARY ${OMP_LIBNAME}
-      HINTS $ENV{LIB} $ENV{LIBRARY_PATH} $ENV{MKLROOT} ${MKL_ROOT} $ENV{CMPLR_ROOT}
+      HINTS $ENV{LIB} ${ENV_LIBRARY_PATH} $ENV{MKLROOT} ${MKL_ROOT} $ENV{CMPLR_ROOT}
       PATH_SUFFIXES "lib" "lib/${MKL_ARCH}"
              "lib/${MKL_ARCH}_lin" "lib/${MKL_ARCH}_win"
              "linux/compiler/lib/${MKL_ARCH}"
@@ -943,6 +996,7 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
              "windows/compiler/lib/${MKL_ARCH}_win"
              "../compiler/lib/${MKL_ARCH}_lin" "../compiler/lib/${MKL_ARCH}_win"
              "../compiler/lib/${MKL_ARCH}" "../compiler/lib" "compiler/lib"
+             "../../compiler/latest/lib"
              "../../compiler/latest/linux/compiler/lib/${MKL_ARCH}"
              "../../compiler/latest/linux/compiler/lib/${MKL_ARCH}_lin"
              "../../compiler/latest/windows/compiler/lib/${MKL_ARCH}"
@@ -952,12 +1006,13 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
     if(WIN32)
       set(OMP_DLLNAME ${LIB_PREFIX}${MKL_OMP_LIB}.dll)
       find_path(OMP_DLL_DIR ${OMP_DLLNAME}
-        HINTS $ENV{LIB} $ENV{LIBRARY_PATH} $ENV{MKLROOT} ${MKL_ROOT} $ENV{CMPLR_ROOT}
+        HINTS $ENV{LIB} ${ENV_LIBRARY_PATH} $ENV{MKLROOT} ${MKL_ROOT} $ENV{CMPLR_ROOT}
         PATH_SUFFIXES "bin"
               # Legacy layout support for oneMKL
               "redist/${MKL_ARCH}"
               "redist/${MKL_ARCH}_win" "redist/${MKL_ARCH}_win/compiler"
               "../redist/${MKL_ARCH}/compiler" "../compiler/lib"
+              "../../compiler/latest/bin"
               "../../compiler/latest/windows/redist/${MKL_ARCH}_win"
               "../../compiler/latest/windows/redist/${MKL_ARCH}_win/compiler"
               "../../compiler/latest/windows/compiler/redist/${MKL_ARCH}_win"
@@ -997,53 +1052,20 @@ if(UNIX)
 endif()
 
 if(SYCL_COMPILER OR ENABLE_OMP_OFFLOAD)
-  if(WIN32)
-    # Detect sycl library version
-    if(NOT DEFINED SYCL_LIB_VER_CACHE)
-      set(SYCL_LIB_VER "")
-      find_library(SYCL_LIB_DIR ${LIB_PREFIX}sycl${LIB_EXT}
-        HINTS $ENV{LIB} $ENV{CMPLR_ROOT}
-        PATH_SUFFIXES "windows/lib" "../lib${MKL_ARCH_DIR}")
-      if(NOT SYCL_LIB_DIR)
-        foreach(ver RANGE 6 99)
-          find_library(SYCL_LIB_DIR ${LIB_PREFIX}sycl${ver}${LIB_EXT}
-            HINTS $ENV{LIB} $ENV{CMPLR_ROOT}
-            PATH_SUFFIXES "windows/lib" "../lib${MKL_ARCH_DIR}")
-          if(SYCL_LIB_DIR)
-            set(SYCL_LIB_VER ${ver})
-            break()
-          endif()
-        endforeach()
-      endif()
-      set(SYCL_LIB_VER_CACHE ${SYCL_LIB_VER} CACHE STRING "")
-    endif()
-
-    if(SYCL_COMPILER)
-      if(CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo")
-        list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}sycl${SYCL_LIB_VER_CACHE}d${LINK_SUFFIX})
-      else()
-        list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}sycl${SYCL_LIB_VER_CACHE}${LINK_SUFFIX})
-      endif()
-    endif()
-    if(ENABLE_OMP_OFFLOAD)
-      if(CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo")
-        list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycl${SYCL_LIB_VER_CACHE}d${LINK_SUFFIX})
-      else()
-        list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycl${SYCL_LIB_VER_CACHE}${LINK_SUFFIX})
-      endif()
-    endif()
-  else()
-    if(SYCL_COMPILER)
+  if(SYCL_COMPILER)
+    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
+      list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}sycld${LINK_SUFFIX})
+    else()
       list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}sycl${LINK_SUFFIX})
     endif()
-    if(ENABLE_OMP_OFFLOAD)
-      list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycl${LINK_SUFFIX})
-    endif()
-  endif()
-  if(SYCL_COMPILER)
     list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}OpenCL${LINK_SUFFIX})
   endif()
   if(ENABLE_OMP_OFFLOAD)
+    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
+      list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycld${LINK_SUFFIX})
+    else()
+      list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycl${LINK_SUFFIX})
+    endif()
     list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}OpenCL${LINK_SUFFIX})
   endif()
 endif()
@@ -1073,15 +1095,15 @@ if(SYCL_COMPILER)
   foreach(lib ${MKL_SYCL_LIBS})
     set(MKL_SYCL_DOMAIN "")
     string(REGEX REPLACE "mkl_sycl_" "" MKL_SYCL_DOMAIN ${lib})
-    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug|DebInfo")
+    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
       string(REGEX REPLACE "d$" "" MKL_SYCL_DOMAIN ${MKL_SYCL_DOMAIN})
     endif()
     string(TOUPPER ${MKL_SYCL_DOMAIN} MKL_SYCL_DOMAIN)
     add_library(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} INTERFACE IMPORTED GLOBAL)
     add_dependencies(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} MKL_SYCL_MESSAGE)
+    target_compile_options(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${MKL_SYCL_COPT}>)
     # Only dynamic link has domain specific libraries
     # Domain specific targets still use mkl_sycl for static
-    # STREQUAL "${lib}_file-NOTFOUND"
     if(MKL_LINK STREQUAL "static")
       target_link_libraries(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} INTERFACE ${MKL_SYCL_LINK_LINE} ${MKL_SYCL_THREAD_LIB} ${MKL_SYCL_SUPP_LINK})
     else()
@@ -1098,12 +1120,55 @@ if(NOT TARGET MKL::MKL)
   add_library(MKL::MKL INTERFACE IMPORTED GLOBAL)
 endif()
 target_compile_options(MKL::MKL INTERFACE
-    $<$<STREQUAL:$<TARGET_PROPERTY:LINKER_LANGUAGE>,C>:${MKL_C_COPT}>
-    $<$<STREQUAL:$<TARGET_PROPERTY:LINKER_LANGUAGE>,Fortran>:${MKL_F_COPT}>
-    $<$<STREQUAL:$<TARGET_PROPERTY:LINKER_LANGUAGE>,CXX>:${MKL_CXX_COPT}>
+    $<$<COMPILE_LANGUAGE:C>:${MKL_C_COPT}>
+    $<$<COMPILE_LANGUAGE:Fortran>:${MKL_F_COPT}>
+    $<$<COMPILE_LANGUAGE:CXX>:${MKL_CXX_COPT}>
     $<IF:$<BOOL:${ENABLE_OMP_OFFLOAD}>,${MKL_OFFLOAD_COPT},>)
 target_link_libraries(MKL::MKL INTERFACE ${MKL_LINK_LINE} ${MKL_THREAD_LIB} ${MKL_SUPP_LINK})
 list(APPEND LINK_TYPES MKL::MKL)
+
+# Define cluster components
+if(NOT ${${MKL_CDFT}_file} STREQUAL "${MKL_CDFT}_file-NOTFOUND")
+  if(NOT TARGET MKL::MKL_BLACS)
+    add_library(MKL::MKL_BLACS INTERFACE IMPORTED GLOBAL)
+  endif()
+  if(MKL_LINK STREQUAL "static")
+    # Static link requires duplications for cross library dependency resolutions
+    target_link_libraries(MKL::MKL_BLACS INTERFACE ${${MKL_IFACE_LIB}_file} ${${MKL_THREAD}_file} ${${MKL_CORE}_file} ${${MKL_BLACS}_file})
+    target_link_libraries(MKL::MKL_BLACS INTERFACE ${${MKL_IFACE_LIB}_file} ${${MKL_THREAD}_file} ${${MKL_CORE}_file} ${${MKL_BLACS}_file})
+    target_link_libraries(MKL::MKL_BLACS INTERFACE MKL::MKL)
+  else()
+    target_link_libraries(MKL::MKL_BLACS INTERFACE MKL::MKL MKL::${MKL_BLACS})
+  endif()
+endif()
+if(NOT ${${MKL_CDFT}_file} STREQUAL "${MKL_CDFT}_file-NOTFOUND"
+        AND NOT ${${MKL_BLACS}_file} STREQUAL "${MKL_BLACS}_file-NOTFOUND")
+  if(NOT TARGET MKL::MKL_CDFT)
+    add_library(MKL::MKL_CDFT INTERFACE IMPORTED GLOBAL)
+  endif()
+  if(UNIX AND NOT APPLE AND MKL_LINK STREQUAL "static")
+    # Static link requires duplications for cross library dependency resolutions
+    target_link_libraries(MKL::MKL_CDFT INTERFACE ${${MKL_CDFT}_file} ${${MKL_IFACE_LIB}_file} ${${MKL_THREAD}_file} ${${MKL_CORE}_file} ${${MKL_BLACS}_file})
+    target_link_libraries(MKL::MKL_CDFT INTERFACE ${${MKL_CDFT}_file} ${${MKL_IFACE_LIB}_file} ${${MKL_THREAD}_file} ${${MKL_CORE}_file} ${${MKL_BLACS}_file})
+    target_link_libraries(MKL::MKL_CDFT INTERFACE MKL::MKL)
+  else()
+    target_link_libraries(MKL::MKL_CDFT INTERFACE MKL::${MKL_CDFT} MKL::MKL_BLACS)
+  endif()
+endif()
+if(NOT ${${MKL_SCALAPACK}_file} STREQUAL "${MKL_SCALAPACK}_file-NOTFOUND"
+        AND NOT ${${MKL_BLACS}_file} STREQUAL "${MKL_BLACS}_file-NOTFOUND")
+  if(NOT TARGET MKL::MKL_SCALAPACK)
+    add_library(MKL::MKL_SCALAPACK INTERFACE IMPORTED GLOBAL)
+  endif()
+  if(UNIX AND NOT APPLE AND MKL_LINK STREQUAL "static")
+    # Static link requires duplications for cross library dependency resolutions
+    target_link_libraries(MKL::MKL_SCALAPACK INTERFACE ${${MKL_SCALAPACK}_file} ${${MKL_IFACE_LIB}_file} ${${MKL_THREAD}_file} ${${MKL_CORE}_file} ${${MKL_BLACS}_file})
+    target_link_libraries(MKL::MKL_SCALAPACK INTERFACE ${${MKL_SCALAPACK}_file} ${${MKL_IFACE_LIB}_file} ${${MKL_THREAD}_file} ${${MKL_CORE}_file} ${${MKL_BLACS}_file})
+    target_link_libraries(MKL::MKL_SCALAPACK INTERFACE MKL::MKL)
+  else()
+    target_link_libraries(MKL::MKL_SCALAPACK INTERFACE MKL::${MKL_SCALAPACK} MKL::MKL_BLACS)
+  endif()
+endif()
 
 foreach(link ${LINK_TYPES})
   # Set properties on all INTERFACE targets
@@ -1142,7 +1207,6 @@ endif()
 
 # Add oneMKL dynamic libraries to PATH on Windows
 if(WIN32 AND NOT MKL_LINK STREQUAL "static")
-  get_filename_component(MKL_DLL_DIR ${MKL_DLL_FILE} DIRECTORY)
   set(MKL_ENV_PATH "${MKL_DLL_DIR}\;${MKL_ENV_PATH}")
 endif()
 
@@ -1153,6 +1217,140 @@ if(MKL_ENV_PATH)
   endif()
 endif()
 
-unset(MKL_DLL_FILE)
+# Additional checks
+if(ENABLE_TRY_SYCL_COMPILE AND "CXX" IN_LIST CURR_LANGS AND SYCL_COMPILER AND MKL_SYCL_LIBS)
+  # The check is run only once with the result cached
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_LIBRARIES MKL::MKL_SYCL)
+  foreach(lib IN LISTS MKL_SYCL_LIBS)
+    if(lib STREQUAL "mkl_sycl_blas")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/blas.hpp\"
+        
+        int main()
+        {
+            sycl::queue q;
+            float x[1], res[1];
+            oneapi::mkl::blas::asum(q, 1, x, 1, res);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    elseif(lib STREQUAL "mkl_sycl_lapack")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/lapack.hpp\"
+        
+        int main()
+        {
+            sycl::queue q;
+            float a[1], scratchpad[1];
+            std::int64_t ipiv[1];
+            oneapi::mkl::lapack::getrf(q, 1, 1, a, 1, ipiv, scratchpad, 1);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    elseif(lib STREQUAL "mkl_sycl_dft")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/dfti.hpp\"
+        
+        int main()
+        {
+            namespace dft = oneapi::mkl::dft;
+            dft::descriptor<dft::precision::SINGLE, dft::domain::REAL> desc(1);
+            sycl::queue q;
+            desc.commit(q);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    elseif(lib STREQUAL "mkl_sycl_sparse")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/spblas.hpp\"
+        
+        int main()
+        {
+            sycl::queue q;
+            oneapi::mkl::sparse::matrix_handle_t handle;
+            float x[1], y[1];
+            oneapi::mkl::sparse::gemv(q, oneapi::mkl::transpose::nontrans, 1, handle, x, 1, y);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    elseif(lib STREQUAL "mkl_sycl_data_fitting")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/experimental/data_fitting.hpp\"
+        
+        int main()
+        {
+            namespace df = oneapi::mkl::experimental::data_fitting;
+            sycl::queue q;
+            df::spline<double, df::linear_spline::default_type> spl(q);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    elseif(lib STREQUAL "mkl_sycl_rng")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/rng.hpp\"
+        
+        int main()
+        {
+            sycl::queue q;
+            oneapi::mkl::rng::default_engine engine(q, 0);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    elseif(lib STREQUAL "mkl_sycl_stats")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/stats.hpp\"
+        
+        int main()
+        {
+            namespace stats = oneapi::mkl::stats;
+            sycl::queue q;
+            float x[1], min[1];
+            stats::min(q, stats::make_dataset<stats::layout::row_major>(1, 1, x), min);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    elseif(lib STREQUAL "mkl_sycl_vm")
+      check_cxx_source_compiles("
+        #include <sycl/sycl.hpp>
+        #include \"oneapi/mkl/vm.hpp\"
+        
+        int main()
+        {
+            sycl::queue q;
+            float a[1], b[1], y[1];
+            oneapi::mkl::vm::add(q, 1, a, b, y);
+            return 0;
+        }
+        " MKL_TRY_SYCL_COMPILE)
+      break()
+    endif()
+  endforeach()
+  unset(CMAKE_REQUIRED_LIBRARIES)
+  if(NOT MKL_TRY_SYCL_COMPILE)
+    mkl_not_found_and_return("The SYCL compiler \"${CMAKE_CXX_COMPILER}\" is not able to \
+                              compile a simple test program that calls a oneMKL DPC++ API. \
+                              See \"CMakeError.log\" for details. Besides environment issues, \
+                              this could be caused by a compiler version that is incompatible \
+                              with oneMKL ${${CMAKE_FIND_PACKAGE_NAME}_VERSION}.")
+  endif()
+endif()
 
-endif() # MKL_LIBRARIES
+unset(MKL_DLL_FILE)
+unset(MKL_LIBRARIES)
+
+endif() # MKL::MKL

--- a/cmake/mkl/MKLConfigVersion.cmake
+++ b/cmake/mkl/MKLConfigVersion.cmake
@@ -17,16 +17,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-set(PACKAGE_VERSION "2023.2.0")
+set(PACKAGE_VERSION "2024.2.0")
 
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
   set(PACKAGE_VERSION_COMPATIBLE FALSE)
 else()
 
-  if("2023.2.0" MATCHES "^([0-9]+)\\.")
+  if("2024.2.0" MATCHES "^([0-9]+)\\.")
     set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
   else()
-    set(CVF_VERSION_MAJOR "2024.0.0")
+    set(CVF_VERSION_MAJOR "2024.2.0")
   endif()
 
   if(PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR)


### PR DESCRIPTION
# Description

PR updates local version of MKLConfig.cmake file to the latest available from Intel oneMKL 2024.2.1 release.

This update includes several fixes.
Fixes https://github.com/oneapi-src/oneMKL/issues/332 

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? 
- [x] Have you formatted the code using clang-format? N/A, cmake change sonly
