### PR TITLE
[Unit tests] skip BLAS and LAPACK unit tests if Netlib is not found

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -17,15 +17,27 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-if("blas" IN_LIST TARGET_DOMAINS)
-  find_package(CBLAS REQUIRED)
+set(TEST_TARGET_DOMAINS ${TARGET_DOMAINS})
+
+if("blas" IN_LIST TEST_TARGET_DOMAINS)
+  find_package(CBLAS)
+  if(NOT CBLAS_FOUND)
+    # TODO: add list of tests without Netlib dependency
+    message(WARNING "Netlib CBLAS headers or libraries are not found, BLAS unit tests will be skipped")
+    list(REMOVE_ITEM TEST_TARGET_DOMAINS "blas")
+  endif()
 endif()
 
-if("lapack" IN_LIST TARGET_DOMAINS)
-    find_package(LAPACKE REQUIRED)
+if("lapack" IN_LIST TEST_TARGET_DOMAINS)
+  find_package(LAPACKE)
+  if(NOT LAPACKE_FOUND)
+    # TODO: add list of tests without Netlib dependency
+    message(WARNING "Netlib LAPACKE headers or libraries are not found, LAPACK unit tests will be skipped")
+    list(REMOVE_ITEM TEST_TARGET_DOMAINS "lapack")
+  endif()
 endif()
 
-foreach(domain ${TARGET_DOMAINS})
+foreach(domain ${TEST_TARGET_DOMAINS})
   # Build tests first
   add_subdirectory(${domain})
 endforeach()
@@ -50,7 +62,9 @@ set(blas_TEST_LINK "")
 set(lapack_TEST_LIST
         lapack_source)
 
-set(lapack_TEST_LINK ${LAPACKE_LINK})
+if(LAPACKE_FOUND)
+  set(lapack_TEST_LINK ${LAPACKE_LINK})
+endif()
 
 # RNG config
 set(rng_TEST_LIST
@@ -75,7 +89,7 @@ set(sparse_blas_TEST_LIST
 
 set(sparse_blas_TEST_LINK "")
 
-foreach(domain ${TARGET_DOMAINS})
+foreach(domain ${TEST_TARGET_DOMAINS})
   # Generate RT and CT test lists
   set(${domain}_TEST_LIST_RT ${${domain}_TEST_LIST})
   set(${domain}_TEST_LIST_CT ${${domain}_TEST_LIST})
@@ -195,7 +209,7 @@ foreach(domain ${TARGET_DOMAINS})
 
   string(TOUPPER ${domain} DOMAIN_PREFIX)
 
-  if(domain STREQUAL "blas")
+  if(domain STREQUAL "blas" AND CBLAS_FOUND)
     set(TEST_LD_LIBRARY_PATH ${CMAKE_BINARY_DIR}/lib:${CBLAS_LIB_DIR}:$ENV{LD_LIBRARY_PATH})
   else()
     set(TEST_LD_LIBRARY_PATH ${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH})

--- a/tests/unit_tests/blas/batch/CMakeLists.txt
+++ b/tests/unit_tests/blas/batch/CMakeLists.txt
@@ -18,7 +18,14 @@
 #===============================================================================
 
 # Build object from all test sources
-set(BATCH_SOURCES "copy_batch_stride.cpp" "axpy_batch_stride.cpp" "dgmm_batch_stride.cpp" "gemm_batch_stride.cpp" "gemv_batch_stride.cpp" "trsm_batch_stride.cpp" "syrk_batch_stride.cpp" "copy_batch_usm.cpp" "copy_batch_stride_usm.cpp" "axpy_batch_usm.cpp" "axpy_batch_stride_usm.cpp" "dgmm_batch_usm.cpp" "dgmm_batch_stride_usm.cpp" "gemm_batch_usm.cpp" "gemm_batch_stride_usm.cpp" "gemv_batch_usm.cpp" "gemv_batch_stride_usm.cpp" "trsm_batch_usm.cpp" "trsm_batch_stride_usm.cpp" "syrk_batch_usm.cpp" "syrk_batch_stride_usm.cpp" "omatcopy_batch_stride.cpp" "omatcopy_batch_stride_usm.cpp" "imatcopy_batch_stride.cpp" "imatcopy_batch_stride_usm.cpp" "omatadd_batch_stride.cpp" "omatadd_batch_stride_usm.cpp" "omatcopy_batch_usm.cpp" "imatcopy_batch_usm.cpp")
+# TODO: add list of tests without Netlib dependency
+set(BATCH_SOURCES)
+
+set(BATCH_SOURCES_W_CBLAS "copy_batch_stride.cpp" "axpy_batch_stride.cpp" "dgmm_batch_stride.cpp" "gemm_batch_stride.cpp" "gemv_batch_stride.cpp" "trsm_batch_stride.cpp" "syrk_batch_stride.cpp" "copy_batch_usm.cpp" "copy_batch_stride_usm.cpp" "axpy_batch_usm.cpp" "axpy_batch_stride_usm.cpp" "dgmm_batch_usm.cpp" "dgmm_batch_stride_usm.cpp" "gemm_batch_usm.cpp" "gemm_batch_stride_usm.cpp" "gemv_batch_usm.cpp" "gemv_batch_stride_usm.cpp" "trsm_batch_usm.cpp" "trsm_batch_stride_usm.cpp" "syrk_batch_usm.cpp" "syrk_batch_stride_usm.cpp" "omatcopy_batch_stride.cpp" "omatcopy_batch_stride_usm.cpp" "imatcopy_batch_stride.cpp" "imatcopy_batch_stride_usm.cpp" "omatadd_batch_stride.cpp" "omatadd_batch_stride_usm.cpp" "omatcopy_batch_usm.cpp" "imatcopy_batch_usm.cpp")
+
+if(CBLAS_FOUND)
+  list(APPEND BATCH_SOURCES ${BATCH_SOURCES_W_CBLAS})
+endif()
 
 if(BUILD_SHARED_LIBS)
   add_library(blas_batch_rt OBJECT ${BATCH_SOURCES})
@@ -29,7 +36,7 @@ if(BUILD_SHARED_LIBS)
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
-      PUBLIC ${CBLAS_INCLUDE}
+      $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
   )
   if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
     add_sycl_to_target(TARGET blas_batch_rt SOURCES ${BATCH_SOURCES})
@@ -46,7 +53,7 @@ target_include_directories(blas_batch_ct
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
     PUBLIC ${CMAKE_BINARY_DIR}/bin
-    PUBLIC ${CBLAS_INCLUDE}
+    $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
 )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET blas_batch_ct SOURCES ${BATCH_SOURCES})

--- a/tests/unit_tests/blas/extensions/CMakeLists.txt
+++ b/tests/unit_tests/blas/extensions/CMakeLists.txt
@@ -18,7 +18,15 @@
 #===============================================================================
 
 # Build object from all test sources
-set(EXTENSIONS_SOURCES "gemm_bias.cpp" "gemmt.cpp" "gemm_bias_usm.cpp" "gemmt_usm.cpp" "omatcopy.cpp" "omatcopy_usm.cpp" "imatcopy.cpp" "imatcopy_usm.cpp" "omatadd.cpp" "omatadd_usm.cpp" "omatcopy2.cpp" "omatcopy2_usm.cpp")
+# TODO: add list of tests without Netlib dependency
+set(EXTENSIONS_SOURCES)
+
+set(EXTENSIONS_SOURCES_W_CBLAS "gemm_bias.cpp" "gemmt.cpp" "gemm_bias_usm.cpp" "gemmt_usm.cpp" "omatcopy.cpp" "omatcopy_usm.cpp" "imatcopy.cpp" "imatcopy_usm.cpp" "omatadd.cpp" "omatadd_usm.cpp" "omatcopy2.cpp" "omatcopy2_usm.cpp")
+
+if(CBLAS_FOUND)
+  list(APPEND EXTENSIONS_SOURCES ${EXTENSIONS_SOURCES_W_CBLAS})
+endif()
+
 
 if(BUILD_SHARED_LIBS)
   add_library(blas_extensions_rt OBJECT ${EXTENSIONS_SOURCES})
@@ -29,7 +37,7 @@ if(BUILD_SHARED_LIBS)
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
-      PUBLIC ${CBLAS_INCLUDE}
+      $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
   )
   if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
     add_sycl_to_target(TARGET blas_extensions_rt SOURCES ${EXTENSIONS_SOURCES})
@@ -46,7 +54,7 @@ target_include_directories(blas_extensions_ct
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
     PUBLIC ${CMAKE_BINARY_DIR}/bin
-    PUBLIC ${CBLAS_INCLUDE}
+    $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
 )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET blas_extensions_ct  SOURCES ${EXTENSIONS_SOURCES})

--- a/tests/unit_tests/blas/level1/CMakeLists.txt
+++ b/tests/unit_tests/blas/level1/CMakeLists.txt
@@ -18,7 +18,14 @@
 #===============================================================================
 
 # Build object from all test sources
-set(L1_SOURCES "nrm2.cpp" "iamin.cpp" "iamax.cpp" "dotu.cpp" "dot.cpp" "dotc.cpp" "copy.cpp" "axpy.cpp" "axpby.cpp" "asum.cpp" "swap.cpp" "sdsdot.cpp" "scal.cpp" "rotmg.cpp" "rotm.cpp" "rotg.cpp" "rot.cpp" "nrm2_usm.cpp" "iamin_usm.cpp" "iamax_usm.cpp" "dotu_usm.cpp" "dot_usm.cpp" "dotc_usm.cpp" "copy_usm.cpp" "axpy_usm.cpp" "axpby_usm.cpp" "asum_usm.cpp" "swap_usm.cpp" "sdsdot_usm.cpp" "scal_usm.cpp" "rotmg_usm.cpp" "rotm_usm.cpp" "rotg_usm.cpp" "rot_usm.cpp")
+# TODO: add list of tests without Netlib dependency
+set(L1_SOURCES)
+
+set(L1_SOURCES_W_CBLAS "nrm2.cpp" "iamin.cpp" "iamax.cpp" "dotu.cpp" "dot.cpp" "dotc.cpp" "copy.cpp" "axpy.cpp" "axpby.cpp" "asum.cpp" "swap.cpp" "sdsdot.cpp" "scal.cpp" "rotmg.cpp" "rotm.cpp" "rotg.cpp" "rot.cpp" "nrm2_usm.cpp" "iamin_usm.cpp" "iamax_usm.cpp" "dotu_usm.cpp" "dot_usm.cpp" "dotc_usm.cpp" "copy_usm.cpp" "axpy_usm.cpp" "axpby_usm.cpp" "asum_usm.cpp" "swap_usm.cpp" "sdsdot_usm.cpp" "scal_usm.cpp" "rotmg_usm.cpp" "rotm_usm.cpp" "rotg_usm.cpp" "rot_usm.cpp")
+
+if(CBLAS_FOUND)
+  list(APPEND L1_SOURCES ${L1_SOURCES_W_CBLAS})
+endif()
 
 if(BUILD_SHARED_LIBS)
   add_library(blas_level1_rt OBJECT ${L1_SOURCES})
@@ -29,7 +36,7 @@ if(BUILD_SHARED_LIBS)
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
-      PUBLIC ${CBLAS_INCLUDE}
+      $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
   )
   if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
     add_sycl_to_target(TARGET blas_level1_rt SOURCES ${L1_SOURCES})
@@ -46,7 +53,7 @@ target_include_directories(blas_level1_ct
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
     PUBLIC ${CMAKE_BINARY_DIR}/bin
-    PUBLIC ${CBLAS_INCLUDE}
+    $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
 )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET blas_level1_ct SOURCES ${L1_SOURCES})

--- a/tests/unit_tests/blas/level2/CMakeLists.txt
+++ b/tests/unit_tests/blas/level2/CMakeLists.txt
@@ -18,7 +18,14 @@
 #===============================================================================
 
 # Build object from all test sources
-set(L2_SOURCES "hpr2.cpp" "hpmv.cpp" "her.cpp" "her2.cpp" "hemv.cpp" "hbmv.cpp" "geru.cpp" "ger.cpp" "gerc.cpp" "gemv.cpp" "gbmv.cpp" "trsv.cpp" "trmv.cpp" "tpsv.cpp" "tpmv.cpp" "tbsv.cpp" "tbmv.cpp" "syr.cpp" "syr2.cpp" "symv.cpp" "spr.cpp" "spr2.cpp" "spmv.cpp" "sbmv.cpp" "hpr.cpp" "hpr2_usm.cpp" "hpmv_usm.cpp" "her_usm.cpp" "her2_usm.cpp" "hemv_usm.cpp" "hbmv_usm.cpp" "geru_usm.cpp" "ger_usm.cpp" "gerc_usm.cpp" "gemv_usm.cpp" "gbmv_usm.cpp" "trsv_usm.cpp" "trmv_usm.cpp" "tpsv_usm.cpp" "tpmv_usm.cpp" "tbsv_usm.cpp" "tbmv_usm.cpp" "syr_usm.cpp" "syr2_usm.cpp" "symv_usm.cpp" "spr_usm.cpp" "spr2_usm.cpp" "spmv_usm.cpp" "sbmv_usm.cpp" "hpr_usm.cpp")
+# TODO: add list of tests without Netlib dependency
+set(L2_SOURCES)
+
+set(L2_SOURCES_W_CBLAS "hpr2.cpp" "hpmv.cpp" "her.cpp" "her2.cpp" "hemv.cpp" "hbmv.cpp" "geru.cpp" "ger.cpp" "gerc.cpp" "gemv.cpp" "gbmv.cpp" "trsv.cpp" "trmv.cpp" "tpsv.cpp" "tpmv.cpp" "tbsv.cpp" "tbmv.cpp" "syr.cpp" "syr2.cpp" "symv.cpp" "spr.cpp" "spr2.cpp" "spmv.cpp" "sbmv.cpp" "hpr.cpp" "hpr2_usm.cpp" "hpmv_usm.cpp" "her_usm.cpp" "her2_usm.cpp" "hemv_usm.cpp" "hbmv_usm.cpp" "geru_usm.cpp" "ger_usm.cpp" "gerc_usm.cpp" "gemv_usm.cpp" "gbmv_usm.cpp" "trsv_usm.cpp" "trmv_usm.cpp" "tpsv_usm.cpp" "tpmv_usm.cpp" "tbsv_usm.cpp" "tbmv_usm.cpp" "syr_usm.cpp" "syr2_usm.cpp" "symv_usm.cpp" "spr_usm.cpp" "spr2_usm.cpp" "spmv_usm.cpp" "sbmv_usm.cpp" "hpr_usm.cpp")
+
+if(CBLAS_FOUND)
+  list(APPEND L2_SOURCES ${L2_SOURCES_W_CBLAS})
+endif()
 
 if(BUILD_SHARED_LIBS)
   add_library(blas_level2_rt OBJECT ${L2_SOURCES})
@@ -29,7 +36,7 @@ if(BUILD_SHARED_LIBS)
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
-      PUBLIC ${CBLAS_INCLUDE}
+      $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
   )
   if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
     add_sycl_to_target(TARGET blas_level2_rt SOURCES ${L2_SOURCES})
@@ -46,7 +53,7 @@ target_include_directories(blas_level2_ct
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
     PUBLIC ${CMAKE_BINARY_DIR}/bin
-    PUBLIC ${CBLAS_INCLUDE}
+    $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
 )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET blas_level2_ct SOURCES ${L2_SOURCES})

--- a/tests/unit_tests/blas/level3/CMakeLists.txt
+++ b/tests/unit_tests/blas/level3/CMakeLists.txt
@@ -18,7 +18,14 @@
 #===============================================================================
 
 # Build object from all test sources
-set(L3_SOURCES "gemm.cpp" "symm.cpp" "syrk.cpp" "hemm.cpp" "herk.cpp" "syr2k.cpp" "her2k.cpp" "trmm.cpp" "trsm.cpp" "gemm_usm.cpp" "symm_usm.cpp" "syrk_usm.cpp" "hemm_usm.cpp" "herk_usm.cpp" "syr2k_usm.cpp" "her2k_usm.cpp" "trmm_usm.cpp" "trsm_usm.cpp")
+# TODO: add list of tests without Netlib dependency
+set(L3_SOURCES)
+
+set(L3_SOURCES_W_CBLAS "gemm.cpp" "symm.cpp" "syrk.cpp" "hemm.cpp" "herk.cpp" "syr2k.cpp" "her2k.cpp" "trmm.cpp" "trsm.cpp" "gemm_usm.cpp" "symm_usm.cpp" "syrk_usm.cpp" "hemm_usm.cpp" "herk_usm.cpp" "syr2k_usm.cpp" "her2k_usm.cpp" "trmm_usm.cpp" "trsm_usm.cpp")
+
+if(CBLAS_FOUND)
+  list(APPEND L3_SOURCES ${L3_SOURCES_W_CBLAS})
+endif()
 
 if(BUILD_SHARED_LIBS)
   add_library(blas_level3_rt OBJECT ${L3_SOURCES})
@@ -29,7 +36,7 @@ if(BUILD_SHARED_LIBS)
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
-      PUBLIC ${CBLAS_INCLUDE}
+      $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
   )
   if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
     add_sycl_to_target(TARGET blas_level3_rt SOURCES ${L3_SOURCES})
@@ -46,7 +53,7 @@ target_include_directories(blas_level3_ct
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
     PUBLIC ${CMAKE_BINARY_DIR}/bin
-    PUBLIC ${CBLAS_INCLUDE}
+    $<$<BOOL:${CBLAS_FOUND}>:${CBLAS_INCLUDE}>
 )
 if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
   add_sycl_to_target(TARGET blas_level3_ct SOURCES ${L3_SOURCES})

--- a/tests/unit_tests/lapack/source/CMakeLists.txt
+++ b/tests/unit_tests/lapack/source/CMakeLists.txt
@@ -18,7 +18,10 @@
 #===============================================================================
 
 #Build object from all test sources
-set(LAPACK_SOURCES
+# TODO: add list of tests without Netlib dependency
+set(LAPACK_SOURCES)
+
+set(LAPACK_SOURCES_W_LAPACKE
     "gebrd.cpp"
     "geqrf.cpp"
     "geqrf_batch_group.cpp"
@@ -68,6 +71,10 @@ set(LAPACK_SOURCES
     "unmtr.cpp"
 )
 
+if(LAPACKE_FOUND)
+  list(APPEND LAPACK_SOURCES ${LAPACK_SOURCES_W_LAPACKE})
+endif()
+
 if(BUILD_SHARED_LIBS)
   add_library(lapack_source_rt OBJECT ${LAPACK_SOURCES})
   target_compile_options(lapack_source_rt PRIVATE -DCALL_RT_API -DNOMINMAX)
@@ -77,7 +84,7 @@ if(BUILD_SHARED_LIBS)
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
-      PUBLIC ${LAPACKE_INCLUDE}
+      $<$<BOOL:${LAPACKE_FOUND}>:${LAPACKE_INCLUDE}>
   )
   target_link_libraries(lapack_source_rt PUBLIC ONEMKL::SYCL::SYCL)
 endif()
@@ -90,6 +97,6 @@ target_include_directories(lapack_source_ct
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PUBLIC ${PROJECT_SOURCE_DIR}/deps/googletest/include
     PUBLIC ${CMAKE_BINARY_DIR}/bin
-    PUBLIC ${LAPACKE_INCLUDE}
+    $<$<BOOL:${LAPACKE_FOUND}>:${LAPACKE_INCLUDE}>
 )
 target_link_libraries(lapack_source_ct PUBLIC ONEMKL::SYCL::SYCL)


### PR DESCRIPTION
# Description

This PR implements one more possible solution for the problem described in https://github.com/oneapi-src/oneMKL/pull/557 
In case Netlib libraries are not available it shouldn't block completely oneMKL Interfaces building, instead we can generate warning that BLAS and LAPACK unit tests will be skipped because of Netlib absence. 

This PR also includes some pre-work for adding BLAS and LAPACK tests that won't require Netlib.

* Example of the output users will get if Netlib is found
```
-- Found LAPACKE: /usr/lib64/liblapacke64.so
-- Found LAPACKE: /usr/lib64/liblapack64.so
-- Found LAPACKE: /usr/lib64/libcblas64.so
-- Found LAPACKE: /usr/lib64/libblas64.so
-- Found LAPACKE: /usr/include
...
-- Configuring done
-- Generating done
```

* Example of the output users will get if Netlib is NOT found
```
-- Could NOT find LAPACKE (missing: LAPACKE64_file)
-- Could NOT find LAPACKE (missing: LAPACK64_file)
-- Could NOT find LAPACKE (missing: CBLAS64_file)
-- Could NOT find LAPACKE (missing: BLAS64_file)
-- Could NOT find LAPACKE (missing: LAPACKE_INCLUDE LAPACKE_LINK)
CMake Warning at tests/unit_tests/CMakeLists.txt:33 (message):
  Netlib LAPACKE headers or libraries are not found, LAPACK unit tests will
  be skipped
...
-- Configuring done
-- Generating done
```

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. Both public and internal CIs were passed
- [x] Have you formatted the code using clang-format? N/A, all changes are CMake related only
