### PR TITLE
[RAND] rocrand/curand enqueue_native_command impls

### DIFF
--- a/src/rng/backends/curand/curand_task.hpp
+++ b/src/rng/backends/curand/curand_task.hpp
@@ -47,6 +47,10 @@ static inline void host_task_internal(H &cgh, A acc, E e, F f) {
         auto r_ptr = reinterpret_cast<typename A::value_type *>(
             ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc));
         f(r_ptr);
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+        CUresult err;
+        CUDA_ERROR_FUNC(cuStreamSynchronize, err, stream);
+#endif
     });
 }
 
@@ -61,6 +65,10 @@ static inline void host_task_internal(H &cgh, E e, F f) {
         auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         CURAND_CALL(curandSetStream, status, e, stream);
         f(ih);
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+        CUresult err;
+        CUDA_ERROR_FUNC(cuStreamSynchronize, err, stream);
+#endif
     });
 }
 #endif

--- a/src/rng/backends/curand/curand_task.hpp
+++ b/src/rng/backends/curand/curand_task.hpp
@@ -36,7 +36,11 @@ static inline void host_task_internal(H &cgh, E e, F f) {
 #else
 template <typename H, typename A, typename E, typename F>
 static inline void host_task_internal(H &cgh, A acc, E e, F f) {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih){
+#else
     cgh.host_task([=](sycl::interop_handle ih) {
+#endif
         curandStatus_t status;
         auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         CURAND_CALL(curandSetStream, status, e, stream);
@@ -48,7 +52,11 @@ static inline void host_task_internal(H &cgh, A acc, E e, F f) {
 
 template <typename H, typename E, typename F>
 static inline void host_task_internal(H &cgh, E e, F f) {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih){
+#else
     cgh.host_task([=](sycl::interop_handle ih) {
+#endif
         curandStatus_t status;
         auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
         CURAND_CALL(curandSetStream, status, e, stream);

--- a/src/rng/backends/rocrand/rocrand_task.hpp
+++ b/src/rng/backends/rocrand/rocrand_task.hpp
@@ -36,7 +36,11 @@ static inline void host_task_internal(H &cgh, E e, F f) {
 #else
 template <typename H, typename A, typename E, typename F>
 static inline void host_task_internal(H &cgh, A acc, E e, F f) {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih){
+#else
     cgh.host_task([=](sycl::interop_handle ih) {
+#endif
         rocrand_status status;
         auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
         ROCRAND_CALL(rocrand_set_stream, status, e, stream);
@@ -51,7 +55,11 @@ static inline void host_task_internal(H &cgh, A acc, E e, F f) {
 
 template <typename H, typename E, typename F>
 static inline void host_task_internal(H &cgh, E e, F f) {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih){
+#else
     cgh.host_task([=](sycl::interop_handle ih) {
+#endif
         rocrand_status status;
         auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
         ROCRAND_CALL(rocrand_set_stream, status, e, stream);

--- a/src/rng/backends/rocrand/rocrand_task.hpp
+++ b/src/rng/backends/rocrand/rocrand_task.hpp
@@ -47,9 +47,10 @@ static inline void host_task_internal(H &cgh, A acc, E e, F f) {
         auto r_ptr = reinterpret_cast<typename A::value_type *>(
             ih.get_native_mem<sycl::backend::ext_oneapi_hip>(acc));
         f(r_ptr);
-
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
         hipError_t err;
         HIP_ERROR_FUNC(hipStreamSynchronize, err, stream);
+#endif
     });
 }
 
@@ -64,9 +65,10 @@ static inline void host_task_internal(H &cgh, E e, F f) {
         auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
         ROCRAND_CALL(rocrand_set_stream, status, e, stream);
         f(ih);
-
+#ifndef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
         hipError_t err;
         HIP_ERROR_FUNC(hipStreamSynchronize, err, stream);
+#endif
     });
 }
 #endif


### PR DESCRIPTION
This implements the dpc++ `enqueue_native_command` extension that correctly integrates native commands with sycl scheduling. Both HIP (rocrand) and CUDA (curand) backends are implemented and tested. 

See https://github.com/oneapi-src/oneMKL/pull/572 for further details of this extension.

Tests:

- native_enqueue path

[test_main_rng_rt_amd.txt](https://github.com/user-attachments/files/17245014/test_main_rng_rt_amd.txt)
[test_main_rng_ct_amd.txt](https://github.com/user-attachments/files/17245015/test_main_rng_ct_amd.txt)
[test_main_rng_ct_nvidia.txt](https://github.com/user-attachments/files/17245016/test_main_rng_ct_nvidia.txt)
[test_main_rng_rt_nvidia.txt](https://github.com/user-attachments/files/17245017/test_main_rng_rt_nvidia.txt)

- host_task path

[test_main_rng_ct_nvidia_host_task.txt](https://github.com/user-attachments/files/17306754/test_main_rng_ct_nvidia_host_task.txt)
[test_main_rng_rt_nvidia_host_task.txt](https://github.com/user-attachments/files/17306756/test_main_rng_rt_nvidia_host_task.txt)
[test_main_rng_ct_amd_host_task.txt](https://github.com/user-attachments/files/17306758/test_main_rng_ct_amd_host_task.txt)
[test_main_rng_rt_amd_host_task.txt](https://github.com/user-attachments/files/17306759/test_main_rng_rt_amd_host_task.txt)



