### PR TITLE
[Docs] add page about project maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,19 @@ Before sending your pull requests, ensure that you follow this checklist:
 
 * Ensure that [unit tests](CONTRIBUTING.md#unit-tests) pass. Include logs from tests as attachments to the pull request.
 
+* Ensure that corresponding maintainer GitHub team is assigned to the PR review.
+
+  | GitHub team name | Description |
+  :-----------|:------------|
+  | @oneapi-src/onemkl-maintain  | All oneMKL maintainers |
+  | @oneapi-src/onemkl-arch-write | oneMKL Architecture maintainers |
+  | @oneapi-src/onemkl-blas-write | oneMKL BLAS maintainers |
+  | @oneapi-src/onemkl-dft-write | oneMKL DFT maintainers |
+  | @oneapi-src/onemkl-lapack-write | oneMKL LAPACK maintainers |
+  | @oneapi-src/onemkl-rng-write | oneMKL RNG maintainers |
+  | @oneapi-src/onemkl-sparse-write | oneMKL Sparse Algebra maintainers |
+  | @oneapi-src/onemkl-vm-write | oneMKL Vector Math maintainers |
+
 ## Library Functionality Guidelines
 
 oneMKL focuses on the following criteria:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,18 +15,7 @@ Before sending your pull requests, ensure that you follow this checklist:
 
 * Ensure that [unit tests](CONTRIBUTING.md#unit-tests) pass. Include logs from tests as attachments to the pull request.
 
-* Ensure that corresponding maintainer GitHub team is assigned to the PR review.
-
-  | GitHub team name | Description |
-  :-----------|:------------|
-  | @oneapi-src/onemkl-maintain  | All oneMKL maintainers |
-  | @oneapi-src/onemkl-arch-write | oneMKL Architecture maintainers |
-  | @oneapi-src/onemkl-blas-write | oneMKL BLAS maintainers |
-  | @oneapi-src/onemkl-dft-write | oneMKL DFT maintainers |
-  | @oneapi-src/onemkl-lapack-write | oneMKL LAPACK maintainers |
-  | @oneapi-src/onemkl-rng-write | oneMKL RNG maintainers |
-  | @oneapi-src/onemkl-sparse-write | oneMKL Sparse Algebra maintainers |
-  | @oneapi-src/onemkl-vm-write | oneMKL Vector Math maintainers |
+* Ensure that corresponding [maintainer GitHub team](#onemkl-interfaces-maintainers) is assigned to the PR review.
 
 ## Library Functionality Guidelines
 
@@ -58,6 +47,7 @@ Please also provide the following details as part of the RFC:
 
 * What existing libraries have implementations of this function and can be used under the oneMKL interface.
 
+* Ensure that corresponding [maintainer GitHub team](#onemkl-interfaces-maintainers) is assigned to the RFC review.
 
 ## Bug Reporting
 
@@ -68,6 +58,22 @@ If you find a bug or problem, please open a request under [Issues](https://githu
 
 Report security issues to onemkl.maintainers@intel.com.
 
+## oneMKL Interfaces Maintainers
+
+For GitHub questions, issues, RFCs, or PRs you can contact maintainers via one of the following GitHub teams based on the topic:
+
+| GitHub team name | Description |
+:-----------|:------------|
+| @oneapi-src/onemkl-maintain  | All oneMKL Interfaces maintainers |
+| @oneapi-src/onemkl-arch-write | oneMKL Interfaces Architecture maintainers |
+| @oneapi-src/onemkl-blas-write | oneMKL Interfaces BLAS maintainers |
+| @oneapi-src/onemkl-dft-write | oneMKL Interfaces DFT maintainers |
+| @oneapi-src/onemkl-lapack-write | oneMKL Interfaces LAPACK maintainers |
+| @oneapi-src/onemkl-rng-write | oneMKL Interfaces RNG maintainers |
+| @oneapi-src/onemkl-sparse-write | oneMKL Interfaces Sparse Algebra maintainers |
+| @oneapi-src/onemkl-vm-write | oneMKL Interfaces Vector Math maintainers |
+
+Please read [MAINTAINERS page](MAINTAINERS.md) for more information about maintainer roles, responsibilities, and how to become one of them.
 
 ## Coding Style
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,113 @@
+# Introduction
+
+This document defines roles in oneMKL Interfaces project.
+
+# Roles and responsibilities
+
+oneMKL Interfaces project defines three main roles:
+ * [Contributor](#contributor)
+ * [Domain maintainer](#domain-maintainer)
+ * [Architecture maintainer](#architecture-maintainer)
+
+These roles are merit based. Refer to the corresponding section for specific
+requirements and the nomination process.
+
+## Contributor
+
+A Contributor invests time and resources to improve oneMKL Interfaces project.
+Anyone can become a Contributor by bringing value in one of the following ways:
+  * Answer questions from community members.
+  * Submit feedback to design proposals.
+  * Review and/or test pull requests.
+  * Test releases and report bugs.
+  * Contribute code, including bug fixes, features implementations,
+and performance optimizations.
+  * Contribute design proposals.
+
+Responsibilities:
+  * Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+  * Follow the project [contributing guidelines](CONTRIBUTING.md).
+
+Privileges:
+  * Eligible to join one of the maintainer groups.
+
+## Domain Maintainer
+
+Domain maintainer has responsibility for a specific domain in the project.
+Domain maintainers are collectively responsible for developing and maintaining their domain,
+including reviewing all changes to their domain and indicating
+whether those changes are ready to merge. They have a track record of
+contribution and review in the project.
+
+Responsibilities:
+  * Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+  * Follow and enforce the project [contributing guidelines](CONTRIBUTING.md).
+  * Co-own with other domain maintainers a specific domain, including contributing
+    bug fixes, implementing features, and answering domain specific questions
+    in [#onemkl](https://uxlfoundation.slack.com/archives/onemkl) Slack channel.
+  * Review pull requests in their specific domain.
+  * Monitor testing results and flag issues in their specific areas of
+    responsibility.
+  * Support and guide Contributors.
+
+Requirements:
+  * Experience as Contributor in the specific domain for at least 6 months.
+  * Commit at least 25% of working time to the project.
+  * Track record of accepted code contributions to a specific domain.
+  * Track record of contributions to the code review process.
+  * Demonstrated in-depth knowledge of the specific domain.
+  * Commits to being responsible for that specific domain.
+
+Privileges:
+  * PR approval counts towards approval requirements for a specific domain.
+  * Can promote fully approved Pull Requests to the `develop` branch.
+  * Can recommend Contributors to become Domain maintainer.
+  * Eligible to become an Architecture maintainer.
+
+The process of becoming a Domain maintainer is:
+1. A Contributor requests to join corresponding Domain maintainer GitHub team.
+2. At least one specific Domain maintainers approve the request.
+
+### List of GitHub teams for Domain maintainers
+
+| GitHub team name | Domain maintainers |
+:-----------|:------------|
+| @oneapi-src/onemkl-blas-write | oneMKL BLAS maintainers |
+| @oneapi-src/onemkl-dft-write | oneMKL DFT maintainers |
+| @oneapi-src/onemkl-lapack-write) | oneMKL LAPACK maintainers |
+| @oneapi-src/onemkl-rng-write | oneMKL RNG maintainers |
+| @oneapi-src/onemkl-sparse-write | oneMKL Sparse Algebra maintainers |
+| @oneapi-src/onemkl-vm-write | oneMKL Vector Math maintainers |
+
+## Architecture Maintainer
+Architecture maintainers are the most established contributors who are responsible for the
+project technical direction and participate in making decisions about the
+strategy and priorities of the project.
+
+Responsibilities:
+  * Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+  * Follow and enforce the project [contributing guidelines](CONTRIBUTING.md)
+  * Co-own with other Domain maintainers on the technical direction of a specific domain.
+  * Co-own with other Architecture maintainers on the project as a whole, including
+determining strategy and policy for the project.
+  * Support and guide Contributors and Domain maintainers.
+
+Requirements:
+  * Experience as a Domain maintainer or Contributor with focus on the project architecture
+for at least 12 months.
+  * Commit at least 25% of working time to the project.
+  * Track record of major project contributions.
+  * Demonstrated deep knowledge of the project architecture and build.
+  * Demonstrated broad knowledge of the project across multiple domains.
+  * Is able to exercise judgment for the good of the project, independent of
+    their employer, friends, or team.
+
+Privileges:
+  * Can represent the project in public as a Maintainer.
+  * Can recommend Contributor or Domain maintainer to become Architecture maintainers.
+
+Process of becoming a maintainer:
+1. A Contributor or Domain maintainer requests to join oneMKL Architecture maintainers GitHub team
+(@oneapi-src/onemkl-arch-write).
+2. At least one of Architecture maintainers approves the request.
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -72,12 +72,12 @@ The process of becoming a Domain maintainer is:
 
 | GitHub team name | Domain maintainers |
 :-----------|:------------|
-| @oneapi-src/onemkl-blas-write | oneMKL BLAS maintainers |
-| @oneapi-src/onemkl-dft-write | oneMKL DFT maintainers |
-| @oneapi-src/onemkl-lapack-write) | oneMKL LAPACK maintainers |
-| @oneapi-src/onemkl-rng-write | oneMKL RNG maintainers |
-| @oneapi-src/onemkl-sparse-write | oneMKL Sparse Algebra maintainers |
-| @oneapi-src/onemkl-vm-write | oneMKL Vector Math maintainers |
+| @oneapi-src/onemkl-blas-write | oneMKL Interfaces BLAS maintainers |
+| @oneapi-src/onemkl-dft-write | oneMKL Interfaces DFT maintainers |
+| @oneapi-src/onemkl-lapack-write) | oneMKL Interfaces LAPACK maintainers |
+| @oneapi-src/onemkl-rng-write | oneMKL Interfaces RNG maintainers |
+| @oneapi-src/onemkl-sparse-write | oneMKL Interfaces Sparse Algebra maintainers |
+| @oneapi-src/onemkl-vm-write | oneMKL Interfaces Vector Math maintainers |
 
 ## Architecture Maintainer
 Architecture maintainers are the most established contributors who are responsible for the
@@ -107,7 +107,7 @@ Privileges:
   * Can recommend Contributor or Domain maintainer to become Architecture maintainers.
 
 Process of becoming a maintainer:
-1. A Contributor or Domain maintainer requests to join oneMKL Architecture maintainers GitHub team
+1. A Contributor or Domain maintainer requests to join oneMKL Interfaces Architecture maintainers GitHub team
 (@oneapi-src/onemkl-arch-write).
 2. At least one of Architecture maintainers approves the request.
 

--- a/README.md
+++ b/README.md
@@ -546,21 +546,6 @@ You can also join the mailing lists for the [UXL Foundation](https://lists.uxlfo
 
 You can contribute to this project and also contribute to [the specification for this project](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/). Please read the [CONTRIBUTING](CONTRIBUTING.md) page for more information. You can also contact oneMKL developers and maintainers via [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using [#onemkl](https://uxlfoundation.slack.com/archives/onemkl) channel.
 
-For GitHub questions, issues, RFCs, or PRs you can contact maintainers via one of the following GitHub teams based on the topic:
-
-| GitHub team name | Description |
-:-----------|:------------|
-| @oneapi-src/onemkl-maintain  | All oneMKL maintainers |
-| @oneapi-src/onemkl-arch-write | oneMKL Architecture maintainers |
-| @oneapi-src/onemkl-blas-write | oneMKL BLAS maintainers |
-| @oneapi-src/onemkl-dft-write | oneMKL DFT maintainers |
-| @oneapi-src/onemkl-lapack-write | oneMKL LAPACK maintainers |
-| @oneapi-src/onemkl-rng-write | oneMKL RNG maintainers |
-| @oneapi-src/onemkl-sparse-write | oneMKL Sparse Algebra maintainers |
-| @oneapi-src/onemkl-vm-write | oneMKL Vector Math maintainers |
-
-Please read [MAINTAINERS page](MAINTAINERS.md) for more information about maintainer roles, responsibilities, and how to become one of them.
-
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -554,10 +554,12 @@ For GitHub questions, issues, RFCs, or PRs you can contact maintainers via one o
 | @oneapi-src/onemkl-arch-write | oneMKL Architecture maintainers |
 | @oneapi-src/onemkl-blas-write | oneMKL BLAS maintainers |
 | @oneapi-src/onemkl-dft-write | oneMKL DFT maintainers |
-| @oneapi-src/onemkl-lapack-write) | oneMKL LAPACK maintainers |
+| @oneapi-src/onemkl-lapack-write | oneMKL LAPACK maintainers |
 | @oneapi-src/onemkl-rng-write | oneMKL RNG maintainers |
 | @oneapi-src/onemkl-sparse-write | oneMKL Sparse Algebra maintainers |
 | @oneapi-src/onemkl-vm-write | oneMKL Vector Math maintainers |
+
+Please read [MAINTAINERS page](MAINTAINERS.md) for more information about maintainer roles, responsibilities, and how to become one of them.
 
 ---
 


### PR DESCRIPTION
# Description

PR introduces page about project maintainers: their roles and responsibilities, and how to become one of them.

Fixes https://github.com/uxlfoundation/open-source-working-group/issues/18 
Fixes https://github.com/uxlfoundation/open-source-working-group/issues/19

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. N/A documentation only changes
- [x] Have you formatted the code using clang-format? N/A, documentation only changes
