### PR TITLE
[DFT][MKLGPU] Update mklgpu support to mkl preparing for oneapi 2025.0 release

### DIFF
--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -36,6 +36,9 @@ target_include_directories(${LIB_NAME}
   PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
 )
 
+# Due to using the same file name for different headers in this library and in
+# MKL Intel library, we force the compiler to follow C++ Core Guideline SF.12
+# using the flag "-iquote" to avoid conflicts and find the correct header.
 target_compile_options(${LIB_OBJ}
   BEFORE PRIVATE -iquote $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -32,12 +32,14 @@ add_library(${LIB_OBJ} OBJECT
 )
 add_dependencies(onemkl_backend_libs_dft ${LIB_NAME})
 
-target_include_directories(${LIB_OBJ}
-  PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
-)
 target_include_directories(${LIB_NAME}
   PUBLIC ${ONEMKL_INTERFACE_INCLUDE_DIRS}
 )
+
+target_compile_options(${LIB_OBJ}
+  BEFORE PRIVATE -iquote $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+
 target_include_directories(${LIB_OBJ}
   PRIVATE ${PROJECT_SOURCE_DIR}/src
           ${CMAKE_BINARY_DIR}/bin

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -37,8 +37,9 @@ target_include_directories(${LIB_NAME}
 )
 
 # Due to using the same file name for different headers in this library and in
-# MKL Intel library, we force the compiler to follow C++ Core Guideline SF.12
-# using the flag "-iquote" to avoid conflicts and find the correct header.
+# the Intel(R) oneAPI Math Kernel Library, we force the compiler to follow C++
+# Core Guideline SF.12 using the flag "-iquote" to avoid conflicts and find the
+# correct header.
 target_compile_options(${LIB_OBJ}
   BEFORE PRIVATE -iquote $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -31,7 +31,11 @@
 #include "mklgpu_helpers.hpp"
 
 // MKLGPU header
-#include "oneapi/mkl/dfti.hpp"
+#if INTEL_MKL_VERSION < 20250000
+#include <oneapi/mkl/dfti.hpp>
+#else
+#include <oneapi/mkl/dft.hpp>
+#endif
 
 namespace oneapi::mkl::dft::mklgpu {
 namespace detail {

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -30,6 +30,7 @@
 
 #include "mklgpu_helpers.hpp"
 
+#include "mkl_version.h"
 // MKLGPU header
 #if INTEL_MKL_VERSION < 20250000
 #include <oneapi/mkl/dfti.hpp>

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -35,6 +35,7 @@
 #include "dft/backends/mklgpu/mklgpu_helpers.hpp"
 #include "../stride_helper.hpp"
 
+#include "mkl_version.h"
 // MKLGPU header
 #if INTEL_MKL_VERSION < 20250000
 #include <oneapi/mkl/dfti.hpp>
@@ -43,7 +44,6 @@
 #endif
 
 // MKL 2024.1 deprecates input/output strides.
-#include "mkl_version.h"
 #if INTEL_MKL_VERSION < 20240001
 #error MKLGPU requires oneMKL 2024.1 or later
 #endif

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -36,7 +36,11 @@
 #include "../stride_helper.hpp"
 
 // MKLGPU header
-#include "oneapi/mkl/dfti.hpp"
+#if INTEL_MKL_VERSION < 20250000
+#include <oneapi/mkl/dfti.hpp>
+#else
+#include <oneapi/mkl/dft.hpp>
+#endif
 
 // MKL 2024.1 deprecates input/output strides.
 #include "mkl_version.h"

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -31,6 +31,7 @@
 
 #include "mklgpu_helpers.hpp"
 
+#include "mkl_version.h"
 // MKLGPU header
 #if INTEL_MKL_VERSION < 20250000
 #include <oneapi/mkl/dfti.hpp>

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -32,7 +32,11 @@
 #include "mklgpu_helpers.hpp"
 
 // MKLGPU header
-#include "oneapi/mkl/dfti.hpp"
+#if INTEL_MKL_VERSION < 20250000
+#include <oneapi/mkl/dfti.hpp>
+#else
+#include <oneapi/mkl/dft.hpp>
+#endif
 
 /**
 Note that in this file, the Intel oneMKL-GPU library's interface mirrors the

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -69,13 +69,13 @@ inline constexpr dft::config_param to_mklgpu(dft::detail::config_param param) {
         case iparam::FORWARD_SCALE: return oparam::FORWARD_SCALE;
         case iparam::NUMBER_OF_TRANSFORMS: return oparam::NUMBER_OF_TRANSFORMS;
         case iparam::COMPLEX_STORAGE: return oparam::COMPLEX_STORAGE;
-        case iparam::REAL_STORAGE: return oparam::REAL_STORAGE;
+        //case iparam::REAL_STORAGE: return oparam::REAL_STORAGE;
         case iparam::CONJUGATE_EVEN_STORAGE: return oparam::CONJUGATE_EVEN_STORAGE;
         case iparam::FWD_DISTANCE: return oparam::FWD_DISTANCE;
         case iparam::BWD_DISTANCE: return oparam::BWD_DISTANCE;
         case iparam::WORKSPACE: return oparam::WORKSPACE;
-        case iparam::ORDERING: return oparam::ORDERING;
-        case iparam::TRANSPOSE: return oparam::TRANSPOSE;
+        //case iparam::ORDERING: return oparam::ORDERING;
+        //case iparam::TRANSPOSE: return oparam::TRANSPOSE;
         case iparam::PACKED_FORMAT: return oparam::PACKED_FORMAT;
         case iparam::WORKSPACE_PLACEMENT: return oparam::WORKSPACE; // Same as WORKSPACE
         case iparam::WORKSPACE_EXTERNAL_BYTES: return oparam::WORKSPACE_BYTES;

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -24,7 +24,11 @@
 #include "oneapi/mkl/dft/detail/types_impl.hpp"
 
 // MKLGPU header
-#include "oneapi/mkl/dfti.hpp"
+#if INTEL_MKL_VERSION < 20250000
+#include <oneapi/mkl/dfti.hpp>
+#else
+#include <oneapi/mkl/dft.hpp>
+#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -23,6 +23,7 @@
 #include "oneapi/mkl/detail/exceptions.hpp"
 #include "oneapi/mkl/dft/detail/types_impl.hpp"
 
+#include "mkl_version.h"
 // MKLGPU header
 #if INTEL_MKL_VERSION < 20250000
 #include <oneapi/mkl/dfti.hpp>

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -69,13 +69,10 @@ inline constexpr dft::config_param to_mklgpu(dft::detail::config_param param) {
         case iparam::FORWARD_SCALE: return oparam::FORWARD_SCALE;
         case iparam::NUMBER_OF_TRANSFORMS: return oparam::NUMBER_OF_TRANSFORMS;
         case iparam::COMPLEX_STORAGE: return oparam::COMPLEX_STORAGE;
-        //case iparam::REAL_STORAGE: return oparam::REAL_STORAGE;
         case iparam::CONJUGATE_EVEN_STORAGE: return oparam::CONJUGATE_EVEN_STORAGE;
         case iparam::FWD_DISTANCE: return oparam::FWD_DISTANCE;
         case iparam::BWD_DISTANCE: return oparam::BWD_DISTANCE;
         case iparam::WORKSPACE: return oparam::WORKSPACE;
-        //case iparam::ORDERING: return oparam::ORDERING;
-        //case iparam::TRANSPOSE: return oparam::TRANSPOSE;
         case iparam::PACKED_FORMAT: return oparam::PACKED_FORMAT;
         case iparam::WORKSPACE_PLACEMENT: return oparam::WORKSPACE; // Same as WORKSPACE
         case iparam::WORKSPACE_EXTERNAL_BYTES: return oparam::WORKSPACE_BYTES;

--- a/tests/unit_tests/dft/source/compute_tests.cpp
+++ b/tests/unit_tests/dft/source/compute_tests.cpp
@@ -76,7 +76,7 @@ class ComputeTests_real_real_out_of_place_REAL
         catch (std::exception & e) {                                                      \
             std::string msg = e.what();                                                   \
             if ((msg.find("FFT_UNIMPLEMENTED") != std::string::npos) ||                   \
-                msg.find("unimplemented") != std::string::npos) {                         \
+                (msg.find("Unimplemented") != std::string::npos)) {                       \
                 std::cout << "Skipping test because: \"" << msg << "\"" << std::endl;     \
                 GTEST_SKIP();                                                             \
             }                                                                             \

--- a/tests/unit_tests/dft/source/compute_tests.cpp
+++ b/tests/unit_tests/dft/source/compute_tests.cpp
@@ -75,7 +75,8 @@ class ComputeTests_real_real_out_of_place_REAL
         }                                                                                 \
         catch (std::exception & e) {                                                      \
             std::string msg = e.what();                                                   \
-            if (msg.find("FFT_UNIMPLEMENTED") != std::string::npos) {                     \
+            if ((msg.find("FFT_UNIMPLEMENTED") != std::string::npos) ||                   \
+                msg.find("unimplemented") != std::string::npos) {                         \
                 std::cout << "Skipping test because: \"" << msg << "\"" << std::endl;     \
                 GTEST_SKIP();                                                             \
             }                                                                             \


### PR DESCRIPTION

# Description

Update how dft mklgpu backend includes header files from MKL and how cmake adds them to compilation. 
This is done to avoid future name conflicts between this library and backend library. Forcing the compiler to look for some headers following the "" and <> inclusions rules accordingly with [C++ Core Guideline SF.12](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-incform)
# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
[arc_mklgpu_dft_log.txt](https://github.com/user-attachments/files/17161322/arc_mklgpu_dft_log.txt)
**N.B.** Tests ran with current oneAPI release (2024.2) I cannot run tests with next one.

- [x] Have you formatted the code using clang-format?


