### PR TITLE
Add generic device support to dft domain through portFFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ oneMKL is part of the [UXL Foundation](http://www.uxlfoundation.org).
         </tr>
         <tr>
             <td align="center"><a href="https://github.com/codeplaysoftware/portFFT"> portFFT </a></td>
-            <td align="center">x86 CPU, Intel GPU, NVIDIA GPU, AMD GPU</td>
+            <td align="center">x86 CPU, Intel GPU, NVIDIA GPU, AMD GPU, Other SYCL devices (unsupported)</td>
         </tr>
     </tbody>
 </table>
@@ -278,7 +278,7 @@ Supported compilers include:
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
-            <td rowspan=8 align="center">DFT</td>
+            <td rowspan=9 align="center">DFT</td>
             <td rowspan=2 align="center">x86 CPU</td>
             <td align="center">Intel(R) oneMKL</td>
             <td align="center">Intel DPC++</td>
@@ -320,6 +320,12 @@ Supported compilers include:
         <tr>
             <td align="center">portFFT (<a href="https://github.com/codeplaysoftware/portFFT#supported-configurations">limited API support</a>)</td>
             <td align="center">Open DPC++</td>
+            <td align="center">Dynamic, Static</td>
+        </tr>
+        <tr>
+            <td rowspan=1 align="center">Other SYCL devices (unsupported)</td>
+            <td align="center">portFFT</td>
+            <td align="center">Open DPC++</br>Open DPC++</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>

--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -234,10 +234,10 @@ SYCL enables portable heterogeneous computing on a wide range of accelerators.
 Consequently, it is possible to use oneMKL Interfaces with accelerators not
 anticipated by the oneMKL Interfaces team.
 
-For generic SYCL devices, only portBLAS and portFFT backend are enabled. The user must
-set the appropriate ``-fsycl-targets`` for their device, and also any
-other option required for performance. See
-`Building for portBLAS`_ and `Building for portFFT`_. Extensive testing is strongly advised for these
+For generic SYCL devices, only portBLAS and portFFT backend are enabled.
+The user must set the appropriate ``-fsycl-targets`` for their device, and also
+any other option required for performance. See `Building for portBLAS`_ and
+`Building for portFFT`_. Extensive testing is strongly advised for these
 unsupported configurations.
 
 .. _build_for_portlibs_dpcpp:

--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -234,10 +234,10 @@ SYCL enables portable heterogeneous computing on a wide range of accelerators.
 Consequently, it is possible to use oneMKL Interfaces with accelerators not
 anticipated by the oneMKL Interfaces team.
 
-For generic SYCL devices, only the portBLAS backend is enabled. The user must
+For generic SYCL devices, only portBLAS and portFFT backend are enabled. The user must
 set the appropriate ``-fsycl-targets`` for their device, and also any
-``PORTBLAS_TUNING_TARGET`` required for performance. See
-`Building for portBLAS`_. Extensive testing is strongly advised for these
+other option required for performance. See
+`Building for portBLAS`_ and `Building for portFFT`_. Extensive testing is strongly advised for these
 unsupported configurations.
 
 .. _build_for_portlibs_dpcpp:
@@ -436,6 +436,21 @@ Build oneMKL for the BLAS domain on a generic SYCL device:
 
 Note that this is not a tested configuration. This builds oneMKL Interfaces
 with the portBLAS backend only, for a generic SYCL device supported by the 
+Open DPC++ project.
+
+Build oneMKL for the DFT domain on a generic SYCL device:
+
+.. code-block:: bash
+
+  cmake $ONEMKL_DIR \
+      -DCMAKE_CXX_COMPILER=clang++ \
+      -DCMAKE_C_COMPILER=clang \
+      -DENABLE_MKLCPU_BACKEND=False \
+      -DENABLE_MKLGPU_BACKEND=False \
+      -DENABLE_PORTFFT_BACKEND=True
+
+Note that this is not a tested configuration. This builds oneMKL Interfaces
+with the portFFT backend only, for a generic SYCL device supported by the
 Open DPC++ project.
 
 .. _project_cleanup:

--- a/include/oneapi/mkl/detail/backends_table.hpp
+++ b/include/oneapi/mkl/detail/backends_table.hpp
@@ -127,6 +127,12 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
 #ifdef ENABLE_PORTFFT_BACKEND
                   LIB_NAME("dft_portfft")
 #endif
+          } },
+        { device::generic_device,
+          {
+#ifdef ENABLE_PORTFFT_BACKEND
+              LIB_NAME("dft_portfft"),
+#endif
           } } } },
 
     { domain::lapack,

--- a/include/oneapi/mkl/detail/get_device_id.hpp
+++ b/include/oneapi/mkl/detail/get_device_id.hpp
@@ -58,9 +58,8 @@ inline oneapi::mkl::device get_device_id(sycl::queue &queue) {
             device_id = device::nvidiagpu;
         else if (vendor_id == AMD_ID)
             device_id = device::amdgpu;
-        else {
+        else
             device_id = device::generic_device;
-        }
     }
     else {
         device_id = device::generic_device;

--- a/src/include/function_table_initializer.hpp
+++ b/src/include/function_table_initializer.hpp
@@ -67,7 +67,7 @@ public:
     }
 
 private:
-#if defined(ENABLE_PORTBLAS_BACKEND) || defined (ENABLE_PORTFFT_BACKEND)
+#if defined(ENABLE_PORTBLAS_BACKEND) || defined(ENABLE_PORTFFT_BACKEND)
     static constexpr bool is_generic_device_supported = true;
 #else
     static constexpr bool is_generic_device_supported = false;

--- a/src/include/function_table_initializer.hpp
+++ b/src/include/function_table_initializer.hpp
@@ -67,7 +67,7 @@ public:
     }
 
 private:
-#ifdef ENABLE_PORTBLAS_BACKEND
+#if defined(ENABLE_PORTBLAS_BACKEND) || defined (ENABLE_PORTFFT_BACKEND)
     static constexpr bool is_generic_device_supported = true;
 #else
     static constexpr bool is_generic_device_supported = false;


### PR DESCRIPTION
# Description

This PR is the continuation of PR #566 and it is based on it. 
It adds generic devices support by enabling portFFT and generic device the same way it is done for portBLAS.

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
  - I don't have a non Intel/NVIDIA/AMD device to test with. Tests are successful when forcing Intel devices to go through generic_device path.

Following logs show that all domains still work properly:
[portfft_log.txt](https://github.com/user-attachments/files/16931112/portfft_log.txt)
[arc_blas_log.txt](https://github.com/user-attachments/files/16931117/arc_blas_log.txt)
[cufft_log.txt](https://github.com/user-attachments/files/16931119/cufft_log.txt)
[arc_lapack_log.txt](https://github.com/user-attachments/files/16931120/arc_lapack_log.txt)
[arc_rng_log.txt](https://github.com/user-attachments/files/16931122/arc_rng_log.txt)



- [x] Have you formatted the code using clang-format?

## New features

- [x] Have you provided motivation for adding a new feature?
Same reason added to https://github.com/oneapi-src/oneMKL/pull/566

- [x] Have you added relevant tests?
Generic device doesn't require new tests